### PR TITLE
regression: Passport OAuth popup specific commands

### DIFF
--- a/apps/meteor/client/views/root/AppLayout.tsx
+++ b/apps/meteor/client/views/root/AppLayout.tsx
@@ -33,6 +33,7 @@ import { useMessageLinkClicks } from './hooks/useMessageLinkClicks';
 import { useNativeEmoji } from './hooks/useNativeEmoji';
 import { useNotificationPermission } from './hooks/useNotificationPermission';
 import { useOAuthLogin } from './hooks/useOAuthLogin';
+import { useOAuthPopupCommands } from './hooks/useOAuthPopupCommands';
 import { useRedirectToSetupWizard } from './hooks/useRedirectToSetupWizard';
 import { useSettingsOnLoadSiteUrl } from './hooks/useSettingsOnLoadSiteUrl';
 import { useShareSessionWithOtherClients } from './hooks/useShareSessionWithOtherClients';
@@ -76,6 +77,7 @@ const AppLayout = () => {
 	useLoginViaQuery();
 	useLoginOtherClients();
 	useOAuthLogin();
+	useOAuthPopupCommands();
 	useShareSessionWithOtherClients();
 	useLoadMissedMessages();
 	useDesktopFavicon();

--- a/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
@@ -56,7 +56,7 @@ export const useOAuthPopupCommands = () => {
 
 			const { oauthPopupCommand } = event.data as { oauthPopupCommand?: unknown };
 
-			if (typeof oauthPopupCommand !== 'string' || !(oauthPopupCommand in commands)) {
+			if (typeof oauthPopupCommand !== 'string' || !Object.hasOwn(commands, oauthPopupCommand)) {
 				return;
 			}
 

--- a/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
@@ -1,0 +1,68 @@
+import { escapeRegExp } from '@rocket.chat/string-helpers';
+import { type LocationPathname, useLoginWithToken } from '@rocket.chat/ui-contexts';
+import { useEffect } from 'react';
+
+import { ltrim, rtrim } from '../../../../lib/utils/stringUtils';
+import { baseURI } from '../../../lib/baseURI';
+import { getRootUrlPathPrefix } from '../../../lib/meteorRuntimeConfig';
+import { router } from '../../../providers/RouterProvider';
+
+export const useOAuthPopupCommands = () => {
+	const loginWithToken = useLoginWithToken();
+
+	useEffect(() => {
+		const commands = {
+			//Used for the 2FA challenge and for handing the session over to the desktop/mobile clients.
+			'redirect'(data: { path: string }) {
+				if (typeof data.path !== 'string' || data.path.trim().length === 0) {
+					return console.error('OAuth popup command [navigate]: `path` not defined');
+				}
+
+				const newUrl = new URL(`${rtrim(baseURI, '/')}/${ltrim(data.path, '/')}`);
+
+				const newParams = Object.fromEntries(newUrl.searchParams.entries());
+
+				const newPath = newUrl.pathname.replace(new RegExp(`^${escapeRegExp(getRootUrlPathPrefix())}`), '') as LocationPathname;
+
+				router.navigate({
+					pathname: newPath,
+					search: { ...router.getSearchParameters(), ...newParams },
+				});
+			},
+
+			'oauth-login-with-token'(data: { token: string }) {
+				if (typeof data.token !== 'string') {
+					return console.error('OAuth popup command [login]: `token` not defined');
+				}
+
+				void loginWithToken(data.token);
+			},
+		} as const;
+
+		const messageListener = (event: MessageEvent) => {
+			//The popup is same-origin, anything else is not ours to act on.
+			if (event.origin !== window.location.origin) {
+				return;
+			}
+
+			if (typeof event.data !== 'object' || event.data === null) {
+				return;
+			}
+
+			const { oauthPopupCommand } = event.data as { oauthPopupCommand?: unknown };
+
+			if (typeof oauthPopupCommand !== 'string' || !(oauthPopupCommand in commands)) {
+				return;
+			}
+
+			const command: (data: MessageEvent['data']) => void = commands[oauthPopupCommand as keyof typeof commands];
+			command(event.data);
+		};
+
+		window.addEventListener('message', messageListener);
+
+		return () => {
+			window.removeEventListener('message', messageListener);
+		};
+	}, [loginWithToken]);
+};

--- a/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
+++ b/apps/meteor/client/views/root/hooks/useOAuthPopupCommands.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp } from '@rocket.chat/string-helpers';
-import { type LocationPathname, useLoginWithToken } from '@rocket.chat/ui-contexts';
+import { type LocationPathname, useLoginWithToken, useSetting } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
 
 import { ltrim, rtrim } from '../../../../lib/utils/stringUtils';
@@ -9,8 +9,13 @@ import { router } from '../../../providers/RouterProvider';
 
 export const useOAuthPopupCommands = () => {
 	const loginWithToken = useLoginWithToken();
+	const enableModernOAuthFlow = useSetting('Accounts_OAuth_Use_Modern_Flow', true);
 
 	useEffect(() => {
+		if (!enableModernOAuthFlow) {
+			return;
+		}
+
 		const commands = {
 			//Used for the 2FA challenge and for handing the session over to the desktop/mobile clients.
 			'redirect'(data: { path: string }) {
@@ -64,5 +69,5 @@ export const useOAuthPopupCommands = () => {
 		return () => {
 			window.removeEventListener('message', messageListener);
 		};
-	}, [loginWithToken]);
+	}, [loginWithToken, enableModernOAuthFlow]);
 };

--- a/apps/meteor/server/lib/oauth/passportOAuthCallback.ts
+++ b/apps/meteor/server/lib/oauth/passportOAuthCallback.ts
@@ -40,7 +40,7 @@ const handlePopupStyleOAuth = async (res: Response, oAuthUser: IUser, loginClien
 	if (secondFactorMethod) {
 		const challengeId = await secondFactorMethod.sendTwoFactorChallenge(oAuthUser);
 		sendPopupMessage(res, {
-			externalCommand: 'go',
+			oauthPopupCommand: 'redirect',
 			path: `/2fa/${secondFactorMethod.method}/${challengeId}${loginClient ? `?loginClient=${loginClient}` : ''}`,
 		});
 		return;
@@ -50,13 +50,13 @@ const handlePopupStyleOAuth = async (res: Response, oAuthUser: IUser, loginClien
 
 	if (loginClient) {
 		sendPopupMessage(res, {
-			externalCommand: 'go',
+			oauthPopupCommand: 'redirect',
 			path: `home?resumeToken=${token}&userId=${oAuthUser._id}&loginClient=${loginClient}`,
 		});
 		return;
 	}
 
-	sendPopupMessage(res, { externalCommand: 'login-with-token', token });
+	sendPopupMessage(res, { oauthPopupCommand: 'oauth-login-with-token', token });
 };
 
 export const passportOAuthCallback =


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Introduced here: #40882

The OAuth popup uses `window.postMessage` api to communicate between parent and popup windows. In original implementation we were reusing the iframe commands used by other integrations, but these commands are only registered when iframe integration is enabled. The OAuth popup stops working when we disable iframe integrations.

This PR solves this by registering OAuth specific commands which will always be registered and will always work on same origin. OAuth popup login now uses these commands to process the flow.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Go to Workspace → Settings → OAuth.
- Enable Accounts_OAuth_Use_Modern_Flow
- Configure a Custom OAuth provider with login style popup
- Go to Workspace → Settings → General → Iframe Integration
- Disable Enable Receive and save the changes
- Open the workspace URL in a fresh incognito window
- Select the Custom OAuth provider on the login page
- Complete authentication successfully
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2488](https://rocketchat.atlassian.net/browse/CORE-2488)

[CORE-2488]: https://rocketchat.atlassian.net/browse/CORE-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth popup sign-in to support modern popup command handling, including secure redirect navigation and token-based login.
  * Improved continuation of authentication when using modern OAuth popup interactions.

* **Bug Fixes**
  * Fixed OAuth popup messaging so two-factor authentication and post-login navigation proceed correctly using the updated command contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->