### PR TITLE
fix(ui): prevent app crash when import type is an object

### DIFF
--- a/apps/meteor/client/views/admin/import/ImportOperationSummary.tsx
+++ b/apps/meteor/client/views/admin/import/ImportOperationSummary.tsx
@@ -87,16 +87,16 @@ function ImportOperationSummary({
 
 	const props = hasAction
 		? {
-				tabIndex: 0,
-				role: 'link',
-				action: true,
-				onClick: handleClick,
-			}
+			tabIndex: 0,
+			role: 'link',
+			action: true,
+			onClick: handleClick,
+		}
 		: {};
 
 	return (
 		<TableRow {...props}>
-			<TableCell>{type}</TableCell>
+			<TableCell>{typeof type === 'string' ? type : JSON.stringify(type)}</TableCell>
 			<TableCell>{formatDateAndTime(_updatedAt)}</TableCell>
 			{!small && (
 				<>

--- a/apps/meteor/client/views/admin/import/ImportOperationSummary.tsx
+++ b/apps/meteor/client/views/admin/import/ImportOperationSummary.tsx
@@ -106,7 +106,7 @@ function ImportOperationSummary({
 					<TableCell align='center'>{contacts}</TableCell>
 					<TableCell align='center'>{channels}</TableCell>
 					<TableCell align='center'>{messages}</TableCell>
-					<TableCell align='center'>{total}</TableCell>
+					<TableCell align='center'>{typeof total === 'object'?JSON.stringify(total):total}</TableCell>
 				</>
 			)}
 		</TableRow>


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

Added a safeguard in the ImportOperationSummary component to check the data type of the type prop before rendering it in the table cell. If it receives an object, it now uses JSON.stringify() to safely display it, preventing the application from crashing with an "Objects are not valid as a React child" error on narrow viewports.

BEFORE: The application crashes completely when the component attemtps to render an object.
<img width="1405" height="792" alt="Screenshot 2026-07-25 at 5 27 52 PM" src="https://github.com/user-attachments/assets/fc8570b6-811f-4e2d-8a67-bb450534e82e" />


AFTER: The UI remains stable, and the object is safely stringified in the table cell.
<img width="1413" height="801" alt="Screenshot 2026-07-25 at 5 28 18 PM" src="https://github.com/user-attachments/assets/a0f8c442-871b-453f-9ea4-549f3da27904" />

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Fixes #29509

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Start the Rocket.Chat local development server.
2. Open the file `apps/meteor/client/views/admin/import/ImportOperationSummary.tsx`.
3. Temporarily inject a dummy object into the `total` or `type` props at the top of the component (e.g., `total = { _isPromise: true } as any;`).
4. Navigate to **Administration -> Workspace -> Import** in the browser.
5. Ensure the browser window is wider than 768px so the `total` column renders. 
6. Observe that without this PR, the application throws a fatal `Objects are not valid as a React child` error. With this PR, the object is safely stringified and the UI remains stable.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

Issue #29509 indicates that an unresolved Promise/object is occasionally being passed from the backend to the `total` field during the "Download Pending Avatars" phase of a Slack import. While the root cause likely lies in the backend importer logic, this PR adds a defensive frontend safeguard. By checking if `type` or `total` are objects and safely stringifying them, we prevent a complete React Error Boundary crash, ensuring the rest of the Admin UI remains accessible to the user.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved import operation summaries so operation types and totals display correctly even when they contain structured values.
  - Preserved row actions such as selection and click behavior for actionable import operations.
  - Prevented display errors caused by unexpected data formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->