### PR TITLE
fix: reaction list shows blank entries when UI_Use_Real_Name is enabled

### DIFF
--- a/.changeset/wet-turtles-fix.md
+++ b/.changeset/wet-turtles-fix.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes reaction list modal showing blank entries (mobile) or usernames (web) instead of real names when `UI_Use_Real_Name` is enabled. The broadcast pipeline now enriches reactions with display names via batch query.

--- a/apps/meteor/server/lib/notifyListener.ts
+++ b/apps/meteor/server/lib/notifyListener.ts
@@ -431,6 +431,14 @@ const getUserNameCached = mem(
 
 const getSettingCached = mem(async (setting: string): Promise<SettingValue> => Settings.getValueById(setting), { maxAge: 10000 });
 
+const getUsersByUsernamesCached = mem(
+	async (usernames: string[]): Promise<Map<string, string | undefined>> => {
+		const users = await Users.findByUsernames(usernames, { projection: { username: 1, name: 1 } }).toArray();
+		return new Map(users.filter((u): u is IUser & { username: string } => !!u.username).map((u) => [u.username, u.name]));
+	},
+	{ maxAge: 10000, cacheKey: ([usernames]) => JSON.stringify([...usernames].sort()) },
+);
+
 export async function getMessageToBroadcast({ id, data }: { id: IMessage['_id']; data?: IMessage }): Promise<IMessage | void> {
 	const message = data ?? (await Messages.findOneById(id));
 	if (!message) {
@@ -470,10 +478,11 @@ export async function getMessageToBroadcast({ id, data }: { id: IMessage['_id'];
 
 		if (message.reactions) {
 			const allUsernames = [...new Set(Object.values(message.reactions).flatMap((r) => r.usernames))];
-			const users = await Users.findByUsernames(allUsernames, { projection: { username: 1, name: 1 } }).toArray();
-			const nameByUsername = new Map(users.filter((u): u is IUser & { username: string } => !!u.username).map((u) => [u.username, u.name]));
-			for (const reaction of Object.values(message.reactions)) {
-				reaction.names = reaction.usernames.map((username) => nameByUsername.get(username) || username);
+			if (allUsernames.length > 0) {
+				const nameByUsername = await getUsersByUsernamesCached(allUsernames);
+				for (const reaction of Object.values(message.reactions)) {
+					reaction.names = reaction.usernames.map((username) => nameByUsername.get(username) || username);
+				}
 			}
 		}
 	}

--- a/apps/meteor/server/lib/notifyListener.ts
+++ b/apps/meteor/server/lib/notifyListener.ts
@@ -467,6 +467,15 @@ export async function getMessageToBroadcast({ id, data }: { id: IMessage['_id'];
 				}
 			}
 		}
+
+		if (message.reactions) {
+			const allUsernames = [...new Set(Object.values(message.reactions).flatMap((r) => r.usernames))];
+			const users = await Users.findByUsernames(allUsernames, { projection: { username: 1, name: 1 } }).toArray();
+			const nameByUsername = new Map(users.filter((u): u is IUser & { username: string } => !!u.username).map((u) => [u.username, u.name]));
+			for (const reaction of Object.values(message.reactions)) {
+				reaction.names = reaction.usernames.map((username) => nameByUsername.get(username) || username);
+			}
+		}
 	}
 
 	return message;

--- a/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 describe('Message Broadcast Tests', () => {
 	let getSettingValueByIdStub: sinon.SinonStub;
 	let usersFindOneStub: sinon.SinonStub;
+	let usersFindByUsernamesStub: sinon.SinonStub;
 	let messagesFindOneStub: sinon.SinonStub;
 	let broadcastStub: sinon.SinonStub;
 	let getMessageToBroadcast: any;
@@ -29,6 +30,7 @@ describe('Message Broadcast Tests', () => {
 		},
 		Users: {
 			findOne: usersFindOneStub,
+			findByUsernames: usersFindByUsernamesStub,
 		},
 		Settings: {
 			getValueById: getSettingValueByIdStub,
@@ -44,6 +46,7 @@ describe('Message Broadcast Tests', () => {
 	beforeEach(() => {
 		getSettingValueByIdStub = sinon.stub();
 		usersFindOneStub = sinon.stub();
+		usersFindByUsernamesStub = sinon.stub();
 		messagesFindOneStub = sinon.stub();
 		broadcastStub = sinon.stub();
 		memStub = sinon.stub().callsFake((fn: any) => fn);
@@ -98,6 +101,28 @@ describe('Message Broadcast Tests', () => {
 				hideSystemMessages: [],
 				useRealName: true,
 				expectedResult: { ...sampleMessage, u: { ...sampleMessage.u, name: 'Real User' } },
+			},
+			{
+				description: 'should return the message with reactions real names if useRealName is true',
+				message: {
+					...sampleMessage,
+					t: undefined,
+					reactions: {
+						':smile:': { usernames: ['user1', 'user2'] },
+						':heart:': { usernames: ['user3'] },
+					},
+				},
+				hideSystemMessages: [],
+				useRealName: true,
+				expectedResult: {
+					...sampleMessage,
+					t: undefined,
+					u: { ...sampleMessage.u, name: 'Real User' },
+					reactions: {
+						':smile:': { usernames: ['user1', 'user2'], names: ['Real User', 'Name for user2'] },
+						':heart:': { usernames: ['user3'], names: ['Name for user3'] },
+					},
+				},
 			},
 			{
 				description: 'should return the message with mentions real name if useRealName is true',
@@ -184,12 +209,22 @@ describe('Message Broadcast Tests', () => {
 				getSettingValueByIdStub.withArgs('UI_Use_Real_Name').resolves(useRealName);
 
 				if (useRealName) {
-					const realNames =
-						message.mentions && message.mentions.length > 0
-							? [message.u.name, ...message.mentions.map((mention) => mention.name)]
-							: [message.u.name];
+					const realNames: (string | undefined)[] = [message.u.name];
+
+					if (message.mentions) {
+						message.mentions.forEach((mention) => realNames.push(mention.name));
+					}
 
 					realNames.forEach((user, index) => usersFindOneStub.onCall(index).resolves({ name: user }));
+
+					if (message.reactions) {
+						const allUsernames = [...new Set(Object.values(message.reactions).flatMap((r) => r.usernames))];
+						const users = allUsernames.map((username) => ({
+							username,
+							name: username === message.u.username ? message.u.name : `Name for ${username}`,
+						}));
+						usersFindByUsernamesStub.returns({ toArray: () => Promise.resolve(users) });
+					}
 				}
 
 				const result = await getMessageToBroadcast({ id: '123' });

--- a/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
@@ -109,7 +109,7 @@ describe('Message Broadcast Tests', () => {
 					t: undefined,
 					reactions: {
 						':smile:': { usernames: ['user1', 'user2'] },
-						':heart:': { usernames: ['user3'] },
+						':heart:': { usernames: ['user1', 'user3'] },
 					},
 				},
 				hideSystemMessages: [],
@@ -120,7 +120,7 @@ describe('Message Broadcast Tests', () => {
 					u: { ...sampleMessage.u, name: 'Real User' },
 					reactions: {
 						':smile:': { usernames: ['user1', 'user2'], names: ['Real User', 'Name for user2'] },
-						':heart:': { usernames: ['user3'], names: ['Name for user3'] },
+						':heart:': { usernames: ['user1', 'user3'], names: ['Real User', 'Name for user3'] },
 					},
 				},
 			},
@@ -230,6 +230,12 @@ describe('Message Broadcast Tests', () => {
 				const result = await getMessageToBroadcast({ id: '123' });
 
 				expect(result).to.deep.equal(expectedResult);
+
+				if (useRealName && message.reactions) {
+					const deduplicated = [...new Set(Object.values(message.reactions).flatMap((r) => r.usernames))];
+					expect(usersFindByUsernamesStub.calledOnce).to.be.true;
+					expect(usersFindByUsernamesStub.calledWith(deduplicated, { projection: { username: 1, name: 1 } })).to.be.true;
+				}
 			});
 		});
 	});

--- a/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/notifyListener.spec.ts
@@ -125,6 +125,22 @@ describe('Message Broadcast Tests', () => {
 				},
 			},
 			{
+				description: 'should return the message with empty reactions without querying users if useRealName is true',
+				message: {
+					...sampleMessage,
+					t: undefined,
+					reactions: {},
+				},
+				hideSystemMessages: [],
+				useRealName: true,
+				expectedResult: {
+					...sampleMessage,
+					t: undefined,
+					u: { ...sampleMessage.u, name: 'Real User' },
+					reactions: {},
+				},
+			},
+			{
 				description: 'should return the message with mentions real name if useRealName is true',
 				message: {
 					...sampleMessage,
@@ -231,10 +247,14 @@ describe('Message Broadcast Tests', () => {
 
 				expect(result).to.deep.equal(expectedResult);
 
-				if (useRealName && message.reactions) {
+				if (useRealName && message.reactions && Object.keys(message.reactions).length) {
 					const deduplicated = [...new Set(Object.values(message.reactions).flatMap((r) => r.usernames))];
 					expect(usersFindByUsernamesStub.calledOnce).to.be.true;
 					expect(usersFindByUsernamesStub.calledWith(deduplicated, { projection: { username: 1, name: 1 } })).to.be.true;
+				}
+
+				if (useRealName && message.reactions && !Object.keys(message.reactions).length) {
+					expect(usersFindByUsernamesStub.called).to.be.false;
 				}
 			});
 		});


### PR DESCRIPTION
## Proposed changes

Resolves real names for message reactions in the broadcast pipeline. When `UI_Use_Real_Name` is enabled, the server now enriches each reaction with a `names` array containing the display names of users who reacted.

Previously only the message author (`message.u.name`) and mentions (`mentions[].name`) were resolved. This change extends the same pattern to reactions using a batch query (`Users.findByUsernames`) instead of per-username lookups.

## Issue(s)

https://rocketchat.atlassian.net/browse/NATIVE-1047

## Steps to test or reproduce

### Web

1. Enable `UI_Use_Real_Name` in admin settings
2. Hover over a reaction to see the tooltip — real names should appear instead of usernames
3. Click the reaction list from the message menu — real names should be displayed

### Mobile app

1. Open any channel in the mobile app
2. React to any message
3. Long-press a reaction to open the reaction list
4. It should display names instead of blank entries

Note: Current behaviour differs by platform:
- Web: Usernames are shown instead of real names.
- Mobile: The reaction list shows blank entries.

## Further comments

Uses a single batch query (`Users.findByUsernames`) to resolve all reaction usernames at once, deduplicated via `Set`, with a fallback to `username` when a user has no display name set.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Enhancements**
  * Reaction items in broadcast messages are now enriched with users’ display names when the real-name setting is enabled.
  * Uses a batch lookup to resolve reaction usernames to display names (falling back to the original username when no match is found).
* **Bug Fixes**
  * Fixes incorrect, blank, or username-only reaction entries in the reaction list modal when real-name display is enabled (especially on mobile).
* **Tests**
  * Added unit test coverage for reaction name resolution under the real-name setting, including ensuring the lookup is skipped when reactions are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->