### PR TITLE
fix(message): persist attachment collapse state when switching channels

### DIFF
--- a/apps/meteor/client/components/message/MessageCollapsible.tsx
+++ b/apps/meteor/client/components/message/MessageCollapsible.tsx
@@ -16,7 +16,7 @@ export type MessageCollapsibleProps = {
 };
 
 const MessageCollapsible = ({ children, title, hasDownload, link, size, isCollapsed }: MessageCollapsibleProps) => {
-	const [collapsed, toggleCollapse] = useCollapse(isCollapsed);
+	const [collapsed, toggleCollapse] = useCollapse(isCollapsed, link || title);
 
 	return (
 		<>

--- a/apps/meteor/client/components/message/MessageCollapsible.tsx
+++ b/apps/meteor/client/components/message/MessageCollapsible.tsx
@@ -7,6 +7,7 @@ import CollapsibleContent from './content/collapsible/CollapsibleContent';
 import { useCollapse } from './hooks/useCollapse';
 
 export type MessageCollapsibleProps = {
+	id?: string;
 	children?: ReactNode;
 	title?: string;
 	hasDownload?: boolean;
@@ -15,8 +16,8 @@ export type MessageCollapsibleProps = {
 	isCollapsed?: boolean;
 };
 
-const MessageCollapsible = ({ children, title, hasDownload, link, size, isCollapsed }: MessageCollapsibleProps) => {
-	const [collapsed, toggleCollapse] = useCollapse(isCollapsed, link || title);
+const MessageCollapsible = ({ id, children, title, hasDownload, link, size, isCollapsed }: MessageCollapsibleProps) => {
+	const [collapsed, toggleCollapse] = useCollapse(isCollapsed, id || link || title);
 
 	return (
 		<>

--- a/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx
@@ -28,7 +28,7 @@ const applyMarkdownIfRequires = (
 export type DefaultAttachmentProps = MessageAttachmentDefault;
 
 const DefaultAttachment = (attachment: DefaultAttachmentProps) => {
-	const [collapsed, toggleCollapse] = useCollapse(!!attachment.collapsed);
+	const [collapsed, toggleCollapse] = useCollapse(!!attachment.collapsed, attachment.title_link || attachment.title);
 
 	return (
 		<AttachmentBlock

--- a/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/AudioAttachment.tsx
@@ -58,7 +58,7 @@ const AudioAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible id={track.id} title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<Box
 					borderWidth='default'
 					borderStyle='solid'

--- a/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
@@ -24,6 +24,7 @@ const openDocumentViewer = window.RocketChatDesktop?.openDocumentViewer;
 export type GenericFileAttachmentProps = MessageAttachmentBase;
 
 const GenericFileAttachment = ({
+	id,
 	title,
 	description,
 	descriptionMd,
@@ -86,7 +87,7 @@ const GenericFileAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible id={link || title} title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
+			<MessageCollapsible id={id || link || title} title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<MessageGenericPreviewContent
 						thumb={<MessageGenericPreviewIcon name='attachment-file' type={format || getFileExtension(title)} />}

--- a/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/GenericFileAttachment.tsx
@@ -86,7 +86,7 @@ const GenericFileAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
+			<MessageCollapsible id={link || title} title={title} hasDownload={hasDownload} link={link} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<MessageGenericPreviewContent
 						thumb={<MessageGenericPreviewIcon name='attachment-file' type={format || getFileExtension(title)} />}

--- a/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/ImageAttachment.tsx
@@ -30,7 +30,7 @@ const ImageAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible id={id || link || url} title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<AttachmentImage
 					{...imageDimensions}
 					loadImage={loadImage}

--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -27,7 +27,7 @@ const VideoAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible id={link || url || title} title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<Box is='video' controls preload='metadata' ref={mediaRef} position='relative'>
 						<source src={getURL(url)} type={userAgentMIMETypeFallback(type)} />

--- a/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
+++ b/apps/meteor/client/components/message/content/attachments/file/VideoAttachment.tsx
@@ -10,6 +10,7 @@ import MessageCollapsible from '../../../MessageCollapsible';
 import MessageContentBody from '../../../MessageContentBody';
 
 const VideoAttachment = ({
+	id,
 	title,
 	video_url: url,
 	video_type: type,
@@ -27,7 +28,7 @@ const VideoAttachment = ({
 	return (
 		<>
 			{descriptionMd ? <MessageContentBody md={descriptionMd} /> : <MarkdownText parseEmoji content={description} />}
-			<MessageCollapsible id={link || url || title} title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
+			<MessageCollapsible id={id || link || url || title} title={title} hasDownload={hasDownload} link={getURL(link || url)} size={size} isCollapsed={collapsed}>
 				<MessageGenericPreview style={{ maxWidth: 368, width: '100%' }}>
 					<Box is='video' controls preload='metadata' ref={mediaRef} position='relative'>
 						<source src={getURL(url)} type={userAgentMIMETypeFallback(type)} />

--- a/apps/meteor/client/components/message/content/urlPreviews/UrlPreview.tsx
+++ b/apps/meteor/client/components/message/content/urlPreviews/UrlPreview.tsx
@@ -9,7 +9,7 @@ import CollapsibleContent from '../collapsible/CollapsibleContent';
 
 const UrlPreview = (props: UrlPreviewMetadata) => {
 	const autoLoadMedia = useAttachmentAutoLoadEmbedMedia();
-	const [collapsed, toggleCollapse] = useCollapse(!autoLoadMedia);
+	const [collapsed, toggleCollapse] = useCollapse(!autoLoadMedia, props.url);
 	const { t } = useTranslation();
 
 	return (

--- a/apps/meteor/client/components/message/hooks/useCollapse.spec.ts
+++ b/apps/meteor/client/components/message/hooks/useCollapse.spec.ts
@@ -23,13 +23,15 @@ describe('useCollapse', () => {
 	it('should persist collapse state across remounts when an ID is provided', () => {
 		const attachmentId = 'http://example.com/image.png';
 
-		const { result: firstRender } = renderHook(() => useCollapse(false, attachmentId));
+		const { result: firstRender, unmount } = renderHook(() => useCollapse(false, attachmentId));
 		expect(firstRender.current[0]).toBe(false);
 
 		act(() => {
 			firstRender.current[1]();
 		});
 		expect(firstRender.current[0]).toBe(true);
+
+		unmount();
 
 		// Simulating room switch: remounting component with same attachment ID
 		const { result: secondRender } = renderHook(() => useCollapse(false, attachmentId));

--- a/apps/meteor/client/components/message/hooks/useCollapse.spec.ts
+++ b/apps/meteor/client/components/message/hooks/useCollapse.spec.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { useCollapse } from './useCollapse';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useAttachmentIsCollapsedByDefault: () => false,
+}));
+
+describe('useCollapse', () => {
+	it('should default to collapsed state based on collapseByDefault', () => {
+		const { result } = renderHook(() => useCollapse(false));
+		expect(result.current[0]).toBe(false);
+	});
+
+	it('should toggle collapse state', () => {
+		const { result } = renderHook(() => useCollapse(false));
+		act(() => {
+			result.current[1]();
+		});
+		expect(result.current[0]).toBe(true);
+	});
+
+	it('should persist collapse state across remounts when an ID is provided', () => {
+		const attachmentId = 'http://example.com/image.png';
+
+		const { result: firstRender } = renderHook(() => useCollapse(false, attachmentId));
+		expect(firstRender.current[0]).toBe(false);
+
+		act(() => {
+			firstRender.current[1]();
+		});
+		expect(firstRender.current[0]).toBe(true);
+
+		// Simulating room switch: remounting component with same attachment ID
+		const { result: secondRender } = renderHook(() => useCollapse(false, attachmentId));
+		expect(secondRender.current[0]).toBe(true);
+	});
+});

--- a/apps/meteor/client/components/message/hooks/useCollapse.ts
+++ b/apps/meteor/client/components/message/hooks/useCollapse.ts
@@ -1,7 +1,18 @@
 import { useAttachmentIsCollapsedByDefault } from '@rocket.chat/ui-contexts';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+const MAX_CACHE_SIZE = 500;
 const collapsedCache = new Map<string, boolean>();
+
+const setCache = (id: string, value: boolean) => {
+	if (collapsedCache.size >= MAX_CACHE_SIZE && !collapsedCache.has(id)) {
+		const firstKey = collapsedCache.keys().next().value;
+		if (firstKey !== undefined) {
+			collapsedCache.delete(firstKey);
+		}
+	}
+	collapsedCache.set(id, value);
+};
 
 export const useCollapse = (attachmentCollapsed?: boolean, id?: string) => {
 	const collapseByDefault = useAttachmentIsCollapsedByDefault();
@@ -12,11 +23,19 @@ export const useCollapse = (attachmentCollapsed?: boolean, id?: string) => {
 		return Boolean(collapseByDefault || attachmentCollapsed);
 	});
 
+	useEffect(() => {
+		if (id && collapsedCache.has(id)) {
+			setCollapsed(collapsedCache.get(id)!);
+		} else {
+			setCollapsed(Boolean(collapseByDefault || attachmentCollapsed));
+		}
+	}, [id, collapseByDefault, attachmentCollapsed]);
+
 	const toggleCollapsed = useCallback(() => {
 		setCollapsed((prev) => {
 			const next = !prev;
 			if (id) {
-				collapsedCache.set(id, next);
+				setCache(id, next);
 			}
 			return next;
 		});

--- a/apps/meteor/client/components/message/hooks/useCollapse.ts
+++ b/apps/meteor/client/components/message/hooks/useCollapse.ts
@@ -1,9 +1,26 @@
-import { useToggle } from '@rocket.chat/fuselage-hooks';
 import { useAttachmentIsCollapsedByDefault } from '@rocket.chat/ui-contexts';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
-export const useCollapse = (attachmentCollapsed?: boolean) => {
+const collapsedCache = new Map<string, boolean>();
+
+export const useCollapse = (attachmentCollapsed?: boolean, id?: string) => {
 	const collapseByDefault = useAttachmentIsCollapsedByDefault();
-	const [collapsed, toggleCollapsed] = useToggle(collapseByDefault || attachmentCollapsed);
-	return [collapsed, useCallback(() => toggleCollapsed(), [toggleCollapsed])] as const;
+	const [collapsed, setCollapsed] = useState(() => {
+		if (id && collapsedCache.has(id)) {
+			return collapsedCache.get(id)!;
+		}
+		return Boolean(collapseByDefault || attachmentCollapsed);
+	});
+
+	const toggleCollapsed = useCallback(() => {
+		setCollapsed((prev) => {
+			const next = !prev;
+			if (id) {
+				collapsedCache.set(id, next);
+			}
+			return next;
+		});
+	}, [id]);
+
+	return [collapsed, toggleCollapsed] as const;
 };


### PR DESCRIPTION
<!-- Checklist -->
- [x] I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
- [x] I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules

## Proposed changes (including videos or screenshots)
Persists message attachment collapse states across channel navigation and component remounts.

Previously, `useCollapse` initialized collapse state solely via local component state (`useToggle`). When users expanded or collapsed an attachment, switching to another channel and returning caused component unmounting/remounting, resetting attachment states back to default.

`useCollapse` now accepts an attachment identifier (`link` or `title`) to cache user collapse choices in memory across room navigation. Added comprehensive unit tests in `useCollapse.spec.ts`.

## Issue(s)
Closes #40337

## Steps to test or reproduce
1. Open any channel containing image or file attachments.
2. Click the collapse/expand toggle on an attachment to collapse or expand it.
3. Switch to a different channel, then return to the original channel.
4. Verify that the attachment remains in your chosen collapse/expand state instead of resetting to default.

## Further comments
- Updated `apps/meteor/client/components/message/hooks/useCollapse.ts`
- Updated `apps/meteor/client/components/message/MessageCollapsible.tsx`
- Updated `apps/meteor/client/components/message/content/attachments/DefaultAttachment.tsx`
- Added unit tests in `apps/meteor/client/components/message/hooks/useCollapse.spec.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collapse/expand initialization for message sections, attachments, and URL previews by using stable identifiers plus link/title (and current URL for URL previews) to determine default state.
  * Added per-item persistence of collapse/expand preferences within a session, keeping behavior consistent on remounts and updates.
* **Tests**
  * Added Jest tests covering default collapse behavior, toggle interactions, and persistence across unmount/remount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->