### PR TITLE
regression: custom HTML in sidebar footer and login pages repeatedly reloads

### DIFF
--- a/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
+++ b/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
@@ -3,12 +3,15 @@ import { Box, SidebarDivider, Palette, SidebarFooter as Footer } from '@rocket.c
 import { useThemeMode } from '@rocket.chat/ui-client';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
 
 import { SidebarFooterWatermark } from './SidebarFooterWatermark';
 
 const SidebarFooterDefault = () => {
 	const theme = useThemeMode();
 	const logo = useSetting(theme === 'dark' ? 'Layout_Sidenav_Footer_Dark' : 'Layout_Sidenav_Footer', '').trim();
+
+	const dangerousLogo = useMemo(() => ({ __html: DOMPurify.sanitize(logo) }), [logo]);
 
 	const sidebarFooterStyle = css`
 		& img {
@@ -31,9 +34,7 @@ const SidebarFooterDefault = () => {
 				height='x48'
 				width='auto'
 				className={sidebarFooterStyle}
-				dangerouslySetInnerHTML={{
-					__html: DOMPurify.sanitize(logo),
-				}}
+				dangerouslySetInnerHTML={dangerousLogo}
 			/>
 			<SidebarFooterWatermark />
 		</Footer>

--- a/packages/web-ui-registration/src/CMSPage.tsx
+++ b/packages/web-ui-registration/src/CMSPage.tsx
@@ -1,6 +1,7 @@
 import { Box, IconButton } from '@rocket.chat/fuselage';
 import { VerticalWizardLayout, VerticalWizardLayoutFooter, VerticalWizardLayoutForm, VerticalWizardLayoutTitle } from '@rocket.chat/layout';
 import { useSetting, useTranslation, useAssetWithDarkModePath } from '@rocket.chat/ui-contexts';
+import { useMemo } from 'react';
 
 import { LoginPoweredBy } from './components/LoginPoweredBy';
 
@@ -15,6 +16,8 @@ const CMSPage = ({ page }: CMSPageProps) => {
 	const customLogo = useAssetWithDarkModePath('logo');
 	const customBackground = useAssetWithDarkModePath('background');
 
+	const dangerousContent = useMemo(() => ({ __html: pageContent }), [pageContent]);
+
 	return (
 		<VerticalWizardLayout
 			background={customBackground}
@@ -24,7 +27,7 @@ const CMSPage = ({ page }: CMSPageProps) => {
 			<VerticalWizardLayoutForm>
 				<Box padding={32}>
 					<IconButton title={t('Back')} icon='arrow-back' onClick={() => window.history.back()} style={{ float: 'right' }} />
-					<Box withRichContent dangerouslySetInnerHTML={{ __html: pageContent }} />
+					<Box withRichContent dangerouslySetInnerHTML={dangerousContent} />
 				</Box>
 			</VerticalWizardLayoutForm>
 			<VerticalWizardLayoutFooter>

--- a/packages/web-ui-registration/src/components/LoginTerms.tsx
+++ b/packages/web-ui-registration/src/components/LoginTerms.tsx
@@ -2,21 +2,21 @@ import { Box } from '@rocket.chat/fuselage';
 import { HorizontalWizardLayoutCaption } from '@rocket.chat/layout';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const LoginTerms = () => {
 	const { t } = useTranslation();
 	const loginTerms = useSetting('Layout_Login_Terms', '');
 
+	const dangerousTerms = useMemo(
+		() => ({ __html: loginTerms !== '' ? DOMPurify.sanitize(loginTerms) : DOMPurify.sanitize(t('Layout_Login_Terms_Content')) }),
+		[loginTerms, t],
+	);
+
 	return (
 		<HorizontalWizardLayoutCaption>
-			<Box
-				color='default'
-				withRichContent
-				dangerouslySetInnerHTML={{
-					__html: loginTerms !== '' ? DOMPurify.sanitize(loginTerms) : DOMPurify.sanitize(t('Layout_Login_Terms_Content')),
-				}}
-			/>
+			<Box color='default' withRichContent dangerouslySetInnerHTML={dangerousTerms} />
 		</HorizontalWizardLayoutCaption>
 	);
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Custom HTML defined by admins was being destroyed and rebuilt on every unrelated re-render, reloading any embedded media (video, iframe, animated GIF) from the start.

Same root cause as #41299 and #41582: since React 19, content set through inner HTML is re-applied whenever the object holding it is a new reference, even when the markup is identical. React 18 compared the markup itself, so it was a no-op. The fix here is the same one applied in those two PRs — keep the object stable across re-renders.

This covers the remaining places that render admin-authored HTML settings:

- Sidebar footer (light and dark)
- Terms of Service, Privacy Policy and Legal Notice pages
- Login terms

Other places rendering inner HTML show emoji, code blocks or translated text, so they have no equivalent failure and are intentionally left unchanged.

## Issue(s)

- [CORE-2487](https://rocketchat.atlassian.net/browse/CORE-2487)

## Steps to test or reproduce

1. Go to Admin → Settings → Layout → Content and set **Sidebar footer** to an image tag pointing at an animated GIF.
2. Use the app normally — open admin, a contextual bar, the marketplace.
3. Before the fix the logo restarts from the first frame every so often, as translations load in the background. After the fix it plays uninterrupted.

The same applies to the Terms of Service, Privacy Policy and Legal Notice pages, and to the login terms, when their content includes a video or animated image.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved rendering efficiency for footer content, CMS pages, and login terms by reusing processed HTML when content remains unchanged.
* **Security**
  * Preserved HTML sanitization for footer and login terms content.
* **Refactor**
  * Simplified rich HTML rendering without changing the visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2487]: https://rocketchat.atlassian.net/browse/CORE-2487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ