### PR TITLE
fix(password-policies): validate repeating character count

### DIFF
--- a/packages/password-policies/src/PasswordPolicy.spec.ts
+++ b/packages/password-policies/src/PasswordPolicy.spec.ts
@@ -101,6 +101,23 @@ describe('Password tests with options', () => {
 		expect(passwordPolicy.validate('123456')).toBe(true);
 	});
 
+	it.each([-1, 0, 1.5, Number.NaN, 1e21, '3'])('should use the default repeating character count when configured with %p', (count) => {
+		const passwordPolicy = new PasswordPolicy({
+			enabled: true,
+			forbidRepeatingCharacters: true,
+			forbidRepeatingCharactersCount: count as number,
+			throwError: false,
+		});
+
+		expect(passwordPolicy.validate('111')).toBe(true);
+		expect(passwordPolicy.validate('1111')).toBe(false);
+		expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
+			name: 'get-password-policy-forbidRepeatingCharactersCount',
+			isValid: false,
+			limit: 3,
+		});
+	});
+
 	it('should contain one lowercase', () => {
 		const passwordPolicy = new PasswordPolicy({
 			enabled: true,

--- a/packages/password-policies/src/PasswordPolicy.spec.ts
+++ b/packages/password-policies/src/PasswordPolicy.spec.ts
@@ -116,6 +116,10 @@ describe('Password tests with options', () => {
 			isValid: false,
 			limit: 3,
 		});
+		expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
+			'get-password-policy-forbidRepeatingCharactersCount',
+			{ forbidRepeatingCharactersCount: 3 },
+		]);
 	});
 
 	it('should contain one lowercase', () => {

--- a/packages/password-policies/src/PasswordPolicy.ts
+++ b/packages/password-policies/src/PasswordPolicy.ts
@@ -79,11 +79,18 @@ export class PasswordPolicy {
 		mustContainAtLeastOneSpecialCharacter = false,
 		throwError = true,
 	}: PasswordPolicyOptions) {
+		const safeForbidRepeatingCharactersCount =
+			typeof forbidRepeatingCharactersCount === 'number' &&
+			Number.isSafeInteger(forbidRepeatingCharactersCount) &&
+			forbidRepeatingCharactersCount >= 1
+				? forbidRepeatingCharactersCount
+				: 3;
+
 		this.enabled = enabled;
 		this.minLength = minLength;
 		this.maxLength = maxLength;
 		this.forbidRepeatingCharacters = forbidRepeatingCharacters;
-		this.forbidRepeatingCharactersCount = forbidRepeatingCharactersCount;
+		this.forbidRepeatingCharactersCount = safeForbidRepeatingCharactersCount;
 		this.mustContainAtLeastOneLowercase = mustContainAtLeastOneLowercase;
 		this.mustContainAtLeastOneUppercase = mustContainAtLeastOneUppercase;
 		this.mustContainAtLeastOneNumber = mustContainAtLeastOneNumber;
@@ -91,7 +98,7 @@ export class PasswordPolicy {
 		this.throwError = throwError;
 
 		this.regex = {
-			forbiddingRepeatingCharacters: new RegExp(`(.)\\1{${forbidRepeatingCharactersCount},}`),
+			forbiddingRepeatingCharacters: new RegExp(`(.)\\1{${safeForbidRepeatingCharactersCount},}`),
 			mustContainAtLeastOneLowercase: new RegExp('[a-z]'),
 			mustContainAtLeastOneUppercase: new RegExp('[A-Z]'),
 			mustContainAtLeastOneNumber: new RegExp('[0-9]'),


### PR DESCRIPTION
## Summary

- sanitize `forbidRepeatingCharactersCount` before interpolating it into the password-policy regular expression
- use the normalized value in both validation and returned policy metadata
- cover negative, zero, fractional, `NaN`, unsafe large, and runtime non-number values

## Why

Invalid configuration values could be interpolated directly into the regular expression. Negative values throw during `PasswordPolicy` construction, while values rendered in exponent notation can silently produce an unintended expression.

Invalid values now fall back to the existing default count of `3`, preventing workspace failures while keeping the advertised policy limit consistent with the enforced expression.

## Validation

- `yarn workspace @rocket.chat/password-policies test --runInBand`
- `yarn workspace @rocket.chat/password-policies typecheck`
- `yarn workspace @rocket.chat/password-policies lint`

Fixes #41620


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened password policy handling for invalid repeated-character limits.
  * Non-integer and out-of-range `forbidRepeatingCharactersCount` values now safely fall back to the default limit of 3, ensuring consistent validation results and messages.  
* **Tests**
  * Added parameterized coverage to verify fallback behavior for invalid inputs and confirm the effective policy limit in validation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->