### PR TITLE
test: add unit tests for message sending validation

### DIFF
--- a/apps/meteor/server/lib/messages/sendMessage.spec.ts
+++ b/apps/meteor/server/lib/messages/sendMessage.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { prepareMessageObject } from './sendMessage';
+
+describe('sendMessage', () => {
+	describe('prepareMessageObject', () => {
+		it('should set ts if not provided', () => {
+			const message: any = {};
+			prepareMessageObject(message, 'rid123', { _id: 'u123', username: 'testuser', name: 'Test User' });
+			expect(message.ts).to.be.a('date');
+		});
+
+		it('should preserve existing ts', () => {
+			const date = new Date('2023-01-01T00:00:00.000Z');
+			const message: any = { ts: date };
+			prepareMessageObject(message, 'rid123', { _id: 'u123', username: 'testuser', name: 'Test User' });
+			expect(message.ts).to.equal(date);
+		});
+
+		it('should set rid correctly', () => {
+			const message: any = {};
+			prepareMessageObject(message, 'rid123', { _id: 'u123', username: 'testuser', name: 'Test User' });
+			expect(message.rid).to.equal('rid123');
+		});
+
+		it('should set user details correctly', () => {
+			const message: any = {};
+			prepareMessageObject(message, 'rid123', { _id: 'u123', username: 'testuser', name: 'Test User' });
+			expect(message.u).to.be.an('object');
+			expect(message.u._id).to.equal('u123');
+			expect(message.u.username).to.equal('testuser');
+			expect(message.u.name).to.equal('Test User');
+		});
+
+		it('should throw an error if username is not provided', () => {
+			const message: any = {};
+			expect(() => {
+				prepareMessageObject(message, 'rid123', { _id: 'u123', name: 'Test User' });
+			}).to.throw('error-invalid-user');
+		});
+
+		it('should delete tshow if it is not exactly true', () => {
+			const message: any = { tshow: false };
+			prepareMessageObject(message, 'rid123', { _id: 'u123', username: 'testuser', name: 'Test User' });
+			expect(message).to.not.have.property('tshow');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for the `prepareMessageObject` logic within `sendMessage.ts` to ensure robust message validation.

## What Changed
- Added `apps/meteor/server/lib/messages/sendMessage.spec.ts`
- Wrote tests covering `ts` timestamp generation, property preservation, `rid` assignment, and user detail assignment.
- Added test coverage to guarantee that an `error-invalid-user` exception is thrown when a username is missing.
- Added test coverage for `tshow` property behavior.

## Why
Adding these unit tests ensures that critical message dispatch logic (and previous validation fixes) will not regress in future updates.

## Testing
- [x] Verified code statically
- [x] Added unit tests 

## Checklist
- [x] I have followed the [Rocket.Chat Contribution Guidelines](https://developer.rocket.chat/docs/contribution-process)
- [x] My code passes all local linting and type checks
- [x] My commit history is clean and rebased


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for message preparation, including timestamps, room assignment, user details, invalid-user handling, and conditional field removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->