### PR TITLE
refactor(ui-voip): Make draggable optional and extract `MediaCallWidgetViewRouter` from `MediaCallWidget`

### DIFF
--- a/packages/ui-voip/src/components/Widget/Widget.tsx
+++ b/packages/ui-voip/src/components/Widget/Widget.tsx
@@ -1,61 +1,29 @@
 import { FocusScope } from '@react-aria/focus';
-import { Palette } from '@rocket.chat/fuselage';
-import styled from '@rocket.chat/styled';
-import type { ComponentProps, ReactNode } from 'react';
-import { useLayoutEffect } from 'react';
+import type { ReactNode } from 'react';
 
-import { DragContext } from './WidgetDraggableContext';
-import { useDraggable } from '../../hooks';
-import { type LastKnownPosition } from '../../providers/useWidgetPositionTracker';
-
-// TODO: Initial position from the draggable api instead of style props
-// TODO: A11Y
-const WidgetBase = styled('div')`
-	position: fixed;
-	padding: 0;
-	right: 2em;
-	top: 11em;
-	display: flex;
-	flex-direction: column;
-	width: 248px;
-	min-height: 128px;
-	border-radius: 4px;
-	border: 1px solid ${Palette.stroke['stroke-dark'].toString()};
-	box-shadow:
-		0px 0px 1px 0px ${Palette.shadow['shadow-elevation-2x'].toString()},
-		0px 0px 12px 0px ${Palette.shadow['shadow-elevation-2y'].toString()};
-	background-color: ${Palette.surface['surface-tint'].toString()};
-	color: ${Palette.text['font-default'].toString()};
-	z-index: 100;
-	overflow: hidden;
-`;
+import WidgetBase from './WidgetBase';
+import { useDraggableWidget } from './WidgetDraggableContext';
 
 export type WidgetProps = {
 	children: ReactNode;
-	restorePosition?: LastKnownPosition | null;
-	onChangePosition?: (position: LastKnownPosition | null) => void;
-} & ComponentProps<typeof WidgetBase>;
+	autoFocus?: boolean;
+};
 
-const Widget = ({ children, onChangePosition, restorePosition, ...props }: WidgetProps) => {
-	const [draggableRef, boundingRef, handleRef] = useDraggable({ onChangePosition, restorePosition });
-
-	useLayoutEffect(() => {
-		boundingRef(document.body);
-	}, [boundingRef]);
+const Widget = ({ children, autoFocus = true, ...props }: WidgetProps) => {
+	const draggableContext = useDraggableWidget();
 
 	return (
-		<DragContext.Provider value={{ draggableRef, boundingRef, handleRef }}>
-			<FocusScope autoFocus>
-				<WidgetBase
-					{...props}
-					ref={draggableRef}
-					role='dialog'
-					aria-labelledby='rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info'
-				>
-					{children}
-				</WidgetBase>
-			</FocusScope>
-		</DragContext.Provider>
+		<FocusScope autoFocus={autoFocus}>
+			<WidgetBase
+				{...props}
+				ref={draggableContext?.draggableRef}
+				inline={!draggableContext}
+				role='dialog'
+				aria-labelledby='rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info'
+			>
+				{children}
+			</WidgetBase>
+		</FocusScope>
 	);
 };
 

--- a/packages/ui-voip/src/components/Widget/WidgetBase.tsx
+++ b/packages/ui-voip/src/components/Widget/WidgetBase.tsx
@@ -1,0 +1,41 @@
+import { Palette } from '@rocket.chat/fuselage';
+import styled from '@rocket.chat/styled';
+
+type WidgetBaseProps = { inline?: boolean; borderless?: boolean };
+
+// TODO: Initial position from the draggable api instead of style props
+// TODO: A11Y
+const WidgetBase = styled('div', ({ borderless: _borderless, inline: _inline, ...props }: WidgetBaseProps) => props)`
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	width: 248px;
+	min-height: 128px;
+	border-radius: 4px;
+	background-color: ${Palette.surface['surface-tint'].toString()};
+	color: ${Palette.text['font-default'].toString()};
+	z-index: 100;
+	overflow: hidden;
+
+	${({ borderless }) =>
+		borderless
+			? ''
+			: `
+        border: 1px solid ${Palette.stroke['stroke-dark'].toString()};
+    `}
+
+	${({ inline }) =>
+		inline
+			? ''
+			: `
+        position: fixed;
+        right: 2em;
+        top: 11em;
+        z-index: 100;
+        box-shadow:
+            0px 0px 1px 0px ${Palette.shadow['shadow-elevation-2x'].toString()},
+            0px 0px 12px 0px ${Palette.shadow['shadow-elevation-2y'].toString()};
+    `}
+`;
+
+export default WidgetBase;

--- a/packages/ui-voip/src/components/Widget/WidgetBase.tsx
+++ b/packages/ui-voip/src/components/Widget/WidgetBase.tsx
@@ -3,8 +3,6 @@ import styled from '@rocket.chat/styled';
 
 type WidgetBaseProps = { inline?: boolean; borderless?: boolean };
 
-// TODO: Initial position from the draggable api instead of style props
-// TODO: A11Y
 const WidgetBase = styled('div', ({ borderless: _borderless, inline: _inline, ...props }: WidgetBaseProps) => props)`
 	padding: 0;
 	display: flex;

--- a/packages/ui-voip/src/components/Widget/WidgetBase.tsx
+++ b/packages/ui-voip/src/components/Widget/WidgetBase.tsx
@@ -14,7 +14,6 @@ const WidgetBase = styled('div', ({ borderless: _borderless, inline: _inline, ..
 	border-radius: 4px;
 	background-color: ${Palette.surface['surface-tint'].toString()};
 	color: ${Palette.text['font-default'].toString()};
-	z-index: 100;
 	overflow: hidden;
 
 	${({ borderless }) =>

--- a/packages/ui-voip/src/components/Widget/WidgetDraggableContext.ts
+++ b/packages/ui-voip/src/components/Widget/WidgetDraggableContext.ts
@@ -1,18 +1,12 @@
-import type { Ref } from 'react';
+import type { RefCallback } from 'react';
 import { createContext, useContext } from 'react';
 
 type DragContextValue = {
-	draggableRef: Ref<HTMLElement>;
-	boundingRef: Ref<HTMLElement>;
-	handleRef: Ref<HTMLElement>;
+	draggableRef: RefCallback<HTMLElement>;
+	boundingRef: RefCallback<HTMLElement>;
+	handleRef: RefCallback<HTMLElement>;
 };
 
 export const DragContext = createContext<DragContextValue | undefined>(undefined);
 
-export const useDraggableWidget = (): DragContextValue => {
-	const context = useContext(DragContext);
-	if (!context) {
-		throw new Error('useDraggableWidget - context unavailable');
-	}
-	return context;
-};
+export const useDraggableWidget = (): DragContextValue | undefined => useContext(DragContext);

--- a/packages/ui-voip/src/components/Widget/WidgetDraggableProvider.tsx
+++ b/packages/ui-voip/src/components/Widget/WidgetDraggableProvider.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { useLayoutEffect } from 'react';
+
+import { DragContext } from './WidgetDraggableContext';
+import { useMediaCallView } from '../../context';
+import { useDraggable } from '../../hooks';
+
+type WidgetDraggableProviderProps = {
+	children: ReactNode;
+};
+
+const WidgetDraggableProvider = ({ children }: WidgetDraggableProviderProps) => {
+	const { widgetPositionTracker } = useMediaCallView();
+	const [draggableRef, boundingRef, handleRef] = useDraggable({
+		onChangePosition: widgetPositionTracker?.onChangePosition,
+		restorePosition: widgetPositionTracker?.getRestorePosition(),
+	});
+
+	useLayoutEffect(() => {
+		boundingRef(document.body);
+	}, [boundingRef]);
+
+	return <DragContext.Provider value={{ draggableRef, boundingRef, handleRef }}>{children}</DragContext.Provider>;
+};
+
+export default WidgetDraggableProvider;

--- a/packages/ui-voip/src/components/Widget/WidgetHandle.tsx
+++ b/packages/ui-voip/src/components/Widget/WidgetHandle.tsx
@@ -20,7 +20,11 @@ const dragHandle = css`
 `;
 
 const WidgetHandle = (props: ComponentProps<typeof Box>) => {
-	const { handleRef } = useDraggableWidget();
+	const draggableContext = useDraggableWidget();
+	if (!draggableContext) {
+		return null;
+	}
+	const { handleRef } = draggableContext;
 	return (
 		<Box height={20} display='flex' flexDirection='row' justifyContent='center' className={dragHandle} ref={handleRef} {...props}>
 			<Icon name='stacked-meatballs' size='x20' />

--- a/packages/ui-voip/src/components/Widget/__snapshots__/Widget.spec.tsx.snap
+++ b/packages/ui-voip/src/components/Widget/__snapshots__/Widget.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders FullWidget without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-151x2vn"
+      class="rcx-css-1ww4mnk"
       role="dialog"
     >
       <header

--- a/packages/ui-voip/src/components/Widget/__snapshots__/Widget.spec.tsx.snap
+++ b/packages/ui-voip/src/components/Widget/__snapshots__/Widget.spec.tsx.snap
@@ -9,20 +9,9 @@ exports[`renders FullWidget without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-151x2vn"
       role="dialog"
     >
-      <div
-        class="rcx-box rcx-box--full rcx-css-1aw4sw4 rcx-css-11m6c1h"
-        style="user-select: none; webkit-user-select: none;"
-      >
-        <i
-          aria-hidden="true"
-          class="rcx-box rcx-box--full rcx-icon--name-stacked-meatballs rcx-icon rcx-css-4pvxx3"
-        >
-          
-        </i>
-      </div>
       <header
         class="rcx-box rcx-box--full rcx-css-4vvilp"
       >

--- a/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidget.stories.tsx
+++ b/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidget.stories.tsx
@@ -18,6 +18,7 @@ const mockedContexts = mockAppRoot()
 	.buildStoryDecorator();
 
 const meta = {
+	title: 'Views/MediaCallWidget/Draggable Widget',
 	component: MediaCallWidget,
 	args: {
 		state: 'closed',

--- a/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidget.tsx
+++ b/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidget.tsx
@@ -1,40 +1,27 @@
-import { OngoingCall, NewCall, IncomingCall, OutgoingCall, IncomingCallTransfer, OutgoingCallTransfer } from '..';
-import OngoingCallWithScreen from './OngoingCallWithScreen';
+import MediaCallWidgetViewRouter from './MediaCallWidgetViewRouter';
+import WidgetDraggableProvider from '../../components/Widget/WidgetDraggableProvider';
 import { useMediaCallView } from '../../context/MediaCallViewContext';
 import useRegisterView from '../../context/useRegisterView';
 
 const MediaCallWidget = () => {
 	const currentViews = useRegisterView('widget');
 	const {
-		sessionState: { state, hidden, transferredBy, peerInfo, supportedFeatures },
+		sessionState: { state, hidden },
 	} = useMediaCallView();
 
 	if (hidden || !currentViews.includes('widget')) {
 		return null;
 	}
 
-	switch (state) {
-		case 'ongoing':
-			if ('username' in peerInfo && supportedFeatures.includes('screen-share')) {
-				return <OngoingCallWithScreen />;
-			}
-			return <OngoingCall />;
-		case 'new':
-			return <NewCall />;
-		case 'ringing':
-			if (transferredBy) {
-				return <IncomingCallTransfer />;
-			}
-			return <IncomingCall />;
-		case 'calling':
-			if (transferredBy) {
-				return <OutgoingCallTransfer />;
-			}
-			return <OutgoingCall />;
-		case 'closed':
-		default:
-			return null;
+	if (state === 'closed') {
+		return null;
 	}
+
+	return (
+		<WidgetDraggableProvider>
+			<MediaCallWidgetViewRouter />
+		</WidgetDraggableProvider>
+	);
 };
 
 export default MediaCallWidget;

--- a/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidgetViewRouter.tsx
+++ b/packages/ui-voip/src/views/MediaCallWidget/MediaCallWidgetViewRouter.tsx
@@ -1,0 +1,34 @@
+import { OngoingCall, NewCall, IncomingCall, OutgoingCall, IncomingCallTransfer, OutgoingCallTransfer } from '..';
+import OngoingCallWithScreen from './OngoingCallWithScreen';
+import { useMediaCallView } from '../../context/MediaCallViewContext';
+
+const MediaCallWidgetViewRouter = () => {
+	const {
+		sessionState: { state, transferredBy, peerInfo, supportedFeatures },
+	} = useMediaCallView();
+
+	switch (state) {
+		case 'ongoing':
+			if ('username' in peerInfo && supportedFeatures.includes('screen-share')) {
+				return <OngoingCallWithScreen />;
+			}
+			return <OngoingCall />;
+		case 'new':
+			return <NewCall />;
+		case 'ringing':
+			if (transferredBy) {
+				return <IncomingCallTransfer />;
+			}
+			return <IncomingCall />;
+		case 'calling':
+			if (transferredBy) {
+				return <OutgoingCallTransfer />;
+			}
+			return <OutgoingCall />;
+		case 'closed':
+		default:
+			return null;
+	}
+};
+
+export default MediaCallWidgetViewRouter;

--- a/packages/ui-voip/src/views/MediaCallWidget/OngoingCallWithScreen.tsx
+++ b/packages/ui-voip/src/views/MediaCallWidget/OngoingCallWithScreen.tsx
@@ -34,7 +34,6 @@ const OngoingCall = () => {
 		onOpenPopout,
 		streams,
 		onToggleScreenSharing,
-		widgetPositionTracker,
 		onClosePopout,
 	} = useMediaCallView();
 	const { muted, held, remoteMuted, remoteHeld, peerInfo, connectionState, startedAt } = sessionState;
@@ -58,7 +57,7 @@ const OngoingCall = () => {
 	}
 
 	return (
-		<Widget restorePosition={widgetPositionTracker?.getRestorePosition()} onChangePosition={widgetPositionTracker?.onChangePosition}>
+		<Widget>
 			<WidgetHandle />
 			<WidgetHeader title={connecting ? t('meteor_status_connecting') : <Timer startAt={startedAt} />}>
 				{onClickDirectMessage && (

--- a/packages/ui-voip/src/views/MediaCallWidget/__snapshots__/MediaCallWidget.spec.tsx.snap
+++ b/packages/ui-voip/src/views/MediaCallWidget/__snapshots__/MediaCallWidget.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders IncomingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div
@@ -175,7 +175,7 @@ exports[`renders IncomingCallTransfer without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div
@@ -378,7 +378,7 @@ exports[`renders NewCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div
@@ -583,7 +583,7 @@ exports[`renders OngoingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div
@@ -810,7 +810,7 @@ exports[`renders OutgoingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div
@@ -959,7 +959,7 @@ exports[`renders OutgoingCallTransfer without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-ibrujl"
+      class="rcx-css-6amvz1"
       role="dialog"
     >
       <div

--- a/packages/ui-voip/src/views/MediaCallWidget/__snapshots__/MediaCallWidget.spec.tsx.snap
+++ b/packages/ui-voip/src/views/MediaCallWidget/__snapshots__/MediaCallWidget.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`renders IncomingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div
@@ -175,7 +175,7 @@ exports[`renders IncomingCallTransfer without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div
@@ -378,7 +378,7 @@ exports[`renders NewCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div
@@ -583,7 +583,7 @@ exports[`renders OngoingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div
@@ -810,7 +810,7 @@ exports[`renders OutgoingCall without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div
@@ -959,7 +959,7 @@ exports[`renders OutgoingCallTransfer without crashing 1`] = `
     />
     <div
       aria-labelledby="rcx-media-call-widget-title-prefix rcx-media-call-widget-title rcx-media-call-widget-caller-info"
-      class="rcx-css-1rau14i"
+      class="rcx-css-ibrujl"
       role="dialog"
     >
       <div


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[DMVPR-26](https://rocketchat.atlassian.net/browse/DMVPR-26)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added draggable call widgets that can be moved within the browser window.
  * Added configurable widget autofocus, enabled by default.
  * Improved automatic selection of call views, including screen sharing and transfer states.
* **Bug Fixes**
  * Widgets now safely handle unavailable drag functionality.
  * Closed or unrecognized call sessions no longer display an empty widget.
* **Documentation**
  * Updated the Storybook label to identify the draggable widget experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DMVPR-26]: https://rocketchat.atlassian.net/browse/DMVPR-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ