### PR TITLE
fix: restore away status after websocket reconnection

### DIFF
--- a/.changeset/wicked-moons-reconnect.md
+++ b/.changeset/wicked-moons-reconnect.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes users being set back to online after a websocket reconnection (connection drop, network change, server restart) even though they had gone idle and never interacted with the UI again. The client now tracks the last UI interaction across connection drops and restates the away status as soon as the reconnected session is authenticated, instead of assuming the new session is online and restarting the idle countdown from scratch.

--- a/.changeset/wicked-moons-reconnect.md
+++ b/.changeset/wicked-moons-reconnect.md
@@ -1,5 +1,4 @@
 ---
-'@rocket.chat/models': patch
 '@rocket.chat/meteor': patch
 ---
 

--- a/apps/meteor/client/lib/userPresence.spec.ts
+++ b/apps/meteor/client/lib/userPresence.spec.ts
@@ -166,16 +166,23 @@ describe('UserPresence', () => {
 	});
 
 	it('should keep a desktop user away when the desktop app reported them idle while disconnected', async () => {
-		const setUserPresenceDetection = jest.fn<(options: { setUserOnline: (online: boolean) => void }) => void>();
-		Object.assign(window, { RocketChatDesktop: { setUserPresenceDetection } });
+		let setUserOnline: ((online: boolean) => void) | undefined;
+
+		Object.assign(window, {
+			RocketChatDesktop: {
+				setUserPresenceDetection: (options: { setUserOnline: (online: boolean) => void }) => {
+					setUserOnline = options.setUserOnline;
+				},
+			},
+		});
 
 		try {
 			const { rerender } = render();
-			const { setUserOnline } = setUserPresenceDetection.mock.calls[0][0];
+			expect(setUserOnline).toBeDefined();
 
 			dropConnection(rerender);
 
-			setUserOnline(false);
+			setUserOnline?.(false);
 			await jest.advanceTimersByTimeAsync(DEBOUNCE_WAIT);
 			expect(goAway).not.toHaveBeenCalled();
 

--- a/apps/meteor/client/lib/userPresence.spec.ts
+++ b/apps/meteor/client/lib/userPresence.spec.ts
@@ -7,7 +7,6 @@ import { UserPresence } from './userPresence';
 const IDLE_TIME_LIMIT = 300;
 const IDLE_TIME_LIMIT_MS = IDLE_TIME_LIMIT * 1000;
 const DEBOUNCE_WAIT = 1000;
-const AWAY_RETRY_DELAY = 500;
 
 const state = {
 	connected: true,
@@ -97,28 +96,6 @@ describe('UserPresence', () => {
 		expect(goOnline).not.toHaveBeenCalled();
 	});
 
-	it('should retry the away assertion while the server has not registered the reconnected session', async () => {
-		const { rerender } = render();
-
-		await goIdle();
-		expect(goAway).toHaveBeenCalledTimes(1);
-
-		// the reconnected session is not in `usersSessions` yet, so the first assertion updates nothing
-		goAway.mockResolvedValueOnce(false);
-
-		dropConnection(rerender);
-		restoreConnection(rerender);
-		await jest.advanceTimersByTimeAsync(0);
-		expect(goAway).toHaveBeenCalledTimes(2);
-
-		await jest.advanceTimersByTimeAsync(AWAY_RETRY_DELAY);
-		expect(goAway).toHaveBeenCalledTimes(3);
-
-		// stops retrying once the server confirms the update
-		await jest.advanceTimersByTimeAsync(AWAY_RETRY_DELAY * 5);
-		expect(goAway).toHaveBeenCalledTimes(3);
-	});
-
 	it('should not re-assert presence before the reconnected session is logged in', async () => {
 		const { rerender } = render();
 
@@ -186,6 +163,29 @@ describe('UserPresence', () => {
 		await jest.advanceTimersByTimeAsync(0);
 
 		expect(goAway).toHaveBeenCalledTimes(1);
+	});
+
+	it('should keep a desktop user away when the desktop app reported them idle while disconnected', async () => {
+		const setUserPresenceDetection = jest.fn<(options: { setUserOnline: (online: boolean) => void }) => void>();
+		Object.assign(window, { RocketChatDesktop: { setUserPresenceDetection } });
+
+		try {
+			const { rerender } = render();
+			const { setUserOnline } = setUserPresenceDetection.mock.calls[0][0];
+
+			dropConnection(rerender);
+
+			setUserOnline(false);
+			await jest.advanceTimersByTimeAsync(DEBOUNCE_WAIT);
+			expect(goAway).not.toHaveBeenCalled();
+
+			restoreConnection(rerender);
+			await jest.advanceTimersByTimeAsync(0);
+
+			expect(goAway).toHaveBeenCalledTimes(1);
+		} finally {
+			delete (window as { RocketChatDesktop?: unknown }).RocketChatDesktop;
+		}
 	});
 
 	it('should not force the user away on reconnection when auto away is disabled', async () => {

--- a/apps/meteor/client/lib/userPresence.spec.ts
+++ b/apps/meteor/client/lib/userPresence.spec.ts
@@ -1,0 +1,220 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
+import { renderHook } from '@testing-library/react';
+
+import { UserPresence } from './userPresence';
+
+const IDLE_TIME_LIMIT = 300;
+const IDLE_TIME_LIMIT_MS = IDLE_TIME_LIMIT * 1000;
+const DEBOUNCE_WAIT = 1000;
+const AWAY_RETRY_DELAY = 500;
+
+const state = {
+	connected: true,
+	isLoggingIn: false,
+	user: { _id: 'john.doe', status: UserStatus.ONLINE, statusDefault: UserStatus.ONLINE } as unknown as IUser | undefined,
+	preferences: { enableAutoAway: true, idleTimeLimit: IDLE_TIME_LIMIT } as Record<string, unknown>,
+};
+
+const goOnline = jest.fn(async (): Promise<boolean | undefined> => true);
+const goAway = jest.fn(async (): Promise<boolean | undefined> => true);
+const storeUser = jest.fn();
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useUser: () => state.user,
+	useConnectionStatus: () => ({ connected: state.connected }),
+	useIsLoggingIn: () => state.isLoggingIn,
+	useUserPreference: (key: string) => state.preferences[key],
+	useMethod: (method: string) => (method === 'UserPresence:online' ? goOnline : goAway),
+}));
+
+jest.mock('../stores', () => ({
+	Users: { use: (selector: (state: { store: unknown }) => unknown) => selector({ store: storeUser }) },
+}));
+
+describe('UserPresence', () => {
+	let userPresence: UserPresence;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+		goOnline.mockReset().mockResolvedValue(true);
+		goAway.mockReset().mockResolvedValue(true);
+		storeUser.mockReset();
+
+		state.connected = true;
+		state.isLoggingIn = false;
+		state.user = { _id: 'john.doe', status: UserStatus.ONLINE, statusDefault: UserStatus.ONLINE } as unknown as IUser;
+		state.preferences = { enableAutoAway: true, idleTimeLimit: IDLE_TIME_LIMIT };
+
+		userPresence = new UserPresence();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	const render = () => renderHook(() => userPresence.use());
+
+	const dropConnection = (rerender: () => void) => {
+		state.connected = false;
+		rerender();
+	};
+
+	const restoreConnection = (rerender: () => void) => {
+		state.connected = true;
+		rerender();
+	};
+
+	const goIdle = async () => {
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS + DEBOUNCE_WAIT);
+	};
+
+	it('should set the user away once the idle time limit is reached', async () => {
+		render();
+
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS - 1000);
+		expect(goAway).not.toHaveBeenCalled();
+
+		await jest.advanceTimersByTimeAsync(1000 + DEBOUNCE_WAIT);
+		expect(goAway).toHaveBeenCalledTimes(1);
+	});
+
+	it('should keep an idle user away after a reconnection', async () => {
+		const { rerender } = render();
+
+		await goIdle();
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		dropConnection(rerender);
+		await jest.advanceTimersByTimeAsync(30_000);
+
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(0);
+
+		expect(goAway).toHaveBeenCalledTimes(2);
+		expect(goOnline).not.toHaveBeenCalled();
+	});
+
+	it('should retry the away assertion while the server has not registered the reconnected session', async () => {
+		const { rerender } = render();
+
+		await goIdle();
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		// the reconnected session is not in `usersSessions` yet, so the first assertion updates nothing
+		goAway.mockResolvedValueOnce(false);
+
+		dropConnection(rerender);
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(0);
+		expect(goAway).toHaveBeenCalledTimes(2);
+
+		await jest.advanceTimersByTimeAsync(AWAY_RETRY_DELAY);
+		expect(goAway).toHaveBeenCalledTimes(3);
+
+		// stops retrying once the server confirms the update
+		await jest.advanceTimersByTimeAsync(AWAY_RETRY_DELAY * 5);
+		expect(goAway).toHaveBeenCalledTimes(3);
+	});
+
+	it('should not re-assert presence before the reconnected session is logged in', async () => {
+		const { rerender } = render();
+
+		await goIdle();
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		dropConnection(rerender);
+
+		state.connected = true;
+		state.isLoggingIn = true;
+		rerender();
+		await jest.advanceTimersByTimeAsync(0);
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		state.isLoggingIn = false;
+		rerender();
+		await jest.advanceTimersByTimeAsync(0);
+		expect(goAway).toHaveBeenCalledTimes(2);
+	});
+
+	it('should bring the user back online on reconnection if they interacted while disconnected', async () => {
+		const { rerender } = render();
+
+		await goIdle();
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		dropConnection(rerender);
+
+		document.dispatchEvent(new MouseEvent('mousemove'));
+
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(DEBOUNCE_WAIT);
+
+		// the reconnected session is already online on the server, so nothing else has to be asserted
+		expect(goAway).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not restart the idle countdown from scratch on a reconnection', async () => {
+		const { rerender } = render();
+
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS - 60_000);
+		expect(goAway).not.toHaveBeenCalled();
+
+		dropConnection(rerender);
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(0);
+
+		// still online, but only the remaining minute of inactivity is left
+		expect(goAway).not.toHaveBeenCalled();
+
+		await jest.advanceTimersByTimeAsync(60_000 + DEBOUNCE_WAIT);
+		expect(goAway).toHaveBeenCalledTimes(1);
+	});
+
+	it('should count the time spent disconnected as inactivity', async () => {
+		const { rerender } = render();
+
+		await jest.advanceTimersByTimeAsync(60_000);
+
+		dropConnection(rerender);
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS);
+		expect(goAway).not.toHaveBeenCalled();
+
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(0);
+
+		expect(goAway).toHaveBeenCalledTimes(1);
+	});
+
+	it('should not force the user away on reconnection when auto away is disabled', async () => {
+		state.preferences = { enableAutoAway: false, idleTimeLimit: IDLE_TIME_LIMIT };
+
+		const { rerender } = render();
+
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS * 2);
+
+		dropConnection(rerender);
+		restoreConnection(rerender);
+		await jest.advanceTimersByTimeAsync(DEBOUNCE_WAIT);
+
+		expect(goAway).not.toHaveBeenCalled();
+	});
+
+	it('should go online again after interacting with the UI', async () => {
+		render();
+
+		await goIdle();
+		expect(goAway).toHaveBeenCalledTimes(1);
+
+		document.dispatchEvent(new MouseEvent('mousemove'));
+		await jest.advanceTimersByTimeAsync(DEBOUNCE_WAIT);
+
+		expect(goOnline).toHaveBeenCalledTimes(1);
+
+		// and goes away again after a new idle period
+		await jest.advanceTimersByTimeAsync(IDLE_TIME_LIMIT_MS + DEBOUNCE_WAIT);
+		expect(goAway).toHaveBeenCalledTimes(2);
+	});
+});

--- a/apps/meteor/client/lib/userPresence.ts
+++ b/apps/meteor/client/lib/userPresence.ts
@@ -9,13 +9,6 @@ import { Users } from '../stores';
 
 // TODO: merge this with the current React-based implementation of idle detection
 
-// `UserPresence:away` only sticks after the server has registered the new DDP session
-// (`Presence.newConnection`, triggered by the login that follows a reconnection). The login method
-// may resolve on the client before that write lands, so the assertion is retried while the server
-// reports that no connection was updated.
-const AWAY_ASSERTION_ATTEMPTS = 3;
-const AWAY_ASSERTION_RETRY_DELAY = 500;
-
 export class UserPresence {
 	private user: IUser | undefined;
 
@@ -32,9 +25,6 @@ export class UserPresence {
 
 	/** Idle flag used when there is no local away timer (i.e. presence detection delegated to the desktop app). */
 	private idle = false;
-
-	/** Identifies the running away assertion, so a newer one supersedes the retries of the previous. */
-	private awayAssertionToken = 0;
 
 	private goOnline: () => Promise<boolean | undefined> = async () => undefined;
 
@@ -57,13 +47,19 @@ export class UserPresence {
 		clearTimeout(this.timer);
 	}
 
+	// both entry points record the idle state right away, even while disconnected: the status update
+	// itself is debounced and skipped when there is no connection, but going idle in the meantime is
+	// exactly what has to be remembered to be restated on the next reconnection
 	private readonly registerActivity = () => {
 		this.lastActivityAt = Date.now();
 		this.idle = false;
 		this.setStatus(UserStatus.ONLINE);
 	};
 
-	private readonly setAway = () => this.setStatus(UserStatus.AWAY);
+	private readonly setAway = () => {
+		this.idle = true;
+		this.setStatus(UserStatus.AWAY);
+	};
 
 	/** Whether the user is idle according to what this client observed, regardless of the connection state. */
 	private isIdle(): boolean {
@@ -88,44 +84,23 @@ export class UserPresence {
 			this.storeUser({ ...this.user, status: newStatus });
 		}
 
-		this.status = newStatus;
-
 		switch (newStatus) {
 			case UserStatus.ONLINE:
-				this.idle = false;
 				this.startTimer();
 				await this.goOnline();
 				this.startTimer();
 				break;
 
 			case UserStatus.AWAY:
-				this.idle = true;
 				this.stopTimer();
-				await this.assertAway();
+				await this.goAway();
 				break;
 		}
+
+		this.status = newStatus;
 	};
 
 	private readonly setStatus = withDebouncing({ wait: 1000 })(this.applyStatus);
-
-	private async assertAway(): Promise<void> {
-		const token = ++this.awayAssertionToken;
-
-		for (let attempt = 1; attempt <= AWAY_ASSERTION_ATTEMPTS; attempt++) {
-			// bail out if the user is back online, disconnected, or a newer assertion took over
-			if (!this.connected || this.status !== UserStatus.AWAY || token !== this.awayAssertionToken) {
-				return;
-			}
-
-			if (await this.goAway()) {
-				return;
-			}
-
-			if (attempt < AWAY_ASSERTION_ATTEMPTS) {
-				await new Promise((resolve) => setTimeout(resolve, AWAY_ASSERTION_RETRY_DELAY));
-			}
-		}
-	}
 
 	/**
 	 * Restates the presence this client knows about.

--- a/apps/meteor/client/lib/userPresence.ts
+++ b/apps/meteor/client/lib/userPresence.ts
@@ -9,6 +9,13 @@ import { Users } from '../stores';
 
 // TODO: merge this with the current React-based implementation of idle detection
 
+// `UserPresence:away` only sticks after the server has registered the new DDP session
+// (`Presence.newConnection`, triggered by the login that follows a reconnection). The login method
+// may resolve on the client before that write lands, so the assertion is retried while the server
+// reports that no connection was updated.
+const AWAY_ASSERTION_ATTEMPTS = 3;
+const AWAY_ASSERTION_RETRY_DELAY = 500;
+
 export class UserPresence {
 	private user: IUser | undefined;
 
@@ -20,6 +27,15 @@ export class UserPresence {
 
 	private connected = true;
 
+	/** Last time the user interacted with the UI. Kept across connection drops. */
+	private lastActivityAt = Date.now();
+
+	/** Idle flag used when there is no local away timer (i.e. presence detection delegated to the desktop app). */
+	private idle = false;
+
+	/** Identifies the running away assertion, so a newer one supersedes the retries of the previous. */
+	private awayAssertionToken = 0;
+
 	private goOnline: () => Promise<boolean | undefined> = async () => undefined;
 
 	private goAway: () => Promise<boolean | undefined> = async () => undefined;
@@ -30,19 +46,40 @@ export class UserPresence {
 		this.stopTimer();
 		if (!this.awayTime) return;
 
-		this.timer = setTimeout(this.setAway, this.awayTime);
+		// Schedule for the *remaining* idle time so a reconnection doesn't restart the countdown from
+		// scratch, keeping an already idle user away instead of granting them another full idle period.
+		const remaining = Math.max(this.awayTime - (Date.now() - this.lastActivityAt), 0);
+
+		this.timer = setTimeout(this.setAway, remaining);
 	}
 
 	private stopTimer() {
 		clearTimeout(this.timer);
 	}
 
-	private readonly setOnline = () => this.setStatus(UserStatus.ONLINE);
+	private readonly registerActivity = () => {
+		this.lastActivityAt = Date.now();
+		this.idle = false;
+		this.setStatus(UserStatus.ONLINE);
+	};
 
 	private readonly setAway = () => this.setStatus(UserStatus.AWAY);
 
-	private readonly setStatus = withDebouncing({ wait: 1000 })(async (newStatus: UserStatus.ONLINE | UserStatus.AWAY) => {
-		if (!this.connected || newStatus === this.status) {
+	/** Whether the user is idle according to what this client observed, regardless of the connection state. */
+	private isIdle(): boolean {
+		if (this.awayTime) {
+			return Date.now() - this.lastActivityAt >= this.awayTime;
+		}
+
+		return this.idle;
+	}
+
+	private readonly applyStatus = async (newStatus: UserStatus.ONLINE | UserStatus.AWAY, { force = false } = {}) => {
+		if (!this.connected) {
+			return;
+		}
+
+		if (newStatus === this.status && !force) {
 			this.startTimer();
 			return;
 		}
@@ -51,20 +88,65 @@ export class UserPresence {
 			this.storeUser({ ...this.user, status: newStatus });
 		}
 
+		this.status = newStatus;
+
 		switch (newStatus) {
 			case UserStatus.ONLINE:
+				this.idle = false;
+				this.startTimer();
 				await this.goOnline();
 				this.startTimer();
 				break;
 
 			case UserStatus.AWAY:
-				await this.goAway();
+				this.idle = true;
 				this.stopTimer();
+				await this.assertAway();
 				break;
 		}
+	};
 
-		this.status = newStatus;
-	});
+	private readonly setStatus = withDebouncing({ wait: 1000 })(this.applyStatus);
+
+	private async assertAway(): Promise<void> {
+		const token = ++this.awayAssertionToken;
+
+		for (let attempt = 1; attempt <= AWAY_ASSERTION_ATTEMPTS; attempt++) {
+			// bail out if the user is back online, disconnected, or a newer assertion took over
+			if (!this.connected || this.status !== UserStatus.AWAY || token !== this.awayAssertionToken) {
+				return;
+			}
+
+			if (await this.goAway()) {
+				return;
+			}
+
+			if (attempt < AWAY_ASSERTION_ATTEMPTS) {
+				await new Promise((resolve) => setTimeout(resolve, AWAY_ASSERTION_RETRY_DELAY));
+			}
+		}
+	}
+
+	/**
+	 * Restates the presence this client knows about.
+	 *
+	 * The server registers every new DDP session as online, so any reconnection (dropped socket,
+	 * network change, server restart, resumed login) brings the user back to online. The server has no
+	 * way to know whether the user interacted with the UI while the socket was down, so the client has
+	 * to state it again as soon as the session is authenticated.
+	 */
+	private readonly reassertPresence = () => {
+		this.setStatus.cancel();
+
+		if (!this.isIdle()) {
+			// the reconnected session is already online on the server side
+			this.status = UserStatus.ONLINE;
+			this.startTimer();
+			return;
+		}
+
+		void this.applyStatus(UserStatus.AWAY, { force: true });
+	};
 
 	readonly use = () => {
 		const user = useUser() ?? undefined;
@@ -74,9 +156,10 @@ export class UserPresence {
 		const idleTimeLimit = useUserPreference<number>('idleTimeLimit') ?? 300;
 		const { RocketChatDesktop } = window;
 
+		const awayTime = enableAutoAway && !RocketChatDesktop ? idleTimeLimit * 1000 : undefined;
+
 		this.user = user;
 		this.connected = connected;
-		this.awayTime = enableAutoAway && !RocketChatDesktop ? idleTimeLimit * 1000 : undefined;
 		this.goOnline = useMethod('UserPresence:online');
 		this.goAway = useMethod('UserPresence:away');
 		this.storeUser = Users.use((state) => state.store);
@@ -89,10 +172,10 @@ export class UserPresence {
 				idleThreshold: idleTimeLimit,
 				setUserOnline: (online) => {
 					if (!online) {
-						this.goAway();
+						this.setAway();
 						return;
 					}
-					this.goOnline();
+					this.registerActivity();
 				},
 			});
 
@@ -109,28 +192,28 @@ export class UserPresence {
 			if (RocketChatDesktop) return;
 
 			const documentEvents = ['mousemove', 'mousedown', 'touchend', 'keydown'] as const;
-			documentEvents.forEach((key) => document.addEventListener(key, this.setOnline));
-			window.addEventListener('focus', this.setOnline);
+			documentEvents.forEach((key) => document.addEventListener(key, this.registerActivity));
+			window.addEventListener('focus', this.registerActivity);
 
 			return () => {
-				documentEvents.forEach((key) => document.removeEventListener(key, this.setOnline));
-				window.removeEventListener('focus', this.setOnline);
+				documentEvents.forEach((key) => document.removeEventListener(key, this.registerActivity));
+				window.removeEventListener('focus', this.registerActivity);
 			};
 		}, [RocketChatDesktop]);
 
 		useEffect(() => {
-			if (!user?._id || !connected || isLoggingIn) return;
-			this.startTimer();
-		}, [connected, isLoggingIn, user?._id]);
+			this.awayTime = awayTime;
 
-		useEffect(() => {
-			if (connected) {
-				this.startTimer();
-				this.status = UserStatus.ONLINE;
+			if (!connected) {
+				this.setStatus.cancel();
+				this.stopTimer();
+				this.status = UserStatus.OFFLINE;
 				return;
 			}
-			this.stopTimer();
-			this.status = UserStatus.OFFLINE;
-		}, [connected]);
+
+			if (!user?._id || isLoggingIn) return;
+
+			this.reassertPresence();
+		}, [connected, isLoggingIn, user?._id, awayTime]);
 	};
 }

--- a/apps/meteor/client/lib/userPresence.ts
+++ b/apps/meteor/client/lib/userPresence.ts
@@ -20,10 +20,8 @@ export class UserPresence {
 
 	private connected = true;
 
-	/** Last time the user interacted with the UI. Kept across connection drops. */
 	private lastActivityAt = Date.now();
 
-	/** Idle flag used when there is no local away timer (i.e. presence detection delegated to the desktop app). */
 	private idle = false;
 
 	private goOnline: () => Promise<boolean | undefined> = async () => undefined;
@@ -35,11 +33,7 @@ export class UserPresence {
 	startTimer() {
 		this.stopTimer();
 		if (!this.awayTime) return;
-
-		// Schedule for the *remaining* idle time so a reconnection doesn't restart the countdown from
-		// scratch, keeping an already idle user away instead of granting them another full idle period.
 		const remaining = Math.max(this.awayTime - (Date.now() - this.lastActivityAt), 0);
-
 		this.timer = setTimeout(this.setAway, remaining);
 	}
 
@@ -47,9 +41,6 @@ export class UserPresence {
 		clearTimeout(this.timer);
 	}
 
-	// both entry points record the idle state right away, even while disconnected: the status update
-	// itself is debounced and skipped when there is no connection, but going idle in the meantime is
-	// exactly what has to be remembered to be restated on the next reconnection
 	private readonly registerActivity = () => {
 		this.lastActivityAt = Date.now();
 		this.idle = false;
@@ -61,12 +52,10 @@ export class UserPresence {
 		this.setStatus(UserStatus.AWAY);
 	};
 
-	/** Whether the user is idle according to what this client observed, regardless of the connection state. */
 	private isIdle(): boolean {
 		if (this.awayTime) {
 			return Date.now() - this.lastActivityAt >= this.awayTime;
 		}
-
 		return this.idle;
 	}
 
@@ -88,7 +77,6 @@ export class UserPresence {
 			case UserStatus.ONLINE:
 				this.startTimer();
 				await this.goOnline();
-				this.startTimer();
 				break;
 
 			case UserStatus.AWAY:
@@ -103,18 +91,14 @@ export class UserPresence {
 	private readonly setStatus = withDebouncing({ wait: 1000 })(this.applyStatus);
 
 	/**
-	 * Restates the presence this client knows about.
-	 *
-	 * The server registers every new DDP session as online, so any reconnection (dropped socket,
-	 * network change, server restart, resumed login) brings the user back to online. The server has no
-	 * way to know whether the user interacted with the UI while the socket was down, so the client has
-	 * to state it again as soon as the session is authenticated.
+	 * When auto-away is enabled, after a dropped socket, reconnection, or network change,
+	 * the server sets the user as online. Since we may have marked the user away in the UI,
+	 * we need to re-send away to the server if still idle.
 	 */
 	private readonly reassertPresence = () => {
 		this.setStatus.cancel();
 
 		if (!this.isIdle()) {
-			// the reconnected session is already online on the server side
 			this.status = UserStatus.ONLINE;
 			this.startTimer();
 			return;

--- a/packages/models/src/models/UsersSessions.ts
+++ b/packages/models/src/models/UsersSessions.ts
@@ -20,16 +20,14 @@ export class UsersSessionsRaw extends BaseRaw<IUserSession> implements IUsersSes
 			'connections.id': connectionId,
 		};
 
-		// every entry matching the connection id is updated: a login happening twice over the same
-		// connection pushes duplicated entries, and leaving one of them behind would keep the user online
 		const update = {
 			$set: {
-				'connections.$[connection].status': status,
-				'connections.$[connection]._updatedAt': new Date(),
+				'connections.$.status': status,
+				'connections.$._updatedAt': new Date(),
 			},
 		};
 
-		return this.updateOne(query, update, { arrayFilters: [{ 'connection.id': connectionId }] });
+		return this.updateOne(query, update);
 	}
 
 	async removeConnectionsFromInstanceId(instanceId: string): ReturnType<BaseRaw<IUserSession>['updateMany']> {

--- a/packages/models/src/models/UsersSessions.ts
+++ b/packages/models/src/models/UsersSessions.ts
@@ -20,14 +20,16 @@ export class UsersSessionsRaw extends BaseRaw<IUserSession> implements IUsersSes
 			'connections.id': connectionId,
 		};
 
+		// every entry matching the connection id is updated: a login happening twice over the same
+		// connection pushes duplicated entries, and leaving one of them behind would keep the user online
 		const update = {
 			$set: {
-				'connections.$.status': status,
-				'connections.$._updatedAt': new Date(),
+				'connections.$[connection].status': status,
+				'connections.$[connection]._updatedAt': new Date(),
 			},
 		};
 
-		return this.updateOne(query, update);
+		return this.updateOne(query, update, { arrayFilters: [{ 'connection.id': connectionId }] });
 	}
 
 	async removeConnectionsFromInstanceId(instanceId: string): ReturnType<BaseRaw<IUserSession>['updateMany']> {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Auto-away is lost on every websocket reconnection.

`Presence.newConnection()` registers every new DDP session as `online`, and the client kept no memory of activity across the drop — it assumed the reconnected session was online and restarted the idle countdown from zero. An idle user came back online on every reconnect and stayed online for a full idle period; on desktop indefinitely, since the OS idle poller only reports state *changes*. Any infrastructure that recycles long-lived connections on a timer (HAProxy `timeout tunnel`, nginx `proxy_read_timeout`, ALB/Cloudflare idle timeouts, LB failover, restarts) reproduces this workspace-wide on that cadence.

The client now:

- tracks `lastActivityAt` across drops, so disconnected time counts as inactivity;
- restates `away` once the reconnected session is authenticated, instead of assuming online;
- schedules the idle timer for the *remaining* time, not a fresh full period;
- records the idle state at the away entry point, so an idle transition reported by the desktop app **while disconnected** is no longer dropped;
- only forces away when `enableAutoAway` is enabled.

It also fixes the countdown being restarted by unrelated user-document updates: the effect now depends on `user?._id` instead of the whole `user` object, which minted a new reference on every store update.

## Steps to test or reproduce

Use two accounts — checking A's own UI means moving the pointer into A's window, which resets the idle countdown, so observe from B instead.

1. In **Admin → Settings → Accounts → Default User Preferences**, enable *Enable Auto Away*, set *Idle Time Limit* to 60s, reload.
2. Open **A** (your user) in a normal window and **B** (another user) in incognito, with B viewing A in a DM so A's status dot is visible.
3. In A, undock DevTools into a separate window and **stop touching A's window**. Once the idle limit passes, B shows A as away.
4. In A's console, trigger a reconnect and leave it alone:

   ```js
   Meteor.disconnect(); setTimeout(() => Meteor.reconnect(), 5000);
   ```

5. Watch B: A goes offline, then online on reconnect, then **back to away within a round trip**, with no interaction. Before this PR, A stayed online for a full idle period.

> Undocking matters: the client listens for `mousemove`/`mousedown`/`keydown` on the document **and `focus` on the window**, so with the console docked, merely moving the pointer across the page to reach it stamps `lastActivityAt` and legitimately brings A online. Once undocked, stay in the DevTools window.

## Issues

- [CORE-2503](https://rocketchat.atlassian.net/browse/CORE-2503)

## Further comments

- The server still writes `online` in `newConnection` and broadcasts it, so there is a ~1 round-trip window where clients see the user online before the `away` lands.
- The non-idle branch intentionally does **not** send `UserPresence:online`: the session is already online server-side, so it would add a method call plus a presence broadcast per client on every reconnect, doubling presence work on a mass reconnect for no gain.
- Mobile needs no equivalent change — it already re-asserts away on the resume login via `checkBackgroundAndSetAway`.
- **Why not server-side.** Preserving the previous status in `newConnection` sounds cheaper, but nothing is left to preserve: `connection.onClose` → `removeConnection` already recomputed the user to `offline` before the reconnect arrives. It would need new persisted state, a rule keeping bots and API clients defaulting to online, and the client declaring `online` so nobody gets stuck away — a lot of machinery to close a sub-second window, for something the server cannot observe anyway. Only the client knows whether the user is idle.

https://claude.ai/code/session_01PQu7gFiCHs1nyDtq3Wmufi

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved users’ away status and inactivity progress after websocket reconnections.
  * Restored online status when users interact while disconnected.
  * Improved presence updates during login, reconnection, and connection changes.
  * Ensured desktop and browser activity consistently resets away status.
  * Prevented inactivity timers from restarting unnecessarily after reconnecting.
  * More accurately restored presence based on the user’s latest activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2503]: https://rocketchat.atlassian.net/browse/CORE-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ