### PR TITLE
fix: audio attachments cannot be seeked using the progress slider

### DIFF
--- a/.changeset/lucky-donkeys-listen.md
+++ b/.changeset/lucky-donkeys-listen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes audio attachments not being seekable using the progress slider

--- a/apps/meteor/server/lib/media/file-upload/config/FileSystem.ts
+++ b/apps/meteor/server/lib/media/file-upload/config/FileSystem.ts
@@ -31,6 +31,7 @@ const FileSystemUploads = new FileUploadClass({
 			res.setHeader('Content-Disposition', `${getContentDisposition(req)}; filename*=UTF-8''${encodeURIComponent(file.name || '')}`);
 			file.uploadedAt && res.setHeader('Last-Modified', file.uploadedAt.toUTCString());
 			res.setHeader('Content-Type', file.type || 'application/octet-stream');
+			res.setHeader('Accept-Ranges', 'bytes');
 
 			if (req.headers.range) {
 				const range = getFileRange(file, req);

--- a/apps/meteor/server/lib/media/file-upload/config/GridFS.ts
+++ b/apps/meteor/server/lib/media/file-upload/config/GridFS.ts
@@ -71,6 +71,8 @@ const readFromGridFS = async function (
 	const rs = await store.getReadStream(fileId, file);
 	const ws = new stream.PassThrough();
 
+	res.setHeader('Accept-Ranges', 'bytes');
+
 	[rs, ws].forEach((stream) =>
 		stream.on('error', (err) => {
 			store.onReadError.call(store, err, fileId, file);

--- a/apps/meteor/server/lib/media/file-upload/lib/ranges.spec.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/ranges.spec.ts
@@ -1,0 +1,59 @@
+import type http from 'node:http';
+
+import type { IUpload } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { getFileRange } from './ranges';
+
+const req = (range?: string) => ({ headers: { range } }) as http.IncomingMessage;
+const file = (size: number) => ({ size }) as IUpload;
+
+describe('getFileRange', () => {
+	it('returns undefined when no Range header is present', () => {
+		expect(getFileRange(file(1000), req())).to.equal(undefined);
+	});
+
+	it('returns undefined for a malformed Range header', () => {
+		expect(getFileRange(file(1000), req('bytes=abc'))).to.equal(undefined);
+		expect(getFileRange(file(1000), req('items=0-99'))).to.equal(undefined);
+		expect(getFileRange(file(1000), req('bytes=-'))).to.equal(undefined);
+	});
+
+	it('returns undefined when the file has no size', () => {
+		expect(getFileRange(file(0), req('bytes=0-'))).to.equal(undefined);
+	});
+
+	it('serves an open-ended range `bytes=0-` as the whole file', () => {
+		expect(getFileRange(file(1000), req('bytes=0-'))).to.deep.equal({ outOfRange: false, start: 0, stop: 999 });
+	});
+
+	it('serves an open-ended range from a mid-file offset to EOF', () => {
+		expect(getFileRange(file(1000), req('bytes=77-'))).to.deep.equal({ outOfRange: false, start: 77, stop: 999 });
+	});
+
+	it('serves an explicit closed range', () => {
+		expect(getFileRange(file(1000), req('bytes=100-199'))).to.deep.equal({ outOfRange: false, start: 100, stop: 199 });
+	});
+
+	it('clamps an end that runs past EOF', () => {
+		expect(getFileRange(file(1000), req('bytes=100-5000'))).to.deep.equal({ outOfRange: false, start: 100, stop: 999 });
+	});
+
+	it('serves a suffix range `bytes=-N` as the last N bytes', () => {
+		expect(getFileRange(file(1000), req('bytes=-200'))).to.deep.equal({ outOfRange: false, start: 800, stop: 999 });
+	});
+
+	it('clamps a suffix range larger than the file to the whole file', () => {
+		expect(getFileRange(file(1000), req('bytes=-5000'))).to.deep.equal({ outOfRange: false, start: 0, stop: 999 });
+	});
+
+	it('flags a start at or beyond EOF as out of range', () => {
+		expect(getFileRange(file(1000), req('bytes=1000-'))).to.deep.equal({ outOfRange: true, start: 1000, stop: 999 });
+		expect(getFileRange(file(1000), req('bytes=1500-1600'))).to.deep.equal({ outOfRange: true, start: 1500, stop: 999 });
+	});
+
+	it('serves the final byte of the file', () => {
+		expect(getFileRange(file(1000), req('bytes=999-'))).to.deep.equal({ outOfRange: false, start: 999, stop: 999 });
+	});
+});

--- a/apps/meteor/server/lib/media/file-upload/lib/ranges.spec.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/ranges.spec.ts
@@ -53,6 +53,10 @@ describe('getFileRange', () => {
 		expect(getFileRange(file(1000), req('bytes=1500-1600'))).to.deep.equal({ outOfRange: true, start: 1500, stop: 999 });
 	});
 
+	it('flags an inverted closed range as out of range', () => {
+		expect(getFileRange(file(1000), req('bytes=200-100'))).to.deep.equal({ outOfRange: true, start: 200, stop: 100 });
+	});
+
 	it('serves the final byte of the file', () => {
 		expect(getFileRange(file(1000), req('bytes=999-'))).to.deep.equal({ outOfRange: false, start: 999, stop: 999 });
 	});

--- a/apps/meteor/server/lib/media/file-upload/lib/ranges.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/ranges.ts
@@ -8,7 +8,6 @@ function parseByteRange(header?: string): ByteRange | undefined {
 	if (!header) {
 		return;
 	}
-	// Either bound may be omitted: `bytes=500-` (open-ended) or `bytes=-500` (suffix).
 	const matches = header.match(/^bytes=(\d*)-(\d*)$/);
 	if (!matches) {
 		return;
@@ -37,7 +36,6 @@ export function getFileRange(file: IUpload, req: http.IncomingMessage) {
 	let { start, stop } = parsed;
 
 	if (start === undefined) {
-		// Suffix range `bytes=-N`: the last N bytes.
 		if (!stop) {
 			return { outOfRange: true, start: 0, stop: size - 1 };
 		}
@@ -63,8 +61,6 @@ export const setRangeHeaders = function (
 	if (!range) {
 		return;
 	}
-
-	res.setHeader('Accept-Ranges', 'bytes');
 
 	if (range.outOfRange) {
 		// out of range request, return 416

--- a/apps/meteor/server/lib/media/file-upload/lib/ranges.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/ranges.ts
@@ -2,31 +2,56 @@ import type http from 'node:http';
 
 import type { IUpload } from '@rocket.chat/core-typings';
 
-function getByteRange(header?: string) {
+type ByteRange = { start?: number; stop?: number };
+
+function parseByteRange(header?: string): ByteRange | undefined {
 	if (!header) {
 		return;
 	}
-	const matches = header.match(/(\d+)-(\d+)/);
+	// Either bound may be omitted: `bytes=500-` (open-ended) or `bytes=-500` (suffix).
+	const matches = header.match(/^bytes=(\d*)-(\d*)$/);
 	if (!matches) {
 		return;
 	}
+	const [, startStr, stopStr] = matches;
+	if (startStr === '' && stopStr === '') {
+		return;
+	}
 	return {
-		start: parseInt(matches[1], 10),
-		stop: parseInt(matches[2], 10),
+		start: startStr === '' ? undefined : parseInt(startStr, 10),
+		stop: stopStr === '' ? undefined : parseInt(stopStr, 10),
 	};
 }
 
 export function getFileRange(file: IUpload, req: http.IncomingMessage) {
-	const range = getByteRange(req.headers.range);
-	if (!range) {
+	const parsed = parseByteRange(req.headers.range);
+	if (!parsed) {
 		return;
 	}
+
 	const size = file.size || 0;
-	if (range.start > size || range.stop <= range.start || range.stop > size) {
-		return { outOfRange: true, start: range.start, stop: range.stop };
+	if (size <= 0) {
+		return;
 	}
 
-	return { outOfRange: false, start: range.start, stop: range.stop };
+	let { start, stop } = parsed;
+
+	if (start === undefined) {
+		// Suffix range `bytes=-N`: the last N bytes.
+		if (!stop) {
+			return { outOfRange: true, start: 0, stop: size - 1 };
+		}
+		start = Math.max(0, size - stop);
+		stop = size - 1;
+	} else if (stop === undefined || stop > size - 1) {
+		stop = size - 1;
+	}
+
+	if (start > stop || start >= size) {
+		return { outOfRange: true, start, stop };
+	}
+
+	return { outOfRange: false, start, stop };
 }
 
 // code from: https://github.com/jalik/jalik-ufs/blob/master/ufs-server.js#L310
@@ -38,6 +63,8 @@ export const setRangeHeaders = function (
 	if (!range) {
 		return;
 	}
+
+	res.setHeader('Accept-Ranges', 'bytes');
 
 	if (range.outOfRange) {
 		// out of range request, return 416


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating translations
  regression: Issues created during development phase
-->

<!-- Checklist 
- I have read the Contributing Guide
- I have signed the CLA
- Lint and unit tests pass locally
- I have added tests (if applicable)
- I have added documentation (if applicable)
- Any dependent changes are merged
-->
## Proposed changes (including videos or screenshots)

Seeking an audio (or video) attachment with the progress slider snapped back to `0` and would not move. The browser reported the media as non-seekable (`seekable = [[0, 0]]`) despite a known duration and buffered data.

The root cause was server-side. Media requests are answered by `getFileRange`, whose header parser only matched fully-closed ranges (`bytes=a-b`). Browsers request media with **open-ended** ranges instead: `bytes=0-` on load and `bytes=N-` on seek. These failed to parse, so the server fell through to a gzipped `200` response instead of a `206 Partial Content`, and a `200`/gzip response is non-seekable by definition.

Changes:
- Parse open-ended (`bytes=N-`) and suffix (`bytes=-N`) ranges, not just closed ones, and anchor the pattern to the `bytes=` unit.
- Resolve any omitted bound against the file size per the HTTP spec, and clamp/flag out-of-range requests correctly (drives a proper `416`).
- Always advertise `Accept-Ranges: bytes` so browsers know ranged requests are supported.

With a valid range parsed, the server takes the `206` + range-extract branch and bypasses gzip, restoring seekability for all audio/video served from both GridFS and FileSystem storage. Added unit tests for `getFileRange` covering open-ended, closed, suffix, clamping, and out-of-range cases.

## Issue(s)

CORE-2477

## Steps to test or reproduce

1. Send or open a room with an audio message attachment.
2. Start playback, then drag the progress slider to a different position.
3. Expected: playback seeks to the dragged position and continues from there (previously it snapped back to 0 and would not seek).

## Further comments

Server-side change — a full Meteor server restart is required to pick it up (client HMR is not enough).

[CORE-2477](https://rocketchat.atlassian.net/browse/CORE-2477)


[CORE-2477]: https://rocketchat.atlassian.net/browse/CORE-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio attachments now support seeking with the playback progress slider.
  * Improved handling of byte-range requests, including open-ended, suffix, and out-of-range ranges.
  * File downloads now advertise byte-range support for more reliable media playback and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->