### PR TITLE
fix: normalize OAuth app redirect URI list parsing

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes OAuth apps rejecting valid authorization requests when the configured Redirect URI had surrounding whitespace. A single redirect URI was stored verbatim, so a stray leading/trailing space or tab was kept and never matched the `redirect_uri` sent by the client, failing the authorization with `invalid_redirect_uri`. Redirect URIs are now trimmed consistently whether one or several are configured.

--- a/apps/meteor/server/lib/auth/oauth2-server/addOAuthApp.ts
+++ b/apps/meteor/server/lib/auth/oauth2-server/addOAuthApp.ts
@@ -43,9 +43,17 @@ export async function addOAuthApp(applicationParams: OauthAppsAddParams, uid: IU
 		});
 	}
 
+	const redirectUris = parseUriList(applicationParams.redirectUri);
+
+	if (redirectUris.length === 0) {
+		throw new Meteor.Error('error-invalid-redirectUri', 'Invalid redirectUri', {
+			method: 'addOAuthApp',
+		});
+	}
+
 	const application = {
 		...applicationParams,
-		redirectUri: parseUriList(applicationParams.redirectUri),
+		redirectUri: redirectUris.join(','),
 		clientId: Random.id(),
 		clientSecret: Random.secret(),
 		_createdAt: new Date(),
@@ -55,12 +63,6 @@ export async function addOAuthApp(applicationParams: OauthAppsAddParams, uid: IU
 			username: user.username,
 		},
 	};
-
-	if (application.redirectUri.length === 0) {
-		throw new Meteor.Error('error-invalid-redirectUri', 'Invalid redirectUri', {
-			method: 'addOAuthApp',
-		});
-	}
 
 	return {
 		...application,

--- a/apps/meteor/server/lib/auth/oauth2-server/parseUriList.ts
+++ b/apps/meteor/server/lib/auth/oauth2-server/parseUriList.ts
@@ -1,17 +1,5 @@
-export const parseUriList = (userUri: string) => {
-	if (userUri.indexOf('\n') < 0 && userUri.indexOf(',') < 0) {
-		return userUri;
-	}
-
-	const uriList: string[] = [];
-	userUri.split(/[,\n]/).forEach((item) => {
-		const uri = item.trim();
-		if (uri === '') {
-			return;
-		}
-
-		uriList.push(uri);
-	});
-
-	return uriList.join(','); // TODO: This is a hack because the original code was returning a string or an array of strings
-};
+export const parseUriList = (userUri: string): string[] =>
+	userUri
+		.split(/[,\n]/)
+		.map((uri) => uri.trim())
+		.filter((uri) => uri !== '');

--- a/apps/meteor/server/meteor-methods/auth/updateOAuthApp.ts
+++ b/apps/meteor/server/meteor-methods/auth/updateOAuthApp.ts
@@ -42,9 +42,9 @@ export const updateOAuthApp = async (
 		});
 	}
 
-	const redirectUri = parseUriList(application.redirectUri);
+	const redirectUris = parseUriList(application.redirectUri);
 
-	if (redirectUri.length === 0) {
+	if (redirectUris.length === 0) {
 		throw new Meteor.Error('error-invalid-redirectUri', 'Invalid redirectUri', {
 			method: 'updateOAuthApp',
 		});
@@ -53,7 +53,7 @@ export const updateOAuthApp = async (
 	const updatedApplication = await OAuthApps.updateById(applicationId, {
 		name: application.name,
 		active: application.active,
-		redirectUri,
+		redirectUri: redirectUris.join(','),
 		_updatedBy: await Users.findOneById(userId, {
 			projection: {
 				username: 1,

--- a/apps/meteor/tests/end-to-end/api/oauthapps.ts
+++ b/apps/meteor/tests/end-to-end/api/oauthapps.ts
@@ -145,6 +145,42 @@ describe('[OAuthApps]', () => {
 					createdAppsIds.push(res.body.application._id);
 				});
 		});
+
+		it('should trim surrounding whitespace from the redirectUri', async () => {
+			await request
+				.post(api('oauth-apps.create'))
+				.set(credentials)
+				.send({
+					name: `new app ${Date.now()}`,
+					redirectUri: '  http://localhost:3000  ',
+					active: true,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('application.redirectUri', 'http://localhost:3000');
+					createdAppsIds.push(res.body.application._id);
+				});
+		});
+
+		it('should trim and normalize a list of redirectUris', async () => {
+			await request
+				.post(api('oauth-apps.create'))
+				.set(credentials)
+				.send({
+					name: `new app ${Date.now()}`,
+					redirectUri: ' http://localhost:3000 \n\n http://localhost:4000 \n',
+					active: true,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('application.redirectUri', 'http://localhost:3000,http://localhost:4000');
+					createdAppsIds.push(res.body.application._id);
+				});
+		});
 	});
 
 	describe('[/oauth-apps.get]', () => {

--- a/apps/meteor/tests/end-to-end/api/oauthapps.ts
+++ b/apps/meteor/tests/end-to-end/api/oauthapps.ts
@@ -383,6 +383,24 @@ describe('[OAuthApps]', () => {
 				});
 		});
 
+		it('should trim and normalize the redirectUri when updating an app', async () => {
+			await request
+				.post(api(`oauth-apps.update`))
+				.set(credentials)
+				.send({
+					appId,
+					name: `new app ${Date.now()}`,
+					redirectUri: ' http://localhost:3000 \n\n http://localhost:4000 \n',
+					active: false,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('redirectUri', 'http://localhost:3000,http://localhost:4000');
+				});
+		});
+
 		it('should fail updating an app if user does NOT have the manage-oauth-apps permission', async () => {
 			const name = `new app ${Date.now()}`;
 			const redirectUri = 'http://localhost:3000';

--- a/apps/meteor/tests/unit/server/lib/auth/oauth2-server/parseUriList.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/auth/oauth2-server/parseUriList.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { parseUriList } from '../../../../../../server/lib/auth/oauth2-server/parseUriList';
+
+describe('parseUriList', () => {
+	it('should return an empty list for an empty string', () => {
+		expect(parseUriList('')).to.deep.equal([]);
+	});
+
+	it('should return an empty list for a blank string', () => {
+		expect(parseUriList('   \n  ')).to.deep.equal([]);
+	});
+
+	it('should return a single-entry list for a single uri', () => {
+		expect(parseUriList('https://example.com')).to.deep.equal(['https://example.com']);
+	});
+
+	it('should trim surrounding whitespace from a single uri', () => {
+		expect(parseUriList('  https://example.com  ')).to.deep.equal(['https://example.com']);
+	});
+
+	it('should trim a trailing separator from a single uri', () => {
+		expect(parseUriList('https://example.com\n')).to.deep.equal(['https://example.com']);
+	});
+
+	it('should split and trim a comma separated list', () => {
+		expect(parseUriList('https://a.com , https://b.com')).to.deep.equal(['https://a.com', 'https://b.com']);
+	});
+
+	it('should split and trim a newline separated list', () => {
+		expect(parseUriList('https://a.com\n  https://b.com  \n')).to.deep.equal(['https://a.com', 'https://b.com']);
+	});
+
+	it('should ignore blank entries when separators are mixed', () => {
+		expect(parseUriList('https://a.com,,\n , https://b.com\n')).to.deep.equal(['https://a.com', 'https://b.com']);
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`parseUriList` had an inconsistent contract. It short-circuited and returned the **raw, untrimmed input** whenever the value contained no `,` or `\n`, and otherwise returned a trimmed, comma-joined string:

```ts
export const parseUriList = (userUri: string) => {
	if (userUri.indexOf('\n') < 0 && userUri.indexOf(',') < 0) {
		return userUri;                 // <-- not trimmed
	}
	...
	return uriList.join(','); // TODO: This is a hack because the original code was returning a string or an array of strings
};
```

That short-circuit is a real user-facing bug, not just a typing wart. The returned value is persisted as `IOAuthApps.redirectUri` and later compared with **strict equality** against the `redirect_uri` the client sends:

```ts
// apps/meteor/server/oauth2-server/oauth.ts
const redirectUris: string[] = client.redirectUri.split(',');
if (typeof req.query.redirect_uri === 'string' && !redirectUris.includes(req.query.redirect_uri)) {
	return res.redirect('/oauth/error/invalid_redirect_uri');
}
```

So an OAuth app whose Redirect URI was saved with a stray leading/trailing space (trivially easy to introduce by copy/paste into the admin textarea) stored `"http://localhost:3000 "`, never matched `"http://localhost:3000"`, and **failed every authorization** with `invalid_redirect_uri`. Configuring two or more URIs happened to work, because only the multi-entry path trimmed.

### Changes

- `parseUriList` now has one consistent contract: it always returns the trimmed, non-empty entries as `string[]`, for empty, single, and multiple inputs alike. The `TODO` hack is gone.
- `addOAuthApp` / `updateOAuthApp` join the parsed entries when persisting, and now validate on **entry count** (`redirectUris.length === 0`) instead of on the character length of the joined string.
- `addOAuthApp` validates before building the document rather than after, so no partially-built application object is constructed on the invalid path.

### Deliberate deviation from the issue

The issue also suggests migrating the stored value to an array. I kept the **persisted shape unchanged** (comma-joined `string`), because `IOAuthApps.redirectUri` is typed `string` and drives the generated `#/components/schemas/IOAuthApps` response schema used by `oauth-apps.list` / `.get` / `.create` / `.update`, and both OAuth2 consumers (`server/oauth2-server/oauth.ts`, `server/oauth2-server/model.ts`) do `client.redirectUri.split(',')`. Changing the stored shape would be an API/schema break plus a data migration — out of scope for this bug fix, and a separate call for maintainers. The helper's own contract is now `string[]` as the issue asks, with the string-joining confined to the persistence boundary.

## Issue(s)

Closes #39762

## Steps to test or reproduce

Before this change:

1. Admin → Workspace → OAuth Apps → Add.
2. Set **Redirect URI** to `http://localhost:3000 ` (note the single trailing space) and save.
3. Start an authorization: `GET /oauth/authorize?response_type=code&client_id=<clientId>&redirect_uri=http://localhost:3000`.
4. You are redirected to `/oauth/error/invalid_redirect_uri`.

After this change the URI is stored as `http://localhost:3000` and the authorization proceeds. Entering two URIs was unaffected before and after.

Automated coverage added:

- `apps/meteor/tests/unit/server/lib/auth/oauth2-server/parseUriList.spec.ts` — 8 cases covering empty, blank, single, single-with-whitespace, trailing separator, comma-separated, newline-separated, and mixed separators with blank entries. All 8 fail on `develop` and pass with this change.
- `apps/meteor/tests/end-to-end/api/oauthapps.ts` — two `oauth-apps.create` cases asserting the stored `redirectUri` is trimmed for a single URI and trimmed/normalized for a list.

## Further comments

Verified locally (Node 22.22.3):

- `mocha --config ./.mocharc.js` — 2129 passing, 0 failing, 12 pending (with `TZ=UTC`, matching CI; without it, 3 pre-existing timezone-dependent `parseMessageSearchQuery` specs fail on `develop` too, unrelated to this change).
- `mocha --config ./.mocharc.definition.js` — 149 passing.
- `tsc --noEmit --skipLibCheck` — clean.
- `eslint` on all changed files — clean.
- `prettier --check` on all changed files — clean.

While tracing this I noticed a separate latent issue that I did **not** touch: `EditOauthApp.tsx` guards with `Array.isArray(data.redirectUri)`, which suggests some workspaces still hold array-valued `redirectUri` from the pre-`join(',')` era. Those documents would throw on `client.redirectUri.split(',')` in `oauth.ts`/`model.ts`. Happy to open a separate issue/PR if maintainers confirm that shape exists in the wild.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - OAuth applications now accept valid authorization requests when redirect URI settings include surrounding whitespace.
  - Redirect URI lists are consistently trimmed, normalized, and validated; blank entries are rejected.

- **Tests**
  - Added end-to-end and unit test coverage for redirect URI sanitization on both OAuth app creation and updates, including handling of whitespace, multiple separators, and empty entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->