### PR TITLE
fix: livechat transfer comments truncated instead of wrapping

### DIFF
--- a/.changeset/wrap-livechat-transfer-comment.md
+++ b/.changeset/wrap-livechat-transfer-comment.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes system messages (e.g. Livechat transfer comments) being truncated with an ellipsis instead of wrapping onto multiple lines

--- a/apps/meteor/app/theme/client/imports/components/message-system.css
+++ b/apps/meteor/app/theme/client/imports/components/message-system.css
@@ -1,0 +1,15 @@
+/* Allow system messages (e.g. Livechat transfer comments) to wrap onto multiple
+   lines instead of being truncated with an ellipsis */
+.rcx-message-system {
+	&__container,
+	&__body {
+		white-space: normal;
+		overflow: visible;
+		text-overflow: unset;
+		word-break: break-word;
+	}
+
+	&__block {
+		align-items: flex-start;
+	}
+}

--- a/apps/meteor/app/theme/client/main.css
+++ b/apps/meteor/app/theme/client/main.css
@@ -9,6 +9,7 @@
 @import url('imports/components/flex-nav.css');
 @import url('imports/components/emoji.css');
 @import url('imports/components/loading.css');
+@import url('imports/components/message-system.css');
 
 /* Legacy theming */
 @import url('imports/general/theme_old.css');


### PR DESCRIPTION
## Proposed changes

Fixes #26723

Long Livechat transfer comments were rendered with `white-space: nowrap` and
`text-overflow: ellipsis` (inherited from fuselage's `.rcx-message-system__body` /
`.rcx-message-system__container` styles), so instead of wrapping onto multiple
lines the text was silently truncated with a `…`.

This adds a scoped CSS override for system messages so long text (transfer
comments, and other system message bodies) wraps normally instead of being
clipped.

## Steps to test or reproduce

1. As an agent, transfer an omnichannel conversation to another agent with a
   long comment attached.
2. Before: the comment is cut off with an ellipsis on one line.
3. After: the comment wraps across multiple lines and is fully readable.

## Further comments

- Verified with `stylelint` across `apps/meteor` (passes clean).
- Verified visually with a repro page built from the real compiled
  `fuselage.css` and the actual `SystemMessage` markup, confirming the
  before/after wrapping behavior.
- Added a changeset for release notes.
- Note: this styles all system messages, not just transfer comments, since
  the truncation classes are shared — happy to scope further if maintainers
  prefer a narrower selector.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System messages, including Livechat transfer comments, now wrap across multiple lines instead of being truncated with an ellipsis.
  * Improved alignment and readability of longer system message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->