### PR TITLE
regression: native emojis crowding surrounding text on Linux

### DIFF
--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -30,5 +30,13 @@
 	/* emojis on messages */
 	&__emoji {
 		font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Twemoji Mozilla', 'Android Emoji', sans-serif;
+
+		/* fuselage's fixed-size inline-block box (meant for image-based custom emojis) is too small for native glyphs on fonts with wider metrics (e.g. Linux), so they overflow the box and crowd the surrounding text; :not(--custom) outranks its specificity to override reliably */
+		&:not(&--custom) {
+			display: inline;
+			width: auto;
+			height: auto;
+			margin: 0 .15em;
+		}
 	}
 }

--- a/apps/meteor/app/theme/client/imports/components/emoji.css
+++ b/apps/meteor/app/theme/client/imports/components/emoji.css
@@ -33,10 +33,8 @@
 
 		/* fuselage's fixed-size inline-block box (meant for image-based custom emojis) is too small for native glyphs on fonts with wider metrics (e.g. Linux), so they overflow the box and crowd the surrounding text; :not(--custom) outranks its specificity to override reliably */
 		&:not(&--custom) {
-			display: inline;
 			width: auto;
-			height: auto;
-			margin: 0 .15em;
+			margin: .15em .05em;
 		}
 	}
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Cause: The fuselage package brings a rule that applies to all emojis in a message, not only to custom ones:

`node_modules/@rocket.chat/fuselage/dist/fuselage.css)`
``` css
.rcx-message__emoji { 
   background-size:contain;
   display:inline-block;
   font-size:1.5rem;
   height:1.5rem;
   line-height:1.5rem;
   margin-left:.125rem;
   margin-right:.125rem;
   width:1.5rem
}
```
This forces a fixed box of `1.5rem` x `1.5rem` with `display: inline-block`, but for a native emoji, if the font draws the glyph wider than that box (the case of Linux), it overflows visually, eating that margin of `0.125rem`.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2482 [Regression] Native emojis render too close to surrounding text on Linux](https://rocketchat.atlassian.net/browse/CORE-2482)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Precondition: Being on a Linux OS

1. Send a message with a native emoji (not custom) to any channel, for example: `hello 😛 hello`
2. Check that there's a consisten gap between the emoji and the surrounding text, like this:

<img width="353" height="78" alt="image" src="https://github.com/user-attachments/assets/acfcc906-6542-4e08-a22e-d42e2729a896" />

How it shouldn't look like:

<img width="353" height="79" alt="image" src="https://github.com/user-attachments/assets/be4f33bc-6d6f-4684-b467-58022554a7f8" />

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native emoji rendering in messages.
  * Prevented native emojis from being constrained by custom emoji sizing, preserving proper dimensions and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->