### PR TITLE
fix: correct omnichannel livechat auto-scroll behavior for long messages

### DIFF
--- a/packages/livechat/src/components/Messages/MessageList/index.js
+++ b/packages/livechat/src/components/Messages/MessageList/index.js
@@ -82,9 +82,10 @@ export class MessageList extends MemoizedComponent {
 	};
 
 	componentWillUpdate() {
-		if (this.scrollPosition === MessageList.SCROLL_AT_TOP) {
-			this.previousScrollHeight = this.base.scrollHeight;
-		}
+		// Capture the scroll height before the new message renders into the DOM.
+		
+		this.previousScrollHeight = this.base.scrollHeight;
+		
 	}
 
 	componentDidUpdate(prevProps) {
@@ -99,10 +100,21 @@ export class MessageList extends MemoizedComponent {
 			}
 		}
 
+		
 		if (this.scrollPosition === MessageList.SCROLL_AT_BOTTOM) {
-			this.base.scrollTop = this.base.scrollHeight;
-			return;
-		}
+            // Calculate exactly how tall the new incoming message is
+            const newMessageHeight = this.base.scrollHeight - this.previousScrollHeight;
+            
+            // If the message is taller than the user's visible screen...
+            if (newMessageHeight > this.base.clientHeight) {
+                // Scroll to where the top of the new message begins
+                this.base.scrollTop = this.previousScrollHeight;
+            } else {
+                // Otherwise, it's a normal short message, just stick to the bottom
+                this.base.scrollTop = this.base.scrollHeight;
+            }
+            return;
+        }
 
 		if (this.scrollPosition === MessageList.SCROLL_AT_TOP) {
 			const delta = this.base.scrollHeight - this.previousScrollHeight;


### PR DESCRIPTION
## Proposed changes
**The Problem:** 
Previously, when an agent sent a very long message (taller than the visitor's viewport), the Livechat widget blindly scrolled to the absolute bottom of the container (`this.base.scrollHeight`). This forced the visitor to manually scroll back up to read the beginning of the incoming message, creating a poor user experience.

**The Solution:**
I updated the scrolling logic inside the `MessageList` component. 
* Added a capture in `componentWillUpdate` to always save `this.previousScrollHeight` before a new message renders.
* Updated `componentDidUpdate` to calculate the actual height of the incoming message. 
* If the incoming message is taller than the user's visible screen (`this.base.clientHeight`), the window now dynamically scrolls to the top of the new message bubble instead of the absolute bottom.

## Issue(s)
<!-- Leave this blank if you don't have a specific issue number to link -->
Closes #37342

## Steps to test or reproduce
1. Open a new Incognito/Private window and navigate to the Livechat widget URL (e.g., `/livechat`).
2. Start a new chat as a visitor.
3. Switch to the Agent view in a normal browser window and accept the incoming chat.
4. As the Agent, paste and send a massive block of text (15-20 lines, tall enough to overflow the visitor's screen).
5. Switch back to the visitor window.
**Expected Result:** The chat window should scroll to align with the *top* of the newly received message, allowing the visitor to start reading immediately without manually scrolling up.

## Further comments
This change only affects the visitor-facing Livechat widget. The fallback auto-scroll behavior for standard-length messages remains unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message list scrolling when new messages arrive.
  * Preserved the user’s reading position more reliably when viewing the latest messages.
  * Adjusted handling for messages taller than the chat viewport to keep the relevant content visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->