### PR TITLE
chore: log Cloud push gateway response on accepted (200) pushes

### DIFF
--- a/.changeset/push-gateway-debug-logging.md
+++ b/.changeset/push-gateway-debug-logging.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Adds debug-level logging of the Cloud push gateway's response status and body when a push notification is accepted, making it possible to diagnose cases where the gateway accepts a push (HTTP 200) but it isn't delivered downstream to FCM/APNs.

--- a/apps/meteor/server/lib/notifications/push/push.ts
+++ b/apps/meteor/server/lib/notifications/push/push.ts
@@ -302,6 +302,7 @@ class PushClass {
 		}
 
 		if (result.ok) {
+			logger.debug({ msg: 'push sent to gateway', service, status: result.status, response });
 			return;
 		}
 

--- a/apps/meteor/tests/unit/server/lib/notifications/push/push.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/notifications/push/push.spec.ts
@@ -6,11 +6,13 @@ import sinon from 'sinon';
 
 const loggerStub = { debug: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), info: sinon.stub(), log: sinon.stub() };
 const settingsStub = { get: sinon.stub().returns('') };
+const fetchStub = sinon.stub();
 
 const { Push } = proxyquire.noCallThru().load('../../../../../../server/lib/notifications/push/push', {
 	'./logger': { logger: loggerStub },
 	'../../../settings': { settings: settingsStub },
 	'@rocket.chat/tools': { pick, truncateString },
+	'@rocket.chat/server-fetch': { serverFetch: fetchStub },
 	'meteor/check': {
 		check: sinon.stub(),
 		Match: {
@@ -107,6 +109,31 @@ describe('Push Notifications [PushClass]', () => {
 			await expect(Push.send(options)).to.be.rejectedWith('No userId found');
 
 			expect(sendNotificationStub.called).to.be.false;
+		});
+	});
+
+	describe('sendGatewayPush()', () => {
+		afterEach(() => {
+			fetchStub.reset();
+			loggerStub.debug.reset();
+		});
+
+		it('should log the gateway response at debug level when the push is accepted (200)', async () => {
+			fetchStub.resolves({ status: 200, ok: true, text: sinon.stub().resolves('') });
+
+			await Push.sendGatewayPush('https://gateway.rocket.chat', 'apn', 'token123', {
+				createdAt: new Date(),
+			});
+
+			expect(fetchStub.calledOnce).to.be.true;
+
+			const debugCall = loggerStub.debug
+				.getCalls()
+				.map((call) => call.args[0])
+				.find((arg) => arg?.msg === 'push sent to gateway');
+
+			expect(debugCall).to.not.be.undefined;
+			expect(debugCall).to.include({ service: 'apn', status: 200, response: '' });
 		});
 	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When a push is sent through the Cloud push gateway (`gateway.rocket.chat`), `sendGatewayPush` already logs on the 406, 422 and 401 branches, but the success path (`result.ok`) just returns silently. That means once the gateway accepts a push, the server has zero record of what it actually returned, only that the HTTP call didn't error out.

This showed up clearly in #41569: the gateway was returning 200 with an empty body for every push, and the only way the reporter could see that was by putting a transparent proxy in front of the gateway and capturing raw responses by hand. That's not something we should be asking self-hosted admins to do to get basic visibility into their own push pipeline.

This PR adds a single debug-level log line on the success path with the service (`apn`/`gcm`), status code and response body, mirroring the log calls already used for the other branches. It doesn't change any behavior, just makes the existing "black box" 200 response visible in logs (`LOG_LEVEL=debug`) so admins/support can tell at a glance whether the gateway is actually echoing anything useful back, instead of having to intercept traffic themselves.

Worth noting: this doesn't fix delivery for the workspace in #41569. I dug through the gateway request/payload code in this repo (`push.ts`, `apn.ts`, the `Push_production` setting) and found nothing wrong on the client side, no missing fields, no recent regression. The gateway consistently accepting (200) but never delivering to FCM/APNs for one specific workspace looks like a server-side issue on the Cloud gateway (credential provisioning for that workspace, most likely), which lives outside this repo. This is a small, self-contained improvement to make that class of problem diagnosable from server logs going forward.

## Issue(s)

Related to #41569

## Steps to test or reproduce

1. Enable gateway push (`Push_enable`, `Push_enable_gateway`) with `LOG_LEVEL=debug`.
2. Send a push notification to a registered device.
3. Once the gateway responds with a successful status, check the server logs for a `push sent to gateway` debug entry containing `service`, `status` and `response`.

Unit test added: `apps/meteor/tests/unit/server/lib/notifications/push/push.spec.ts` (`sendGatewayPush()` suite), covering the new log call.

## Further comments

Considered forwarding this info back to the client/API response instead, but that's unnecessary. This is purely an operator-facing diagnostic, so a debug log is the right scope, no API or behavior changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added debug logging for successful Cloud push gateway responses, including the service, HTTP status, and response content.
  * Provides additional diagnostic information when a gateway accepts a notification but delivery does not complete downstream.

* **Tests**
  * Added coverage verifying successful gateway responses are logged correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->