### PR TITLE
fix: video/audio Accept-Ranges header never sent, breaking seek in Electron

### DIFF
--- a/.changeset/fix-desktop-video-seek-accept-ranges.md
+++ b/.changeset/fix-desktop-video-seek-accept-ranges.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes uploaded video/audio files not being seekable in Rocket.Chat Desktop (Electron) while working fine in the web app. The `ufs` file server only advertised `Accept-Ranges: bytes` inside an unreachable code path (`req.headers` is always an object for real HTTP requests, so the `else` branch that set this header never ran), so the header was never sent on the initial response. `Accept-Ranges` is now always included, and `206 Partial Content` responses continue to work as before.

--- a/apps/meteor/server/ufs/ufs-server.spec.ts
+++ b/apps/meteor/server/ufs/ufs-server.spec.ts
@@ -1,0 +1,112 @@
+import { Readable, Writable } from 'node:stream';
+
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+class FakeResponse extends Writable {
+	statusCode: number | undefined;
+
+	headers: Record<string, any> = {};
+
+	headersSent = false;
+
+	chunks: Buffer[] = [];
+
+	_write(chunk: any, _enc: string, cb: (error?: Error | null) => void) {
+		this.chunks.push(Buffer.from(chunk));
+		cb();
+	}
+
+	writeHead(status: number, headers?: Record<string, any>) {
+		this.statusCode = status;
+		this.headers = headers || {};
+		this.headersSent = true;
+		return this;
+	}
+
+	setHeader(name: string, value: any) {
+		this.headers[name] = value;
+	}
+}
+
+describe('ufs-server request handler', () => {
+	let handler: (req: any, res: any, next: () => void) => Promise<void>;
+	let store: any;
+	const fileContent = Buffer.from('0123456789');
+	const file = {
+		_id: 'file123',
+		size: fileContent.length,
+		type: 'video/mp4',
+		etag: 'etag123',
+	};
+
+	beforeEach(() => {
+		let capturedHandler: any;
+
+		store = {
+			onRead: sinon.stub().resolves(true),
+			onReadError: sinon.stub(),
+			getCollection: () => ({ findOne: sinon.stub().resolves(file) }),
+			getReadStream: sinon.stub().callsFake(async (_fileId: string, _file: any, options: { start?: number; end?: number } = {}) => {
+				const { start = 0, end = fileContent.length - 1 } = options;
+				return Readable.from(fileContent.subarray(start, end + 1));
+			}),
+			transformRead: (rs: Readable, ws: Writable) => {
+				rs.pipe(ws);
+			},
+		};
+
+		const ufsServerModule = proxyquire.noCallThru().load('./ufs-server', {
+			'meteor/meteor': {
+				Meteor: { startup: (_fn: () => void) => {} },
+			},
+			'meteor/webapp': {
+				WebApp: {
+					connectHandlers: {
+						use: (fn: any) => {
+							capturedHandler = fn;
+						},
+					},
+				},
+			},
+			mkdirp: sinon.stub().resolves(),
+			'./ufs': {
+				UploadFS: {
+					config: { tmpDir: '/tmp/ufs', tmpDirPermissions: 0o755, storesPath: 'ufs' },
+					getStore: sinon.stub().returns(store),
+				},
+			},
+		});
+
+		handler = capturedHandler;
+		expect(handler, 'handler should have been registered via WebApp.connectHandlers.use').to.be.a('function');
+	});
+
+	it('advertises Accept-Ranges: bytes on a plain GET request', async () => {
+		const req = { url: '/ufs/store1/file123/video.mp4', method: 'GET', headers: {} };
+		const res = new FakeResponse();
+
+		await handler(req, res, () => {});
+
+		expect(res.statusCode).to.equal(200);
+		expect(res.headers['Accept-Ranges']).to.equal('bytes');
+	});
+
+	it('returns 206 and Content-Range for a byte-range GET request', async () => {
+		const req = {
+			url: '/ufs/store1/file123/video.mp4',
+			method: 'GET',
+			headers: { range: 'bytes=2-5' },
+		};
+		const res = new FakeResponse();
+
+		await handler(req, res, () => {});
+
+		expect(res.statusCode).to.equal(206);
+		expect(res.headers['Content-Range']).to.equal(`bytes 2-5/${fileContent.length}`);
+		expect(res.headers['Accept-Ranges']).to.equal('bytes');
+		expect(Buffer.concat(res.chunks).toString()).to.equal('2345');
+	});
+});

--- a/apps/meteor/server/ufs/ufs-server.ts
+++ b/apps/meteor/server/ufs/ufs-server.ts
@@ -151,6 +151,9 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 					headers['Last-Modified'] = file.uploadedAt.toUTCString();
 				}
 
+				// Advertise Range support so clients know they can seek before requesting a Range
+				headers['Accept-Ranges'] = 'bytes';
+
 				// Parse request headers
 				if (typeof req.headers === 'object') {
 					// Compare ETag
@@ -224,8 +227,6 @@ WebApp.connectHandlers.use(async (req, res, next) => {
 						}
 						status = 206; // partial content
 					}
-				} else {
-					headers['Accept-Ranges'] = 'bytes';
 				}
 
 				// Open the file stream


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The `ufs` file server (`apps/meteor/server/ufs/ufs-server.ts`) is supposed to advertise
`Accept-Ranges: bytes` on every response so clients know they can issue byte-range
requests to seek within an uploaded file. That header was only being set inside the
`else` branch of `if (typeof req.headers === 'object')` — a branch that is unreachable
for real HTTP requests, since Node's `http.IncomingMessage.headers` is always an object.
As a result, `Accept-Ranges: bytes` was never actually sent, on any request, regardless
of auth method.

Range/206 parsing itself was already correct — a Range request still got a 206 with a
correct Content-Range. The bug is that the header advertising Range support up front was
silently missing.

This looks like the same underlying symptom class as #19786/#19866, but that earlier fix
was purely client-side (`preload='metadata'` on `<video>`/`<audio>`), which is still
present and unregressed. This PR targets a separate, previously-unnoticed server-side gap.

**Caveat / what I could NOT verify:** I do not have a working local dev environment
(Meteor/MongoDB/Electron) to reproduce the Electron-specific symptom end-to-end. This
fix is proven with a request-handler-level unit test showing 206 + Content-Range +
Accept-Ranges are all correctly returned. I could not run live curl requests against a
running server comparing cookie vs X-Auth-Token/X-User-Id vs rc_token/rc_uid auth paths,
so I can't rule out that the Electron symptom in #39946 has an additional cause on the
Electron/Rocket.Chat.Electron side. If seeking is still broken after this fix, the next
step is checking whether Electron's net stack strips or ignores `Accept-Ranges`/`Range`
headers on its custom protocol handler.

## Issue(s)
Fixes #39946
Related to #19786 / #19866

## Steps to test or reproduce
1. Upload an MP4 to a channel/DM.
2. `curl -I <file-url>` on develop — note `Accept-Ranges` is absent.
3. Apply this fix, repeat — `Accept-Ranges: bytes` is present.
4. `curl -H "Range: bytes=0-1023" <file-url>` — 206 + Content-Range, unchanged by this fix (already worked).
5. Automated: `apps/meteor/server/ufs/ufs-server.spec.ts` — asserts both cases against the real registered request handler.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop video seeking by consistently advertising byte-range support when serving files.
  * Preserved partial-content responses for ranged requests, enabling more reliable playback and seeking.

* **Tests**
  * Added coverage for standard file requests and ranged video responses, including status codes, headers, and returned content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->