### PR TITLE
regression: federated reactions dropped or sent as raw shortcode text

### DIFF
--- a/ee/packages/federation-matrix/src/utils/emojiConverter.spec.ts
+++ b/ee/packages/federation-matrix/src/utils/emojiConverter.spec.ts
@@ -1,0 +1,43 @@
+import { shortnameToUnicode, unicodeToShortname } from './emojiConverter';
+
+describe('shortnameToUnicode', () => {
+	it('converts joypixels-primary shortnames', () => {
+		expect(shortnameToUnicode(':slight_smile:')).toBe('🙂');
+		expect(shortnameToUnicode(':smiley:')).toBe('😃');
+	});
+
+	it('resolves contested shortcodes to the joypixels meaning', () => {
+		expect(shortnameToUnicode(':cat:')).toBe('🐱');
+	});
+
+	it('converts legacy emojione-only shortnames', () => {
+		expect(shortnameToUnicode(':digit_one:')).toBe('1️⃣');
+	});
+
+	it('converts skin-tone variants', () => {
+		expect(shortnameToUnicode(':thumbsup_tone3:')).toBe('👍🏽');
+	});
+
+	it('keeps unknown shortnames as text', () => {
+		expect(shortnameToUnicode(':not_a_real_emoji:')).toBe(':not_a_real_emoji:');
+	});
+});
+
+describe('unicodeToShortname', () => {
+	it('emits joypixels-primary shortnames valid in the app emoji list', () => {
+		expect(unicodeToShortname('😃')).toBe(':smiley:');
+	});
+
+	it('matches unqualified (FE0F-stripped) emoji', () => {
+		expect(unicodeToShortname('\u{1F44D}')).toBe(':thumbsup:');
+		expect(unicodeToShortname('❤')).toBe(':heart:');
+	});
+
+	it('matches fully-qualified emoji', () => {
+		expect(unicodeToShortname('\u{1F44D}️')).toBe(':thumbsup:');
+	});
+
+	it('returns unknown text unchanged', () => {
+		expect(unicodeToShortname('abc')).toBe('abc');
+	});
+});

--- a/ee/packages/federation-matrix/src/utils/emojiConverter.ts
+++ b/ee/packages/federation-matrix/src/utils/emojiConverter.ts
@@ -1,14 +1,53 @@
 import type { Emoji } from 'emojibase';
 import data from 'emojibase-data/en/data.json';
-import shortcodes from 'emojibase-data/en/shortcodes/emojibase.json';
+import emojibaseShortcodes from 'emojibase-data/en/shortcodes/emojibase.json';
+import joypixelsShortcodes from 'emojibase-data/en/shortcodes/joypixels.json';
+
+// Mirrors apps/meteor/app/emoji-native/lib/legacyEmojioneMap.ts: shortcodes that existed in
+// emojione but are absent from both presets, still stored in old reactions.
+const legacyEmojioneMap: Record<string, string> = {
+	bride_with_veil_tone1: '👰🏻',
+	bride_with_veil_tone2: '👰🏼',
+	bride_with_veil_tone3: '👰🏽',
+	bride_with_veil_tone4: '👰🏾',
+	bride_with_veil_tone5: '👰🏿',
+	bride_with_veil: '👰',
+	digit_zero: '0️⃣',
+	digit_one: '1️⃣',
+	digit_two: '2️⃣',
+	digit_three: '3️⃣',
+	digit_four: '4️⃣',
+	digit_five: '5️⃣',
+	digit_six: '6️⃣',
+	digit_seven: '7️⃣',
+	digit_eight: '8️⃣',
+	digit_nine: '9️⃣',
+	pound_symbol: '#️⃣',
+	asterisk_symbol: '*️⃣',
+};
 
 let _unicodeToShort: Map<string, string> | null = null;
 let _shortToUnicode: Map<string, string> | null = null;
 
 function getShortcodes(hexcode: string): string[] {
-	const entry = (shortcodes as Record<string, string | string[]>)[hexcode];
+	// joypixels first, matching the app's emoji list (apps/meteor/app/emoji-native/lib/generateEmojiData.ts),
+	// so the shortnames we emit are valid there and the ones we receive resolve here
+	const entry =
+		(joypixelsShortcodes as Record<string, string | string[]>)[hexcode] ??
+		(emojibaseShortcodes as Record<string, string | string[]>)[hexcode];
 	if (!entry) return [];
 	return Array.isArray(entry) ? entry : [entry];
+}
+
+const VS16 = String.fromCodePoint(0xfe0f);
+
+function registerUnicode(unicode: string, shortname: string) {
+	_unicodeToShort!.set(unicode, shortname);
+	// Matrix clients commonly send unqualified keys (no U+FE0F)
+	const bare = unicode.replaceAll(VS16, '');
+	if (bare !== unicode && !_unicodeToShort!.has(bare)) {
+		_unicodeToShort!.set(bare, shortname);
+	}
 }
 
 function buildMaps() {
@@ -19,24 +58,27 @@ function buildMaps() {
 		const codes = getShortcodes(emoji.hexcode);
 		if (codes.length === 0) continue;
 
-		const shortname = `:${codes[0]}:`;
-		_unicodeToShort.set(emoji.emoji, shortname);
-		_shortToUnicode.set(shortname, emoji.emoji);
-
-		for (const alt of codes.slice(1)) {
-			_shortToUnicode.set(`:${alt}:`, emoji.emoji);
+		registerUnicode(emoji.emoji, `:${codes[0]}:`);
+		for (const code of codes) {
+			_shortToUnicode.set(`:${code}:`, emoji.emoji);
 		}
 
 		if (emoji.skins) {
 			for (const skin of emoji.skins) {
 				const skinCodes = getShortcodes(skin.hexcode);
 				if (skinCodes.length > 0) {
-					_unicodeToShort.set(skin.emoji, `:${skinCodes[0]}:`);
+					registerUnicode(skin.emoji, `:${skinCodes[0]}:`);
 					for (const code of skinCodes) {
 						_shortToUnicode.set(`:${code}:`, skin.emoji);
 					}
 				}
 			}
+		}
+	}
+
+	for (const [code, unicode] of Object.entries(legacyEmojioneMap)) {
+		if (!_shortToUnicode.has(`:${code}:`)) {
+			_shortToUnicode.set(`:${code}:`, unicode);
 		}
 	}
 }
@@ -49,7 +91,7 @@ function ensureMaps() {
 
 export function unicodeToShortname(text: string): string {
 	ensureMaps();
-	return _unicodeToShort!.get(text) ?? text;
+	return _unicodeToShort!.get(text) ?? _unicodeToShort!.get(text.replaceAll(VS16, '')) ?? text;
 }
 
 export function shortnameToUnicode(text: string): string {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The federation emoji converter (`ee/packages/federation-matrix/src/utils/emojiConverter.ts`) built its shortcode maps from the **emojibase** preset, while the app emoji list is **joypixels-first** since the native emoji migration (#39411, aligned by #41587). The converter was never updated, breaking federated reactions in both directions:

- **RC → Matrix**: joypixels-only shortnames (`:slight_smile:`, `:upside_down:`, tone variants like `:hand_splayed_tone3:`) don't resolve, so Matrix/Element users see the literal shortcode text as the reaction key instead of the emoji.
- **Matrix → RC**: `unicodeToShortname` emits emojibase-primary names (`:grinning_face_with_big_eyes:`) that are not in the app's `emoji.list`, so `setReaction` throws `Invalid emoji provided` and the reaction is silently dropped. Affects ~620 emojis including 😃 😄 😅 😘 🤗 😎.
- **Matrix → RC (unqualified keys)**: reaction keys without VS16 (bare 👍, ❤ — what most clients send) missed the map keyed on fully-qualified strings and were dropped the same way.
- Same-emoji reactions split into two chips (`:thumbsup:` local vs `:+1:` federated), and contested shortcodes diverged in meaning (`:cat:` → 🐈 outbound while RC renders 🐱).

Fix aligns the converter with the app's emoji data:
- joypixels-first shortcode lookup (same pattern as #41587)
- bare-form (VS16-stripped) unicode aliases for inbound keys
- legacy emojione shortcode backfill (mirrors the app's `legacyEmojioneMap`)

## Issue(s)

Regression from #39411

## Steps to test or reproduce

1. Federate a room between Rocket.Chat and a Matrix server (Element).
2. From RC, react to a message with 🙂 (`:slight_smile:`) → Element previously showed the literal text `:slight_smile:`; now shows 🙂.
3. From Element, react with 😃 or bare 👍 → RC previously dropped the reaction with `Invalid emoji provided` in logs; now the reaction appears and aggregates with local `:thumbsup:` reactions.

## Further comments

Unit spec added covering both directions, tone variants, legacy shortcodes and unqualified keys. No changeset (regression fix targeting release-8.7.0).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

