### PR TITLE
fix(api)!: return 403 for authorization failures, reserve 401 for missing session

### DIFF
--- a/.changeset/rest-401-403-semantics.md
+++ b/.changeset/rest-401-403-semantics.md
@@ -1,0 +1,14 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Stops the REST API from answering `401 Unauthorized` for authorization failures, so that a 401 only ever means "no valid session".
+
+Every `error-unauthorized` / `error-not-authorized` throw in the codebase follows an authorization check (`hasPermissionAsync`, `canAccessRoom`, `canDeleteFile`, agent department scope), never a missing session, but the error switch in `server/api/ApiClass.ts` mapped `error-unauthorized` to 401 once the 9.0.0 breaking-change flag turned on — while the permission middleware answered 403 for the very same condition. A client could not infer session state from the status code, which is what broke live sessions in the `sendMessage` / `getReadReceipts` migration.
+
+- `error-unauthorized` / `unauthorized` now always map to 403, dropping the 401 they would have been promoted to in 9.0.0 (403 today, unchanged).
+- `error-not-authorized` / `not-authorized` (the dominant permission code, previously unmapped and falling through to 400) map to 403 from 9.0.0.
+- `rooms.membersOrderedByRole` (broadcast member list), `rooms.hide` and `rooms.bannedUsers` returned 401 for access/permission failures; they return 403 from 9.0.0, and their response schemas now declare it.
+- Removed a dead `if (applyBreakingChanges)` fork in the permissions middleware whose branches were identical.
+
+The unauthenticated side is unchanged here: those checks still throw `error-invalid-user` and answer 400. Splitting them out needs a dedicated error code and is tracked separately.

--- a/.changeset/rest-401-403-semantics.md
+++ b/.changeset/rest-401-403-semantics.md
@@ -1,14 +1,18 @@
 ---
-'@rocket.chat/meteor': minor
+'@rocket.chat/meteor': major
 ---
 
-Stops the REST API from answering `401 Unauthorized` for authorization failures, so that a 401 only ever means "no valid session".
+**Breaking:** the REST API no longer answers `401 Unauthorized` for authorization failures. A 401 now means one thing only — the request carries no valid session.
 
-Every `error-unauthorized` / `error-not-authorized` throw in the codebase follows an authorization check (`hasPermissionAsync`, `canAccessRoom`, `canDeleteFile`, agent department scope), never a missing session, but the error switch in `server/api/ApiClass.ts` mapped `error-unauthorized` to 401 once the 9.0.0 breaking-change flag turned on — while the permission middleware answered 403 for the very same condition. A client could not infer session state from the status code, which is what broke live sessions in the `sendMessage` / `getReadReceipts` migration.
+Every `error-unauthorized` / `error-not-authorized` throw in the codebase follows an authorization check (`hasPermissionAsync`, `canAccessRoom`, `canDeleteFile`, agent department scope), never a missing session, but the error switch in `server/api/ApiClass.ts` mapped `error-unauthorized` to 401 while the permission middleware answered 403 for the very same condition. A client could not infer session state from the status code, which is what logged out live sessions in the `sendMessage` / `getReadReceipts` migration.
 
-- `error-unauthorized` / `unauthorized` now always map to 403, dropping the 401 they would have been promoted to in 9.0.0 (403 today, unchanged).
-- `error-not-authorized` / `not-authorized` (the dominant permission code, previously unmapped and falling through to 400) map to 403 from 9.0.0.
-- `rooms.membersOrderedByRole` (broadcast member list), `rooms.hide` and `rooms.bannedUsers` returned 401 for access/permission failures; they return 403 from 9.0.0, and their response schemas now declare it.
-- Removed a dead `if (applyBreakingChanges)` fork in the permissions middleware whose branches were identical.
+Status code changes:
 
-The unauthenticated side is unchanged here: those checks still throw `error-invalid-user` and answer 400. Splitting them out needs a dedicated error code and is tracked separately.
+- `error-not-authorized` / `not-authorized` — the dominant permission code, previously unmapped and falling through to `API.v1.failure()`: **400 → 403**.
+- `error-unauthorized` / `unauthorized`: stays **403**, and no longer flips to 401.
+- `rooms.membersOrderedByRole` (broadcast member list), `rooms.hide`, `rooms.bannedUsers` — returned 401 for access and permission failures: **401 → 403**. Their response schemas now declare it.
+- Routes declaring `permissionsRequired` without `authRequired`, called with no session: **403 → 401**.
+
+Also removed a dead `if (applyBreakingChanges)` fork in the permissions middleware whose two branches were identical.
+
+The unauthenticated side is unchanged here: those checks still throw `error-invalid-user` and answer 400. Splitting them out needs a dedicated error code, since `error-invalid-user` also means "that user does not exist", and is tracked separately.

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -898,12 +898,17 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 								switch (e.error) {
 									case 'error-too-many-requests':
 										return api.tooManyRequests(typeof e === 'string' ? e : e.message);
+									// every `error-unauthorized`/`error-not-authorized` throw in the codebase follows an authorization check,
+									// so they map to 403; 401 is reserved for a missing or invalid session
 									case 'unauthorized':
 									case 'error-unauthorized':
-										if (applyBreakingChanges) {
-											return api.unauthorized(typeof e === 'string' ? e : e.message);
-										}
 										return api.forbidden(typeof e === 'string' ? e : e.message);
+									case 'not-authorized':
+									case 'error-not-authorized':
+										if (applyBreakingChanges) {
+											return api.forbidden(typeof e === 'string' ? e : e.message);
+										}
+										return api.failure(typeof e === 'string' ? e : e.message, e.error, process.env.TEST_MODE ? e.stack : undefined, e);
 									case 'forbidden':
 									case 'error-forbidden':
 										if (applyBreakingChanges) {

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -902,13 +902,9 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 									// so they map to 403; 401 is reserved for a missing or invalid session
 									case 'unauthorized':
 									case 'error-unauthorized':
-										return api.forbidden(typeof e === 'string' ? e : e.message);
 									case 'not-authorized':
 									case 'error-not-authorized':
-										if (applyBreakingChanges) {
-											return api.forbidden(typeof e === 'string' ? e : e.message);
-										}
-										return api.failure(typeof e === 'string' ? e : e.message, e.error, process.env.TEST_MODE ? e.stack : undefined, e);
+										return api.forbidden(typeof e === 'string' ? e : e.message);
 									case 'forbidden':
 									case 'error-forbidden':
 										if (applyBreakingChanges) {

--- a/apps/meteor/server/api/v1/middlewares/permissions.ts
+++ b/apps/meteor/server/api/v1/middlewares/permissions.ts
@@ -43,13 +43,8 @@ export const permissionsMiddleware =
 		}
 
 		if (!hasPermission) {
-			if (applyBreakingChanges) {
-				const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-				return c.json(forbidden.body, forbidden.statusCode);
-			}
-
-			const failure = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-			return c.json(failure.body, failure.statusCode);
+			const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
+			return c.json(forbidden.body, forbidden.statusCode);
 		}
 
 		return next();

--- a/apps/meteor/server/api/v1/middlewares/permissions.ts
+++ b/apps/meteor/server/api/v1/middlewares/permissions.ts
@@ -2,7 +2,6 @@ import { Logger } from '@rocket.chat/logger';
 import type { Method } from '@rocket.chat/rest-typings';
 import type { MiddlewareHandler } from 'hono';
 
-import { applyBreakingChanges } from '../../ApiClass';
 import { API } from '../../api';
 import { type PermissionsPayload, checkPermissionsForInvocation } from '../../api.helpers';
 import type { TypedOptions } from '../../definition';
@@ -20,13 +19,8 @@ export const permissionsMiddleware =
 		const user = c.get('user');
 
 		if (!user) {
-			if (applyBreakingChanges) {
-				const unauthorized = API.v1.unauthorized('You must be logged in to do this');
-				return c.json(unauthorized.body, unauthorized.statusCode);
-			}
-
-			const failure = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-			return c.json(failure.body, failure.statusCode);
+			const unauthorized = API.v1.unauthorized('You must be logged in to do this');
+			return c.json(unauthorized.body, unauthorized.statusCode);
 		}
 
 		let hasPermission: boolean;

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -77,7 +77,7 @@ import { saveNotificationSettingsMethod } from '../../meteor-methods/users/saveN
 import type { NotificationFieldType } from '../../meteor-methods/users/saveNotificationSettings';
 import { roomsGetMethod } from '../../publications/room';
 import { settings } from '../../settings';
-import { applyBreakingChanges, type ExtractRoutesFromAPI } from '../ApiClass';
+import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 import { MultipartUploadHandler } from '../lib/MultipartUploadHandler';
 import { composeRoomWithLastMessage } from '../lib/composeRoomWithLastMessage';
@@ -1153,8 +1153,7 @@ API.v1.get(
 		}
 
 		if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult._id))) {
-			// TODO: MAJOR drop the 401 branch — an authorization failure is 403
-			return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		// Ensures that role priorities for the specified room are synchronized correctly.
@@ -1301,8 +1300,7 @@ API.v1.post(
 		const { roomId } = this.bodyParams;
 
 		if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-			// TODO: MAJOR drop the 401 branch — an authorization failure is 403
-			return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
@@ -1706,8 +1704,7 @@ export const roomEndpoints = API.v1
 			const { roomId } = this.queryParams;
 
 			if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-				// TODO: MAJOR drop the 401 branch — an authorization failure is 403
-				return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
+				return API.v1.forbidden();
 			}
 
 			const { offset, count } = await getPaginationItems(this.queryParams);

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -77,7 +77,7 @@ import { saveNotificationSettingsMethod } from '../../meteor-methods/users/saveN
 import type { NotificationFieldType } from '../../meteor-methods/users/saveNotificationSettings';
 import { roomsGetMethod } from '../../publications/room';
 import { settings } from '../../settings';
-import type { ExtractRoutesFromAPI } from '../ApiClass';
+import { applyBreakingChanges, type ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 import { MultipartUploadHandler } from '../lib/MultipartUploadHandler';
 import { composeRoomWithLastMessage } from '../lib/composeRoomWithLastMessage';
@@ -1134,6 +1134,7 @@ API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 			404: validateNotFoundErrorResponse,
 		},
 	},
@@ -1152,7 +1153,8 @@ API.v1.get(
 		}
 
 		if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult._id))) {
-			return API.v1.unauthorized();
+			// TODO: MAJOR drop the 401 branch — an authorization failure is 403
+			return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
 		}
 
 		// Ensures that role priorities for the specified room are synchronized correctly.
@@ -1292,13 +1294,15 @@ API.v1.post(
 			200: successResponseSchema,
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
 		const { roomId } = this.bodyParams;
 
 		if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-			return API.v1.unauthorized();
+			// TODO: MAJOR drop the 401 branch — an authorization failure is 403
+			return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
 		}
 
 		const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
@@ -1695,13 +1699,15 @@ export const roomEndpoints = API.v1
 			response: {
 				200: roomsBannedUsersResponseSchema,
 				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
 			},
 		},
 		async function action() {
 			const { roomId } = this.queryParams;
 
 			if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-				return API.v1.unauthorized();
+				// TODO: MAJOR drop the 401 branch — an authorization failure is 403
+				return applyBreakingChanges ? API.v1.forbidden() : API.v1.unauthorized();
 			}
 
 			const { offset, count } = await getPaginationItems(this.queryParams);

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -4663,6 +4663,7 @@ describe('[Rooms]', () => {
 				.set(nonMemberCredentials)
 				.send({ roomId: roomB._id })
 				.expect('Content-Type', 'application/json')
+				// TODO: MAJOR 403 — currently 401 until the 9.0.0 breaking changes are applied
 				.expect(401)
 				.expect((res) => {
 					expect(res.body).to.have.property('success', false);
@@ -5099,6 +5100,28 @@ describe('[Rooms]', () => {
 		after(async () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 			await Promise.all(bannedUsers.map((user) => deleteUser(user)));
+		});
+
+		it('should return forbidden if user does not have access to the room', async () => {
+			const privateRoom = (await createRoom({ type: 'p', name: `banned-users-private-${Date.now()}-${Math.random()}` })).body.group;
+			const nonMember = await createUser({ joinDefaultChannels: false });
+			const nonMemberCredentials = await login(nonMember.username, password);
+
+			try {
+				await request
+					.get(api('rooms.bannedUsers'))
+					.set(nonMemberCredentials)
+					.query({ roomId: privateRoom._id })
+					.expect('Content-Type', 'application/json')
+					// TODO: MAJOR 403 — currently 401 until the 9.0.0 breaking changes are applied
+					.expect(401)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', false);
+					});
+			} finally {
+				await deleteRoom({ type: 'p', roomId: privateRoom._id });
+				await deleteUser(nonMember);
+			}
 		});
 
 		it('should list every banned user of the room with only the projected fields', async () => {

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -4663,8 +4663,7 @@ describe('[Rooms]', () => {
 				.set(nonMemberCredentials)
 				.send({ roomId: roomB._id })
 				.expect('Content-Type', 'application/json')
-				// TODO: MAJOR 403 — currently 401 until the 9.0.0 breaking changes are applied
-				.expect(401)
+				.expect(403)
 				.expect((res) => {
 					expect(res.body).to.have.property('success', false);
 				});
@@ -5113,8 +5112,7 @@ describe('[Rooms]', () => {
 					.set(nonMemberCredentials)
 					.query({ roomId: privateRoom._id })
 					.expect('Content-Type', 'application/json')
-					// TODO: MAJOR 403 — currently 401 until the 9.0.0 breaking changes are applied
-					.expect(401)
+					.expect(403)
 					.expect((res) => {
 						expect(res.body).to.have.property('success', false);
 					});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

In the REST API the status codes for authentication and authorization failures are inverted relative to their meaning: `error-invalid-user` ("you are not logged in") falls through to `API.v1.failure()` → **400**, while `error-unauthorized` ("you are logged in but not allowed") was mapped to **401** under the `9.0.0` flag. So the only code that reached 401 never meant unauthenticated, and the condition that genuinely is 401 answered 400.

I classified all 31 `error-unauthorized` / `error-not-authorized` throws in `apps/meteor/server`, `apps/meteor/app` and `apps/meteor/ee` by the guard preceding them — every single one is an authorization check (`hasPermissionAsync`, `canAccessRoom`, `canDeleteFile`, agent department scope). None means unauthenticated. Full per-site census in the issue.

This PR makes 401 mean exactly one thing — no valid session — so a client can act on it again. **The change is applied directly, not deferred behind `applyBreakingChanges`**, hence the `major` changeset.

- **`server/api/ApiClass.ts`** — `error-unauthorized` / `unauthorized` and `error-not-authorized` / `not-authorized` all map to `forbidden()` (403). `error-unauthorized` was already 403 and simply no longer flips to 401; `error-not-authorized` was not handled by the switch at all and fell through to 400.
- **`server/api/v1/rooms.ts`** — `rooms.membersOrderedByRole` (`view-broadcast-member-list`), `rooms.hide` and `rooms.bannedUsers` returned 401 for access/permission failures and now return 403. Response schemas declare `403`.
- **`server/api/v1/middlewares/permissions.ts`** — a missing session now answers 401 instead of 403-with-`[error-unauthorized]`-in-the-message. Also removed the dead `if (applyBreakingChanges)` fork on the `!hasPermission` path, whose two branches were byte-identical (the legacy branch named its variable `failure`, so `API.v1.failure` was probably intended and the if/else was left half-finished).

Worth calling out: before this, the *same* permission denial answered **403 from `permissionsMiddleware`** and **401 from a handler** once the flag turned on. That inconsistency is gone.

### Why this matters beyond tidiness

The ~134 unauthenticated checks live almost entirely in `apps/meteor/server/meteor-methods/`. Over DDP the error code reaches the client verbatim and no status code is involved. As each method migrates to a typed route, that same check starts answering 400 — indistinguishable from a validation error.

It already cost us once: in #40675 (`sendMessage` + `getReadReceipts` migration) a client handler that treated any REST 401 as an expired session logged out live sessions and failed the omnichannel e2e shards. It was reverted, and it cannot be reimplemented correctly until 401 has a single meaning. This PR is the prerequisite.

## Issue(s)

Refs #41589
Refs ARCH-2297

## Steps to test or reproduce

1. `rooms.hide` as a user without access to the room → was 401, now 403.
2. `rooms.bannedUsers` on a private room the caller is not in → was 401, now 403.
3. `rooms.membersOrderedByRole` on a broadcast room without `view-broadcast-member-list` → was 401, now 403. (Untested branch: `findRoomByIdOrName` answers `notFound` first for non-members, so it is only reachable for a member of a broadcast room.)
4. Any endpoint whose handler throws `error-not-authorized` (e.g. `rooms.changeArchivationState` without `archive-room`) → was 400, now 403.
5. A route with `permissionsRequired` and no `authRequired`, called with no session → was 403, now 401.

Tests: `apps/meteor/tests/end-to-end/api/rooms.ts`. Updated the `rooms.hide` no-access assertion to 403, and added the missing no-access test for `rooms.bannedUsers`, which had none.

## Further comments

**Status: draft while CI tells us the real blast radius.** Two things I expect the suite to surface, and I'd rather have the numbers than guess:

1. Tests asserting 400 on endpoints that reach an `error-not-authorized` throw now get 403.
2. Routes that can now return 403 without declaring `403:` in their response schema — response validation runs against the declared schema in `TEST_MODE`, so those may fail rather than pass through.

One subtlety found while auditing: several `error-not-authorized` sites throw a plain `Error`, not `Meteor.Error` / `MeteorError` — `server/api/lib/rooms.ts:27,68,113`, `server/api/v1/omnichannel/lib/inquiries.ts:28`, `server/lib/omnichannel/closeLivechatRoom.ts:39`, `ee/server/lib/omnichannel/business-hour/lib/business-hour.ts:14`, `ee/server/api/ldap.ts:36`. The switch keys off `e.error`, which is `undefined` on a plain `Error`, so those still fall through to 400 and are **not** affected by this PR. They carry the code in `message` instead and want a separate cleanup.

Deliberately **not** in this PR — step 2 of the issue: introducing a dedicated `error-unauthenticated` code mapped to 401 and moving the ~134 missing-session guards onto it. A blanket remap of `error-invalid-user` is not viable, since the same code also means "that user does not exist" (244 occurrences in total, only 134 of them guarded by a missing-session check). Separate, much larger change, and it depends on this one landing first.

I also left `rooms.ts:1147` alone — in the same handler as the broadcast check, it answers `notFound` for an access failure, a third treatment of the same class of condition in one file. Changing it to 403 would leak room existence, so it deserves its own discussion rather than a drive-by fix.
