### PR TITLE
regression: video embedded in custom homepage content repeatedly reloads

### DIFF
--- a/apps/meteor/client/views/home/CustomHomePageContent.tsx
+++ b/apps/meteor/client/views/home/CustomHomePageContent.tsx
@@ -1,11 +1,14 @@
 import { Box } from '@rocket.chat/fuselage';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
+import { useMemo } from 'react';
 
 const CustomHomePageContent = (props: ComponentProps<typeof Box>) => {
 	const body = useSetting('Layout_Home_Body', '');
 
-	return <Box withRichContent dangerouslySetInnerHTML={{ __html: body }} {...props} />;
+	const dangerous = useMemo(() => ({ __html: body }), [body]);
+
+	return <Box withRichContent dangerouslySetInnerHTML={dangerous} {...props} />;
 };
 
 export default CustomHomePageContent;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

**Problem:** `CustomHomePageContent` passed a new `dangerouslySetInnerHTML` object on every render. On each unrelated re-render React rebuilds the content, so the embedded `<video>` becomes a new element and restarts from scratch — the reload.

**Fix:** memoize the object so its identity stays stable across re-renders.

This was always wrong, but harmless under React 18 (it compared the HTML string). React 19 compares by reference and re-applies `innerHTML` on every new object, which made it visible — same fix as **#41299**. Surfaced by the React 19 upgrade (#40796).

## Issue(s)

- [CORE-2474](https://rocketchat.atlassian.net/browse/CORE-2474)

## Steps to test or reproduce

1. As admin: **Administration → Workspace → Settings → Layout → Home Page Content**.
2. Set the block to a `<video controls>` with an `mp4` source.
3. Save, open Home, stop interacting.

**Before:** reloads repeatedly on its own. **After:** loads once.

<details>
<summary>Repro block for Home Page Content</summary>

```html
<div style="max-width: 640px; margin: 20px auto;">
  <video controls width="100%" preload="metadata">
    <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4" type="video/mp4">
  </video>
</div>
```

</details>

## Further comments

[CORE-2474]: https://rocketchat.atlassian.net/browse/CORE-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved home page rendering efficiency by reducing unnecessary recalculation of custom HTML content.
  * Preserved existing rich-content display and customization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->