### PR TITLE
regression: blank thread preview on horizontal rule

### DIFF
--- a/packages/gazzodown/src/PreviewMarkup.spec.tsx
+++ b/packages/gazzodown/src/PreviewMarkup.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+
+import PreviewMarkup from './PreviewMarkup';
+
+it('renders empty', () => {
+	const { container } = render(<PreviewMarkup tokens={[]} />);
+	expect(container).toBeEmptyDOMElement();
+});
+
+it('renders the first block with content when the message starts with a horizontal rule', () => {
+	render(
+		<PreviewMarkup
+			tokens={[
+				{ type: 'HORIZONTAL_RULE', value: undefined, fallback: [0, 3] },
+				{ type: 'PARAGRAPH', value: [{ type: 'PLAIN_TEXT', value: 'Important update' }] },
+			]}
+		/>,
+	);
+
+	expect(screen.getByText('Important update')).toBeInTheDocument();
+});

--- a/packages/gazzodown/src/PreviewMarkup.tsx
+++ b/packages/gazzodown/src/PreviewMarkup.tsx
@@ -21,7 +21,9 @@ const PreviewMarkup = ({ tokens, source }: PreviewMarkupProps) => {
 		return <PreviewBigEmojiBlock emoji={tokens[0].value} />;
 	}
 
-	const firstBlock = tokens.find((block) => block.type !== 'LINE_BREAK');
+	const firstBlock =
+		tokens.find((block) => block.type !== 'LINE_BREAK' && block.type !== 'HORIZONTAL_RULE') ??
+		tokens.find((block) => block.type !== 'LINE_BREAK');
 
 	if (!firstBlock) {
 		return null;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

A preview renders a single block, and `PreviewMarkup` was picking the `HORIZONTAL_RULE` introduced by #41113 as that block. The rule carries no content and has no case in the switch, so the preview rendered nothing.

Content-less blocks are now skipped when choosing the block to preview, as line breaks already were, falling back to the previous selection when the message has nothing else.

## Issue(s)

- [CORE-2491](https://rocketchat.atlassian.net/browse/CORE-2491)

## Steps to test or reproduce

1. Reply in a thread with `---`, then Shift+Enter, then `Important update`.
2. Tick **Also send to channel** and send.
3. The thread preview in the message list shows `Important update` instead of a blank line.

## Further comments

Known gap, unchanged here: a reply whose entire content is `---` still previews blank, since there is no other block to fall back to.

[CORE-2491]: https://rocketchat.atlassian.net/browse/CORE-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview rendering when content begins with horizontal rules, ensuring the first meaningful paragraph is displayed correctly.

* **Tests**
  * Added coverage for empty content and content beginning with a horizontal rule followed by a paragraph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->