### PR TITLE
regression: canned response emojis appear as shortcodes to livechat visitors

### DIFF
--- a/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
@@ -14,11 +14,17 @@ jest.mock('../../../../../contexts/EmojiPickerContext', () => ({
 	useEmojiPicker: jest.fn(),
 }));
 
+jest.mock('react-i18next', () => ({
+	useTranslation: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
 const mockedUseUserPreference = useUserPreference as jest.Mock;
 const mockedUseEmojiPicker = useEmojiPicker as jest.Mock;
 
 describe('CannedResponsesComposer emoji insertion', () => {
-	beforeEach(() => {
+	beforeAll(() => {
 		mockedUseUserPreference.mockReturnValue(true);
 
 		emoji.list = {

--- a/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
@@ -1,0 +1,77 @@
+import { useUserPreference } from '@rocket.chat/ui-contexts';
+import { render, screen } from '@testing-library/react';
+
+import CannedResponsesComposer from './CannedResponsesComposer';
+import { emoji } from '../../../../../../app/emoji/client';
+import { useEmojiPicker } from '../../../../../contexts/EmojiPickerContext';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	...jest.requireActual('@rocket.chat/ui-contexts'),
+	useUserPreference: jest.fn(),
+}));
+
+jest.mock('../../../../../contexts/EmojiPickerContext', () => ({
+	useEmojiPicker: jest.fn(),
+}));
+
+const mockedUseUserPreference = useUserPreference as jest.Mock;
+const mockedUseEmojiPicker = useEmojiPicker as jest.Mock;
+
+describe('CannedResponsesComposer emoji insertion', () => {
+	beforeEach(() => {
+		mockedUseUserPreference.mockReturnValue(true);
+
+		emoji.list = {
+			':grinning_face_with_big_eyes:': {
+				category: 'people',
+				emojiPackage: 'native',
+				shortnames: [],
+				uc_base: '1f603',
+				uc_greedy: '1f603',
+				uc_match: '1f603',
+				uc_output: '1f603',
+				unicode: '😃',
+			},
+			':my_custom_emoji:': {
+				category: 'custom',
+				emojiPackage: 'emojiCustom',
+				shortnames: [],
+				uc_base: '',
+				uc_greedy: '',
+				uc_match: '',
+				uc_output: '',
+			},
+		};
+	});
+
+	const renderWithPickedEmoji = (pickedEmojiName: string) => {
+		mockedUseEmojiPicker.mockReturnValue({
+			open: (_ref: Element, callback: (emojiName: string) => void) => callback(pickedEmojiName),
+			isOpen: false,
+			close: jest.fn(),
+		});
+
+		const onChange = jest.fn();
+		render(<CannedResponsesComposer onChange={onChange} />);
+
+		return { onChange };
+	};
+
+	it('inserts the unicode character when the picked emoji has a native unicode value', async () => {
+		const { onChange } = renderWithPickedEmoji('grinning_face_with_big_eyes');
+
+		const emojiButton = await screen.findByRole('button', { name: 'Emoji' });
+		emojiButton.click();
+
+		expect(onChange).toHaveBeenLastCalledWith('😃 ');
+	});
+
+	it('falls back to the raw shortcode text when the picked emoji has no unicode value (custom emoji)', async () => {
+		const { onChange } = renderWithPickedEmoji('my_custom_emoji');
+
+		const emojiButton = await screen.findByRole('button', { name: 'Emoji' });
+		emojiButton.click();
+
+		expect(onChange).toHaveBeenLastCalledWith(':my_custom_emoji: ');
+	});
+});

--- a/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.spec.tsx
@@ -24,6 +24,8 @@ const mockedUseUserPreference = useUserPreference as jest.Mock;
 const mockedUseEmojiPicker = useEmojiPicker as jest.Mock;
 
 describe('CannedResponsesComposer emoji insertion', () => {
+	const originalEmojiList = emoji.list;
+
 	beforeAll(() => {
 		mockedUseUserPreference.mockReturnValue(true);
 
@@ -48,6 +50,14 @@ describe('CannedResponsesComposer emoji insertion', () => {
 				uc_output: '',
 			},
 		};
+	});
+
+	afterAll(() => {
+		emoji.list = originalEmojiList;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
 	});
 
 	const renderWithPickedEmoji = (pickedEmojiName: string) => {

--- a/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/components/CannedResponsesComposer/CannedResponsesComposer.tsx
@@ -13,6 +13,7 @@ import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import InsertPlaceholderDropdown from './InsertPlaceholderDropdown';
+import { emoji } from '../../../../../../app/emoji/client';
 import { Backdrop } from '../../../../../components/Backdrop';
 import { useEmojiPicker } from '../../../../../contexts/EmojiPickerContext';
 
@@ -61,11 +62,12 @@ const CannedResponsesComposer = ({ onChange, ...props }: CannedResponsesComposer
 			}
 		}, [char]);
 
-	const onClickEmoji = (emoji: string): void => {
+	const onClickEmoji = (emojiName: string): void => {
 		if (textAreaRef?.current) {
 			const text = textAreaRef.current.value;
 			const startPos = textAreaRef.current.selectionStart;
-			const emojiValue = `:${emoji}: `;
+			const emojiEntry = emoji.list[`:${emojiName}:`];
+			const emojiValue = emojiEntry && 'unicode' in emojiEntry && emojiEntry.unicode ? `${emojiEntry.unicode} ` : `:${emojiName}: `;
 
 			textAreaRef.current.value = text.slice(0, startPos) + emojiValue + text.slice(startPos);
 
@@ -85,7 +87,7 @@ const CannedResponsesComposer = ({ onChange, ...props }: CannedResponsesComposer
 			throw new Error('Missing textAreaRef');
 		}
 
-		openEmojiPicker(textAreaRef.current, (emoji: string) => onClickEmoji(emoji));
+		openEmojiPicker(textAreaRef.current, (emojiName: string) => onClickEmoji(emojiName));
 	};
 
 	const openPlaceholderSelect = (): void => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Root cause: When inserting an emoji in the canned response text, the `CannedResponsesComposer.tsx` component saved the literal shortcode (e.g :grinning_face_with_big_eyes:) instead of the unicode character. I guided myself with the `MessageBox.tsx` component, which resolved the shortcode to unicode before inserting it.

To address it, the same lookup that `MessageBox.tsx` does was implemented: look for the entry in `emoji.list[':name:']` and, if it has unicode, then the real character is inserted, otherwise it falls back to the shortcode.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2468 [Regression] Canned response emojis appear as shortcodes to Livechat visitors](https://rocketchat.atlassian.net/browse/CORE-2468)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
You'll need a EE license for the Canned Responses feature.
1. Go to Omnichannel → Canned Responses.
2. Create a canned response.
3. Select 😃 using the emoji picker in the `Message` field.
4. Save the response.
5. Use the response in a Livechat conversation.
6. Compare the agent and visitor views.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji insertion in canned responses.
  * Native emojis are inserted as Unicode characters; custom emojis fall back to their shortcode.
  * Emoji insertion now consistently includes a trailing space for smoother continued typing.
* **Tests**
  * Added Jest + React Testing Library coverage to verify emoji selection triggers the correct `onChange` value for both native and custom emojis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->