### PR TITLE
chore: migrate readThreads and push_test DDP callers to REST

### DIFF
--- a/.changeset/ddp-migrate-readthreads-pushtest.md
+++ b/.changeset/ddp-migrate-readthreads-pushtest.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Migrated the last two thread-read call sites (`ThreadChat`, `useThreadMessagesQuery`) from the `readThreads` DDP method to `POST /v1/chat.readThread`, and pointed the admin "send a test push to my user" setting at `POST /v1/push.test` instead of the `push_test` DDP method. Both DDP methods stay registered with deprecation logs pointing at the new routes until 9.0.0.
+
+`POST /v1/push.test` now also returns the `message` translation key and its `params`, matching what the DDP method returned, so the admin setting still reports how many devices the test reached.

--- a/.changeset/rest-chat-read-thread.md
+++ b/.changeset/rest-chat-read-thread.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Added `POST /v1/chat.readThread` body `{ tmid }`, which marks a single thread as read for the caller — clearing the thread from the subscription's unread list and running the `beforeReadMessages` / `afterReadMessages` callbacks. It replaces the `readThreads` DDP method, which stays registered with a deprecation log pointing at the new route until 9.0.0.
+
+`POST /v1/subscriptions.read` does not cover this: it takes `{ rid, readThreads? }` and operates on the whole room, with no way to address one thread.

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
@@ -71,7 +71,7 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 					return;
 				}
 
-				void readThread({ tmid: mainMessage._id });
+				void Promise.resolve(readThread({ tmid: mainMessage._id })).catch(() => undefined);
 			},
 			clientCallbacks.priority.MEDIUM,
 			`thread-${room._id}`,

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadChat.tsx
@@ -2,7 +2,7 @@ import type { IMessage, IThreadMainMessage } from '@rocket.chat/core-typings';
 import { isEditedMessage, isThreadMainMessage } from '@rocket.chat/core-typings';
 import { Box, CheckBox, Field, FieldLabel, FieldRow } from '@rocket.chat/fuselage';
 import { clientCallbacks, ContextualbarContent } from '@rocket.chat/ui-client';
-import { useMethod, useTranslation, useUserPreference, useRoomToolbox } from '@rocket.chat/ui-contexts';
+import { useEndpoint, useTranslation, useUserPreference, useRoomToolbox } from '@rocket.chat/ui-contexts';
 import { useState, useEffect, useCallback, useId } from 'react';
 
 import ThreadMessageList from './ThreadMessageList';
@@ -62,7 +62,7 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 	}, [chat?.messageEditing]);
 
 	const room = useRoom();
-	const readThreads = useMethod('readThreads');
+	const readThread = useEndpoint('POST', '/v1/chat.readThread');
 	useEffect(() => {
 		clientCallbacks.add(
 			'streamNewMessage',
@@ -71,7 +71,7 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 					return;
 				}
 
-				readThreads(mainMessage._id);
+				void readThread({ tmid: mainMessage._id });
 			},
 			clientCallbacks.priority.MEDIUM,
 			`thread-${room._id}`,
@@ -80,7 +80,7 @@ const ThreadChat = ({ mainMessage }: ThreadChatProps) => {
 		return () => {
 			clientCallbacks.remove('streamNewMessage', `thread-${room._id}`);
 		};
-	}, [mainMessage._id, readThreads, room._id]);
+	}, [mainMessage._id, readThread, room._id]);
 
 	const subscription = useRoomSubscription();
 	const sendToChannelID = useId();

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -1,6 +1,6 @@
 import type { IRoom, IMessage, IThreadMainMessage, IThreadMessage, Serialized } from '@rocket.chat/core-typings';
 import { isThreadMessage } from '@rocket.chat/core-typings';
-import { useEndpoint, useMethod, useStream } from '@rocket.chat/ui-contexts';
+import { useEndpoint, useStream } from '@rocket.chat/ui-contexts';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef } from 'react';
 
@@ -36,10 +36,9 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 	const queryClient = useQueryClient();
 	const queryKey = roomsQueryKeys.threadMessages(roomId, tmid);
 	const getThreadMessages = useEndpoint('GET', '/v1/chat.getThreadMessages');
-	// REST has no per-thread read-marker endpoint yet; fall back to the
-	// `readThreads` DDP method so the side effect that DDP getThreadMessages
-	// used to do server-side keeps happening for callers.
-	const readThreads = useMethod('readThreads');
+	// `chat.getThreadMessages` is a plain read, so marking the thread as read is an
+	// explicit call — the DDP method it replaced did both server-side.
+	const readThread = useEndpoint('POST', '/v1/chat.readThread');
 
 	const subscribeToRoomMessages = useStream('room-messages');
 	const subscribeToNotifyRoom = useStream('notify-room');
@@ -143,7 +142,7 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 		queryKey,
 		queryFn: async ({ pageParam: offset }) => {
 			if (offset === 0) {
-				void Promise.resolve(readThreads(tmid)).catch(() => undefined);
+				void Promise.resolve(readThread({ tmid })).catch(() => undefined);
 			}
 
 			const cachedData = offset === 0 ? queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey) : undefined;

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -33,12 +33,14 @@ import { Meteor } from 'meteor/meteor';
 import { roomAccessAttributes } from '../../lib/authorization';
 import { canAccessRoomAsync, canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { callbacks } from '../../lib/callbacks';
 import { applyAirGappedRestrictionsValidation } from '../../lib/cloud/license/airGappedRestrictionsWrapper';
 import { deleteMessageValidatingPermission } from '../../lib/messages/deleteMessage';
 import { processWebhookMessage } from '../../lib/messages/processWebhookMessage';
 import { pinMessage, unpinMessage } from '../../lib/messaging/pins/pinMessage';
 import { executeSetReaction } from '../../lib/messaging/reactions/setReaction';
 import { starMessage } from '../../lib/messaging/stars/starMessage';
+import { readThread } from '../../lib/messaging/threads/functions';
 import { reportMessage } from '../../lib/moderation/reportMessage';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
 import { followMessage } from '../../meteor-methods/messages/followMessage';
@@ -163,6 +165,24 @@ const isChatPinMessageProps = ajv.compile<ChatPinMessage>(ChatPinMessageSchema);
 
 const isChatUnpinMessageProps = ajv.compile<ChatUnpinMessage>(ChatUnpinMessageSchema);
 
+type ChatReadThread = {
+	tmid: IMessage['_id'];
+};
+
+const ChatReadThreadSchema = {
+	type: 'object',
+	properties: {
+		tmid: {
+			type: 'string',
+			minLength: 1,
+		},
+	},
+	required: ['tmid'],
+	additionalProperties: false,
+};
+
+const isChatReadThreadProps = ajv.compile<ChatReadThread>(ChatReadThreadSchema);
+
 const chatEndpoints = API.v1
 	.post(
 		'chat.pinMessage',
@@ -232,6 +252,58 @@ const chatEndpoints = API.v1
 			}
 
 			await unpinMessage(this.userId, msg);
+
+			return API.v1.success();
+		},
+	)
+	.post(
+		'chat.readThread',
+		{
+			authRequired: true,
+			body: isChatReadThreadProps,
+			response: {
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				200: ajv.compile<void>({
+					type: 'object',
+					properties: {
+						success: {
+							type: 'boolean',
+							enum: [true],
+						},
+					},
+					required: ['success'],
+					additionalProperties: false,
+				}),
+			},
+		},
+		async function action() {
+			if (!settings.get<boolean>('Threads_enabled')) {
+				throw new Meteor.Error('error-not-allowed', 'Threads Disabled');
+			}
+
+			const { tmid } = this.bodyParams;
+
+			const thread = await Messages.findOneById(tmid, { projection: { rid: 1 } });
+			if (!thread?.rid) {
+				throw new Meteor.Error('error-invalid-message', 'Invalid Message');
+			}
+
+			const [user, room] = await Promise.all([
+				Users.findOneById(this.userId),
+				Rooms.findOneById(thread.rid, { projection: { ...roomAccessAttributes, t: 1, _id: 1 } }),
+			]);
+
+			if (!room) {
+				throw new Meteor.Error('error-room-does-not-exist', 'This room does not exist');
+			}
+
+			if (!user || !(await canAccessRoomAsync(room, user))) {
+				throw new Meteor.Error('error-not-allowed', 'Not Allowed');
+			}
+
+			await callbacks.run('beforeReadMessages', room._id, user._id);
+			await readThread({ user, room, tmid });
 
 			return API.v1.success();
 		},

--- a/apps/meteor/server/api/v1/push.ts
+++ b/apps/meteor/server/api/v1/push.ts
@@ -357,16 +357,20 @@ const pushTestEndpoints = API.v1.post(
 		response: {
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
-			200: ajv.compile<{ tokensCount: number }>({
+			200: ajv.compile<{ tokensCount: number; message: string; params: number[] }>({
 				type: 'object',
 				properties: {
 					tokensCount: { type: 'integer' },
+					// The admin "send a test push" setting renders the outcome straight from this
+					// response, so it carries the i18n key and its interpolation values.
+					message: { type: 'string' },
+					params: { type: 'array', items: { type: 'integer' } },
 					success: {
 						type: 'boolean',
 						enum: [true],
 					},
 				},
-				required: ['tokensCount', 'success'],
+				required: ['tokensCount', 'message', 'params', 'success'],
 				additionalProperties: false,
 			}),
 		},
@@ -380,7 +384,7 @@ const pushTestEndpoints = API.v1.post(
 		}
 
 		const tokensCount = await executePushTest(this.userId, this.user.username);
-		return API.v1.success({ tokensCount });
+		return API.v1.success({ tokensCount, message: 'Your_push_was_sent_to_s_devices', params: [tokensCount] });
 	},
 );
 

--- a/apps/meteor/server/lib/pushConfig.ts
+++ b/apps/meteor/server/lib/pushConfig.ts
@@ -5,6 +5,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { RateLimiterClass as RateLimiter } from './RateLimiter';
 import { hasPermissionAsync } from './authorization/hasPermission';
+import { methodDeprecationLogger } from './deprecationWarningLogger';
 import { i18n } from './i18n';
 import { settings } from '../settings';
 import { Push } from './notifications/push';
@@ -38,6 +39,8 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async push_test() {
+		methodDeprecationLogger.method('push_test', '9.0.0', '/v1/push.test');
+
 		const user = await Meteor.userAsync();
 
 		if (!user) {

--- a/apps/meteor/server/meteor-methods/messages/readThreads.ts
+++ b/apps/meteor/server/meteor-methods/messages/readThreads.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomAsync } from '../../lib/authorization';
 import { callbacks } from '../../lib/callbacks';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { readThread } from '../../lib/messaging/threads/functions';
 import { settings } from '../../settings';
 
@@ -18,6 +19,8 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async readThreads(tmid) {
+		methodDeprecationLogger.method('readThreads', '9.0.0', '/v1/chat.readThread');
+
 		check(tmid, String);
 
 		if (!Meteor.userId() || !settings.get('Threads_enabled')) {

--- a/apps/meteor/server/settings/push.ts
+++ b/apps/meteor/server/settings/push.ts
@@ -66,14 +66,18 @@ export const createPushSettings = () =>
 			alert: 'Push_Setting_Requires_Restart_Alert',
 			enableQuery: pushEnabledWithoutGateway,
 		});
-		await this.add('Push_test_push', 'push_test', {
-			type: 'action',
-			actionText: 'Send_a_test_push_to_my_user',
-			enableQuery: {
-				_id: 'Push_enable',
-				value: true,
+		await this.add(
+			'Push_test_push',
+			{ method: 'POST', path: '/v1/push.test' },
+			{
+				type: 'action',
+				actionText: 'Send_a_test_push_to_my_user',
+				enableQuery: {
+					_id: 'Push_enable',
+					value: true,
+				},
 			},
-		});
+		);
 		await this.section('Certificates_and_Keys', async function () {
 			await this.add('Push_apn_passphrase', '', {
 				type: 'string',

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -4827,18 +4827,20 @@ describe('Threads', () => {
 		it('should fail when threads are disabled', async () => {
 			await updateSetting('Threads_enabled', false);
 
-			await request
-				.post(api('chat.readThread'))
-				.set(credentials)
-				.send({ tmid: parentMessage._id })
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-not-allowed');
-				});
-
-			await updateSetting('Threads_enabled', true);
+			try {
+				await request
+					.post(api('chat.readThread'))
+					.set(credentials)
+					.send({ tmid: parentMessage._id })
+					.expect('Content-Type', 'application/json')
+					.expect(400)
+					.expect((res) => {
+						expect(res.body).to.have.property('success', false);
+						expect(res.body).to.have.property('errorType', 'error-not-allowed');
+					});
+			} finally {
+				await updateSetting('Threads_enabled', true);
+			}
 		});
 
 		it('should fail when tmid does not match any message', async () => {
@@ -4855,11 +4857,19 @@ describe('Threads', () => {
 		});
 
 		it('should fail when tmid is missing', async () => {
-			await request.post(api('chat.readThread')).set(credentials).send({}).expect(400);
+			await request
+				.post(api('chat.readThread'))
+				.set(credentials)
+				.send({})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('errorType', 'invalid-params');
+				});
 		});
 
 		it('should clear the unread thread flag of the caller subscription', async () => {
-			// The reply lands on the thread the caller owns, so it shows up as unread for the caller.
 			await sendSimpleMessage({
 				roomId: testChannel._id,
 				text: 'Thread reply',

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -4805,6 +4805,88 @@ describe('Threads', () => {
 		});
 	});
 
+	describe('[/chat.readThread]', () => {
+		let testChannel: IRoom;
+		let parentMessage: IMessage;
+		let replier: TestUser<IUser>;
+		let replierCredentials: Credentials;
+
+		before(async () => {
+			testChannel = (await createRoom({ type: 'c', name: `channel.test.readThread.${Date.now()}` })).body.channel;
+			parentMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Message to create thread' })).body.message;
+
+			replier = await createUser();
+			replierCredentials = await login(replier.username, password);
+			await addUserToRoom({ usernames: [replier.username], rid: testChannel._id });
+		});
+
+		after(() =>
+			Promise.all([updateSetting('Threads_enabled', true), deleteRoom({ type: 'c', roomId: testChannel._id }), deleteUser(replier)]),
+		);
+
+		it('should fail when threads are disabled', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			await request
+				.post(api('chat.readThread'))
+				.set(credentials)
+				.send({ tmid: parentMessage._id })
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('errorType', 'error-not-allowed');
+				});
+
+			await updateSetting('Threads_enabled', true);
+		});
+
+		it('should fail when tmid does not match any message', async () => {
+			await request
+				.post(api('chat.readThread'))
+				.set(credentials)
+				.send({ tmid: 'invalid-message-id' })
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('errorType', 'error-invalid-message');
+				});
+		});
+
+		it('should fail when tmid is missing', async () => {
+			await request.post(api('chat.readThread')).set(credentials).send({}).expect(400);
+		});
+
+		it('should clear the unread thread flag of the caller subscription', async () => {
+			// The reply lands on the thread the caller owns, so it shows up as unread for the caller.
+			await sendSimpleMessage({
+				roomId: testChannel._id,
+				text: 'Thread reply',
+				tmid: parentMessage._id,
+				userCredentials: replierCredentials,
+			});
+
+			await retry('caller subscription has the thread as unread', async () => {
+				const subscription = await getSubscriptionByRoomId(testChannel._id);
+				expect(subscription.tunread).to.include(parentMessage._id);
+			});
+
+			await request
+				.post(api('chat.readThread'))
+				.set(credentials)
+				.send({ tmid: parentMessage._id })
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+				});
+
+			const subscription = await getSubscriptionByRoomId(testChannel._id);
+			expect(subscription.tunread ?? []).to.not.include(parentMessage._id);
+		});
+	});
+
 	describe('[/chat.syncThreadMessages]', () => {
 		let testChannel: IRoom;
 		let threadMessage: IThreadMessage;


### PR DESCRIPTION
Part of the DDP → REST migration (ARCH-2166). Removes two more client callers off DDP: `readThreads` and `push_test`.

## `readThreads` → `POST /v1/chat.readThread`

`GET /v1/chat.getThreadMessages` (#40998) is a plain read — a GET must not mutate — so the read side effect the DDP `getThreadMessages` used to perform server-side had to be called explicitly. That left `readThreads` with *two* call sites and no REST target.

`POST /v1/subscriptions.read` cannot absorb it: it takes `{ rid, readThreads? }` and marks the whole room, with no way to address a single thread.

So this adds the missing per-thread route, with the same checks the method did (`Threads_enabled`, message exists, room access) and the same effects (`beforeReadMessages` callback, `readThread`). Both call sites — `ThreadChat` and `useThreadMessagesQuery` — move over.

Follows the `chat.pinMessage` pattern in the same file: local schema + `ajv.compile`, type exposed through `ExtractRoutesFromAPI`, no manual entry in `rest-typings` (which would collide with the interface declaration).

## `push_test` → `POST /v1/push.test`

The "Send a test push to my user" admin setting stored the DDP method name, which `MethodActionInput` calls through `useMethod`. `POST /v1/push.test` already existed with the same permission (`test-push-notifications`), the same 1 req/s rate limit and the same `Push_enable` guard, so the setting only needed to hold `{ method, path }` — `ActionSettingInput` then routes it through `EndpointActionInput`, exactly like the ABAC health check already does.

One catch: `ActionInputBase` renders the outcome straight from the response (`t(data.message, { sprintf: data.params })`), and the endpoint returned only `{ tokensCount }` — the toast would have resolved `t(undefined)`. The endpoint now also returns the `message` translation key and its `params`, matching the DDP return value, so the admin still sees how many devices the test reached. `tokensCount` is unchanged for existing consumers.

## Deprecation

Both DDP methods keep their registration with `methodDeprecationLogger` entries pointing at the new routes, to be removed with the rest in 9.0.0.

## Tests

New API test block for `chat.readThread` covering:

- 400 when `Threads_enabled` is off
- 400 for a `tmid` that matches no message
- 400 when `tmid` is missing
- the actual effect: a reply from a second user puts the thread in the caller's `tunread`, and the call clears it

`push.test` already had API coverage for the unauthenticated and push-disabled paths; the success path needs a configured gateway, so the response change is exercised through the admin setting rather than a new API test.

## Steps to test

1. Open a thread with unread replies (have another user reply while you are following it) → the thread badge clears, and `POST /v1/chat.readThread` shows in the network tab instead of a `method.call` for `readThreads`.
2. Admin → Push → enable push, click **Send a test push to my user** → the toast still reports the device count, and the request goes to `/v1/push.test`.
3. With `Threads_enabled` off, `POST /v1/chat.readThread` answers 400 `error-not-allowed`.

## Remaining after this PR

37 methods still called from the UI. Next cheapest group is the remaining admin action settings (8 methods), which need thin POST endpoints over functions that already exist.

Related: ARCH-2166 · #40998 (thread pagination, which created the `readThreads` gap) · #41589 / ARCH-2297 (401/403 semantics, unrelated to this PR but relevant to the migration as a whole)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2298]

[ARCH-2298]: https://rocketchat.atlassian.net/browse/ARCH-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /v1/chat.readThread` to mark a single thread as read (accepts `{ tmid }`) and clear its unread state for the caller.
  * Updated the admin “send a test push” action to use `POST /v1/push.test`.
* **Improvements**
  * Added request validation, room access checks, and read-message callbacks for thread-read requests.
  * `POST /v1/push.test` now returns a localized `message` plus `params` (with `tokensCount`).
* **Deprecations**
  * Legacy `readThreads` and `push_test` now emit migration warnings and remain available until 9.0.0.
* **Tests**
  * Added end-to-end coverage for `POST /v1/chat.readThread`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->