### PR TITLE
regression: audio attachment duration is not shown until playback

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -3,6 +3,7 @@ import { AudioPlayerControls, Box } from '@rocket.chat/fuselage';
 import { useMediaUrl } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
+import { useMediaDuration } from './hooks/useMediaDuration';
 import { useMediaPlayer } from '../../../../../providers/MediaPlayerProvider';
 import type { PersistentAudioTrack } from '../../../../../providers/MediaPlayerProvider';
 import MarkdownText from '../../../../MarkdownText';
@@ -54,6 +55,7 @@ const AudioAttachment = ({
 	);
 
 	const active = isActive(track.id);
+	const resolvedDuration = useMediaDuration(src);
 
 	return (
 		<>
@@ -74,7 +76,7 @@ const AudioAttachment = ({
 					<AudioPlayerControls
 						isPlaying={active && playing}
 						currentTime={active ? currentTime : 0}
-						durationTime={active ? duration : 0}
+						durationTime={active && duration ? duration : resolvedDuration}
 						playbackSpeed={playbackRate}
 						onTogglePlay={() => (active ? toggle() : play(track))}
 						onSeek={(time) => (active ? seek(time) : play(track))}

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.spec.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.spec.ts
@@ -1,0 +1,90 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { useMediaDuration } from './useMediaDuration';
+
+interface IFakeAudio extends HTMLAudioElement {
+	_emit: (type: string) => void;
+	_setDuration: (value: number) => void;
+}
+
+describe('useMediaDuration', () => {
+	let created: IFakeAudio[];
+	const OriginalAudio = global.Audio;
+
+	beforeEach(() => {
+		created = [];
+		global.Audio = jest.fn().mockImplementation(() => {
+			const el = document.createElement('audio') as IFakeAudio;
+			let value = NaN;
+			Object.defineProperty(el, 'duration', { configurable: true, get: () => value });
+			el._setDuration = (next: number) => {
+				value = next;
+			};
+			el._emit = (type: string) => el.dispatchEvent(new Event(type));
+			jest.spyOn(el, 'load').mockImplementation(() => undefined);
+			created.push(el);
+			return el;
+		}) as unknown as typeof Audio;
+	});
+
+	afterEach(() => {
+		global.Audio = OriginalAudio;
+		jest.restoreAllMocks();
+	});
+
+	const resolveMetadata = (el: IFakeAudio, value: number) => {
+		act(() => {
+			el._setDuration(value);
+			el._emit('loadedmetadata');
+		});
+	};
+
+	it('resolves the duration from metadata without playing', () => {
+		const { result } = renderHook(() => useMediaDuration('/audio-a.mp3'));
+		expect(result.current).toBe(0);
+		expect(created).toHaveLength(1);
+
+		resolveMetadata(created[0], 120);
+		expect(result.current).toBe(120);
+	});
+
+	it('ignores a non-finite or zero duration', () => {
+		const { result } = renderHook(() => useMediaDuration('/audio-b.mp3'));
+
+		resolveMetadata(created[0], Infinity);
+		resolveMetadata(created[0], 0);
+
+		expect(result.current).toBe(0);
+	});
+
+	it('serves a cached duration without a new metadata request', () => {
+		const src = '/audio-c.mp3';
+		const { result: firstResult } = renderHook(() => useMediaDuration(src));
+		resolveMetadata(created[0], 90);
+		expect(firstResult.current).toBe(90);
+
+		const { result: secondResult } = renderHook(() => useMediaDuration(src));
+		expect(secondResult.current).toBe(90);
+		expect(created).toHaveLength(1);
+	});
+
+	it('resets to 0 when the source changes to an unresolved one', () => {
+		const { result, rerender } = renderHook(({ src }) => useMediaDuration(src), {
+			initialProps: { src: '/audio-d.mp3' },
+		});
+		resolveMetadata(created[0], 75);
+		expect(result.current).toBe(75);
+
+		rerender({ src: '/audio-e.mp3' });
+		expect(result.current).toBe(0);
+	});
+
+	it('aborts the pending metadata request on unmount', () => {
+		const { unmount } = renderHook(() => useMediaDuration('/audio-f.mp3'));
+		const el = created[0];
+		expect(el.getAttribute('src')).not.toBeNull();
+
+		unmount();
+		expect(el.getAttribute('src')).toBeNull();
+	});
+});

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.spec.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.spec.ts
@@ -51,10 +51,13 @@ describe('useMediaDuration', () => {
 	it('ignores a non-finite or zero duration', () => {
 		const { result } = renderHook(() => useMediaDuration('/audio-b.mp3'));
 
+		resolveMetadata(created[0], 90);
+		expect(result.current).toBe(90);
+
 		resolveMetadata(created[0], Infinity);
 		resolveMetadata(created[0], 0);
 
-		expect(result.current).toBe(0);
+		expect(result.current).toBe(90);
 	});
 
 	it('serves a cached duration without a new metadata request', () => {

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+const MAX_CACHE_ENTRIES = 256;
 const durationCache = new Map<string, number>();
 
 export const useMediaDuration = (src: string): number => {
@@ -19,6 +20,12 @@ export const useMediaDuration = (src: string): number => {
 		const handleDuration = () => {
 			if (Number.isFinite(audio.duration) && audio.duration > 0) {
 				durationCache.set(src, audio.duration);
+				if (durationCache.size > MAX_CACHE_ENTRIES) {
+					const oldest = durationCache.keys().next().value;
+					if (oldest !== undefined) {
+						durationCache.delete(oldest);
+					}
+				}
 				setDuration(audio.duration);
 			}
 		};

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
@@ -6,13 +6,10 @@ export const useMediaDuration = (src: string): number => {
 	const [duration, setDuration] = useState(() => durationCache.get(src) ?? 0);
 
 	useEffect(() => {
-		if (!src) {
-			return;
-		}
+		const cached = src ? durationCache.get(src) : undefined;
+		setDuration(cached ?? 0);
 
-		const cached = durationCache.get(src);
-		if (cached !== undefined) {
-			setDuration(cached);
+		if (!src || cached !== undefined) {
 			return;
 		}
 

--- a/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
+++ b/apps/meteor/client/components/message/content/attachments/file/hooks/useMediaDuration.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+const durationCache = new Map<string, number>();
+
+export const useMediaDuration = (src: string): number => {
+	const [duration, setDuration] = useState(() => durationCache.get(src) ?? 0);
+
+	useEffect(() => {
+		if (!src) {
+			return;
+		}
+
+		const cached = durationCache.get(src);
+		if (cached !== undefined) {
+			setDuration(cached);
+			return;
+		}
+
+		const audio = new Audio();
+		audio.preload = 'metadata';
+
+		const handleDuration = () => {
+			if (Number.isFinite(audio.duration) && audio.duration > 0) {
+				durationCache.set(src, audio.duration);
+				setDuration(audio.duration);
+			}
+		};
+
+		audio.addEventListener('loadedmetadata', handleDuration);
+		audio.addEventListener('durationchange', handleDuration);
+		audio.src = src;
+		audio.load();
+
+		return () => {
+			audio.removeEventListener('loadedmetadata', handleDuration);
+			audio.removeEventListener('durationchange', handleDuration);
+			audio.removeAttribute('src');
+			audio.load();
+		};
+	}, [src]);
+
+	return duration;
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating translations
  regression: Issues created during development phase
-->

## Proposed changes (including videos or screenshots)

Audio attachments displayed `00:00` as their length until playback started; the duration only appeared once the file began playing.

Root cause: the persistent audio player (#41120) replaced the previous fuselage `<AudioPlayer preload="metadata">` (which loaded each attachment's metadata on mount and showed its length) with a single app-wide `<audio>` element. That shared element only knows the duration of the one track it currently holds, so every non-active attachment was rendered with a hardcoded duration of `0`.

Changes:
- Add a `useMediaDuration` hook that resolves a file's duration from its metadata off a detached, metadata-only media element, without playing it, restoring the pre-shared-player behavior.
- Resolve the duration once per source and cache it for the session, so scrolling an attachment out of and back into the virtualized message list does not re-fetch metadata or flash `00:00`.
- Show the resolved duration for non-active attachments and the player's live duration for the active one.

## Issue(s)

CORE-2476

## Steps to test or reproduce

1. Open a room containing one or more audio attachments.
2. Observe each attachment's length before playing it.
3. Expected: the total duration appears once metadata loads, without requiring playback (previously it showed `00:00` until play started).

## Further comments

Root cause: #41120

[CORE-2476](https://rocketchat.atlassian.net/browse/CORE-2476)


[CORE-2476]: https://rocketchat.atlassian.net/browse/CORE-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-2477](https://rocketchat.atlassian.net/browse/CORE-2477) 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio attachments can now determine and display their duration before playback begins.
* **Bug Fixes**
  * Audio duration displays remain accurate when metadata is initially unavailable or when switching tracks.
  * Invalid or unavailable duration values no longer appear in the player.
* **Tests**
  * Added coverage for duration loading, caching, source changes, invalid values, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->