### PR TITLE
fix(directory,admin): trim search whitespace in user search hooks

### DIFF
--- a/apps/meteor/client/views/admin/users/hooks/useFilteredUsers.ts
+++ b/apps/meteor/client/views/admin/users/hooks/useFilteredUsers.ts
@@ -43,7 +43,7 @@ const useFilteredUsers = ({ searchTerm, prevSearchTerm, sortData, paginationData
 
 		return {
 			...listUsersPayload[tab],
-			searchTerm,
+			searchTerm: searchTerm.trim(),
 			roles: selectedRoles,
 			sort: `{ "${sortBy}": ${sortDirection === 'asc' ? 1 : -1} }`,
 			count: itemsPerPage,

--- a/apps/meteor/client/views/directory/hooks/useDirectoryQuery.ts
+++ b/apps/meteor/client/views/directory/hooks/useDirectoryQuery.ts
@@ -10,7 +10,7 @@ export function useDirectoryQuery(
 	return useDebouncedValue(
 		useMemo(
 			() => ({
-				text,
+				text: text.trim(),
 				type,
 				workspace,
 				sort: JSON.stringify({ [column]: direction === 'asc' ? 1 : -1 }),


### PR DESCRIPTION
<!-- Checklist -->
- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Applies `.trim()` to search input terms in `useDirectoryQuery` and `useFilteredUsers` hooks.

This prevents search queries containing leading or trailing whitespace (e.g. `" john "`) from sending un-trimmed queries to the backend API, fixing user and channel lookup failures when extra spaces are present in search inputs.

## Issue(s)
Closes #41545
Closes #41530

## Steps to test or reproduce
1. Navigate to **Directory** -> **Users** tab (or **Workspace Admin** -> **Users**).
2. Enter a search query with leading or trailing spaces (e.g., `  admin  `).
3. Verify that the user list updates properly without failing to match users due to whitespace.

## Further comments
- Updated `apps/meteor/client/views/directory/hooks/useDirectoryQuery.ts`
- Updated `apps/meteor/client/views/admin/users/hooks/useFilteredUsers.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user and directory searches by ignoring leading and trailing whitespace in search terms.
  * Prevents unintended spaces from affecting search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->