### PR TITLE
fix: unhandled promise rejection when pinning a message fails

### DIFF
--- a/.changeset/pin-message-unhandled-rejection.md
+++ b/.changeset/pin-message-unhandled-rejection.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an unhandled promise rejection raised when pinning a message fails

--- a/apps/meteor/client/components/message/toolbar/usePinMessageAction.tsx
+++ b/apps/meteor/client/components/message/toolbar/usePinMessageAction.tsx
@@ -14,13 +14,13 @@ export const usePinMessageAction = (
 
 	const allowPinning = useSetting('Message_AllowPinning');
 	const hasPermission = usePermission('pin-message', room._id);
-	const { mutateAsync: pinMessage } = usePinMessageMutation();
+	const { mutate: pinMessage } = usePinMessageMutation();
 
 	if (!allowPinning || isOmnichannelRoom(room) || !hasPermission || message.pinned || !subscription) {
 		return null;
 	}
 
-	const onConfirm = async () => {
+	const onConfirm = () => {
 		pinMessage(message);
 		setModal(null);
 	};


### PR DESCRIPTION
`usePinMessageAction` destructured `mutateAsync` from `usePinMessageMutation` but never awaited the returned promise. Unlike `mutate`, `mutateAsync` rejects when the request fails, so a failed pin surfaced as an "Uncaught (in promise)" error even though the failure was already handled.

The mutation owns the full lifecycle through its callbacks: `onMutate` applies the optimistic pin, `onError` rolls it back and dispatches the error toast, and `onSettled` invalidates the pinned messages query. The promise result is therefore unused.

Switch to `mutate`, which returns `void` and accepts the same arguments, so behaviour is unchanged and the hook now matches its sibling `useUnpinMessageAction`, which already uses `mutate`.

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause an unhandled error when pinning a message fails.
  * Improved the pin message action so failures are handled without disrupting the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->