### PR TITLE
regression: Unicode emojis on use emoji preference

### DIFF
--- a/apps/meteor/client/components/GazzodownText.tsx
+++ b/apps/meteor/client/components/GazzodownText.tsx
@@ -53,7 +53,7 @@ const GazzodownText = ({ mentions, channels, searchText, children }: GazzodownTe
 	}, [searchText]);
 
 	const convertAsciiToEmoji = useUserPreference<boolean>('convertAsciiEmoji', true);
-	const useEmoji = Boolean(useUserPreference('useEmojis'));
+	const useEmoji = useUserPreference<boolean>('useEmojis', true);
 	const useRealName = useMessageListShowRealName();
 	const ownUserId = useUserId();
 	const showMentionSymbol = Boolean(useUserPreference<boolean>('mentionsWithSymbol'));

--- a/apps/meteor/client/views/modal/uikit/UiKitModal.tsx
+++ b/apps/meteor/client/views/modal/uikit/UiKitModal.tsx
@@ -1,6 +1,7 @@
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { UiKitContext } from '@rocket.chat/fuselage-ui-kit';
 import { MarkupInteractionContext } from '@rocket.chat/gazzodown';
+import { useUserPreference } from '@rocket.chat/ui-contexts';
 import type * as UiKit from '@rocket.chat/ui-kit';
 import type { FormEvent } from 'react';
 
@@ -20,6 +21,8 @@ const UiKitModal = ({ initialView }: UiKitModalProps) => {
 	const actionManager = useUiKitActionManager();
 	const { view, errors, values, updateValues, state } = useUiKitView(initialView);
 	const contextValue = useModalContextValue({ view, errors, values, updateValues });
+	const useEmoji = useUserPreference<boolean>('useEmojis', true);
+	const convertAsciiToEmoji = useUserPreference<boolean>('convertAsciiEmoji', true);
 
 	const handleSubmit = useStableCallback((e: FormEvent) => {
 		preventSyntheticEvent(e);
@@ -69,6 +72,8 @@ const UiKitModal = ({ initialView }: UiKitModalProps) => {
 			<MarkupInteractionContext.Provider
 				value={{
 					detectEmoji,
+					useEmoji,
+					convertAsciiToEmoji,
 				}}
 			>
 				<ModalBlock view={view} errors={errors} appId={view.appId} onSubmit={handleSubmit} onCancel={handleCancel} onClose={handleClose} />

--- a/packages/gazzodown/src/Markup.spec.tsx
+++ b/packages/gazzodown/src/Markup.spec.tsx
@@ -230,7 +230,7 @@ it('renders a code block', async () => {
 		</Suspense>,
 	);
 
-	await waitFor(() => expect(screen.getByRole('region')).toBeInTheDocument());
+	expect(await screen.findByRole('region')).toBeInTheDocument();
 
 	expect(screen.getByRole('region')).toHaveTextContent('```const foo = bar;```');
 });
@@ -250,7 +250,7 @@ it('renders a code block with language', async () => {
 		</Suspense>,
 	);
 
-	await waitFor(() => expect(screen.getByRole('region')).toBeInTheDocument());
+	expect(await screen.findByRole('region')).toBeInTheDocument();
 
 	expect(screen.getByRole('region')).toHaveTextContent('```const foo = bar;```');
 	expect(screen.getByRole('region').querySelector('.language-javascript')).toBeInTheDocument();
@@ -344,6 +344,87 @@ it('renders plain text instead of ASCII emojis based on useEmojis preference', (
 	);
 
 	expect(screen.getByText('Hey! :smile: :)')).toBeInTheDocument();
+});
+
+describe('unicode emojis with the useEmojis preference disabled', () => {
+	const detectEmoji = (text: string) =>
+		text === '🐕' ? [{ name: ':dog2:', className: 'emoji', content: '🐕' }] : [{ name: '', className: 'emoji', content: text }];
+
+	it('renders the shortcode of an emoji sent as unicode', () => {
+		render(
+			<MarkupInteractionContext.Provider
+				value={{
+					convertAsciiToEmoji: false,
+					useEmoji: false,
+					detectEmoji,
+				}}
+			>
+				<Markup
+					tokens={[
+						{
+							type: 'PARAGRAPH',
+							value: [
+								{ type: 'PLAIN_TEXT', value: 'Hey! ' },
+								{ type: 'EMOJI', value: undefined, unicode: '🐕' },
+							],
+						},
+					]}
+				/>
+			</MarkupInteractionContext.Provider>,
+		);
+
+		expect(screen.getByText('Hey! :dog2:')).toBeInTheDocument();
+	});
+
+	it('renders the glyph when no shortcode is known for the emoji', () => {
+		render(
+			<MarkupInteractionContext.Provider
+				value={{
+					convertAsciiToEmoji: false,
+					useEmoji: false,
+					detectEmoji: () => [],
+				}}
+			>
+				<Markup
+					tokens={[
+						{
+							type: 'PARAGRAPH',
+							value: [{ type: 'EMOJI', value: undefined, unicode: '🫩' }],
+						},
+					]}
+				/>
+			</MarkupInteractionContext.Provider>,
+		);
+
+		expect(screen.getByText('🫩')).toBeInTheDocument();
+	});
+
+	it('renders a big emoji block as plain text', () => {
+		render(
+			<MarkupInteractionContext.Provider
+				value={{
+					convertAsciiToEmoji: false,
+					useEmoji: false,
+					detectEmoji,
+				}}
+			>
+				<Markup
+					tokens={[
+						{
+							type: 'BIG_EMOJI',
+							value: [
+								{ type: 'EMOJI', value: { type: 'PLAIN_TEXT', value: 'dog2' }, shortCode: 'dog2' },
+								{ type: 'EMOJI', value: undefined, unicode: '🐕' },
+							],
+						},
+					]}
+				/>
+			</MarkupInteractionContext.Provider>,
+		);
+
+		expect(screen.getByRole('presentation')).toHaveTextContent(':dog2::dog2:');
+		expect(screen.queryAllByRole('img')).toHaveLength(0);
+	});
 });
 
 describe('ImageElement sanitization', () => {

--- a/packages/gazzodown/src/emoji/EmojiRenderer.tsx
+++ b/packages/gazzodown/src/emoji/EmojiRenderer.tsx
@@ -1,9 +1,10 @@
 import { MessageEmoji, ThreadMessageEmoji } from '@rocket.chat/fuselage';
 import type * as MessageParser from '@rocket.chat/message-parser';
-import DOMPurify from 'dompurify';
-import { useMemo, useContext, memo } from 'react';
+import { useContext, memo } from 'react';
 
 import { MarkupInteractionContext } from '../MarkupInteractionContext';
+import { useEmojiDescriptors } from './useEmojiDescriptors';
+import PlainSpan from '../elements/PlainSpan';
 
 type EmojiProps = MessageParser.Emoji & {
 	big?: boolean;
@@ -11,16 +12,14 @@ type EmojiProps = MessageParser.Emoji & {
 };
 
 const EmojiRenderer = ({ big = false, preview = false, ...emoji }: EmojiProps) => {
-	const { detectEmoji } = useContext(MarkupInteractionContext);
+	const { useEmoji } = useContext(MarkupInteractionContext);
 
-	const fallback = useMemo(() => ('unicode' in emoji ? emoji.unicode : `:${emoji.shortCode ?? emoji.value.value}:`), [emoji]);
+	const { descriptors, sanitizedFallback } = useEmojiDescriptors(emoji);
 
-	const sanitizedFallback = DOMPurify.sanitize(fallback);
-
-	const descriptors = useMemo(() => {
-		const detected = detectEmoji?.(sanitizedFallback);
-		return detected?.length !== 0 ? detected : undefined;
-	}, [detectEmoji, sanitizedFallback]);
+	//handles unicode emojis
+	if (!useEmoji) {
+		return <PlainSpan text={descriptors?.map(({ name, content }) => name || content).join('') ?? sanitizedFallback} />;
+	}
 
 	return (
 		<>

--- a/packages/gazzodown/src/emoji/useEmojiDescriptors.ts
+++ b/packages/gazzodown/src/emoji/useEmojiDescriptors.ts
@@ -1,0 +1,20 @@
+import type * as MessageParser from '@rocket.chat/message-parser';
+import DOMPurify from 'dompurify';
+import { useContext, useMemo } from 'react';
+
+import { MarkupInteractionContext } from '../MarkupInteractionContext';
+
+export const useEmojiDescriptors = (emoji: MessageParser.Emoji) => {
+	const { detectEmoji } = useContext(MarkupInteractionContext);
+
+	const fallback = useMemo(() => ('unicode' in emoji ? emoji.unicode : `:${emoji.shortCode ?? emoji.value.value}:`), [emoji]);
+
+	const sanitizedFallback = useMemo(() => DOMPurify.sanitize(fallback), [fallback]);
+
+	const descriptors = useMemo(() => {
+		const detected = detectEmoji?.(sanitizedFallback);
+		return detected?.length !== 0 ? detected : undefined;
+	}, [detectEmoji, sanitizedFallback]);
+
+	return { descriptors, sanitizedFallback };
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Unicode emojis should respect the user's preference to use emojis or not. 
<img width="597" height="182" alt="image" src="https://github.com/user-attachments/assets/7ad13685-2c91-4fd2-994c-e1724850a66f" />

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- User B disables Account → Preferences → Messages → Use Emojis.
- User B reloads the client.
- User A selects an emoji such as 🐕 from the emoji picker and sends it.
- User A manually types the corresponding shortcode, such as :dog:, without selecting autocomplete, and sends it.
- Observe both messages as User B.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2464](https://rocketchat.atlassian.net/browse/CORE-2464)

[CORE-2464]: https://rocketchat.atlassian.net/browse/CORE-2464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emoji rendering now fully respects user preferences for enabling emojis and ASCII-to-emoji conversion.
  * When emojis are disabled, detected emoji content renders as readable plain text (shortcode or Unicode) instead of emoji imagery.
* **Bug Fixes**
  * Improved handling for unknown Unicode emojis and large emoji blocks to avoid image-based rendering when disabled.
  * Enhanced code-block rendering test stability.
* **Tests**
  * Added coverage for emoji behavior when the “use emojis” preference is turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->