### PR TITLE
regression: audio attachments show no duration and cannot seek until played

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -3,6 +3,7 @@ import { AudioPlayerControls, Box } from '@rocket.chat/fuselage';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
+import { useAudioDuration } from './hooks/useAudioDuration';
 import { useMediaPlayer } from '../../../../../providers/MediaPlayerProvider';
 import type { PersistentAudioTrack } from '../../../../../providers/MediaPlayerProvider';
 import MarkdownText from '../../../../MarkdownText';
@@ -37,6 +38,7 @@ const AudioAttachment = ({
 	const src = useMemo(() => getURL(url), [getURL, url]);
 
 	const { play, toggle, seek, cyclePlaybackRate, isActive, playing, currentTime, duration, playbackRate } = useMediaPlayer();
+	const metadataDuration = useAudioDuration(src);
 
 	const track = useMemo<PersistentAudioTrack>(
 		() => ({
@@ -74,10 +76,10 @@ const AudioAttachment = ({
 					<AudioPlayerControls
 						isPlaying={active && playing}
 						currentTime={active ? currentTime : 0}
-						durationTime={active ? duration : 0}
+						durationTime={(active && duration) || metadataDuration}
 						playbackSpeed={playbackRate}
 						onTogglePlay={() => (active ? toggle() : play(track))}
-						onSeek={(time) => (active ? seek(time) : play(track))}
+						onSeek={(time) => (active ? seek(time) : play(track, time))}
 						onChangePlaybackSpeed={cyclePlaybackRate}
 					/>
 				</Box>

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useAudioDuration.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useAudioDuration.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Fetches the audio metadata off-DOM to know the track duration before it is
+ * ever loaded into the shared player element.
+ */
+export const useAudioDuration = (src: string): number => {
+	const [duration, setDuration] = useState(0);
+
+	useEffect(() => {
+		setDuration(0);
+		const audio = new Audio();
+		audio.preload = 'metadata';
+
+		const onDurationChange = () => {
+			if (audio.duration === Infinity) {
+				// Files recorded without a duration header (e.g. MediaRecorder) report
+				// Infinity until the browser is forced to scan to the end.
+				audio.currentTime = 1e101;
+				return;
+			}
+			setDuration(audio.duration);
+		};
+
+		audio.addEventListener('durationchange', onDurationChange);
+		audio.src = src;
+
+		return () => {
+			audio.removeEventListener('durationchange', onDurationChange);
+			audio.removeAttribute('src');
+			audio.load();
+		};
+	}, [src]);
+
+	return duration;
+};

--- a/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerContext.ts
+++ b/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerContext.ts
@@ -33,8 +33,8 @@ export type MediaPlayerContextValue = {
 	currentTime: number;
 	duration: number;
 	playbackRate: number;
-	/** Loads (only if a different track) and plays the given track in the shared element. */
-	play: (track: PersistentAudioTrack) => void;
+	/** Loads (only if a different track) and plays the given track in the shared element, optionally starting at `at` seconds. */
+	play: (track: PersistentAudioTrack, at?: number) => void;
 	/** Toggles play/pause for the active track. No-op when no track is active. */
 	toggle: () => void;
 	/** Seeks the active track to `time` seconds. */

--- a/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
+++ b/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
@@ -38,7 +38,9 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 	}, []);
 	const setAudioRef = useMergedRefs(audioCallback, mediaRef);
 
-	const play = useStableCallback((next: PersistentAudioTrack) => {
+	const pendingSeekRef = useRef<number | null>(null);
+
+	const play = useStableCallback((next: PersistentAudioTrack, at?: number) => {
 		const audio = audioRef.current;
 		if (!audio) {
 			return;
@@ -48,8 +50,11 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 			setTrack(next);
 			setCurrentTime(0);
 			setDuration(0);
+			pendingSeekRef.current = at ?? null;
 			audio.src = next.url;
 			audio.load();
+		} else if (at !== undefined) {
+			audio.currentTime = at;
 		}
 
 		audio.playbackRate = playbackRate;
@@ -118,7 +123,13 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 				onPause={() => setPlaying(false)}
 				onEnded={() => close()}
 				onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
-				onLoadedMetadata={(e) => setDuration(e.currentTarget.duration || 0)}
+				onLoadedMetadata={(e) => {
+					setDuration(e.currentTarget.duration || 0);
+					if (pendingSeekRef.current !== null) {
+						e.currentTarget.currentTime = pendingSeekRef.current;
+						pendingSeekRef.current = null;
+					}
+				}}
 				onDurationChange={(e) => setDuration(e.currentTarget.duration || 0)}
 				onRateChange={(e) => setPlaybackRate(e.currentTarget.playbackRate)}
 			>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Since the persistent audio player (#41120), message audio attachments render stateless controls against a single shared `<audio>` element. Duration and seek state only exist for the currently active track, so every unplayed audio message showed `0:00` and a locked slider (max = 0), and clicking the slider restarted playback from the beginning.

- Added `useAudioDuration`: loads the audio metadata off-DOM (`preload='metadata'`) so each attachment knows its duration before ever being played, including the Infinity-duration workaround for MediaRecorder files (same behavior the previous per-message fuselage `AudioPlayer` had).
- `AudioPlayerControls` now falls back to that metadata duration when the track is not active, making the duration label and the slider range correct on render.
- `play(track, at?)`: seeking an inactive attachment now starts playback at the clicked position (pending seek applied on `loadedmetadata`).

## Issue(s)

## Steps to test or reproduce

1. Send an audio message (or open a room with one).
2. Without playing it, the duration is shown and the slider is draggable.
3. Drag/click the slider on an unplayed audio: playback starts at that position.

## Further comments

Client-only fix. Storing the duration in the attachment at upload time would avoid the extra metadata request and remains a possible follow-up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

