### PR TITLE
regression: Jump to message not working for audio played from quoted messages

### DIFF
--- a/apps/meteor/client/components/message/content/attachments/AttachmentsItem.tsx
+++ b/apps/meteor/client/components/message/content/attachments/AttachmentsItem.tsx
@@ -19,7 +19,7 @@ const AttachmentsItem = ({ attachment, id, source }: AttachmentsItemProps) => {
 	}
 
 	if (isQuoteAttachment(attachment)) {
-		return <QuoteAttachment attachment={attachment} />;
+		return <QuoteAttachment attachment={attachment} source={source} />;
 	}
 
 	return <DefaultAttachment {...(attachment as any)} />;

--- a/apps/meteor/client/components/message/content/attachments/QuoteAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/QuoteAttachment.tsx
@@ -6,6 +6,7 @@ import { useUserPreference } from '@rocket.chat/ui-contexts';
 import { useTimeAgo } from '../../../../hooks/useTimeAgo';
 import MessageContentBody from '../../MessageContentBody';
 import Attachments from '../Attachments';
+import type { AudioAttachmentSource } from './file/AudioAttachment';
 import AttachmentAuthor from './structure/AttachmentAuthor';
 import AttachmentAuthorAvatar from './structure/AttachmentAuthorAvatar';
 import AttachmentAuthorName from './structure/AttachmentAuthorName';
@@ -34,9 +35,10 @@ const quoteStyles = css`
 
 export type QuoteAttachmentProps = {
 	attachment: MessageQuoteAttachment;
+	source?: AudioAttachmentSource;
 };
 
-export const QuoteAttachment = ({ attachment }: QuoteAttachmentProps) => {
+export const QuoteAttachment = ({ attachment, source }: QuoteAttachmentProps) => {
 	const formatTime = useTimeAgo();
 	const displayAvatarPreference = useUserPreference<boolean>('displayAvatars');
 
@@ -65,7 +67,11 @@ export const QuoteAttachment = ({ attachment }: QuoteAttachmentProps) => {
 					</AttachmentAuthor>
 					{attachment.attachments && (
 						<AttachmentInner>
-							<Attachments attachments={attachment.attachments} id={attachment.attachments[0]?.title_link} />
+							<Attachments
+								attachments={attachment.attachments}
+								id={attachment.attachments[0]?.title_link}
+								source={source && { rid: source.rid, mid: source.mid, name: attachment.author_name }}
+							/>
 						</AttachmentInner>
 					)}
 					{attachment.md ? <MessageContentBody md={attachment.md} /> : attachment.text.substring(attachment.text.indexOf('\n') + 1)}

--- a/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/room/RoomMessageContent.tsx
@@ -57,7 +57,12 @@ const RoomMessageContent = ({ message, unread, all, mention, searchText }: RoomM
 				</MessageBody>
 			)}
 
-			{!!quotes?.length && <Attachments attachments={quotes} />}
+			{!!quotes?.length && (
+				<Attachments
+					attachments={quotes}
+					source={{ rid: message.rid, mid: message._id, username: message.u.username, name: message.u.name }}
+				/>
+			)}
 
 			{!normalizedMessage.blocks?.length && !!normalizedMessage.md?.length && (
 				<>

--- a/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
+++ b/apps/meteor/client/components/message/variants/thread/ThreadMessageContent.tsx
@@ -51,7 +51,12 @@ const ThreadMessageContent = ({ message }: ThreadMessageContentProps) => {
 				</MessageBody>
 			)}
 
-			{!!quotes?.length && <Attachments attachments={quotes} />}
+			{!!quotes?.length && (
+				<Attachments
+					attachments={quotes}
+					source={{ rid: message.rid, mid: message._id, username: message.u.username, name: message.u.name }}
+				/>
+			)}
 
 			{!normalizedMessage.blocks?.length && !!normalizedMessage.md?.length && (
 				<>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When audio is played from a quoted or forwarded message, the **Jump to message** action in the Now Playing sidebar card did nothing.

Quote attachments are split out of the message's attachment list and rendered by a separate `<Attachments>` call in `RoomMessageContent`/`ThreadMessageContent` that did not pass the `source` context (`rid`/`mid`), and `QuoteAttachment` dropped it for its inner attachments as well. The track registered by `AudioAttachment` therefore had no room/message reference and `openConversation` in `NowPlayingSection` bailed out early.

Now `source` is passed to the quotes render in both message variants and threaded through `AttachmentsItem` → `QuoteAttachment` → inner `Attachments`, so the card jumps to the message containing the quote. The track name is taken from the quote's `author_name`, so the card attributes the audio to the quoted author rather than the quoting user.

Verified end-to-end with Playwright against a local server: playing from a quote, switching rooms, and clicking Jump to message navigates to `/channel/<room>?msg=<quoting message id>`; non-quoted audio unchanged.

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-2486

## Steps to test or reproduce

1. Send an audio file in a channel
2. Quote that message (or forward it to another channel)
3. Play the audio from the quoted/forwarded message
4. Switch to another channel
5. Hover the Now Playing card in the sidebar and click **Jump to message**
6. You are taken back to the message containing the quote

## Further comments



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved quoted audio attachment handling in room and thread messages.
  * Preserved attachment source information when displaying quoted content.
  * Enhanced nested attachments with relevant message and author details for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->