### PR TITLE
feat(room): add unhide room option for hidden channels and direct messages

### DIFF
--- a/apps/meteor/client/hooks/useRoomMenuActions.ts
+++ b/apps/meteor/client/hooks/useRoomMenuActions.ts
@@ -8,6 +8,7 @@ import { useLeaveRoomAction } from './menuActions/useLeaveRoom';
 import { useToggleFavoriteAction } from './menuActions/useToggleFavoriteAction';
 import { useToggleReadAction } from './menuActions/useToggleReadAction';
 import { useHideRoomAction } from './useHideRoomAction';
+import { useUnhideRoomAction } from './useUnhideRoomAction';
 import { useOmnichannelPrioritiesMenu } from '../views/omnichannel/hooks/useOmnichannelPrioritiesMenu';
 
 type RoomMenuActionsProps = {
@@ -48,6 +49,7 @@ export const useRoomMenuActions = ({
 	})();
 
 	const handleHide = useHideRoomAction({ rid, type, name }, { redirect: false });
+	const handleUnhide = useUnhideRoomAction({ rid, type });
 	const handleToggleFavorite = useToggleFavoriteAction({ rid, isFavorite });
 	const handleToggleRead = useToggleReadAction({ rid, isUnread, subscription });
 	const handleLeave = useLeaveRoomAction({ rid, type, name, roomOpen });
@@ -60,10 +62,10 @@ export const useRoomMenuActions = ({
 			!hideDefaultOptions
 				? ([
 						!isOmnichannelRoom && {
-							id: 'hideRoom',
-							icon: 'eye-off',
-							content: t('Hide'),
-							onClick: handleHide,
+							id: subscription?.open === false ? 'unhideRoom' : 'hideRoom',
+							icon: subscription?.open === false ? 'eye' : 'eye-off',
+							content: subscription?.open === false ? t('Unhide') : t('Hide'),
+							onClick: subscription?.open === false ? handleUnhide : handleHide,
 						},
 						{
 							id: 'toggleRead',

--- a/apps/meteor/client/hooks/useRoomMenuActions.ts
+++ b/apps/meteor/client/hooks/useRoomMenuActions.ts
@@ -33,6 +33,7 @@ export const useRoomMenuActions = ({
 	const { t } = useTranslation();
 	const subscription = useUserSubscription(rid);
 
+	const isHidden = subscription?.open === false;
 	const isFavorite = Boolean(subscription?.f);
 	const canLeaveChannel = usePermission('leave-c');
 	const canLeavePrivate = usePermission('leave-p');
@@ -62,10 +63,10 @@ export const useRoomMenuActions = ({
 			!hideDefaultOptions
 				? ([
 						!isOmnichannelRoom && {
-							id: subscription?.open === false ? 'unhideRoom' : 'hideRoom',
-							icon: subscription?.open === false ? 'eye' : 'eye-off',
-							content: subscription?.open === false ? t('Unhide') : t('Hide'),
-							onClick: subscription?.open === false ? handleUnhide : handleHide,
+							id: isHidden ? 'unhideRoom' : 'hideRoom',
+							icon: isHidden ? 'eye' : 'eye-off',
+							content: isHidden ? t('Unhide') : t('Hide'),
+							onClick: isHidden ? handleUnhide : handleHide,
 						},
 						{
 							id: 'toggleRead',
@@ -91,6 +92,8 @@ export const useRoomMenuActions = ({
 			hideDefaultOptions,
 			t,
 			handleHide,
+			handleUnhide,
+			isHidden,
 			isUnread,
 			handleToggleRead,
 			canFavorite,

--- a/apps/meteor/client/hooks/useUnhideRoomAction.ts
+++ b/apps/meteor/client/hooks/useUnhideRoomAction.ts
@@ -1,0 +1,44 @@
+import type { RoomType } from '@rocket.chat/core-typings';
+import { useStableCallback } from '@rocket.chat/fuselage-hooks';
+import { useEndpoint, useToastMessageDispatch, useUserId } from '@rocket.chat/ui-contexts';
+import { useMutation } from '@tanstack/react-query';
+
+import { updateSubscription } from '../lib/mutationEffects/updateSubscription';
+
+type UnhideRoomProps = {
+	rid: string;
+	type: RoomType;
+};
+
+const OPEN_ENDPOINTS_BY_ROOM_TYPE = {
+	p: '/v1/groups.open',
+	c: '/v1/channels.open',
+	d: '/v1/im.open',
+	l: '/v1/channels.open',
+} as const;
+
+export const useUnhideRoomAction = ({ rid: roomId, type }: UnhideRoomProps) => {
+	const dispatchToastMessage = useToastMessageDispatch();
+	const userId = useUserId();
+
+	const openRoomEndpoint = useEndpoint('POST', OPEN_ENDPOINTS_BY_ROOM_TYPE[type]);
+
+	const unhideRoom = useMutation({
+		mutationFn: () => openRoomEndpoint({ roomId }),
+		onMutate: async () => {
+			if (userId) {
+				return updateSubscription(roomId, userId, { open: true });
+			}
+		},
+		onError: async (error, _, rollbackDocument) => {
+			dispatchToastMessage({ type: 'error', message: error });
+
+			if (userId && rollbackDocument) {
+				const { open } = rollbackDocument;
+				updateSubscription(roomId, userId, { open });
+			}
+		},
+	});
+
+	return useStableCallback(() => unhideRoom.mutate());
+};


### PR DESCRIPTION
<!-- Checklist -->
- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Adds an **Unhide** option to the room options menu for hidden channels, private groups, and direct messages.

When a room is hidden (`subscription.open === false`), the room menu action dynamically displays:
- **Icon**: `eye`
- **Label**: `Unhide`
- **Action**: Invokes `useUnhideRoomAction` (calling POST `/v1/channels.open`, `/v1/groups.open`, or `/v1/im.open` REST API endpoints) to reopen and restore the hidden room back to the user's active sidebar list.

## Issue(s)
Closes #38838

## Steps to test or reproduce
1. Hide any channel or direct message from your sidebar or room menu options.
2. Search for the hidden room or open its menu.
3. Observe that the menu action displays **Unhide** with an eye icon.
4. Click **Unhide** and verify the room reopens and restores to the active sidebar list.

## Further comments
- Added `apps/meteor/client/hooks/useUnhideRoomAction.ts`
- Updated `apps/meteor/client/hooks/useRoomMenuActions.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Unhide room** option for hidden rooms.
  * Menu actions now switch between “Hide” and “Unhide” based on the room’s current visibility.
  * Restoring a hidden room now updates visibility immediately and synchronizes with the server.
* **Bug Fixes**
  * Added error notifications and automatic rollback if restoring the room fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->