### PR TITLE
regression: Legacy emoji in composer popup

### DIFF
--- a/apps/meteor/app/emoji/client/helpers.ts
+++ b/apps/meteor/app/emoji/client/helpers.ts
@@ -172,7 +172,12 @@ export const getEmojisBySearchTerm = (
 			continue;
 		}
 
-		const { emojiPackage, shortnames = [], name } = emojiObject;
+		const { emojiPackage, shortnames = [], name, legacy } = emojiObject;
+
+		if (legacy) {
+			continue;
+		}
+
 		let tone = '';
 		current = current.replace(/:/g, '');
 

--- a/apps/meteor/app/emoji/lib/rocketchat.ts
+++ b/apps/meteor/app/emoji/lib/rocketchat.ts
@@ -34,6 +34,7 @@ export type EmojiPackages = {
 					extension?: string;
 					etag?: string;
 					unicode?: string;
+					legacy?: boolean;
 			  }
 			| {
 					name?: undefined;
@@ -43,6 +44,7 @@ export type EmojiPackages = {
 					aliases?: undefined;
 					shortnames?: undefined;
 					etag?: string;
+					legacy?: boolean;
 			  };
 	};
 };

--- a/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
+++ b/apps/meteor/client/views/room/providers/ComposerPopupProvider.tsx
@@ -249,7 +249,9 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 							})
 							.filter(
 								({ _id }) =>
-									filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
+									!collection[_id]?.legacy &&
+									filterRegex.test(_id) &&
+									(exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
 							)
 							.sort(emojiSort(recents))
 							.slice(0, 10);
@@ -307,7 +309,9 @@ const ComposerPopupProvider = ({ children, room }: ComposerPopupProviderProps) =
 						})
 						.filter(
 							({ _id }) =>
-								filterRegex.test(_id) && (exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
+								!collection[_id]?.legacy &&
+								filterRegex.test(_id) &&
+								(exactFinalTone.test(_id.substring(key.length)) || seeColor.test(key) || !colorBlind.test(_id)),
 						)
 						.sort(emojiSort(recents))
 						.slice(0, 10);

--- a/apps/meteor/client/views/root/hooks/useNativeEmoji.ts
+++ b/apps/meteor/client/views/root/hooks/useNativeEmoji.ts
@@ -45,6 +45,7 @@ export const useNativeEmoji = () => {
 				category: '',
 				emojiPackage: 'native',
 				unicode,
+				legacy: true,
 			};
 		}
 

--- a/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/helpers.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, beforeEach, before } from 'mocha';
 import { getEmojisBySearchTerm, updateRecent, removeFromRecent, replaceEmojiInRecent } from '../../../../app/emoji/client/helpers';
 import { emoji } from '../../../../app/emoji/client/lib';
 import { getEmojiConfig } from '../../../../app/emoji-native/lib/getEmojiConfig';
+import { legacyEmojioneMap } from '../../../../app/emoji-native/lib/legacyEmojioneMap';
 
 const registerNativeEmojis = () => {
 	const config = getEmojiConfig(emoji);
@@ -26,6 +27,27 @@ const registerNativeEmojis = () => {
 				emoji.list[shortname] = currentEmoji as any;
 			});
 		}
+	}
+
+	//Add legacy emojis to mimic how client currently works.
+	for (const [shortcode, unicode] of Object.entries(legacyEmojioneMap)) {
+		const key = `:${shortcode}:`;
+
+		if (emoji.list[key]) {
+			continue; // already registered by emojibase
+		}
+
+		emoji.list[key] = {
+			uc_base: '',
+			uc_output: '',
+			uc_match: '',
+			uc_greedy: '',
+			shortnames: [],
+			category: '',
+			legacy: true,
+			emojiPackage: 'native',
+			unicode,
+		};
 	}
 };
 
@@ -64,6 +86,23 @@ describe('Emoji Client Helpers', () => {
 
 		it('excludes skin-tone variants from the results', () => {
 			expect(names('+1').some((name) => /_tone[1-5]/.test(name))).to.be.false;
+		});
+
+		it('excludes legacy-only names from the results', () => {
+			expect(names('dog2')).to.be.empty;
+		});
+
+		it('excludes legacy-only names from partial matches', () => {
+			expect(names('dog')).to.not.include('dog2');
+		});
+
+		it('keeps the emojibase name for the same emoji searchable', () => {
+			expect(names('dog')).to.include('dog');
+			expect(names('dog')).to.include('dog_face');
+		});
+
+		it('still renders a legacy shortcode entered manually', () => {
+			expect(emoji.packages.native.render(':dog2:')).to.include(legacyEmojioneMap.dog2);
 		});
 
 		it('applies the selected skin tone when searching by an alias', () => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Currently we don't show legacy emojis in emoji picker but we still show them in composer popup. This results in inconsistent behavior. To keep consistency, we should also remove legacy emojis from composer emoji popup.

This PR introduces a new flag on emoji list `legacy` which is true for legacy emojis and based on this flag we render the emoji on composer popup.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open a message composer.
- Type :dog2.
- Observe the emoji autocomplete popup.
- Confirm that 🐕 :dog2: is displayed as a suggestion.
- Open the emoji picker and search for dog2.
- Confirm that no result is returned.
- Enter the complete :dog2: shortcode manually and send the message.
- Confirm that it renders as 🐕
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2467](https://rocketchat.atlassian.net/browse/CORE-2467)

[CORE-2467]: https://rocketchat.atlassian.net/browse/CORE-2467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji autocomplete by excluding legacy emojis from suggestions and local filtering, while keeping compatibility for manually typed legacy shortcodes.
  * Updated emoji search behavior to avoid returning legacy-only entries in results and partial matches.
* **Tests**
  * Expanded emoji helper tests to verify legacy exclusion in search/autocomplete and continued support for rendering legacy shortcodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->