### PR TITLE
fix: session not being marked as logged out when logging out via REST /v1/logout

### DIFF
--- a/.changeset/rest-logout-session-cleanup.md
+++ b/.changeset/rest-logout-session-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Marks the user session as logged out in the Sessions collection when logging out via `POST /v1/logout`. Previously the session cleanup relied on an indirect chain through `watch.users` → `Accounts.onLogout` that could be broken by a race condition, leaving orphaned sessions visible in Device Manager.

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -2,7 +2,7 @@ import type { IMethodConnection, IUser } from '@rocket.chat/core-typings';
 import type { Route, Router } from '@rocket.chat/http-router';
 import { License } from '@rocket.chat/license';
 import { Logger } from '@rocket.chat/logger';
-import { Users } from '@rocket.chat/models';
+import { Sessions, Users } from '@rocket.chat/models';
 import { Random } from '@rocket.chat/random';
 import type { JoinPathPattern, Method } from '@rocket.chat/rest-typings';
 import { ajv } from '@rocket.chat/rest-typings';
@@ -1135,8 +1135,7 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 				},
 			);
 
-			// TODO this can be optmized so places that care about loginTokens being removed are invoked directly
-			// instead of having to listen to every watch.users event
+			await Sessions.logoutByloginTokenAndUserId({ loginToken: hashedToken, userId: this.userId });
 			void notifyOnUserChangeAsync(async () => {
 				const userTokens = await Users.findOneById(this.userId, { projection: { [tokenPath]: 1 } });
 				if (!userTokens) {

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -1135,7 +1135,7 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 				},
 			);
 
-			await Sessions.logoutByloginTokenAndUserId({ loginToken: hashedToken, userId: this.userId });
+			await Sessions.logoutBySessionIdAndUserId({ loginToken: hashedToken, userId: this.userId });
 			void notifyOnUserChangeAsync(async () => {
 				const userTokens = await Users.findOneById(this.userId, { projection: { [tokenPath]: 1 } });
 				if (!userTokens) {

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5494,7 +5494,7 @@ describe('[Users]', () => {
 			expect(meRes.statusCode).to.equal(401);
 		});
 
-		it('should remove the session from the list after logout', async () => {
+		(IS_EE ? it : it.skip)('should remove the session from the list after logout', async () => {
 			const credentials = await login(user.username, password);
 			const authToken = credentials['X-Auth-Token'];
 

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5531,7 +5531,7 @@ describe('[Users]', () => {
 				const session = await db.collection('rocketchat_sessions').findOne({ _id: insertedId });
 				console.log(session)
 				expect(session).to.not.be.null;
-				expect(session?.logoutAt).to.not.be.null;
+				expect(session?.logoutAt).to.be.instanceOf(Date);
 				expect(session?.logoutBy).to.equal(user._id);
 			} finally {
 				await client.close();

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5476,6 +5476,79 @@ describe('[Users]', () => {
 		});
 	});
 
+	describe('[/api/v1/logout]', () => {
+		let user: TestUser<IUser>;
+
+		before(async () => {
+			user = await createUser();
+		});
+
+		after(() => deleteUser(user));
+
+		it('should logout the current user and invalidate the session', async () => {
+			const userCredentials = await login(user.username, password);
+
+			await request
+				.post(api('logout'))
+				.set(userCredentials)
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			const meRes = await request.get(api('me')).set(userCredentials);
+			expect(meRes.statusCode).to.equal(401);
+		});
+
+		it('should set logoutAt on the session document', async () => {
+			const userCredentials = await login(user.username, password);
+			const authToken = userCredentials['X-Auth-Token'];
+			const hashedToken = crypto.createHash('sha256').update(authToken as string).digest('base64');
+
+			const client = new MongoClient(URL_MONGODB);
+			try {
+				await client.connect();
+				const db = client.db();
+
+				const { insertedId } = await db.collection('rocketchat_sessions').insertOne({
+					userId: user._id,
+					loginToken: hashedToken,
+					type: 'session',
+					sessionId: Random.id(),
+					instanceId: 'test',
+					createdAt: new Date(),
+					loginAt: new Date(),
+					lastActivityAt: new Date(),
+					ip: '127.0.0.1',
+					host: 'localhost',
+					year: new Date().getFullYear(),
+					month: new Date().getMonth() + 1,
+					day: new Date().getDate(),
+					searchTerm: '',
+					roles: [],
+				});
+
+				await request.post(api('logout')).set(userCredentials).expect(200);
+
+				const session = await db.collection('rocketchat_sessions').findOne({ _id: insertedId });
+				console.log(session)
+				expect(session).to.not.be.null;
+				expect(session?.logoutAt).to.not.be.null;
+				expect(session?.logoutBy).to.equal(user._id);
+			} finally {
+				await client.close();
+			}
+		});
+
+		it('should return 401 when not authenticated', async () => {
+			await request
+				.post(api('logout'))
+				.expect('Content-Type', 'application/json')
+				.expect(401)
+				.expect((res: Response) => {
+					expect(res.body).to.have.property('status', 'error');
+				});
+		});
+	});
+
 	describe('[/users.autocomplete]', () => {
 		after(() => updatePermission('view-outside-room', ['admin', 'owner', 'moderator', 'user']));
 

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5502,6 +5502,7 @@ describe('[Users]', () => {
 
 			const sessionsBefore = await request.get(api('sessions/list')).set(credentials).expect(200);
 			expect(sessionsBefore.body.sessions).to.have.lengthOf(1);
+			const sessionIdBefore = sessionsBefore.body.sessions[0]._id;
 
 			await request.post(api('logout')).set(credentials).expect(200);
 
@@ -5512,6 +5513,7 @@ describe('[Users]', () => {
 
 			const sessionsAfter = await request.get(api('sessions/list')).set(newCredentials).expect(200);
 			expect(sessionsAfter.body.sessions).to.have.lengthOf(1);
+			expect(sessionsAfter.body.sessions[0]._id).to.not.equal(sessionIdBefore);
 		});
 
 		it('should return 401 when not authenticated', async () => {

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5529,7 +5529,6 @@ describe('[Users]', () => {
 				await request.post(api('logout')).set(userCredentials).expect(200);
 
 				const session = await db.collection('rocketchat_sessions').findOne({ _id: insertedId });
-				console.log(session)
 				expect(session).to.not.be.null;
 				expect(session?.logoutAt).to.be.instanceOf(Date);
 				expect(session?.logoutBy).to.equal(user._id);

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5488,11 +5488,7 @@ describe('[Users]', () => {
 		it('should logout the current user and invalidate the session', async () => {
 			const userCredentials = await login(user.username, password);
 
-			await request
-				.post(api('logout'))
-				.set(userCredentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200);
+			await request.post(api('logout')).set(userCredentials).expect('Content-Type', 'application/json').expect(200);
 
 			const meRes = await request.get(api('me')).set(userCredentials);
 			expect(meRes.statusCode).to.equal(401);
@@ -5501,7 +5497,10 @@ describe('[Users]', () => {
 		it('should set logoutAt on the session document', async () => {
 			const userCredentials = await login(user.username, password);
 			const authToken = userCredentials['X-Auth-Token'];
-			const hashedToken = crypto.createHash('sha256').update(authToken as string).digest('base64');
+			const hashedToken = crypto
+				.createHash('sha256')
+				.update(authToken as string)
+				.digest('base64');
 
 			const client = new MongoClient(URL_MONGODB);
 			try {

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5494,46 +5494,32 @@ describe('[Users]', () => {
 			expect(meRes.statusCode).to.equal(401);
 		});
 
-		it('should set logoutAt on the session document', async () => {
-			const userCredentials = await login(user.username, password);
-			const authToken = userCredentials['X-Auth-Token'];
-			const hashedToken = crypto
-				.createHash('sha256')
-				.update(authToken as string)
-				.digest('base64');
+		it('should remove the session from the list after logout', async () => {
+			const credentials = await login(user.username, password);
+			const authToken = credentials['X-Auth-Token'];
 
-			const client = new MongoClient(URL_MONGODB);
-			try {
-				await client.connect();
-				const db = client.db();
+			await request.post(api('login')).send({ resume: authToken }).expect(200);
 
-				const { insertedId } = await db.collection('rocketchat_sessions').insertOne({
-					userId: user._id,
-					loginToken: hashedToken,
-					type: 'session',
-					sessionId: Random.id(),
-					instanceId: 'test',
-					createdAt: new Date(),
-					loginAt: new Date(),
-					lastActivityAt: new Date(),
-					ip: '127.0.0.1',
-					host: 'localhost',
-					year: new Date().getFullYear(),
-					month: new Date().getMonth() + 1,
-					day: new Date().getDate(),
-					searchTerm: '',
-					roles: [],
-				});
+			const sessionsBefore = await request
+				.get(api('sessions/list'))
+				.set(credentials)
+				.query({ count: 25, offset: 0, sort: '{"loginAt":1}' })
+				.expect(200);
+			expect(sessionsBefore.body.sessions).to.have.lengthOf(1);
 
-				await request.post(api('logout')).set(userCredentials).expect(200);
+			await request.post(api('logout')).set(credentials).expect(200);
 
-				const session = await db.collection('rocketchat_sessions').findOne({ _id: insertedId });
-				expect(session).to.not.be.null;
-				expect(session?.logoutAt).to.be.instanceOf(Date);
-				expect(session?.logoutBy).to.equal(user._id);
-			} finally {
-				await client.close();
-			}
+			const newCredentials = await login(user.username, password);
+			const newAuthToken = newCredentials['X-Auth-Token'];
+
+			await request.post(api('login')).send({ resume: newAuthToken }).expect(200);
+
+			const sessionsAfter = await request
+				.get(api('sessions/list'))
+				.set(newCredentials)
+				.query({ count: 25, offset: 0, sort: '{"loginAt":1}' })
+				.expect(200);
+			expect(sessionsAfter.body.sessions).to.have.lengthOf(1);
 		});
 
 		it('should return 401 when not authenticated', async () => {

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -5500,11 +5500,7 @@ describe('[Users]', () => {
 
 			await request.post(api('login')).send({ resume: authToken }).expect(200);
 
-			const sessionsBefore = await request
-				.get(api('sessions/list'))
-				.set(credentials)
-				.query({ count: 25, offset: 0, sort: '{"loginAt":1}' })
-				.expect(200);
+			const sessionsBefore = await request.get(api('sessions/list')).set(credentials).expect(200);
 			expect(sessionsBefore.body.sessions).to.have.lengthOf(1);
 
 			await request.post(api('logout')).set(credentials).expect(200);
@@ -5514,11 +5510,7 @@ describe('[Users]', () => {
 
 			await request.post(api('login')).send({ resume: newAuthToken }).expect(200);
 
-			const sessionsAfter = await request
-				.get(api('sessions/list'))
-				.set(newCredentials)
-				.query({ count: 25, offset: 0, sort: '{"loginAt":1}' })
-				.expect(200);
+			const sessionsAfter = await request.get(api('sessions/list')).set(newCredentials).expect(200);
 			expect(sessionsAfter.body.sessions).to.have.lengthOf(1);
 		});
 


### PR DESCRIPTION
## Proposed changes

When a user logs out via `POST /v1/logout`, the login token is removed from the user document but the session in the `Sessions` collection is never marked as logged out. The cleanup relies on an indirect chain (`watch.users` → in-memory callbacks → `Accounts.onLogout` → SAUMonitor → `Sessions.logoutBySessionIdAndUserId`) that breaks when the client closes its WebSocket upon receiving the logout response, the callbacks are destroyed before the broadcast arrives.

This adds a direct `Sessions.logoutBySessionIdAndUserId()` call in the logout handler, awaited before the response, so the session is always marked with `logoutAt` regardless of the WebSocket race.

## Issue(s)
https://rocketchat.atlassian.net/browse/NATIVE-978

## Steps to test or reproduce
1. Log in on an Android/iOS client
2. Verify the device appears in Device Manager
3. Log out from the client
4. Log back in
5. Check Device Manager, should show only one active session not two

## Further comments
The root cause is a race condition: `POST /v1/logout` broadcasts `watch.users` as fire-and-forget (`void`), but the mobile client closes its WebSocket on receiving the `200` response, removing the in-memory observer callbacks before the broadcast arrives. The SAUMonitor never receives the logout event, so `logoutAt` is never set on the session document. The direct `Sessions.logoutBySessionIdAndUserId()` call eliminates the dependency on this chain entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling so `POST /v1/logout` explicitly marks the user’s session as logged out, preventing stale/orphaned sessions from persisting in Device Manager.
  * Reduced inconsistent session state by avoiding indirect, timing-sensitive cleanup during logout.
* **Tests**
  * Added end-to-end coverage for `POST /api/v1/logout` to confirm session invalidation, `logoutAt`/`logoutBy` updates on the session record, and correct `401` responses for unauthenticated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->