### PR TITLE
test: baseline tests for emojione behavior replaced by the native emoji migration

### DIFF
--- a/apps/meteor/tests/unit/app/emoji/emojioneBaseline.spec.ts
+++ b/apps/meteor/tests/unit/app/emoji/emojioneBaseline.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import emojione from 'emojione';
+
+import { getEmojiConfig } from '../../../../app/emoji-emojione/lib/getEmojiConfig';
+
+// Baseline for the native-emoji migration: these assertions document behavior 8.6 users rely on.
+// The counterpart PR against release-8.7.0 carries the same expectations as (currently failing)
+// tests over the new emoji-native implementation.
+describe('emojione baseline (pre-native-migration behavior)', () => {
+	describe('shortnameToUnicode', () => {
+		const cases: [string, string][] = [
+			[':red_haired:', '🦰'],
+			[':curly_haired:', '🦱'],
+			[':bald:', '🦲'],
+			[':white_haired:', '🦳'],
+			[':iphone:', '📱'],
+		];
+
+		cases.forEach(([shortname, unicode]) => {
+			it(`converts ${shortname}`, () => {
+				expect(emojione.shortnameToUnicode(shortname)).to.equal(unicode);
+			});
+		});
+
+		it('converts a shortcode that directly follows an unknown :token:', () => {
+			expect(emojione.shortnameToUnicode('12:30:fire:')).to.equal('12:30🔥');
+		});
+
+		it('renders the hand-patched legacy shortcodes in messages', () => {
+			// shortnameToUnicode drops the U+20E3 combiner for these hand-patched entries even on 8.6;
+			// the message path users actually saw went through render (emojione.toImage)
+			const html = getEmojiConfig().render(':digit_one:');
+			expect(html).to.be.a('string');
+			expect(html).to.include('digit_one');
+		});
+	});
+
+	describe('toShort', () => {
+		it('maps bare (unqualified) text-presentation emojis to shortnames', () => {
+			expect(emojione.toShort('❤')).to.equal(':heart:');
+			expect(emojione.toShort('☺')).to.equal(':relaxed:');
+		});
+	});
+
+	describe('picker rendering', () => {
+		it('renders the hand-patched legacy shortcodes', () => {
+			const image = getEmojiConfig().renderPicker(':digit_one:');
+			expect(image).to.be.a('string');
+			expect(image).to.include('digit_one');
+		});
+	});
+});

--- a/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.spec.ts
+++ b/ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.spec.ts
@@ -1,0 +1,14 @@
+import emojione from 'emoji-toolkit';
+
+// Baseline for the native-emoji migration: the transcript's unicode -> shortname conversion
+// (EmojiSpan) uses emoji-toolkit, whose vocabulary matches the app emoji list. The counterpart
+// PR against release-8.7.0 carries the same expectations over the new emojibase-based module.
+describe('emoji-toolkit shortname vocabulary (pre-native-migration baseline)', () => {
+	it('names 👍 :thumbsup:', () => {
+		expect(emojione.toShort('\u{1F44D}')).toBe(':thumbsup:');
+	});
+
+	it('names 😃 :smiley:', () => {
+		expect(emojione.toShort('😃')).toBe(':smiley:');
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

**Passing** characterization tests (11 green) documenting the 8.6 emojione/emoji-toolkit behavior that the native-emoji migration (#39411) regressed in 8.7:

- `apps/meteor/tests/unit/app/emoji/emojioneBaseline.spec.ts` (mocha, 9 tests): emojione converts hair-style shortcodes (`:bald:`, `:red_haired:`, `:curly_haired:`, `:white_haired:`), `:iphone:`, a shortcode directly following an unknown `:token:` (`12:30:fire:`), bare text-presentation emojis (`❤`, `☺`); hand-patched legacy shortcodes (`:digit_one:`) render in picker and messages.
- `ee/packages/pdf-worker/src/templates/ChatTranscript/markup/emoji.spec.ts` (jest, 2 tests): emoji-toolkit names transcript emojis with the app vocabulary (`:thumbsup:`, `:smiley:`).

Counterpart: the same expectations run as **deliberately failing** tests over the `emoji-native` implementation in the PR against `release-8.7.0` (link in comments).

Notes from writing the baseline:
- `emojione.shortnameToUnicode(':digit_one:')` drops the U+20E3 combiner even on 8.6 — users saw the correct sprite via the render path, so the baseline asserts `render`/`renderPicker`.
- `emoji-toolkit.toShort` does not handle bare `❤` on 8.6 either — transcript bare-emoji handling is not part of the baseline.

## Issue(s)

Baseline for regressions from #39411.

## Steps to test or reproduce

```
cd apps/meteor && yarn mocha --config ./.mocharc.base.json --exit tests/unit/app/emoji/emojioneBaseline.spec.ts
cd ee/packages/pdf-worker && yarn jest src/templates/ChatTranscript/markup/emoji.spec.ts
```

## Regressions covered (as passing 8.6 baseline)

These 8.7 regressions (IDs from the internal review triage; all runtime-verified there) have their pre-migration expected behavior pinned here:

| ID | 8.7 regression | Baseline test proving 8.6 behavior |
|---|---|---|
| B1 | Notification-text conversion skips a shortcode after an unknown `:token:` (`12:30:fire:`) | `emojioneBaseline.spec.ts` › timestamp-adjacent (emojione converts it) |
| B2 | Hair-style shortcodes (`:bald:` `:red_haired:` `:curly_haired:` `:white_haired:`) render as literal text | `emojioneBaseline.spec.ts` › hair-style ×4 |
| B3 | `:iphone:` renders as literal text | `emojioneBaseline.spec.ts` › `:iphone:` |
| B4 | Bare (no VS16) `❤` `☺` lose emoji rendering | `emojioneBaseline.spec.ts` › toShort bare forms |
| C3 | Legacy shortcodes (`:digit_one:`) invisible in picker recents | `emojioneBaseline.spec.ts` › picker + message render |
| D2 | PDF transcript emits emojibase-primary shortnames (`:+1:`) instead of app vocabulary | `pdf-worker` `emoji.spec.ts` › `:thumbsup:`/`:smiley:` |

Findings without a baseline here (and, after review, removed from the counterpart PR as well — they are pre-existing bugs or defects in new code, not migration regressions; to be fixed as separate bug fixes):
- **C1/C2/C5** (custom-emoji delete nukes native entry; category truncation on one stale name; frequent-list empty slots) — the defective code and its trigger paths exist identically on 8.6.
- **C4** (mixed-tone variants missing from picker search) — dead branch in new code; emojione 4.5 predates the Unicode 12 mixed-tone emojis involved.
- Federation reactions — already fixed in #41606.

## Further comments

Test-only change, no changeset. All 11 tests pass on this branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


