### PR TITLE
fix: Stop media player when message is not accessible

### DIFF
--- a/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
+++ b/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
@@ -1,5 +1,5 @@
 import { useMergedRefs, useStableCallback } from '@rocket.chat/fuselage-hooks';
-import { useStream } from '@rocket.chat/ui-contexts';
+import { useStream, useUserId } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -29,6 +29,7 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState(0);
 	const [playbackRate, setPlaybackRate] = useState<number>(1);
+	const userId = useUserId();
 
 	const trackRef = useRef<PersistentAudioTrack | null>(null);
 	trackRef.current = track;
@@ -104,6 +105,7 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 
 	const isActive = useCallback((id: string) => trackRef.current?.id === id, []);
 	const subscribeToNotifyRoom = useStream('notify-room');
+	const subscribeToNotifyUser = useStream('notify-user');
 
 	//For hard message delete, when Message Message_ShowDeletedStatus is off
 	useEffect(() => {
@@ -156,6 +158,24 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 
 		return unsub;
 	}, [track, close, playing]);
+
+	useEffect(() => {
+		if (!track || !playing || !userId) {
+			return;
+		}
+
+		const { rid } = track;
+
+		if (!rid) {
+			return;
+		}
+
+		return subscribeToNotifyUser(`${userId}/subscriptions-changed`, (event, subscription) => {
+			if (event === 'removed' && subscription.rid === rid) {
+				close();
+			}
+		});
+	}, [userId, subscribeToNotifyUser, track, playing, close]);
 
 	const value = useMemo<MediaPlayerContextValue>(
 		() => ({ track, playing, currentTime, duration, playbackRate, play, toggle, seek, cyclePlaybackRate, close, isActive }),

--- a/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
+++ b/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
@@ -109,7 +109,7 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 
 	//For hard message delete, when Message Message_ShowDeletedStatus is off
 	useEffect(() => {
-		if (!track || !playing) {
+		if (!track) {
 			return;
 		}
 
@@ -135,11 +135,11 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 			unsubscribeFromDeleteMessage();
 			unsubscribeFromDeleteMessageBulk();
 		};
-	}, [track, subscribeToNotifyRoom, close, playing]);
+	}, [track, subscribeToNotifyRoom, close]);
 
 	//For soft message delete, when Message_ShowDeletedStatus is on and server updates message.t to rm
 	useEffect(() => {
-		if (!track || !playing) {
+		if (!track) {
 			return;
 		}
 
@@ -157,10 +157,10 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 		});
 
 		return unsub;
-	}, [track, close, playing]);
+	}, [track, close]);
 
 	useEffect(() => {
-		if (!track || !playing || !userId) {
+		if (!track || !userId) {
 			return;
 		}
 
@@ -175,7 +175,7 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 				close();
 			}
 		});
-	}, [userId, subscribeToNotifyUser, track, playing, close]);
+	}, [userId, subscribeToNotifyUser, track, close]);
 
 	const value = useMemo<MediaPlayerContextValue>(
 		() => ({ track, playing, currentTime, duration, playbackRate, play, toggle, seek, cyclePlaybackRate, close, isActive }),

--- a/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
+++ b/apps/meteor/client/providers/MediaPlayerProvider/MediaPlayerProvider.tsx
@@ -1,10 +1,12 @@
 import { useMergedRefs, useStableCallback } from '@rocket.chat/fuselage-hooks';
+import { useStream } from '@rocket.chat/ui-contexts';
 import type { ReactNode } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { MediaPlayerContextValue, PersistentAudioTrack } from './MediaPlayerContext';
 import { MediaPlayerContext } from './MediaPlayerContext';
 import { useReloadOnError } from '../../components/message/content/attachments/file/hooks/useReloadOnError';
+import { Messages } from '../../stores';
 
 const PLAYBACK_RATES = [1, 1.5, 2] as const;
 
@@ -101,6 +103,59 @@ const MediaPlayerProvider = ({ children }: MediaPlayerProviderProps) => {
 	});
 
 	const isActive = useCallback((id: string) => trackRef.current?.id === id, []);
+	const subscribeToNotifyRoom = useStream('notify-room');
+
+	//For hard message delete, when Message Message_ShowDeletedStatus is off
+	useEffect(() => {
+		if (!track || !playing) {
+			return;
+		}
+
+		const { rid, mid } = track;
+
+		if (!rid || !mid) {
+			return;
+		}
+
+		const unsubscribeFromDeleteMessage = subscribeToNotifyRoom(`${rid}/deleteMessage`, ({ _id }) => {
+			if (_id === mid) {
+				close();
+			}
+		});
+
+		const unsubscribeFromDeleteMessageBulk = subscribeToNotifyRoom(`${rid}/deleteMessageBulk`, ({ ids }) => {
+			if (ids?.includes(mid)) {
+				close();
+			}
+		});
+
+		return () => {
+			unsubscribeFromDeleteMessage();
+			unsubscribeFromDeleteMessageBulk();
+		};
+	}, [track, subscribeToNotifyRoom, close, playing]);
+
+	//For soft message delete, when Message_ShowDeletedStatus is on and server updates message.t to rm
+	useEffect(() => {
+		if (!track || !playing) {
+			return;
+		}
+
+		const unsub = Messages.use.subscribe((state, prevState) => {
+			const { mid } = track;
+			if (!mid) {
+				return;
+			}
+
+			const message = state.records.get(mid);
+
+			if (message && message !== prevState.records.get(mid) && message.t === 'rm') {
+				close();
+			}
+		});
+
+		return unsub;
+	}, [track, close, playing]);
 
 	const value = useMemo<MediaPlayerContextValue>(
 		() => ({ track, playing, currentTime, duration, playbackRate, play, toggle, seek, cyclePlaybackRate, close, isActive }),


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Recently we made a global audio player which didn't require the audio message to be mounted but this created issue that audio player should stop once the user no longer has access to the message, either by message being deleted or the user being no longer part of the room.

This PR implements this edge case by listening to the required stream events, it stops playing audio when user can no longer access the message.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2484](https://rocketchat.atlassian.net/browse/CORE-2484)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2484]: https://rocketchat.atlassian.net/browse/CORE-2484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audio playback now stops automatically when the currently playing message is hard-deleted or soft-deleted.
  * Playback also stops when the user’s subscription changes remove access to the associated room.
  * Improved real-time handling of room and account updates to keep media playback in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->