### PR TITLE
refactor: add proper TypeScript types for CannedResponse model

### DIFF
--- a/apps/meteor/client/views/omnichannel/cannedResponses/contextualBar/CannedResponse/CannedResponseList.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/contextualBar/CannedResponse/CannedResponseList.tsx
@@ -31,7 +31,7 @@ export type CannedResponseListProps = {
 	type: string;
 	setType: Dispatch<SetStateAction<string>>;
 	isRoomOverMacLimit: boolean;
-	onClickItem: (data: any) => void; // FIXME: fix typings
+	onClickItem: (data: IOmnichannelCannedResponse & { departmentName?: ILivechatDepartment['name'] }) => void;
 	onClickCreate: (e: MouseEvent<HTMLOrSVGElement>) => void;
 	onClickUse: (e: MouseEvent<HTMLOrSVGElement>, text: string) => void;
 	reload: () => void;

--- a/apps/meteor/ee/server/models/raw/CannedResponse.ts
+++ b/apps/meteor/ee/server/models/raw/CannedResponse.ts
@@ -3,7 +3,7 @@ import type { ICannedResponseModel } from '@rocket.chat/model-typings';
 import { BaseRaw } from '@rocket.chat/models';
 import type { Db, DeleteResult, FindCursor, FindOptions, IndexDescription, UpdateFilter } from 'mongodb';
 
-// TODO need to define type for CannedResponse object
+
 export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> implements ICannedResponseModel {
 	constructor(db: Db) {
 		super(db, 'canned_response');


### PR DESCRIPTION
## Summary
This PR improves type safety in the Omnichannel domain by removing a stale `TODO` and replacing an unsafe `any` cast with proper TypeScript types for Canned Responses.

## What Changed
- Removed a stale `TODO` comment in `apps/meteor/ee/server/models/raw/CannedResponse.ts` because the type was already imported and correctly utilized in the class generic.
- Replaced an explicitly marked `FIXME` `as any` typecast in `apps/meteor/client/views/omnichannel/cannedResponses/contextualBar/CannedResponse/CannedResponseList.tsx` with the correct `IOmnichannelCannedResponse` intersection type.

## Why
This removes technical debt and enforces strict TypeScript validation to prevent unintended bugs in Omnichannel UI components.

## Testing
- [x] Verified code statically

## Checklist
- [x] I have followed the [Rocket.Chat Contribution Guidelines](https://developer.rocket.chat/docs/contribution-process)
- [x] My code passes all local linting and type checks
- [x] My commit history is clean and rebased


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for canned response selection callbacks without changing user-visible behavior.

* **Chores**
  * Removed an outdated internal TODO comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->