### PR TITLE
regression: emoji bottom clipped in messages and announcement banner on Windows/Linux

### DIFF
--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -1,10 +1,40 @@
+@font-face {
+	font-family: rc-emoji;
+	src: local('Segoe UI Emoji');
+	ascent-override: 90%;
+	descent-override: 25%;
+	size-adjust: 85%;
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Apple Color Emoji');
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Noto Color Emoji');
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Twemoji Mozilla');
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Android Emoji');
+}
+
 /* Global emoji styles */
 .emoji {
+	font-family: rc-emoji, sans-serif;
 	font-size: 1.375rem;
 
-	/* Must exceed the emoji fonts' ink height (~1.13em on Noto Color Emoji), otherwise
-	the glyph paints outside the line box and gets cut by overflow: hidden ancestors
-	(message body, announcement banner). */
+	/* Must exceed the emoji fonts' ink height — ~1.13em on Noto Color Emoji and on
+	size-adjusted Segoe UI Emoji (rc-emoji face) — otherwise the glyph paints outside
+	the line box and gets cut by overflow: hidden ancestors (message body, announcement
+	banner). */
 	line-height: 1.2;
 	vertical-align: middle;
 
@@ -34,13 +64,17 @@
 .rcx-message {
 	/* emojis on messages */
 	&__emoji {
-		font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', sans-serif;
+		font-family: rc-emoji, sans-serif;
 
-		/* Fuselage fixes this box at 1.5rem, sized for image emojis. Native glyphs on
-		Segoe UI Emoji/Noto Color Emoji paint taller and wider than that box, and the
-		overhang gets clipped by the message body's overflow: hidden. Let the box grow
-		to the glyph instead. */
+		/* Fuselage fixes this box at 1.5rem inline-block, sized for image emojis. Native
+		glyphs on Segoe UI Emoji/Noto Color Emoji paint taller and wider than that box, and
+		the overhang gets clipped by the message body's overflow: hidden — so let the box
+		grow to the glyph. inline-block also aligns by geometric box while the announcement
+		banner's .emoji span (plain inline) aligns by font metrics; Segoe UI Emoji's
+		asymmetric metrics make those disagree by ~2px, leaving message glyphs off-center.
+		Use the same inline model everywhere. */
 		&:not(&--custom) {
+			display: inline;
 			width: auto;
 			height: auto;
 			line-height: 1.2;

--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -1,28 +1,9 @@
-/* Faces sharing a family with equal descriptors resolve last-declared-first
-(css-fonts-4 font matching), so these are in reverse priority order: Segoe UI
-Emoji must be declared last to win on Windows. */
+/* Wrapper for Segoe UI Emoji correcting its metrics: it paints its ink low
+relative to its metric midpoint (so vertical-align: middle sits glyphs ~2px
+below the text center) and ~15% larger than the other platform emoji fonts.
+Only exists on Windows, so other platforms skip it in the fallback list. */
 @font-face {
-	font-family: rc-emoji;
-	src: local('Android Emoji');
-}
-
-@font-face {
-	font-family: rc-emoji;
-	src: local('Twemoji Mozilla');
-}
-
-@font-face {
-	font-family: rc-emoji;
-	src: local('Noto Color Emoji');
-}
-
-@font-face {
-	font-family: rc-emoji;
-	src: local('Apple Color Emoji');
-}
-
-@font-face {
-	font-family: rc-emoji;
+	font-family: rc-emoji-segoe;
 	src: local('Segoe UI Emoji');
 	ascent-override: 90%;
 	descent-override: 25%;
@@ -31,11 +12,11 @@ Emoji must be declared last to win on Windows. */
 
 /* Global emoji styles */
 .emoji {
-	font-family: rc-emoji, sans-serif;
+	font-family: 'Apple Color Emoji', rc-emoji-segoe, 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', sans-serif;
 	font-size: 1.375rem;
 
 	/* Must exceed the emoji fonts' ink height — ~1.13em on Noto Color Emoji and on
-	size-adjusted Segoe UI Emoji (rc-emoji face) — otherwise the glyph paints outside
+	size-adjusted Segoe UI Emoji (rc-emoji-segoe) — otherwise the glyph paints outside
 	the line box and gets cut by overflow: hidden ancestors (message body, announcement
 	banner). */
 	line-height: 1.2;
@@ -67,7 +48,7 @@ Emoji must be declared last to win on Windows. */
 .rcx-message {
 	/* emojis on messages */
 	&__emoji {
-		font-family: rc-emoji, sans-serif;
+		font-family: 'Apple Color Emoji', rc-emoji-segoe, 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', sans-serif;
 
 		/* Fuselage fixes this box at 1.5rem inline-block, sized for image emojis. Native
 		glyphs on Segoe UI Emoji/Noto Color Emoji paint taller and wider than that box, and

--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -1,19 +1,9 @@
+/* Faces sharing a family with equal descriptors resolve last-declared-first
+(css-fonts-4 font matching), so these are in reverse priority order: Segoe UI
+Emoji must be declared last to win on Windows. */
 @font-face {
 	font-family: rc-emoji;
-	src: local('Segoe UI Emoji');
-	ascent-override: 90%;
-	descent-override: 25%;
-	size-adjust: 85%;
-}
-
-@font-face {
-	font-family: rc-emoji;
-	src: local('Apple Color Emoji');
-}
-
-@font-face {
-	font-family: rc-emoji;
-	src: local('Noto Color Emoji');
+	src: local('Android Emoji');
 }
 
 @font-face {
@@ -23,7 +13,20 @@
 
 @font-face {
 	font-family: rc-emoji;
-	src: local('Android Emoji');
+	src: local('Noto Color Emoji');
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Apple Color Emoji');
+}
+
+@font-face {
+	font-family: rc-emoji;
+	src: local('Segoe UI Emoji');
+	ascent-override: 90%;
+	descent-override: 25%;
+	size-adjust: 85%;
 }
 
 /* Global emoji styles */

--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -1,7 +1,11 @@
 /* Global emoji styles */
 .emoji {
 	font-size: 1.375rem;
-	line-height: 1.5rem;
+
+	/* Must exceed the emoji fonts' ink height (~1.13em on Noto Color Emoji), otherwise
+	the glyph paints outside the line box and gets cut by overflow: hidden ancestors
+	(message body, announcement banner). */
+	line-height: 1.2;
 	vertical-align: middle;
 
 	/* custom emojis */
@@ -31,5 +35,15 @@
 	/* emojis on messages */
 	&__emoji {
 		font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', sans-serif;
+
+		/* Fuselage fixes this box at 1.5rem, sized for image emojis. Native glyphs on
+		Segoe UI Emoji/Noto Color Emoji paint taller and wider than that box, and the
+		overhang gets clipped by the message body's overflow: hidden. Let the box grow
+		to the glyph instead. */
+		&:not(&--custom) {
+			width: auto;
+			height: auto;
+			line-height: 1.2;
+		}
 	}
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Native emoji glyphs render with their bottom cut off in message bodies and the room announcement banner on Windows (Segoe UI Emoji) and Linux (Noto Color Emoji). On Linux the same box mismatch also crowds the emoji against the following word: Noto's advance (~30px at 24px font-size) overflows the fixed 24px box to the right, eating the `.125rem` margin and overlapping ~4px into the adjacent text. Not reproducible on macOS.

Two instances of the same root cause, introduced by the emojione removal (#39411):

- **Messages:** Fuselage's `.rcx-message__emoji` forces a fixed `1.5rem` box (height/width/line-height), sized for the old sprite images. Native glyphs on Segoe/Noto paint taller and wider than that box (Noto ink ≈ 1.13em, advance ≈ 1.25em), and the overhang is clipped by `.rcx-message-body`'s `overflow: hidden`. Apple Color Emoji ink stops just inside the box, which is why macOS is unaffected. Fixed by letting the box grow to the glyph (`width/height: auto`, `line-height: 1.2`), scoped to exclude custom image emojis; unitless line-height also covers the `--big` (emoji-only) variant.
- **Announcement banner (and other `MarkdownText` surfaces):** `.emoji`'s `line-height: 1.5rem` (24px) is smaller than the 22px-font glyph box, so the emoji overhangs the truncated banner Box's `overflow: hidden` by 1px on each side plus the ink below the baseline. Fixed by `line-height: 1.2` (26.4px), which contains the ink of all three platform emoji fonts.

Verified with a Chromium repro using the real Noto Color Emoji font (clip reproduced, then gone with the fix) and against a live server (emoji boxes now fully contained by their `overflow: hidden` ancestors; banner keeps its 40px height). Emoji picker, reactions, and thread previews pin their own line-heights and are unaffected. Lines containing an emoji grow ~2–5px, which is the space the glyph actually needs.

Follow-up (not for this release): move the glyph-aware sizing and the emoji font-family stack into Fuselage's `MessageEmoji` and drop these overrides from `emoji.css`.

## Issue(s)

[CORE-2433](https://rocketchat.atlassian.net/browse/CORE-2433)
[CORE-2482](https://rocketchat.atlassian.net/browse/CORE-2482)

## Steps to test or reproduce

1. On Ubuntu or Windows, send a message containing an emoji between words (`hello 😄 hello`) — the glyph should render fully, nothing cut at the bottom, with visible spacing to the surrounding words.
2. Set a room announcement containing emojis — same result in the banner.
3. Send an emoji-only message (big emoji) and a custom emoji — both render as before, custom emoji box unchanged.

## Further comments

CSS-only change. No changeset (regression fix targeting the release branch).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

Windows
<img width="902" height="639" alt="image" src="https://github.com/user-attachments/assets/b12289ac-8849-47fd-b784-6499f5982b24" />

MacOS
<img width="1052" height="1052" alt="image" src="https://github.com/user-attachments/assets/3ac5aa79-cb02-4481-9635-654f088fa0a3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native emoji rendering by adding a shared Windows emoji font and updating the global emoji font stack for consistency.
  * Adjusted emoji line spacing to reduce clipping/overhang issues when emojis sit inside containers with hidden overflow.
  * Updated native (non-custom) message emojis to size inline and match the glyph more naturally, improving vertical alignment and preventing off-centering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2433]: https://rocketchat.atlassian.net/browse/CORE-2433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
