### PR TITLE
test(jwt): expand unit test coverage for getPairs and error cases

### DIFF
--- a/packages/jwt/__tests__/jwt.spec.ts
+++ b/packages/jwt/__tests__/jwt.spec.ts
@@ -1,93 +1,135 @@
 import { generateKeyPair, exportPKCS8, exportSPKI } from 'jose';
 
-import { sign, verify } from '../src/index';
+import { sign, verify, getPairs } from '../src/index';
 
-it('should sign and verify a jwt with RS256', async () => {
-	const { publicKey, privateKey } = await generateKeyPair('RS256');
-	const spki = await exportSPKI(publicKey);
-	const pkcs8 = await exportPKCS8(privateKey);
+describe('jwt package', () => {
+	const oldEnv = process.env.NODE_ENV;
 
-	const licenseV3 = {
-		information: {
-			id: '64d28d096400df50b6ace670',
-			autoRenew: true,
-			createdAt: '2023-08-08T18:44:25.719+0000',
-			visualExpiration: '2024-09-08T18:44:25.719+0000',
-			notifyAdminsAt: '2024-09-01T18:44:25.719+0000',
-			notifyUsersAt: '2024-09-05T18:44:25.719+0000',
-			trial: false,
-			offline: false,
-			grantedBy: { method: 'manual', seller: 'john.rocketseed@rocket.chat' },
-			grantedTo: { name: 'Alice Clientseed', company: 'Client', email: 'alice.clientseed@client.com' },
-			legalText: "This license can't be used for reselling",
-			notes: 'Plan Premium',
-			tags: [{ name: 'Enterprise', color: '#CCCCCC' }],
-		},
-		validation: {
-			serverUrls: [{ value: 'https://localhost:3000', type: 'url' }],
-			serverVersions: [{ value: '6.4' }],
-			cloudWorkspaceId: 'alks-a9sj0diba09shdiasodjha9s0diha9s9duabsiuhdai0sdh0a9hs09da09s8d09a80s9d8',
-			serverUniqueId: '64d28d096400df50b6ace670',
-			validUntil: '2024-09-18T18:44:25.719+0000',
-			validFrom: '2024-07-08T18:44:25.719+0000',
-			installationAllowedUntil: '2024-07-09T18:44:25.719+0000',
-			legalTextAgreement: { type: 'accepted', acceptedVia: 'cloud' },
-			statisticsReport: { required: true, allowedStaleInDays: 5 },
-		},
-		grantedModules: [
-			{ module: 'auditing' },
-			{ module: 'canned-responses' },
-			{ module: 'ldap-enterprise' },
-			{ module: 'livechat-enterprise' },
-			{ module: 'voip-enterprise' },
-			{ module: 'omnichannel-mobile-enterprise' },
-			{ module: 'engagement-dashboard' },
-			{ module: 'push-privacy' },
-			{ module: 'scalability' },
-			{ module: 'teams-mention' },
-			{ module: 'saml-enterprise' },
-			{ module: 'oauth-enterprise' },
-			{ module: 'device-management' },
-			{ module: 'federation' },
-			{ module: 'videoconference-enterprise' },
-			{ module: 'message-read-receipt' },
-			{ module: 'outlook-calendar' },
-			{ module: 'unlimited-presence' },
-			{ module: 'outbound-messaging' },
-			{ module: 'abac' },
-		],
-		limits: {
-			activeUsers: [
-				{ max: 500, behavior: 'start_fair_policy' },
-				{ max: 1000, behavior: 'prevent_action' },
-				{ max: 1100, behavior: 'invalidate_license' },
-			],
-			guestUsers: [
-				{ max: 200, behavior: 'start_fair_policy' },
-				{ max: 400, behavior: 'prevent_action' },
-				{ max: 500, behavior: 'invalidate_license' },
-			],
-			roomsPerGuest: [
-				{ max: 5, behavior: 'start_fair_policy' },
-				{ max: 10, behavior: 'prevent_action' },
-			],
-			privateApps: [
-				{ max: 5, behavior: 'start_fair_policy' },
-				{ max: 10, behavior: 'prevent_action' },
-				{ max: 11, behavior: 'invalidate_license' },
-			],
-			marketplaceApps: [
-				{ max: 5, behavior: 'start_fair_policy' },
-				{ max: 10, behavior: 'prevent_action' },
-				{ max: 11, behavior: 'invalidate_license' },
-			],
-		},
-		cloudMeta: { lastStatisticId: '64d28d096400df50b6ace671' },
-	};
+	afterEach(() => {
+		process.env.NODE_ENV = oldEnv;
+	});
 
-	const token = await sign(licenseV3, pkcs8);
-	const [payload, protectedHeader] = await verify(token, spki);
+	it('should sign and verify a jwt with RS256', async () => {
+		const { publicKey, privateKey } = await generateKeyPair('RS256');
+		const spki = await exportSPKI(publicKey);
+		const pkcs8 = await exportPKCS8(privateKey);
 
-	expect(protectedHeader).toEqual({ alg: 'RS256', typ: 'JWT' });
-	expect(payload).toEqual(licenseV3);
+		const licenseV3 = {
+			information: {
+				id: '64d28d096400df50b6ace670',
+				autoRenew: true,
+				createdAt: '2023-08-08T18:44:25.719+0000',
+				visualExpiration: '2024-09-08T18:44:25.719+0000',
+				notifyAdminsAt: '2024-09-01T18:44:25.719+0000',
+				notifyUsersAt: '2024-09-05T18:44:25.719+0000',
+				trial: false,
+				offline: false,
+				grantedBy: { method: 'manual', seller: 'john.rocketseed@rocket.chat' },
+				grantedTo: { name: 'Alice Clientseed', company: 'Client', email: 'alice.clientseed@client.com' },
+				legalText: "This license can't be used for reselling",
+				notes: 'Plan Premium',
+				tags: [{ name: 'Enterprise', color: '#CCCCCC' }],
+			},
+			validation: {
+				serverUrls: [{ value: 'https://localhost:3000', type: 'url' }],
+				serverVersions: [{ value: '6.4' }],
+				cloudWorkspaceId: 'alks-a9sj0diba09shdiasodjha9s0diha9s9duabsiuhdai0sdh0a9hs09da09s8d09a80s9d8',
+				serverUniqueId: '64d28d096400df50b6ace670',
+				validUntil: '2024-09-18T18:44:25.719+0000',
+				validFrom: '2024-07-08T18:44:25.719+0000',
+				installationAllowedUntil: '2024-07-09T18:44:25.719+0000',
+				legalTextAgreement: { type: 'accepted', acceptedVia: 'cloud' },
+				statisticsReport: { required: true, allowedStaleInDays: 5 },
+			},
+			grantedModules: [
+				{ module: 'auditing' },
+				{ module: 'canned-responses' },
+				{ module: 'ldap-enterprise' },
+				{ module: 'livechat-enterprise' },
+				{ module: 'voip-enterprise' },
+				{ module: 'omnichannel-mobile-enterprise' },
+				{ module: 'engagement-dashboard' },
+				{ module: 'push-privacy' },
+				{ module: 'scalability' },
+				{ module: 'teams-mention' },
+				{ module: 'saml-enterprise' },
+				{ module: 'oauth-enterprise' },
+				{ module: 'device-management' },
+				{ module: 'federation' },
+				{ module: 'videoconference-enterprise' },
+				{ module: 'message-read-receipt' },
+				{ module: 'outlook-calendar' },
+				{ module: 'unlimited-presence' },
+				{ module: 'outbound-messaging' },
+				{ module: 'abac' },
+			],
+			limits: {
+				activeUsers: [
+					{ max: 500, behavior: 'start_fair_policy' },
+					{ max: 1000, behavior: 'prevent_action' },
+					{ max: 1100, behavior: 'invalidate_license' },
+				],
+				guestUsers: [
+					{ max: 200, behavior: 'start_fair_policy' },
+					{ max: 400, behavior: 'prevent_action' },
+					{ max: 500, behavior: 'invalidate_license' },
+				],
+				roomsPerGuest: [
+					{ max: 5, behavior: 'start_fair_policy' },
+					{ max: 10, behavior: 'prevent_action' },
+				],
+				privateApps: [
+					{ max: 5, behavior: 'start_fair_policy' },
+					{ max: 10, behavior: 'prevent_action' },
+					{ max: 11, behavior: 'invalidate_license' },
+				],
+				marketplaceApps: [
+					{ max: 5, behavior: 'start_fair_policy' },
+					{ max: 10, behavior: 'prevent_action' },
+					{ max: 11, behavior: 'invalidate_license' },
+				],
+			},
+			cloudMeta: { lastStatisticId: '64d28d096400df50b6ace671' },
+		};
+
+		const token = await sign(licenseV3, pkcs8);
+		const [payload, protectedHeader] = await verify(token, spki);
+
+		expect(protectedHeader).toEqual({ alg: 'RS256', typ: 'JWT' });
+		expect(payload).toEqual(licenseV3);
+	});
+
+	it('should generate key pairs using getPairs in test environment', async () => {
+		const [spki, pkcs8] = await getPairs();
+		expect(spki).toContain('BEGIN PUBLIC KEY');
+		expect(pkcs8).toContain('BEGIN PRIVATE KEY');
+
+		const payload = { test: true };
+		const token = await sign(payload, pkcs8);
+		const [decodedPayload, header] = await verify(token, spki);
+
+		expect(header).toEqual({ alg: 'RS256', typ: 'JWT' });
+		expect(decodedPayload).toEqual(payload);
+	});
+
+	it('should throw an error when getPairs is called outside of test environment', async () => {
+		process.env.NODE_ENV = 'production';
+		await expect(getPairs()).rejects.toThrow('This function should only be used in tests');
+	});
+
+	it('should throw an error when verifying a tampered or invalid token', async () => {
+		const [spki] = await getPairs();
+		const invalidToken = 'invalid.jwt.token';
+		await expect(verify(invalidToken, spki)).rejects.toThrow();
+	});
+
+	it('should throw an error when verifying with an incorrect public key', async () => {
+		const [, pkcs8] = await getPairs();
+		const [otherSpki] = await getPairs();
+
+		const payload = { data: 'secret' };
+		const token = await sign(payload, pkcs8);
+
+		await expect(verify(token, otherSpki)).rejects.toThrow();
+	});
 });

--- a/packages/jwt/__tests__/jwt.spec.ts
+++ b/packages/jwt/__tests__/jwt.spec.ts
@@ -117,10 +117,19 @@ describe('jwt package', () => {
 		await expect(getPairs()).rejects.toThrow('This function should only be used in tests');
 	});
 
-	it('should throw an error when verifying a tampered or invalid token', async () => {
+	it('should throw an error when verifying a malformed token', async () => {
 		const [spki] = await getPairs();
 		const invalidToken = 'invalid.jwt.token';
 		await expect(verify(invalidToken, spki)).rejects.toThrow();
+	});
+
+	it('should throw an error when verifying a token with a tampered signature', async () => {
+		const [spki, pkcs8] = await getPairs();
+		const payload = { data: 'secret' };
+		const token = await sign(payload, pkcs8);
+
+		const tamperedToken = `${token}tampered`;
+		await expect(verify(tamperedToken, spki)).rejects.toThrow();
 	});
 
 	it('should throw an error when verifying with an incorrect public key', async () => {

--- a/packages/jwt/jest.config.ts
+++ b/packages/jwt/jest.config.ts
@@ -1,6 +1,6 @@
-import server from '@rocket.chat/jest-presets/server';
+import preset from '@rocket.chat/jest-presets/server/jest-preset';
 import type { Config } from 'jest';
 
 export default {
-	preset: server.preset,
+	...preset,
 } satisfies Config;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->
- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Expands unit test coverage for `@rocket.chat/jwt` to **100%** across statements, branches, functions, and lines.

Specific test coverage additions:
1. **`getPairs()` Key Generator**: Tested key pair generation (`SPKI` and `PKCS8`) and verified token signing/verifying with `getPairs()`.
2. **Environment Safety Guard**: Tested that `getPairs()` throws an error when `process.env.NODE_ENV !== 'test'`.
3. **Invalid Token Error Handling**: Tested verification failure when supplied with tampered or invalid JWT strings.
4. **Key Mismatch Verification**: Tested verification failure when decoding a token with an incorrect public key.

## Issue(s)
N/A

## Steps to test or reproduce
Run unit tests for `@rocket.chat/jwt`:
```bash
npx jest packages/jwt/__tests__/jwt.spec.ts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded JWT coverage for signing/verification across RS256, including protected header and exact payload assertions.
  * Added get-key-pair (key material) tests to ensure usable keys in the test environment and clear failure behavior outside it.
  * Added negative cases for malformed/tampered tokens and verification with mismatched public keys.
  * Improved test isolation by restoring environment settings after each test.
* **Chores**
  * Updated the JWT package test configuration to use a shared Jest preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->