### PR TITLE
test: navigate Omnichannel admin pages by URL

### DIFF
--- a/apps/meteor/client/components/GenericNoResults/GenericNoResults.tsx
+++ b/apps/meteor/client/components/GenericNoResults/GenericNoResults.tsx
@@ -24,7 +24,7 @@ const GenericNoResults = ({
 	const { t } = useTranslation();
 
 	return (
-		<Box display='flex' height='100%' flexDirection='column' justifyContent='center'>
+		<Box role='status' aria-label={t('No_results_found')} display='flex' height='100%' flexDirection='column' justifyContent='center'>
 			<States>
 				{icon && <StatesIcon name={icon} />}
 				<StatesTitle>{title || t('No_results_found')}</StatesTitle>

--- a/apps/meteor/client/components/GenericNoResults/GenericNoResults.tsx
+++ b/apps/meteor/client/components/GenericNoResults/GenericNoResults.tsx
@@ -24,7 +24,7 @@ const GenericNoResults = ({
 	const { t } = useTranslation();
 
 	return (
-		<Box role='status' aria-label={t('No_results_found')} display='flex' height='100%' flexDirection='column' justifyContent='center'>
+		<Box role='group' aria-label={t('No_results_found')} display='flex' height='100%' flexDirection='column' justifyContent='center'>
 			<States>
 				{icon && <StatesIcon name={icon} />}
 				<StatesTitle>{title || t('No_results_found')}</StatesTitle>

--- a/apps/meteor/client/views/admin/permissions/PermissionsTable/__snapshots__/PermissionsTable.spec.tsx.snap
+++ b/apps/meteor/client/views/admin/permissions/PermissionsTable/__snapshots__/PermissionsTable.spec.tsx.snap
@@ -1217,7 +1217,9 @@ exports[`renders Empty without crashing 1`] = `
         </label>
       </div>
       <div
+        aria-label="No_results_found"
         class="rcx-box rcx-box--full rcx-css-1wg1u9h"
+        role="group"
       >
         <div
           class="rcx-states"

--- a/apps/meteor/client/views/admin/permissions/UsersInRole/UsersInRoleTable/__snapshots__/UsersInRoleTable.spec.tsx.snap
+++ b/apps/meteor/client/views/admin/permissions/UsersInRole/UsersInRoleTable/__snapshots__/UsersInRoleTable.spec.tsx.snap
@@ -1092,7 +1092,9 @@ exports[`renders withNoResults without crashing 1`] = `
       class="rcx-box rcx-box--full rcx-css-9x4qdd"
     >
       <div
+        aria-label="No_results_found"
         class="rcx-box rcx-box--full rcx-css-1wg1u9h"
+        role="group"
       >
         <div
           class="rcx-states"

--- a/apps/meteor/client/views/admin/users/UsersTable/__snapshots__/UsersTable.spec.tsx.snap
+++ b/apps/meteor/client/views/admin/users/UsersTable/__snapshots__/UsersTable.spec.tsx.snap
@@ -1521,7 +1521,9 @@ exports[`renders NoResults without crashing 1`] = `
       </div>
     </form>
     <div
+      aria-label="No_results_found"
       class="rcx-box rcx-box--full rcx-css-16js560"
+      role="group"
     >
       <div
         class="rcx-states"

--- a/apps/meteor/client/views/omnichannel/cannedResponses/modals/CannedResponsesTable.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/modals/CannedResponsesTable.tsx
@@ -148,7 +148,7 @@ const CannedResponsesTable = () => {
 			)}
 			{isSuccess && data?.cannedResponses.length > 0 && (
 				<>
-					<GenericTable aria-busy={text !== debouncedText}>
+					<GenericTable aria-label={t('Canned_Responses')} aria-busy={text !== debouncedText}>
 						<GenericTableHeader>{headers}</GenericTableHeader>
 						<GenericTableBody>
 							{data?.cannedResponses.map(({ _id, shortcut, scope, createdBy, _createdAt, tags = [] }) => (

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-agents.spec.ts
@@ -17,12 +17,9 @@ test.describe.serial('OC - Manage Agents', () => {
 		department = await createDepartment(api);
 	});
 
-	// Create page object and redirect to home
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelAgents = new OmnichannelAgents(page);
-
-		await page.goto('/omnichannel');
-		await poOmnichannelAgents.sidebar.linkAgents.click();
+		await poOmnichannelAgents.goTo();
 	});
 
 	test.beforeAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-appearance.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-appearance.spec.ts
@@ -11,9 +11,7 @@ test.describe.serial('OC - Livechat Appearance - EE', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poLivechatAppearance = new OmnichannelLivechatAppearance(page);
-
-		await page.goto('/omnichannel');
-		await poLivechatAppearance.sidebar.linkLivechatAppearance.click();
+		await poLivechatAppearance.goTo();
 	});
 
 	test.afterAll(async ({ api }) => {
@@ -75,9 +73,7 @@ test.describe('OC - Livechat Appearance - CE', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poLivechatAppearance = new OmnichannelLivechatAppearance(page);
-
-		await page.goto('/omnichannel');
-		await poLivechatAppearance.sidebar.linkLivechatAppearance.click();
+		await poLivechatAppearance.goTo();
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-business-hours.spec.ts
@@ -44,9 +44,8 @@ test.describe('OC - Business Hours', () => {
 		poOmnichannelBusinessHours = new OmnichannelBusinessHours(page);
 	});
 
-	test('OC - Manage Business Hours - Create Business Hours', async ({ page }) => {
-		await page.goto('/omnichannel');
-		await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
+	test('OC - Manage Business Hours - Create Business Hours', async () => {
+		await poOmnichannelBusinessHours.goTo();
 
 		await test.step('expect correct form default state', async () => {
 			await poOmnichannelBusinessHours.btnCreateBusinessHour.click();
@@ -76,7 +75,7 @@ test.describe('OC - Business Hours', () => {
 		});
 	});
 
-	test('OC - Business hours - Edit BH departments', async ({ api, page }) => {
+	test('OC - Business hours - Edit BH departments', async ({ api }) => {
 		await test.step('expect to create new businessHours', async () => {
 			const createBH = await createBusinessHour(api, {
 				name: BHName,
@@ -86,8 +85,7 @@ test.describe('OC - Business Hours', () => {
 			expect(createBH.status()).toBe(200);
 		});
 
-		await page.goto('/omnichannel');
-		await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
+		await poOmnichannelBusinessHours.goTo();
 
 		await test.step('expect to add business hours departments', async () => {
 			await poOmnichannelBusinessHours.search(BHName);
@@ -124,7 +122,7 @@ test.describe('OC - Business Hours', () => {
 		});
 	});
 
-	test('OC - Business hours - Toggle BH active status', async ({ api, page }) => {
+	test('OC - Business hours - Toggle BH active status', async ({ api }) => {
 		await test.step('expect to create new businessHours', async () => {
 			const createBH = await createBusinessHour(api, {
 				name: BHName,
@@ -134,8 +132,7 @@ test.describe('OC - Business Hours', () => {
 			expect(createBH.status()).toBe(200);
 		});
 
-		await page.goto('/omnichannel');
-		await poOmnichannelBusinessHours.sidebar.linkBusinessHours.click();
+		await poOmnichannelBusinessHours.goTo();
 
 		await test.step('expect to disable business hours', async () => {
 			await poOmnichannelBusinessHours.search(BHName);

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-close-inquiry.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-close-inquiry.spec.ts
@@ -59,8 +59,7 @@ test.describe('Omnichannel close inquiry', () => {
 		});
 
 		await test.step('Expect to inquiry be closed when navigate back', async () => {
-			await agent.poHomeOmnichannel.navbar.openManageMenuItem('Omnichannel');
-			await agent.poHomeOmnichannel.omnisidenav.linkCurrentChats.click();
+			await agent.poHomeOmnichannel.chats.goTo();
 			await agent.poHomeOmnichannel.chats.openChat(newVisitor.name);
 			await expect(agent.poHomeOmnichannel.content.btnTakeChat).not.toBeVisible();
 		});

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-center-chats.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-contact-center-chats.spec.ts
@@ -21,7 +21,7 @@ test.skip(!IS_EE, 'OC - Contact Center Chats > Enterprise Only');
 test.use({ storageState: Users.admin.state });
 
 test.describe('OC - Contact Center Chats [Auto Selection]', async () => {
-	let poOmnichats: OmnichannelContactCenterChats;
+	let poContactCenterChats: OmnichannelContactCenterChats;
 	let poHomeOmnichannel: HomeOmnichannel;
 	let departments: Awaited<ReturnType<typeof createDepartment>>[];
 	let conversations: Awaited<ReturnType<typeof createConversation>>[];
@@ -113,11 +113,10 @@ test.describe('OC - Contact Center Chats [Auto Selection]', async () => {
 	});
 
 	test.beforeEach(async ({ page }: { page: Page }) => {
-		poOmnichats = new OmnichannelContactCenterChats(page);
+		poContactCenterChats = new OmnichannelContactCenterChats(page);
 		poHomeOmnichannel = new HomeOmnichannel(page);
 
-		await page.goto('/omnichannel');
-		await poOmnichats.sidebar.linkCurrentChats.click();
+		await poContactCenterChats.goTo();
 	});
 
 	test.afterAll(async ({ api }) => {
@@ -151,7 +150,7 @@ test.describe('OC - Contact Center Chats [Auto Selection]', async () => {
 
 	test('OC - Contact Center Chats - Basic navigation', async ({ page }) => {
 		await test.step('expect to be return using return button', async () => {
-			await poOmnichats.openChat(visitorA);
+			await poContactCenterChats.openChat(visitorA);
 			await poHomeOmnichannel.content.btnReturn.click();
 			expect(page.url()).toContain(`/omnichannel/current`);
 		});
@@ -160,7 +159,7 @@ test.describe('OC - Contact Center Chats [Auto Selection]', async () => {
 	test('OC - Contact Center Chats - Access in progress conversation from another agent', async () => {
 		await test.step('expect to be able to join', async () => {
 			const { visitor: visitorB } = conversations[1].data;
-			await poOmnichats.openChat(visitorB.name);
+			await poContactCenterChats.openChat(visitorB.name);
 			await expect(poHomeOmnichannel.composer.btnJoinRoom).toBeVisible();
 			await poHomeOmnichannel.composer.btnJoinRoom.click();
 			await expect(poHomeOmnichannel.composer.btnJoinRoom).not.toBeVisible();
@@ -169,8 +168,8 @@ test.describe('OC - Contact Center Chats [Auto Selection]', async () => {
 
 	test('OC - Contact Center Chats - Remove conversations', async () => {
 		await test.step('expect to be able to remove conversation from table', async () => {
-			await poOmnichats.removeChatByName(visitorC);
-			await expect(poOmnichats.table.findRowByName(visitorC)).not.toBeVisible();
+			await poContactCenterChats.removeChatByName(visitorC);
+			await expect(poContactCenterChats.table.findRowByName(visitorC)).not.toBeVisible();
 		});
 
 		// TODO: await test.step('expect to be able to close all closes conversations', async () => {});
@@ -197,11 +196,10 @@ test.describe('OC - Contact Center [Manual Selection]', () => {
 	});
 
 	test.beforeEach(async ({ page }: { page: Page }) => {
-		poCurrentChats = new OmnichannelContactCenterChats(page);
 		poHomeOmnichannel = new HomeOmnichannel(page);
+		poCurrentChats = new OmnichannelContactCenterChats(page);
 
-		await page.goto('/omnichannel');
-		await poCurrentChats.sidebar.linkCurrentChats.click();
+		await poCurrentChats.goTo();
 	});
 
 	test('OC - Contact Center Chats - Access queued conversation', async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-custom-fields.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-custom-fields.spec.ts
@@ -7,11 +7,10 @@ test.use({ storageState: Users.admin.state });
 test.describe('omnichannel-customFields', () => {
 	let poOmnichannelCustomFields: OmnichannelCustomFields;
 	const newField = 'any_field';
+
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelCustomFields = new OmnichannelCustomFields(page);
-
-		await page.goto('/omnichannel');
-		await poOmnichannelCustomFields.sidebar.linkCustomFields.click();
+		await poOmnichannelCustomFields.goTo();
 	});
 
 	test('expect add new "custom field"', async ({ page }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments-ce.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments-ce.spec.ts
@@ -27,7 +27,7 @@ test.describe.serial('OC - Manage Departments (CE)', () => {
 			await poOmnichannelDepartments.createDepartment(departmentName, faker.internet.email());
 
 			await poOmnichannelDepartments.inputSearch.fill(departmentName);
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentName)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(departmentName)).toBeVisible();
 		});
 
 		await test.step('expect to not be possible adding a second department ', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments-ce.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments-ce.spec.ts
@@ -18,9 +18,7 @@ test.describe.serial('OC - Manage Departments (CE)', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelDepartments = new OmnichannelDepartments(page);
-
-		await page.goto('/omnichannel');
-		await poOmnichannelDepartments.sidebar.linkDepartments.click();
+		await poOmnichannelDepartments.goTo();
 	});
 
 	test('OC - Manage Departments (CE) - Create department', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments.spec.ts
@@ -87,7 +87,7 @@ test.describe('OC - Manage Departments', () => {
 			await test.step('expect create new department', async () => {
 				await poOmnichannelDepartments.btnSave.click();
 				await poOmnichannelDepartments.search(departmentName);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentName)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(departmentName)).toBeVisible();
 			});
 
 			await test.step('expect to delete department', async () => {
@@ -112,7 +112,7 @@ test.describe('OC - Manage Departments', () => {
 
 				await test.step('expect department to have been deleted', async () => {
 					await poOmnichannelDepartments.search(departmentName);
-					await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentName)).toHaveCount(0);
+					await expect(poOmnichannelDepartments.table.findRowByName(departmentName)).toHaveCount(0);
 				});
 			});
 		});
@@ -135,7 +135,7 @@ test.describe('OC - Manage Departments', () => {
 		test('Edit department', async () => {
 			await test.step('expect create new department', async () => {
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 
 				return department;
 			});
@@ -149,24 +149,24 @@ test.describe('OC - Manage Departments', () => {
 				await poOmnichannelDepartments.btnSave.click();
 
 				await poOmnichannelDepartments.search(`edited-${department.name}`);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(`edited-${department.name}`)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(`edited-${department.name}`)).toBeVisible();
 			});
 		});
 
 		test('Archive department', async () => {
 			await test.step('expect create new department', async () => {
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 			});
 
 			await test.step('expect archive department', async () => {
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 
 				await poOmnichannelDepartments.archiveDepartmentByName(department.name);
 				await poOmnichannelDepartments.tabArchivedDepartments.click();
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 			});
 
 			await test.step('expect archived department to not be editable', async () => {
@@ -176,14 +176,14 @@ test.describe('OC - Manage Departments', () => {
 
 			await test.step('expect unarchive department', async () => {
 				await poOmnichannelDepartments.menuUnarchiveOption.click();
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toHaveCount(0);
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toHaveCount(0);
 			});
 		});
 
 		test('Request tag(s) before closing conversation', async () => {
 			await test.step('should create new department', async () => {
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 			});
 
 			const tagName = faker.string.sample(5);
@@ -220,7 +220,7 @@ test.describe('OC - Manage Departments', () => {
 		test('Toggle department removal', async ({ api, page }) => {
 			await test.step('expect create new department', async () => {
 				await poOmnichannelDepartments.search(department.name);
-				await expect(poOmnichannelDepartments.departmentsTable.findRowByName(department.name)).toBeVisible();
+				await expect(poOmnichannelDepartments.table.findRowByName(department.name)).toBeVisible();
 			});
 
 			await test.step('expect to be able to delete department', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-departaments.spec.ts
@@ -37,9 +37,7 @@ test.describe('OC - Manage Departments', () => {
 	test.describe('Create first department', async () => {
 		test.beforeEach(async ({ page }: { page: Page }) => {
 			poOmnichannelDepartments = new OmnichannelDepartments(page);
-
-			await page.goto('/omnichannel');
-			await poOmnichannelDepartments.sidebar.linkDepartments.click();
+			await poOmnichannelDepartments.goTo();
 		});
 
 		test('Create department', async ({ page }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
@@ -106,7 +106,7 @@ test.describe('OC - Manager Role', () => {
 		await test.step('expect agent to not have access to omnichannel administration', async () => {
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Contact Center')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Analytics')).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-Time Monitoring')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-time Monitoring')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Agents')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Departments')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Business Hours')).toBeVisible();

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manager-role.spec.ts
@@ -99,24 +99,23 @@ test.describe('OC - Manager Role', () => {
 
 	test.beforeEach(async ({ page }: { page: Page }) => {
 		poOmnichannel = new HomeOmnichannel(page);
-
-		await page.goto('/omnichannel');
+		await poOmnichannel.chats.goTo();
 	});
 
 	test('OC - Manager Role - Basic permissions', async () => {
 		await test.step('expect agent to not have access to omnichannel administration', async () => {
-			await expect(poOmnichannel.omnisidenav.linkCurrentChats).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkAnalytics).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkRealTimeMonitoring).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkAgents).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkDepartments).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkBusinessHours).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkReports).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkCannedResponses).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Contact Center')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Analytics')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-Time Monitoring')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Agents')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Departments')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Business Hours')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Reports')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Canned Responses')).toBeVisible();
 		});
 	});
 
-	test('OC - Manager Role - Contact Center', async ({ page }) => {
+	test('OC - Manager Role - Contact Center', async () => {
 		await test.step('expect to be able to view all chats', async () => {
 			await expect(poOmnichannel.chats.table.findRowByName(ROOM_A)).toBeVisible();
 			await expect(poOmnichannel.chats.table.findRowByName(ROOM_B)).toBeVisible();
@@ -152,7 +151,7 @@ test.describe('OC - Manager Role', () => {
 
 		await test.step('expect to be able to close a conversation from another agent', async () => {
 			await poOmnichannel.quickActionsRoomToolbar.closeChat();
-			await page.goto('/omnichannel');
+			await poOmnichannel.chats.goTo();
 		});
 
 		await test.step('expect to be able to remove closed rooms', async () => {
@@ -163,7 +162,7 @@ test.describe('OC - Manager Role', () => {
 
 	test('OC - Manager Role - Add/remove agents', async ({ page }) => {
 		const poOmnichannelAgents = new OmnichannelAgents(page);
-		await poOmnichannelAgents.sidebar.linkAgents.click();
+		await poOmnichannelAgents.goTo();
 
 		await test.step('expect add "user1" as agent', async () => {
 			await poOmnichannelAgents.selectUsername('user1');
@@ -185,7 +184,7 @@ test.describe('OC - Manager Role', () => {
 
 	test('OC - Manager Role - Add/remove managers', async ({ page }) => {
 		const poOmnichannelManagers = new OmnichannelManager(page);
-		await poOmnichannelManagers.sidebar.linkManagers.click();
+		await poOmnichannelManagers.goTo();
 
 		await test.step('expect add "user1" as manager', async () => {
 			await poOmnichannelManagers.selectUsername('user1');

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-manager.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-manager.spec.ts
@@ -9,8 +9,7 @@ test.describe.serial('omnichannel-manager', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelManagers = new OmnichannelManager(page);
-
-		await poOmnichannelManagers.goto();
+		await poOmnichannelManagers.goTo();
 	});
 
 	test('OC - Manage Managers - Add, Search and Remove', async ({ page }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-department.spec.ts
@@ -89,7 +89,7 @@ test.describe.serial('OC - Monitor Role', () => {
 		const [unitA, unitB, unitC] = units.map((unit) => unit.data);
 
 		await test.step('expect to see only departmentA in the list', async () => {
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentA.name)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(departmentA.name)).toBeVisible();
 		});
 
 		await test.step('expect to fill departments mandatory field', async () => {
@@ -130,8 +130,8 @@ test.describe.serial('OC - Monitor Role', () => {
 		});
 
 		await test.step('expect to have departmentA and departmentB visible', async () => {
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentA.name)).toBeVisible();
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(newDepartmentName)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(departmentA.name)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(newDepartmentName)).toBeVisible();
 		});
 	});
 
@@ -159,8 +159,8 @@ test.describe.serial('OC - Monitor Role', () => {
 		});
 
 		await test.step('expect departmentB to still be visible', async () => {
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentA.name)).toBeVisible();
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(newDepartmentName)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(departmentA.name)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(newDepartmentName)).toBeVisible();
 		});
 	});
 
@@ -177,8 +177,8 @@ test.describe.serial('OC - Monitor Role', () => {
 		});
 
 		await test.step('expect departmentB to not be visible', async () => {
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(departmentA.name)).toBeVisible();
-			await expect(poOmnichannelDepartments.departmentsTable.findRowByName(newDepartmentName)).not.toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(departmentA.name)).toBeVisible();
+			await expect(poOmnichannelDepartments.table.findRowByName(newDepartmentName)).not.toBeVisible();
 		});
 	});
 });

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-role.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-role.spec.ts
@@ -132,20 +132,19 @@ test.describe('OC - Monitor Role', () => {
 
 	test.beforeEach(async ({ page }: { page: Page }) => {
 		poOmnichannel = new HomeOmnichannel(page);
-
-		await page.goto('/omnichannel');
+		await poOmnichannel.chats.goTo();
 	});
 
 	test('OC - Monitor Role - Basic permissions', async () => {
 		await test.step('expect agent to not have access to omnichannel administration', async () => {
-			await expect(poOmnichannel.omnisidenav.linkCurrentChats).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkAnalytics).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkRealTimeMonitoring).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkAgents).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkDepartments).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkBusinessHours).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkReports).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.linkCannedResponses).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Contact Center')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Analytics')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-Time Monitoring')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Agents')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Departments')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Business Hours')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Reports')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Canned Responses')).toBeVisible();
 		});
 
 		// await test.step('expect to be able to see contact center', async () => {});
@@ -158,13 +157,13 @@ test.describe('OC - Monitor Role', () => {
 	test('OC - Monitor Role - Canned responses', async () => {
 		// TODO: move to unit test
 		await test.step('expect not to be able to create public canned responses (administration)', async () => {
-			await poOmnichannel.omnisidenav.linkCannedResponses.click();
+			await poOmnichannel.cannedResponses.goTo();
 			await poOmnichannel.cannedResponses.btnNew.click();
 			await expect(poOmnichannel.cannedResponses.radioPublic).toBeDisabled();
 		});
 	});
 
-	test('OC - Monitor Role - Contact Center', async ({ page }) => {
+	test('OC - Monitor Role - Contact Center', async () => {
 		await test.step('expect to be able to view only chats from same unit', async () => {
 			await expect(poOmnichannel.chats.table.findRowByName(ROOM_A)).toBeVisible();
 			await expect(poOmnichannel.chats.table.findRowByName(ROOM_B)).toBeVisible();
@@ -201,7 +200,7 @@ test.describe('OC - Monitor Role', () => {
 
 		await test.step('expect to be able to close a conversation from another agent', async () => {
 			await poOmnichannel.quickActionsRoomToolbar.closeChat();
-			await page.goto('/omnichannel');
+			await poOmnichannel.chats.goTo();
 		});
 
 		await test.step('expect not to be able to remove closed room', async () => {
@@ -214,13 +213,14 @@ test.describe('OC - Monitor Role', () => {
 		const [unitA, unitB] = units;
 		const [monitor] = monitors;
 
-		await poOmnichannel.omnisidenav.linkCurrentChats.click();
+		const poContactCenterChats = poOmnichannel.chats;
+		await poContactCenterChats.goTo();
 
 		await test.step('expect not to be able to see chats from removed department', async () => {
 			await test.step('expect rooms from both departments to be visible', async () => {
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_B)).toBeVisible();
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_C)).toBeVisible();
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_D)).not.toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_B)).toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_C)).toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_D)).not.toBeVisible();
 			});
 
 			await test.step('expect to remove departmentB from unit', async () => {
@@ -236,9 +236,9 @@ test.describe('OC - Monitor Role', () => {
 			});
 
 			await test.step('expect to have only room B visible', async () => {
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_B)).toBeVisible();
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_C)).not.toBeVisible();
-				await expect(poOmnichannel.chats.table.findRowByName(ROOM_D)).not.toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_B)).toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_C)).not.toBeVisible();
+				await expect(poContactCenterChats.table.findRowByName(ROOM_D)).not.toBeVisible();
 			});
 		});
 
@@ -246,16 +246,16 @@ test.describe('OC - Monitor Role', () => {
 			const res = await unitA.delete();
 			expect(res.status()).toBe(200);
 			await page.reload();
-			await expect(poOmnichannel.chats.table.findRowByName(ROOM_B)).not.toBeVisible();
-			await expect(poOmnichannel.chats.table.findRowByName(ROOM_C)).not.toBeVisible();
-			await expect(poOmnichannel.chats.table.findRowByName(ROOM_D)).not.toBeVisible();
+			await expect(poContactCenterChats.table.findRowByName(ROOM_B)).not.toBeVisible();
+			await expect(poContactCenterChats.table.findRowByName(ROOM_C)).not.toBeVisible();
+			await expect(poContactCenterChats.table.findRowByName(ROOM_D)).not.toBeVisible();
 		});
 
 		await test.step('expect to be able to see all conversations once all units are removed', async () => {
 			const res = await unitB.delete();
 			expect(res.status()).toBe(200);
 			await page.reload();
-			await expect(poOmnichannel.chats.table.findRowByName(ROOM_D)).toBeVisible();
+			await expect(poContactCenterChats.table.findRowByName(ROOM_D)).toBeVisible();
 		});
 
 		await test.step('expect not to be able to see chats once role is removed', async () => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-role.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-monitor-role.spec.ts
@@ -139,7 +139,7 @@ test.describe('OC - Monitor Role', () => {
 		await test.step('expect agent to not have access to omnichannel administration', async () => {
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Contact Center')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Analytics')).toBeVisible();
-			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-Time Monitoring')).toBeVisible();
+			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Real-time Monitoring')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Agents')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Departments')).toBeVisible();
 			await expect(poOmnichannel.omnisidenav.getSidebarLinkByName('Business Hours')).toBeVisible();

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-priorities.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-priorities.spec.ts
@@ -27,10 +27,7 @@ test.describe.serial('Omnichannel Priorities', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelPriorities = new OmnichannelPriorities(page);
-
-		await page.goto('/omnichannel');
-		await page.locator('#main-content').waitFor();
-		await poOmnichannelPriorities.sidebar.linkPriorities.click();
+		await poOmnichannelPriorities.goTo();
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-sla-policies.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-sla-policies.spec.ts
@@ -36,9 +36,7 @@ test.describe('Omnichannel SLA Policies', () => {
 
 	test.beforeEach(async ({ page }) => {
 		poOmnichannelSlaPolicies = new OmnichannelSlaPolicies(page);
-
-		await page.goto('/omnichannel');
-		await poOmnichannelSlaPolicies.sidebar.linkSlaPolicies.click();
+		await poOmnichannelSlaPolicies.goTo();
 	});
 
 	test.afterAll(async ({ api }) => {

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-sla-policies.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-sla-policies.spec.ts
@@ -90,10 +90,10 @@ test.describe('Omnichannel SLA Policies', () => {
 		await test.step('Search SLA', async () => {
 			await poOmnichannelSlaPolicies.inputSearch.fill('random_text_that_should_have_no_match');
 			await expect(poOmnichannelSlaPolicies.table.findRowByName(INITIAL_SLA.name)).not.toBeVisible();
-			await expect(poOmnichannelSlaPolicies.txtEmptyState).toBeVisible();
+			await expect(poOmnichannelSlaPolicies.emptyState).toBeVisible();
 			await poOmnichannelSlaPolicies.inputSearch.fill(INITIAL_SLA.name);
 			await expect(poOmnichannelSlaPolicies.table.findRowByName(INITIAL_SLA.name)).toBeVisible();
-			await expect(poOmnichannelSlaPolicies.txtEmptyState).not.toBeVisible();
+			await expect(poOmnichannelSlaPolicies.emptyState).not.toBeVisible();
 			await poOmnichannelSlaPolicies.inputSearch.fill('');
 		});
 

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-tags.spec.ts
@@ -45,11 +45,10 @@ test.describe('OC - Manage Tags', () => {
 		poOmnichannelTags = new OmnichannelTags(page);
 	});
 
-	test('OC - Manage Tags - Create Tag', async ({ page }) => {
+	test('OC - Manage Tags - Create Tag', async () => {
 		const tagName = faker.string.uuid();
 
-		await page.goto('/omnichannel');
-		await poOmnichannelTags.sidebar.linkTags.click();
+		await poOmnichannelTags.goTo();
 
 		await test.step('expect correct form default state', async () => {
 			await poOmnichannelTags.createNew();
@@ -89,8 +88,7 @@ test.describe('OC - Manage Tags', () => {
 			return tag;
 		});
 
-		await page.goto('/omnichannel');
-		await poOmnichannelTags.sidebar.linkTags.click();
+		await poOmnichannelTags.goTo();
 
 		await test.step('expect to add tag departments', async () => {
 			await poOmnichannelTags.search(tag.name);

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-units.spec.ts
@@ -56,8 +56,7 @@ test.describe('OC - Manage Units', () => {
 
 	test.beforeEach(async ({ page }: { page: Page }) => {
 		poOmnichannelUnits = new OmnichannelUnits(page);
-		await page.goto('/omnichannel');
-		await poOmnichannelUnits.sidebar.linkUnits.click();
+		await poOmnichannelUnits.goTo();
 	});
 
 	test('OC - Manage Units - Create Unit', async () => {
@@ -92,7 +91,7 @@ test.describe('OC - Manage Units', () => {
 		});
 	});
 
-	test('OC - Manage Units - Edit unit name', async ({ api, page }) => {
+	test('OC - Manage Units - Edit unit name', async ({ api }) => {
 		const unitName = faker.string.uuid();
 		const editedUnitName = faker.string.uuid();
 
@@ -107,8 +106,7 @@ test.describe('OC - Manage Units', () => {
 			return newUnit;
 		});
 
-		await page.goto('/omnichannel');
-		await poOmnichannelUnits.sidebar.linkUnits.click();
+		await poOmnichannelUnits.goTo();
 
 		await test.step('expect to edit unit', async () => {
 			await poOmnichannelUnits.search(unit.name);

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -153,63 +153,7 @@ export class OmnichannelSidebar extends Sidebar {
 		super(page.getByRole('navigation', { name: 'Omnichannel' }));
 	}
 
-	get linkDepartments(): Locator {
-		return this.root.locator('a[href="/omnichannel/departments"]');
-	}
-
-	get linkAgents(): Locator {
-		return this.root.locator('a[href="/omnichannel/agents"]');
-	}
-
-	get linkManagers(): Locator {
-		return this.root.locator('a[href="/omnichannel/managers"]');
-	}
-
-	get linkCustomFields(): Locator {
-		return this.root.locator('a[href="/omnichannel/customfields"]');
-	}
-
-	get linkCurrentChats(): Locator {
-		return this.root.locator('a[href="/omnichannel/current"]');
-	}
-
-	get linkSlaPolicies(): Locator {
-		return this.root.locator('a[href="/omnichannel/sla-policies"]');
-	}
-
-	get linkPriorities(): Locator {
-		return this.root.locator('a[href="/omnichannel/priorities"]');
-	}
-
-	get linkBusinessHours(): Locator {
-		return this.root.locator('a[href="/omnichannel/businessHours"]');
-	}
-
-	get linkAnalytics(): Locator {
-		return this.root.locator('a[href="/omnichannel/analytics"]');
-	}
-
-	get linkRealTimeMonitoring(): Locator {
-		return this.root.locator('a[href="/omnichannel/realtime-monitoring"]');
-	}
-
-	get linkReports(): Locator {
-		return this.root.locator('a[href="/omnichannel/reports"]');
-	}
-
-	get linkCannedResponses(): Locator {
-		return this.root.locator('a[href="/omnichannel/canned-responses"]');
-	}
-
-	get linkUnits(): Locator {
-		return this.root.locator('a[href="/omnichannel/units"]');
-	}
-
-	get linkLivechatAppearance(): Locator {
-		return this.root.locator('a[href="/omnichannel/appearance"]');
-	}
-
-	get linkTags(): Locator {
-		return this.root.locator('a[href="/omnichannel/tags"]');
+	getSidebarLinkByName(name: string): Locator {
+		return this.root.getByRole('link', { name });
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/sidebar.ts
@@ -154,6 +154,6 @@ export class OmnichannelSidebar extends Sidebar {
 	}
 
 	getSidebarLinkByName(name: string): Locator {
-		return this.root.getByRole('link', { name });
+		return this.root.getByRole('link', { name, exact: true });
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/table.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/table.ts
@@ -3,9 +3,15 @@ import type { Locator, Page } from '@playwright/test';
 import { expect } from '../../utils/test';
 
 export abstract class Table {
-	constructor(protected root: Locator) {}
+	constructor(
+		protected root: Locator,
+		protected fallback?: Locator,
+	) {}
 
 	waitForDisplay() {
+		if (this.fallback) {
+			return expect(this.root.or(this.fallback)).toBeVisible();
+		}
 		return expect(this.root).toBeVisible();
 	}
 

--- a/apps/meteor/tests/e2e/page-objects/fragments/table.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/table.ts
@@ -2,17 +2,15 @@ import type { Locator, Page } from '@playwright/test';
 
 import { expect } from '../../utils/test';
 
-export abstract class Table {
-	constructor(
-		protected root: Locator,
-		protected fallback?: Locator,
-	) {}
+export class Table {
+	constructor(protected root: Locator) {}
 
-	waitForDisplay() {
-		if (this.fallback) {
-			return expect(this.root.or(this.fallback)).toBeVisible();
-		}
-		return expect(this.root).toBeVisible();
+	/**
+	 * @param fallback also satisfies the wait, for tables the page may legitimately
+	 * replace with something else — an empty state, most commonly.
+	 */
+	waitForDisplay(fallback?: Locator) {
+		return expect(fallback ? this.root.or(fallback) : this.root).toBeVisible();
 	}
 
 	findRowByName(name: string): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
@@ -4,6 +4,28 @@ import { expect } from '../../utils/test';
 import { OmnichannelSidebar, ToastMessages } from '../fragments';
 import { ConfirmDeleteModal } from '../fragments/modals';
 
+type OmnichannelAdminRoutes =
+	| 'monitors'
+	| 'agents'
+	| 'departments'
+	| 'managers'
+	| 'customfields'
+	| 'current/chats'
+	| 'current/contacts'
+	| 'sla-policies'
+	| 'priorities'
+	| 'triggers'
+	| 'tags'
+	| 'analytics'
+	| 'reports'
+	| 'canned-responses'
+	| 'units'
+	| 'appearance'
+	| 'businessHours'
+	| 'livechat-appearance'
+	| 'realtime-monitoring'
+	| 'security-privacy';
+
 export abstract class OmnichannelAdmin {
 	protected readonly page: Page;
 
@@ -20,7 +42,7 @@ export abstract class OmnichannelAdmin {
 		this.deleteModal = new ConfirmDeleteModal(page.getByRole('dialog', { name: 'Are you sure?' }));
 	}
 
-	protected async goToRoute(route: 'monitors' | 'agents' | 'departments') {
+	protected async goToRoute(route: OmnichannelAdminRoutes) {
 		await this.page.goto(`/omnichannel/${route}`);
 	}
 
@@ -48,7 +70,11 @@ export abstract class OmnichannelAdmin {
 		await this.inputSearch.fill('');
 	}
 
+	protected get emptyState() {
+		return this.page.getByRole('status', { name: 'No results found' });
+	}
+
 	waitForEmptyState() {
-		return expect(this.page.locator('h3 >> text="No results found"')).toBeVisible();
+		return expect(this.emptyState).toBeVisible();
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from '@playwright/test';
 import { expect } from '../../utils/test';
 import { OmnichannelSidebar, ToastMessages } from '../fragments';
 import { ConfirmDeleteModal } from '../fragments/modals';
+import { Table } from '../fragments/table';
 
 type OmnichannelAdminRoutes =
 	| 'monitors'
@@ -26,7 +27,19 @@ type OmnichannelAdminRoutes =
 	| 'realtime-monitoring'
 	| 'security-privacy';
 
+/**
+ * A page under `/omnichannel/*`. Subclasses declare `route` and `title` and get
+ * `goTo()`, `pageHeader` and `table` for free.
+ */
 export abstract class OmnichannelAdmin {
+	protected abstract readonly route: OmnichannelAdminRoutes;
+
+	/** Text of the page's main heading. */
+	protected abstract readonly title: string;
+
+	/** Accessible name of the page's main table, when it differs from `title`. */
+	protected readonly tableName?: string;
+
 	protected readonly page: Page;
 
 	protected readonly toastMessage: ToastMessages;
@@ -40,14 +53,6 @@ export abstract class OmnichannelAdmin {
 		this.sidebar = new OmnichannelSidebar(page);
 		this.toastMessage = new ToastMessages(page);
 		this.deleteModal = new ConfirmDeleteModal(page.getByRole('dialog', { name: 'Are you sure?' }));
-	}
-
-	protected async goToRoute(route: OmnichannelAdminRoutes) {
-		await this.page.goto(`/omnichannel/${route}`);
-	}
-
-	protected getPageHeader(title: string): Locator {
-		return this.page.locator('main').getByRole('heading', { name: title, exact: true });
 	}
 
 	get inputSearch() {
@@ -76,5 +81,23 @@ export abstract class OmnichannelAdmin {
 
 	waitForEmptyState() {
 		return expect(this.emptyState).toBeVisible();
+	}
+
+	get pageHeader(): Locator {
+		return this.page.locator('main').getByRole('heading', { name: this.title, exact: true });
+	}
+
+	get table(): Table {
+		return new Table(this.page.getByRole('table', { name: this.tableName ?? this.title }));
+	}
+
+	async goTo() {
+		await this.page.goto(`/omnichannel/${this.route}`);
+		await this.waitForPage();
+	}
+
+	protected async waitForPage() {
+		await this.pageHeader.waitFor({ state: 'visible' });
+		await this.table.waitForDisplay(this.emptyState);
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-admin.ts
@@ -70,8 +70,8 @@ export abstract class OmnichannelAdmin {
 		await this.inputSearch.fill('');
 	}
 
-	protected get emptyState() {
-		return this.page.getByRole('status', { name: 'No results found' });
+	get emptyState() {
+		return this.page.getByRole('group', { name: 'No results found', exact: true });
 	}
 
 	waitForEmptyState() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-agents.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-agents.ts
@@ -3,7 +3,6 @@ import type { Locator, Page } from '@playwright/test';
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { FlexTab } from '../fragments/flextabs/flextab';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
 
 class OmnichannelEditAgentFlexTab extends FlexTab {
 	readonly listbox: Listbox;
@@ -62,18 +61,14 @@ class OmnichannelAgentInfoFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelAgentsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Agents' }), fallback);
-	}
-}
-
 export class OmnichannelAgents extends OmnichannelAdmin {
+	protected readonly route = 'agents';
+
+	protected readonly title = 'Agents';
+
 	readonly editAgent: OmnichannelEditAgentFlexTab;
 
 	readonly agentInfo: OmnichannelAgentInfoFlexTab;
-
-	readonly table: OmnichannelAgentsTable;
 
 	readonly listbox: Listbox;
 
@@ -81,18 +76,7 @@ export class OmnichannelAgents extends OmnichannelAdmin {
 		super(page);
 		this.editAgent = new OmnichannelEditAgentFlexTab(page);
 		this.agentInfo = new OmnichannelAgentInfoFlexTab(page);
-		this.table = new OmnichannelAgentsTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
-	}
-
-	async goTo() {
-		await this.goToRoute('agents');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Agents').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	get inputUsername(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-agents.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-agents.ts
@@ -63,8 +63,8 @@ class OmnichannelAgentInfoFlexTab extends FlexTab {
 }
 
 class OmnichannelAgentsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Agents' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Agents' }), fallback);
 	}
 }
 
@@ -81,8 +81,18 @@ export class OmnichannelAgents extends OmnichannelAdmin {
 		super(page);
 		this.editAgent = new OmnichannelEditAgentFlexTab(page);
 		this.agentInfo = new OmnichannelAgentInfoFlexTab(page);
-		this.table = new OmnichannelAgentsTable(page);
+		this.table = new OmnichannelAgentsTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
+	}
+
+	async goTo() {
+		await this.goToRoute('agents');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Agents').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	get inputUsername(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-business-hours.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-business-hours.ts
@@ -5,8 +5,8 @@ import { Listbox } from '../fragments/listbox';
 import { Table } from '../fragments/table';
 
 class OmnichannelBusinessHoursTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Business Hours' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Business Hours' }), fallback);
 	}
 }
 
@@ -17,8 +17,18 @@ export class OmnichannelBusinessHours extends OmnichannelAdmin {
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelBusinessHoursTable(page);
+		this.table = new OmnichannelBusinessHoursTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
+	}
+
+	async goTo() {
+		await this.goToRoute('businessHours');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Business Hours').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	get btnCreateBusinessHour(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-business-hours.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-business-hours.ts
@@ -2,33 +2,17 @@ import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
-
-class OmnichannelBusinessHoursTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Business Hours' }), fallback);
-	}
-}
 
 export class OmnichannelBusinessHours extends OmnichannelAdmin {
-	readonly table: OmnichannelBusinessHoursTable;
+	protected readonly route = 'businessHours';
+
+	protected readonly title = 'Business Hours';
 
 	readonly listbox: Listbox;
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelBusinessHoursTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
-	}
-
-	async goTo() {
-		await this.goToRoute('businessHours');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Business Hours').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	get btnCreateBusinessHour(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-canned-responses.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-canned-responses.ts
@@ -1,31 +1,11 @@
-import type { Locator, Page } from '@playwright/test';
+import type { Locator } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
-import { Table } from '../fragments/table';
-
-class OmnichannelCannedResponsesTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Canned Responses' }), fallback);
-	}
-}
 
 export class OmnichannelCannedResponses extends OmnichannelAdmin {
-	readonly table: OmnichannelCannedResponsesTable;
+	protected readonly route = 'canned-responses';
 
-	constructor(page: Page) {
-		super(page);
-		this.table = new OmnichannelCannedResponsesTable(page, this.emptyState);
-	}
-
-	async goTo() {
-		await this.goToRoute('canned-responses');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Canned Responses').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
-	}
+	protected readonly title = 'Canned Responses';
 
 	get inputShortcut() {
 		return this.page.getByRole('textbox', { name: 'Shortcut', exact: true });

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-canned-responses.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-canned-responses.ts
@@ -1,8 +1,32 @@
-import type { Locator } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
+import { Table } from '../fragments/table';
+
+class OmnichannelCannedResponsesTable extends Table {
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Canned Responses' }), fallback);
+	}
+}
 
 export class OmnichannelCannedResponses extends OmnichannelAdmin {
+	readonly table: OmnichannelCannedResponsesTable;
+
+	constructor(page: Page) {
+		super(page);
+		this.table = new OmnichannelCannedResponsesTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('canned-responses');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Canned Responses').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
+	}
+
 	get inputShortcut() {
 		return this.page.getByRole('textbox', { name: 'Shortcut', exact: true });
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-chats.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-chats.ts
@@ -116,40 +116,31 @@ export class OmnichannelChatsFilters extends FlexTab {
 }
 
 class OmnichannelContactCenterChatsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Omnichannel Contact Center Chats' }), fallback);
-	}
-
 	btnRemoveByName(name: string): Locator {
 		return this.findRowByName(name).getByRole('button', { name: 'Remove' });
 	}
 }
 
 export class OmnichannelContactCenterChats extends OmnichannelContactCenter {
+	protected readonly route = 'current/chats';
+
+	protected override readonly tableName = 'Omnichannel Contact Center Chats';
+
 	readonly filters: OmnichannelChatsFilters;
 
 	readonly confirmRemoveChatModal: OmnichannelConfirmRemoveChat;
 
 	readonly conversation: OmnichannelConversationFlexTab;
 
-	readonly table: OmnichannelContactCenterChatsTable;
-
 	constructor(page: Page) {
 		super(page);
 		this.filters = new OmnichannelChatsFilters(page);
 		this.confirmRemoveChatModal = new OmnichannelConfirmRemoveChat(page);
 		this.conversation = new OmnichannelConversationFlexTab(page);
-		this.table = new OmnichannelContactCenterChatsTable(page, this.emptyState);
 	}
 
-	async goTo() {
-		await this.goToRoute('current/chats');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.pageHeader.waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
+	override get table(): OmnichannelContactCenterChatsTable {
+		return new OmnichannelContactCenterChatsTable(this.page.getByRole('table', { name: this.tableName }));
 	}
 
 	async removeChatByName(name: string) {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-chats.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-chats.ts
@@ -116,8 +116,8 @@ export class OmnichannelChatsFilters extends FlexTab {
 }
 
 class OmnichannelContactCenterChatsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Omnichannel Contact Center Chats' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Omnichannel Contact Center Chats' }), fallback);
 	}
 
 	btnRemoveByName(name: string): Locator {
@@ -139,7 +139,17 @@ export class OmnichannelContactCenterChats extends OmnichannelContactCenter {
 		this.filters = new OmnichannelChatsFilters(page);
 		this.confirmRemoveChatModal = new OmnichannelConfirmRemoveChat(page);
 		this.conversation = new OmnichannelConversationFlexTab(page);
-		this.table = new OmnichannelContactCenterChatsTable(page);
+		this.table = new OmnichannelContactCenterChatsTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('current/chats');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.pageHeader.waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	async removeChatByName(name: string) {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-contacts.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center-contacts.ts
@@ -5,20 +5,15 @@ import { OmnichannelContactCenter } from './omnichannel-contact-center';
 import { MenuMoreActions } from '../../fragments';
 import { OmnichannelEditContactFlexTab } from '../../fragments/flextabs';
 import { OmnichannelDeleteContactModal } from '../../fragments/modals';
-import { Table } from '../../fragments/table';
-
-class OmnichannelContactCenterContactsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Omnichannel Contact Center Contacts' }));
-	}
-}
 
 export class OmnichannelContactCenterContacts extends OmnichannelContactCenter {
+	protected readonly route = 'current/contacts';
+
+	protected override readonly tableName = 'Omnichannel Contact Center Contacts';
+
 	readonly contactInfo: OmnichannelContactInfo;
 
 	readonly editContact: OmnichannelEditContactFlexTab;
-
-	readonly table: OmnichannelContactCenterContactsTable;
 
 	readonly deleteContactModal: OmnichannelDeleteContactModal;
 
@@ -28,7 +23,6 @@ export class OmnichannelContactCenterContacts extends OmnichannelContactCenter {
 		super(page);
 		this.contactInfo = new OmnichannelContactInfo(page);
 		this.editContact = new OmnichannelEditContactFlexTab(page);
-		this.table = new OmnichannelContactCenterContactsTable(page);
 		this.deleteContactModal = new OmnichannelDeleteContactModal(page);
 		this.menu = new MenuMoreActions(page);
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center.ts
@@ -3,15 +3,13 @@ import type { Locator } from '@playwright/test';
 import { OmnichannelAdmin } from '../omnichannel-admin';
 
 export abstract class OmnichannelContactCenter extends OmnichannelAdmin {
+	protected readonly title = 'Omnichannel Contact Center';
+
 	get tabContacts(): Locator {
 		return this.page.getByRole('tab', { name: 'Contacts' });
 	}
 
 	get tabChats(): Locator {
 		return this.page.getByRole('tab', { name: 'Chats' });
-	}
-
-	get pageHeader(): Locator {
-		return this.getPageHeader('Omnichannel Contact Center');
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-contact-center/omnichannel-contact-center.ts
@@ -10,4 +10,8 @@ export abstract class OmnichannelContactCenter extends OmnichannelAdmin {
 	get tabChats(): Locator {
 		return this.page.getByRole('tab', { name: 'Chats' });
 	}
+
+	get pageHeader(): Locator {
+		return this.getPageHeader('Omnichannel Contact Center');
+	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-custom-fields.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-custom-fields.ts
@@ -23,8 +23,8 @@ class OmnichannelManageCustomFieldsFlexTab extends FlexTab {
 }
 
 class OmnichannelCustomFieldsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Custom Fields' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Custom Fields' }), fallback);
 	}
 }
 
@@ -36,7 +36,17 @@ export class OmnichannelCustomFields extends OmnichannelAdmin {
 	constructor(page: Page) {
 		super(page);
 		this.manageCustomFields = new OmnichannelManageCustomFieldsFlexTab(page);
-		this.table = new OmnichannelCustomFieldsTable(page);
+		this.table = new OmnichannelCustomFieldsTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('customfields');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Custom Fields').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-custom-fields.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-custom-fields.ts
@@ -2,7 +2,6 @@ import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { FlexTab } from '../fragments/flextabs/flextab';
-import { Table } from '../fragments/table';
 
 class OmnichannelManageCustomFieldsFlexTab extends FlexTab {
 	constructor(page: Page) {
@@ -22,31 +21,16 @@ class OmnichannelManageCustomFieldsFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelCustomFieldsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Custom Fields' }), fallback);
-	}
-}
-
 export class OmnichannelCustomFields extends OmnichannelAdmin {
-	readonly manageCustomFields: OmnichannelManageCustomFieldsFlexTab;
+	protected readonly route = 'customfields';
 
-	readonly table: OmnichannelCustomFieldsTable;
+	protected readonly title = 'Custom Fields';
+
+	readonly manageCustomFields: OmnichannelManageCustomFieldsFlexTab;
 
 	constructor(page: Page) {
 		super(page);
 		this.manageCustomFields = new OmnichannelManageCustomFieldsFlexTab(page);
-		this.table = new OmnichannelCustomFieldsTable(page, this.emptyState);
-	}
-
-	async goTo() {
-		await this.goToRoute('customfields');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Custom Fields').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-departments.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-departments.ts
@@ -6,22 +6,12 @@ import { Listbox } from '../fragments/listbox';
 import { OmnichannelUpsellDepartmentsModal, ConfirmDeleteDepartmentModal } from '../fragments/modals';
 import { Table } from '../fragments/table';
 
-class OmnichannelDepartmentsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Departments' }), fallback);
-	}
-}
-
-class OmnichannelDepartmentAgentsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Agents' }));
-	}
-}
-
 export class OmnichannelDepartments extends OmnichannelAdmin {
-	readonly departmentsTable: OmnichannelDepartmentsTable;
+	protected readonly route = 'departments';
 
-	readonly agentsTable: OmnichannelDepartmentAgentsTable;
+	protected readonly title = 'Departments';
+
+	readonly agentsTable: Table;
 
 	readonly upsellDepartmentsModal: OmnichannelUpsellDepartmentsModal;
 
@@ -33,22 +23,11 @@ export class OmnichannelDepartments extends OmnichannelAdmin {
 
 	constructor(page: Page) {
 		super(page);
-		this.departmentsTable = new OmnichannelDepartmentsTable(page, this.emptyState);
-		this.agentsTable = new OmnichannelDepartmentAgentsTable(page);
+		this.agentsTable = new Table(page.getByRole('table', { name: 'Agents' }));
 		this.upsellDepartmentsModal = new OmnichannelUpsellDepartmentsModal(page);
 		this.listbox = new Listbox(page);
 		this.menOptions = new MenuOptions(page);
 		this.deleteModal = new ConfirmDeleteDepartmentModal(page);
-	}
-
-	async goTo() {
-		await this.goToRoute('departments');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Departments').waitFor({ state: 'visible' });
-		await this.departmentsTable.waitForDisplay();
 	}
 
 	async createNew() {
@@ -84,7 +63,7 @@ export class OmnichannelDepartments extends OmnichannelAdmin {
 	}
 
 	getDepartmentMenuByName(name: string) {
-		return this.departmentsTable.findRowByName(name).getByRole('button', { name: 'Options' });
+		return this.table.findRowByName(name).getByRole('button', { name: 'Options' });
 	}
 
 	get menuEditOption() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-departments.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-departments.ts
@@ -7,8 +7,8 @@ import { OmnichannelUpsellDepartmentsModal, ConfirmDeleteDepartmentModal } from 
 import { Table } from '../fragments/table';
 
 class OmnichannelDepartmentsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Departments' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Departments' }), fallback);
 	}
 }
 
@@ -33,12 +33,22 @@ export class OmnichannelDepartments extends OmnichannelAdmin {
 
 	constructor(page: Page) {
 		super(page);
-		this.departmentsTable = new OmnichannelDepartmentsTable(page);
+		this.departmentsTable = new OmnichannelDepartmentsTable(page, this.emptyState);
 		this.agentsTable = new OmnichannelDepartmentAgentsTable(page);
 		this.upsellDepartmentsModal = new OmnichannelUpsellDepartmentsModal(page);
 		this.listbox = new Listbox(page);
 		this.menOptions = new MenuOptions(page);
 		this.deleteModal = new ConfirmDeleteDepartmentModal(page);
+	}
+
+	async goTo() {
+		await this.goToRoute('departments');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Departments').waitFor({ state: 'visible' });
+		await this.departmentsTable.waitForDisplay();
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-livechat-appearance.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-livechat-appearance.ts
@@ -3,13 +3,12 @@ import type { Locator } from '@playwright/test';
 import { OmnichannelAdmin } from './omnichannel-admin';
 
 export class OmnichannelLivechatAppearance extends OmnichannelAdmin {
-	async goTo() {
-		await this.goToRoute('appearance');
-		await this.waitForPage();
-	}
+	protected readonly route = 'appearance';
 
-	private async waitForPage() {
-		await this.getPageHeader('Appearance').waitFor({ state: 'visible' });
+	protected readonly title = 'Appearance';
+
+	protected override async waitForPage() {
+		await this.pageHeader.waitFor({ state: 'visible' });
 	}
 
 	get inputHideSystemMessages(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-livechat-appearance.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-livechat-appearance.ts
@@ -3,6 +3,15 @@ import type { Locator } from '@playwright/test';
 import { OmnichannelAdmin } from './omnichannel-admin';
 
 export class OmnichannelLivechatAppearance extends OmnichannelAdmin {
+	async goTo() {
+		await this.goToRoute('appearance');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Appearance').waitFor({ state: 'visible' });
+	}
+
 	get inputHideSystemMessages(): Locator {
 		return this.page.locator('label', { hasText: 'Hide system messages' });
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
@@ -2,33 +2,17 @@ import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
-
-class OmnichannelManagersTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Managers' }), fallback);
-	}
-}
 
 export class OmnichannelManager extends OmnichannelAdmin {
-	readonly table: OmnichannelManagersTable;
+	protected readonly route = 'managers';
+
+	protected readonly title = 'Managers';
 
 	readonly listbox: Listbox;
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelManagersTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
-	}
-
-	async goTo() {
-		await this.goToRoute('managers');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Managers').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	get inputUsername(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-manager.ts
@@ -5,8 +5,8 @@ import { Listbox } from '../fragments/listbox';
 import { Table } from '../fragments/table';
 
 class OmnichannelManagersTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Managers' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Managers' }), fallback);
 	}
 }
 
@@ -17,13 +17,18 @@ export class OmnichannelManager extends OmnichannelAdmin {
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelManagersTable(page);
+		this.table = new OmnichannelManagersTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
 	}
 
-	async goto() {
-		await this.page.goto('/omnichannel/managers');
-		await this.btnAddManager.waitFor({ state: 'visible' });
+	async goTo() {
+		await this.goToRoute('managers');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Managers').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	get inputUsername(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
@@ -2,32 +2,17 @@ import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
-
-class OmnichannelMonitorsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Monitors' }), fallback);
-	}
-}
 
 export class OmnichannelMonitors extends OmnichannelAdmin {
-	readonly table: OmnichannelMonitorsTable;
+	protected readonly route = 'monitors';
+
+	protected readonly title = 'Monitors';
 
 	readonly listbox: Listbox;
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelMonitorsTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
-	}
-
-	async goTo() {
-		await this.goToRoute('monitors');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Monitors').waitFor({ state: 'visible' });
 	}
 
 	private get btnAddMonitor(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-monitors.ts
@@ -5,8 +5,8 @@ import { Listbox } from '../fragments/listbox';
 import { Table } from '../fragments/table';
 
 class OmnichannelMonitorsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Monitors' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Monitors' }), fallback);
 	}
 }
 
@@ -17,7 +17,7 @@ export class OmnichannelMonitors extends OmnichannelAdmin {
 
 	constructor(page: Page) {
 		super(page);
-		this.table = new OmnichannelMonitorsTable(page);
+		this.table = new OmnichannelMonitorsTable(page, this.emptyState);
 		this.listbox = new Listbox(page);
 	}
 

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-priorities.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-priorities.ts
@@ -1,10 +1,9 @@
-import type { Locator, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { ToastMessages } from '../fragments';
 import { FlexTab } from '../fragments/flextabs/flextab';
 import { OmnichannelResetPrioritiesModal } from '../fragments/modals';
-import { Table } from '../fragments/table';
 
 class OmnichannelEditPriorityFlexTab extends FlexTab {
 	readonly toastMessage: ToastMessages;
@@ -15,34 +14,19 @@ class OmnichannelEditPriorityFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelPrioritiesTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Priorities' }), fallback);
-	}
-}
-
 export class OmnichannelPriorities extends OmnichannelAdmin {
+	protected readonly route = 'priorities';
+
+	protected readonly title = 'Priorities';
+
 	readonly editPriority: OmnichannelEditPriorityFlexTab;
 
 	readonly resetPrioritiesModal: OmnichannelResetPrioritiesModal;
-
-	readonly table: OmnichannelPrioritiesTable;
 
 	constructor(page: Page) {
 		super(page);
 		this.resetPrioritiesModal = new OmnichannelResetPrioritiesModal(page);
 		this.editPriority = new OmnichannelEditPriorityFlexTab(page);
-		this.table = new OmnichannelPrioritiesTable(page, this.emptyState);
-	}
-
-	async goTo() {
-		await this.goToRoute('priorities');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Priorities').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	get btnReset() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-priorities.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-priorities.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { ToastMessages } from '../fragments';
@@ -16,8 +16,8 @@ class OmnichannelEditPriorityFlexTab extends FlexTab {
 }
 
 class OmnichannelPrioritiesTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Priorities' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Priorities' }), fallback);
 	}
 }
 
@@ -32,7 +32,17 @@ export class OmnichannelPriorities extends OmnichannelAdmin {
 		super(page);
 		this.resetPrioritiesModal = new OmnichannelResetPrioritiesModal(page);
 		this.editPriority = new OmnichannelEditPriorityFlexTab(page);
-		this.table = new OmnichannelPrioritiesTable(page);
+		this.table = new OmnichannelPrioritiesTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('priorities');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Priorities').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	get btnReset() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-settings.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-settings.ts
@@ -1,8 +1,8 @@
 import type { Locator } from '@playwright/test';
 
-import { OmnichannelAdmin } from './omnichannel-admin';
+import { AdminSettings } from '../admin-settings';
 
-export class OmnichannelSettings extends OmnichannelAdmin {
+export class OmnichannelSettings extends AdminSettings {
 	get labelLivechatLogo(): Locator {
 		return this.page.locator('//label[@title="Assets_livechat_widget_logo"]');
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
@@ -2,7 +2,6 @@ import type { Locator, Page } from '@playwright/test';
 
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { FlexTab } from '../fragments/flextabs/flextab';
-import { Table } from '../fragments/table';
 
 class OmnichannelManageSlaPolicyFlexTab extends FlexTab {
 	constructor(page: Page) {
@@ -18,31 +17,16 @@ class OmnichannelManageSlaPolicyFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelSlaPoliciesTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'SLA Policies' }), fallback);
-	}
-}
-
 export class OmnichannelSlaPolicies extends OmnichannelAdmin {
-	readonly manageSlaPolicy: OmnichannelManageSlaPolicyFlexTab;
+	protected readonly route = 'sla-policies';
 
-	readonly table: OmnichannelSlaPoliciesTable;
+	protected readonly title = 'SLA Policies';
+
+	readonly manageSlaPolicy: OmnichannelManageSlaPolicyFlexTab;
 
 	constructor(page: Page) {
 		super(page);
 		this.manageSlaPolicy = new OmnichannelManageSlaPolicyFlexTab(page);
-		this.table = new OmnichannelSlaPoliciesTable(page, this.emptyState);
-	}
-
-	async goTo() {
-		await this.goToRoute('sla-policies');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('SLA Policies').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	btnRemove(name: string) {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
@@ -19,8 +19,8 @@ class OmnichannelManageSlaPolicyFlexTab extends FlexTab {
 }
 
 class OmnichannelSlaPoliciesTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'SLA Policies' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'SLA Policies' }), fallback);
 	}
 }
 
@@ -32,7 +32,17 @@ export class OmnichannelSlaPolicies extends OmnichannelAdmin {
 	constructor(page: Page) {
 		super(page);
 		this.manageSlaPolicy = new OmnichannelManageSlaPolicyFlexTab(page);
-		this.table = new OmnichannelSlaPoliciesTable(page);
+		this.table = new OmnichannelSlaPoliciesTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('sla-policies');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('SLA Policies').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	btnRemove(name: string) {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-sla-policies.ts
@@ -57,8 +57,4 @@ export class OmnichannelSlaPolicies extends OmnichannelAdmin {
 	async createNew() {
 		await this.getButtonByType('SLA policy').click();
 	}
-
-	get txtEmptyState() {
-		return this.page.locator('div >> text="No results found"');
-	}
 }

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
@@ -3,7 +3,6 @@ import type { Locator, Page } from '@playwright/test';
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { FlexTab } from '../fragments/flextabs/flextab';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
 
 class OmnichannelEditTagFlexTab extends FlexTab {
 	readonly listbox: Listbox;
@@ -28,31 +27,16 @@ class OmnichannelEditTagFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelTagsTable extends Table {
-	constructor(page: Page, fallback: Locator) {
-		super(page.getByRole('table', { name: 'Tags' }), fallback);
-	}
-}
-
 export class OmnichannelTags extends OmnichannelAdmin {
-	readonly editTag: OmnichannelEditTagFlexTab;
+	protected readonly route = 'tags';
 
-	readonly table: OmnichannelTagsTable;
+	protected readonly title = 'Tags';
+
+	readonly editTag: OmnichannelEditTagFlexTab;
 
 	constructor(page: Page) {
 		super(page);
 		this.editTag = new OmnichannelEditTagFlexTab(page);
-		this.table = new OmnichannelTagsTable(page, this.emptyState);
-	}
-
-	async goTo() {
-		await this.goToRoute('tags');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Tags').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-tags.ts
@@ -29,8 +29,8 @@ class OmnichannelEditTagFlexTab extends FlexTab {
 }
 
 class OmnichannelTagsTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Tags' }));
+	constructor(page: Page, fallback: Locator) {
+		super(page.getByRole('table', { name: 'Tags' }), fallback);
 	}
 }
 
@@ -42,7 +42,17 @@ export class OmnichannelTags extends OmnichannelAdmin {
 	constructor(page: Page) {
 		super(page);
 		this.editTag = new OmnichannelEditTagFlexTab(page);
-		this.table = new OmnichannelTagsTable(page);
+		this.table = new OmnichannelTagsTable(page, this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('tags');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Tags').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-transcript.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-transcript.ts
@@ -1,8 +1,8 @@
-import type { Locator } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
-import { OmnichannelAdmin } from './omnichannel-admin';
+export class OmnichannelTranscript {
+	constructor(private readonly page: Page) {}
 
-export class OmnichannelTranscript extends OmnichannelAdmin {
 	get contactCenterChats(): Locator {
 		return this.page.locator('//button[contains(.,"Chats")]');
 	}

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-triggers.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-triggers.ts
@@ -3,7 +3,6 @@ import type { Locator, Page } from '@playwright/test';
 import { OmnichannelAdmin } from './omnichannel-admin';
 import { FlexTab } from '../fragments/flextabs/flextab';
 import { Listbox } from '../fragments/listbox';
-import { Table } from '../fragments/table';
 
 type TriggerConditions = 'Visitor page URL' | 'Visitor time on site' | 'Chat opened by the visitor' | 'After guest registration';
 
@@ -79,21 +78,16 @@ class OmnichannelEditTriggerFlexTab extends FlexTab {
 	}
 }
 
-class OmnichannelTriggersTable extends Table {
-	constructor(page: Page) {
-		super(page.getByRole('table', { name: 'Livechat Triggers' }));
-	}
-}
-
 export class OmnichannelTriggers extends OmnichannelAdmin {
-	readonly editTrigger: OmnichannelEditTriggerFlexTab;
+	protected readonly route = 'triggers';
 
-	readonly table: OmnichannelTriggersTable;
+	protected readonly title = 'Livechat Triggers';
+
+	readonly editTrigger: OmnichannelEditTriggerFlexTab;
 
 	constructor(page: Page) {
 		super(page);
 		this.editTrigger = new OmnichannelEditTriggerFlexTab(page);
-		this.table = new OmnichannelTriggersTable(page);
 	}
 
 	async removeTrigger(name: string) {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-units.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-units.ts
@@ -65,34 +65,25 @@ export class OmnichannelUnitFlexTab extends FlexTab {
 }
 
 class OmnichannelUnitsTable extends Table {
-	constructor(page: Locator, fallback: Locator) {
-		super(page, fallback);
-	}
-
 	deleteUnitByName(name: string) {
 		return this.findRowByName(name).getByRole('button', { name: 'Remove' });
 	}
 }
 
 export class OmnichannelUnits extends OmnichannelAdmin {
-	readonly manageUnit: OmnichannelUnitFlexTab;
+	protected readonly route = 'units';
 
-	readonly table: OmnichannelUnitsTable;
+	protected readonly title = 'Units';
+
+	readonly manageUnit: OmnichannelUnitFlexTab;
 
 	constructor(page: Page) {
 		super(page);
 		this.manageUnit = new OmnichannelUnitFlexTab(page);
-		this.table = new OmnichannelUnitsTable(page.getByRole('table', { name: 'Units' }), this.emptyState);
 	}
 
-	async goTo() {
-		await this.goToRoute('units');
-		await this.waitForPage();
-	}
-
-	private async waitForPage() {
-		await this.getPageHeader('Units').waitFor({ state: 'visible' });
-		await this.table.waitForDisplay();
+	override get table() {
+		return new OmnichannelUnitsTable(this.page.getByRole('table', { name: this.title }));
 	}
 
 	async createNew() {

--- a/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-units.ts
+++ b/apps/meteor/tests/e2e/page-objects/omnichannel/omnichannel-units.ts
@@ -65,8 +65,8 @@ export class OmnichannelUnitFlexTab extends FlexTab {
 }
 
 class OmnichannelUnitsTable extends Table {
-	constructor(page: Locator) {
-		super(page);
+	constructor(page: Locator, fallback: Locator) {
+		super(page, fallback);
 	}
 
 	deleteUnitByName(name: string) {
@@ -82,7 +82,17 @@ export class OmnichannelUnits extends OmnichannelAdmin {
 	constructor(page: Page) {
 		super(page);
 		this.manageUnit = new OmnichannelUnitFlexTab(page);
-		this.table = new OmnichannelUnitsTable(page.getByRole('table', { name: 'Units' }));
+		this.table = new OmnichannelUnitsTable(page.getByRole('table', { name: 'Units' }), this.emptyState);
+	}
+
+	async goTo() {
+		await this.goToRoute('units');
+		await this.waitForPage();
+	}
+
+	private async waitForPage() {
+		await this.getPageHeader('Units').waitFor({ state: 'visible' });
+		await this.table.waitForDisplay();
 	}
 
 	async createNew() {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Omnichannel admin E2E tests navigated by clicking sidebar links, coupling every test to sidebar rendering and to hardcoded `a[href="/omnichannel/..."]` selectors.
They now go straight to the route.

- Page objects navigate with `page.goto('/omnichannel/<route>')`. The 15 `linkX` getters are gone from `OmnichannelSidebar`, replaced by a single `getSidebarLinkByName()` for the tests that genuinely assert on sidebar links.
- `OmnichannelAdmin` subclasses now only declare `route` and `title`, inheriting `goTo()`, `pageHeader`, `table` and the post-navigation wait. That also removed 11 `Table` subclasses which differed solely by their table's accessible name.
- `OmnichannelSettings` and `OmnichannelTranscript` moved off `OmnichannelAdmin`: the first is an `/admin/settings` page (now extends `AdminSettings`), the second isn't a page object for any single page.
- Two accessibility additions make the role-based queries possible: `GenericNoResults` renders as a labelled `group`, and the canned responses table gets an `aria-label`. Three admin snapshots updated accordingly.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader labeling for “no results” empty states using translation-based aria-labeling and grouping.
  * Added an accessibility label to the Canned Responses table container.

* **Tests**
  * Refactored Omnichannel end-to-end test navigation to rely on page-object helpers instead of manual URL/side-menu steps.
  * Standardized sidebar link checks, empty-state/table assertions, and page readiness across multiple Omnichannel admin screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [FLAKY-2435]

[FLAKY-2435]: https://rocketchat.atlassian.net/browse/FLAKY-2435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ