### PR TITLE
fix: ignore leading and trailing whitespace in navbar search

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
@@ -65,4 +65,31 @@ describe('useSearchItems', () => {
 			expect(result.current.items).toHaveLength(2);
 		});
 	});
+
+	it('should ignore leading and trailing whitespace in the search term', async () => {
+		const wrapper = mockAppRoot()
+			.withSubscriptions([
+				{
+					_id: 'room_123',
+					t: 'c',
+					name: 'general',
+					fname: 'general',
+				} as unknown as SubscriptionWithRoom,
+			])
+			.withEndpoint('GET', '/v1/spotlight', () => ({
+				users: [],
+				rooms: [],
+			}))
+			.build();
+
+		const { result } = renderHook(() => useSearchItems('  general  '), {
+			wrapper,
+		});
+
+		await waitFor(() => {
+			expect(result.current.items).toHaveLength(1);
+		});
+
+		expect(result.current.items[0].name).toBe('general');
+	});
 });

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -18,7 +18,12 @@ const options = {
 } as const;
 
 export const useSearchItems = (filterText = ''): { items: SubscriptionWithRoom[]; isLoading: boolean } => {
-	const [, mention, name] = useMemo(() => filterText.match(/(@|#)?(.*)/i) || [], [filterText]);
+	const [, mention, rawName = ''] = useMemo(
+		() => filterText.match(/(@|#)?(.*)/i) || [],
+		[filterText],
+	);
+
+	const name = rawName.trim();
 
 	const query = useMemo(() => {
 		const filterRegex = new RegExp(escapeRegExp(name), 'i');

--- a/apps/meteor/server/api/lib/users.ts
+++ b/apps/meteor/server/api/lib/users.ts
@@ -185,14 +185,31 @@ export async function findPaginatedUsersByStatus({
 		freeSwitchExtension: 1,
 	};
 
-	if (searchTerm?.trim()) {
+	const normalizedSearchTerm = searchTerm?.trim();
+
+	if (normalizedSearchTerm) {
 		match.$or = [
-			...(canSeeAllUserInfo ? [{ 'emails.address': { $regex: escapeRegExp(searchTerm || ''), $options: 'i' } }] : []),
+			...(canSeeAllUserInfo
+				? [
+					{
+						'emails.address': {
+							$regex: escapeRegExp(normalizedSearchTerm),
+							$options: 'i',
+						},
+					},
+				]
+				: []),
 			{
-				username: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				username: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 			{
-				name: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				name: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 		];
 	}

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -350,6 +350,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
+		const normalizedSearchTerm = searchTerm.trim();
+
 		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
@@ -369,7 +371,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],
@@ -396,7 +398,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
-		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
+		const normalizedSearchTerm = searchTerm.trim();
+
+		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(normalizedSearchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
 			(acc, el) => {
@@ -415,7 +419,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm  && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes an issue where the Home navbar search (Ctrl + K) failed to return results when the search term contained leading or trailing whitespace.

The search term is now normalized by trimming surrounding whitespace before it is used to filter local subscriptions and perform Spotlight searches. This ensures that accidental spaces do not prevent users from finding channels or direct messages.

Additionally, a regression test has been added to verify that searches with surrounding whitespace return the expected results.

## Issue(s)

Fixes #41604

## Steps to test or reproduce

1. Start the Rocket.Chat development server.
2. Open the Home navbar search using **Ctrl + K**.
3. Search for an existing channel or user (for example, `general` or `@username`) and verify that results are returned.
4. Repeat the search with leading and/or trailing whitespace, such as:
   - ` general`
   - `general `
   - ` general `
   - `# general`
   - ` @username`
5. Verify that the same results are returned regardless of surrounding whitespace.

**After the fix:**

https://github.com/user-attachments/assets/a78db39b-0c8e-463d-8049-678fc9c6b08f

## Further comments

- Added a regression test covering searches with leading and trailing whitespace.
- Verified that unit tests pass locally.
- Verified the fix manually for channel and direct message searches.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user and subscription searches by ignoring leading and trailing whitespace.
  * Prevented blank or whitespace-only searches from triggering unnecessary filtering.
  * Ensured whitespace-padded search terms return the expected matching results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->