### PR TITLE
fix: persist disable link previews room setting

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Info/EditRoomInfo/EditRoomInfo.tsx
@@ -156,6 +156,7 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 		async ({
 			hideSysMes,
 			joinCodeRequired,
+			disableLinkPreviews,
 			retentionEnabled,
 			retentionOverrideGlobal,
 			retentionMaxAge,
@@ -171,6 +172,7 @@ const EditRoomInfo = ({ room, onClickClose, onClickBack }: EditRoomInfoProps) =>
 				await saveAction({
 					rid: room._id,
 					...data,
+					disableLinkPreviews,
 					...((data.joinCode || 'joinCodeRequired' in data) && { joinCode: joinCodeRequired ? data.joinCode : '' }),
 					...((dirtyFields.hideSysMes || dirtyFields.systemMessages) && {
 						systemMessages: hideSysMes ? (data.systemMessages ?? defaultValues.systemMessages) : [],

--- a/apps/meteor/server/meteor-methods/rooms/saveRoomSettings.ts
+++ b/apps/meteor/server/meteor-methods/rooms/saveRoomSettings.ts
@@ -38,6 +38,7 @@ type RoomSettings = {
 	systemMessages: MessageTypesValues[];
 	default: boolean;
 	joinCode: string;
+    disableLinkPreviews: boolean;
 	retentionEnabled: boolean;
 	retentionMaxAge: number;
 	retentionExcludePinned: boolean;
@@ -348,6 +349,11 @@ const settingSavers: RoomSettingsSavers = {
 	async retentionEnabled({ value, rid }) {
 		await Rooms.saveRetentionEnabledById(rid, value);
 	},
+
+    async disableLinkPreviews({ value, rid }) {
+	await Rooms.saveDisableLinkPreviewsById(rid, value);
+    },
+
 	async retentionMaxAge({ value, rid }) {
 		await Rooms.saveRetentionMaxAgeById(rid, value);
 	},
@@ -400,6 +406,7 @@ const fields: (keyof RoomSettings)[] = [
 	'systemMessages',
 	'default',
 	'joinCode',
+	'disableLinkPreviews',
 	'retentionEnabled',
 	'retentionMaxAge',
 	'retentionExcludePinned',

--- a/apps/meteor/server/meteor-methods/rooms/saveRoomSettings.ts
+++ b/apps/meteor/server/meteor-methods/rooms/saveRoomSettings.ts
@@ -170,6 +170,14 @@ const validators: RoomSettingsValidators = {
 	async roomTopic({ room, value }) {
 		guardABACManagedField(room, value, room.topic, 'topic');
 	},
+	async disableLinkPreviews({ value }) {
+	if (!Match.test(value, Boolean)) {
+		throw new Meteor.Error(
+			'error-invalid-parameter',
+			'disableLinkPreviews must be a boolean',
+		  );
+	    }
+    },
 	async roomDescription({ room, value }) {
 		guardABACManagedField(room, value, room.description, 'description');
 	},
@@ -351,7 +359,7 @@ const settingSavers: RoomSettingsSavers = {
 	},
 
     async disableLinkPreviews({ value, rid }) {
-	await Rooms.saveDisableLinkPreviewsById(rid, value);
+	    await Rooms.saveDisableLinkPreviewsById(rid, value);
     },
 
 	async retentionMaxAge({ value, rid }) {

--- a/packages/core-typings/src/IRoom.ts
+++ b/packages/core-typings/src/IRoom.ts
@@ -28,6 +28,8 @@ export interface IRoom extends IRocketChatRecord {
 	topic?: string;
 
 	reactWhenReadOnly?: boolean;
+	disableLinkPreviews?: boolean;
+
 
 	// TODO: this boolean might be an accident
 	sysMes?: MessageTypesValues[] | boolean;

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1704,6 +1704,18 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateOne(query, update);
 	}
 
+	saveDisableLinkPreviewsById(_id: IRoom['_id'], value: boolean): Promise<UpdateResult> {
+	const query: Filter<IRoom> = { _id };
+
+	const update: UpdateFilter<IRoom> = {
+		$set: {
+			disableLinkPreviews: value === true,
+		},
+	};
+
+	return this.updateOne(query, update);
+    }
+
 	saveRetentionMaxAgeById(_id: IRoom['_id'], value = 30): Promise<UpdateResult> {
 		const query: Filter<IRoom> = { _id };
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Fixed an issue where the `disableLinkPreviews` room setting was not being persisted when editing room information.

Changes:
- Added `disableLinkPreviews` to the room update payload.
- Ensured the setting value is saved correctly when updating room settings.

## Issue(s)

Fixes #7734


## Steps to test or reproduce

1. Open a room's settings.
2. Navigate to the Edit Room Info section.
3. Toggle the "Disable Link Previews" setting.
4. Save the changes.
5. Reopen the room settings and verify that the selected value is persisted.


## Further comments



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `disableLinkPreviews` room setting to control whether link previews are shown.
  * Room administrators can now save this preference from the room settings interface.
* **Bug Fixes**
  * Fixed the room-settings save flow to include the link-preview preference (`disableLinkPreviews`) in the settings update request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->