### PR TITLE
regression: Update express OAuth route handlers on re-register

### DIFF
--- a/apps/meteor/server/lib/auth-providers/apple/applePassportOAuth.ts
+++ b/apps/meteor/server/lib/auth-providers/apple/applePassportOAuth.ts
@@ -14,6 +14,7 @@ import { oAuthRouter } from '../../../configuration/configurePassport';
 import { settings } from '../../../settings';
 import { allowPassportOAuthMiddleware } from '../../oauth/allowPassportOAuthMiddleware';
 import { passportOAuthCallback } from '../../oauth/passportOAuthCallback';
+import { removeOAuthRoutes } from '../../oauth/removeOAuthRoutes';
 
 new AppleCustomOAuth('apple', config);
 
@@ -52,6 +53,7 @@ settings.watchMultiple(
 	],
 	async ([enabled, clientId, serverSecret, iss, kid, useModernFlow]) => {
 		passport.unuse('apple');
+		removeOAuthRoutes('apple');
 
 		if (!useModernFlow) {
 			return;

--- a/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
+++ b/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
@@ -4,6 +4,7 @@ import type { DoneCallback, Profile } from 'passport';
 
 import { allowPassportOAuthMiddleware } from './allowPassportOAuthMiddleware';
 import { passportOAuthCallback } from './passportOAuthCallback';
+import { removeOAuthRoutes } from './removeOAuthRoutes';
 import { verifyFunction } from './verifyFunction';
 import { oAuthRouter } from '../../configuration/configurePassport';
 import { settings } from '../../settings';
@@ -15,6 +16,7 @@ export const addPassportCustomOAuth = (
 	isCustomOAuth: boolean = false,
 ) => {
 	passport.unuse(serviceName);
+	removeOAuthRoutes(serviceName);
 
 	if (!config.clientId || !config.clientSecret || !config.serverURL) {
 		return;

--- a/apps/meteor/server/lib/oauth/configureOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/configureOAuthServices.ts
@@ -6,6 +6,7 @@ import type { Profile, DoneCallback } from 'passport';
 import { allowPassportOAuthMiddleware } from './allowPassportOAuthMiddleware';
 import type { OAuthServiceConfig } from './createOAuthServiceConfig';
 import { passportOAuthCallback } from './passportOAuthCallback';
+import { removeOAuthRoutes } from './removeOAuthRoutes';
 import { oAuthRouter } from '../../configuration/configurePassport';
 import type { ICachedSettings } from '../../settings/CachedSettings';
 
@@ -15,6 +16,7 @@ export const configureOAuthServices = (oauthServiceConfig: OAuthServiceConfig[],
 		const siteUrl = settings.get<string>('Site_Url').replace(/\/$/, '');
 
 		passport.unuse(config.provider);
+		removeOAuthRoutes(config.provider);
 
 		passport.use(
 			config.provider,

--- a/apps/meteor/server/lib/oauth/removeOAuthRoutes.ts
+++ b/apps/meteor/server/lib/oauth/removeOAuthRoutes.ts
@@ -1,15 +1,5 @@
 import { oAuthRouter } from '../../configuration/configurePassport';
 
-type RouterLayer = {
-	route?: {
-		path: string;
-	};
-};
-
-type RouterWithStack = {
-	stack: RouterLayer[];
-};
-
 /**
  * Removes every route previously registered for an OAuth service from the OAuth router.
  *
@@ -22,7 +12,7 @@ type RouterWithStack = {
 export const removeOAuthRoutes = (serviceName: string): void => {
 	const paths = [`/oauth/${serviceName}`, `/_oauth/${serviceName}`];
 
-	const router = oAuthRouter as unknown as RouterWithStack;
+	const router = oAuthRouter;
 
 	// Only route layers are dropped; middleware layers registered via `router.use`
 	router.stack = router.stack.filter((layer) => !layer.route || !paths.includes(layer.route.path));

--- a/apps/meteor/server/lib/oauth/removeOAuthRoutes.ts
+++ b/apps/meteor/server/lib/oauth/removeOAuthRoutes.ts
@@ -1,0 +1,29 @@
+import { oAuthRouter } from '../../configuration/configurePassport';
+
+type RouterLayer = {
+	route?: {
+		path: string;
+	};
+};
+
+type RouterWithStack = {
+	stack: RouterLayer[];
+};
+
+/**
+ * Removes every route previously registered for an OAuth service from the OAuth router.
+ *
+ * OAuth services are re-registered whenever their settings change, but express only ever
+ * *appends* to `router.stack` and dispatches on a first-match-wins basis. Without this,
+ * re-registering a service leaves the previous handlers in place and they keep serving the
+ * requests, using the configuration that was captured in their closures at registration time
+ * (`loginStyle`, `scope`, ...). Callers must invoke this before registering the routes again.
+ */
+export const removeOAuthRoutes = (serviceName: string): void => {
+	const paths = [`/oauth/${serviceName}`, `/_oauth/${serviceName}`];
+
+	const router = oAuthRouter as unknown as RouterWithStack;
+
+	// Only route layers are dropped; middleware layers registered via `router.use`
+	router.stack = router.stack.filter((layer) => !layer.route || !paths.includes(layer.route.path));
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
OAuth services are re-registered at runtime when their settings change. The passport strategy is replaced correctly, but the express routes are only appended, the old handlers are also part of execution stack.

`passportOAuthCallback` isn't a request handler, but is a factory that gives out request handler function based on settings configs. Due to this the request handler always uses old handler with old settings within its closure.

The fix implemented in this PR removes old request handlers from express router stack before pushing new handlers. In future we can come up with a better fix to not sure factory and closures, where express route handlers can use new settings directly.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Go to Workspace → Settings → OAuth
- Enable Use Modern OAuth Flow.
- Set Login Style to Redirect and save the changes
- Wait for the settings to be applied or select Refresh OAuth Services
- Change Login Style to Popup and save the changes
- Do not restart the Rocket.Chat server
- Open the workspace URL in a fresh incognito window
- Select the Custom OAuth provider
- Complete authentication successfully

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2489](https://rocketchat.atlassian.net/browse/CORE-2489)

[CORE-2489]: https://rocketchat.atlassian.net/browse/CORE-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth provider reconfiguration by removing existing OAuth routes before registering updated Passport strategies.
  * Prevented duplicate or conflicting OAuth endpoints during OAuth service initialization.
  * Applied the same route cleanup behavior to Apple OAuth and custom OAuth providers.
* **New Features**
  * Added a shared utility to remove OAuth routes for a specified provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->