### PR TITLE
regression: preserve gif animation and correct thumbnail after `sharp` bump

### DIFF
--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -328,15 +328,15 @@ export const FileUpload = {
 		const store = FileUpload.getStore('Uploads');
 		const image = await store._store.getReadStream(file._id, file);
 
-		let transformer = sharp().resize({ width, height, fit: 'inside' });
+		let transformer = sharp({ animated: file.type === 'image/gif' }).resize({ width, height, fit: 'inside' });
 
 		if (file.type === 'image/svg+xml') {
 			transformer = transformer.png();
 		}
-		const result = transformer.toBuffer({ resolveWithObject: true }).then(({ data, info: { width, height, format } }) => ({
+		const result = transformer.toBuffer({ resolveWithObject: true }).then(({ data, info: { width, height, pageHeight, format } }) => ({
 			data,
 			width,
-			height,
+			height: pageHeight ?? height,
 			thumbFileType: (mime.lookup(format) as string) || '',
 			thumbFileName: file?.name as string,
 			originalFileId: file?._id as string,

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -635,7 +635,6 @@ export const FileUpload = {
 		});
 
 		return new Promise<Buffer>((resolve, reject) => {
-			// Settle on write failure instead of hanging.
 			buffer.on('error', reject);
 			buffer.on('finish', () => {
 				const contents = buffer.getContents();

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -332,7 +332,6 @@ export const FileUpload = {
 		const store = FileUpload.getStore('Uploads');
 		const image = await store._store.getReadStream(file._id, file);
 
-		// GIFs need `pages` to stay animated (capped via Math.min); `sharp()` bare is required so non-GIFs still stream.
 		let transformer = (
 			file.type === 'image/gif' ? sharp({ pages: Math.min(file.identify?.pages ?? 1, MAX_ANIMATED_THUMBNAIL_PAGES) }) : sharp()
 		).resize({ width, height, fit: 'inside' });
@@ -399,7 +398,6 @@ export const FileUpload = {
 							height,
 						}
 					: undefined,
-			// Lets thumbnail generation cap frames without re-reading the file.
 			pages: metadata.pages,
 		};
 

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -42,7 +42,26 @@ import { fileUploadIsValidContentType } from '../../../utils/restrictions';
 const cookie = new Cookies();
 
 // Bounds per-frame GIF decode cost; sharp's limitInputPixels alone doesn't catch a huge frame count with tiny per-frame dimensions.
-const MAX_ANIMATED_THUMBNAIL_PAGES = 50;
+const MAX_ANIMATED_THUMBNAIL_PAGES = 100;
+
+// FileUpload.getBuffer never settles if the underlying store read errors (e.g. a network blip on S3/GCS/WebDAV),
+// which would otherwise hang the sendFileMessage method call indefinitely.
+const GET_BUFFER_TIMEOUT_MS = 30_000;
+
+async function getBufferWithTimeout(file: IUpload): Promise<Buffer> {
+	let timer: ReturnType<typeof setTimeout>;
+	try {
+		return await Promise.race([
+			FileUpload.getBuffer(file),
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error('Timed out reading file buffer for thumbnail generation')), GET_BUFFER_TIMEOUT_MS);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer!);
+	}
+}
+
 let maxFileSize = 0;
 
 settings.watch('FileUpload_MaxFileSize', async (value: string) => {
@@ -332,7 +351,7 @@ export const FileUpload = {
 
 		let transformer: Sharp;
 		if (file.type === 'image/gif') {
-			const buffer = await FileUpload.getBuffer(file);
+			const buffer = await getBufferWithTimeout(file);
 			const { pages: totalPages } = await sharp(buffer).metadata();
 			const pages = Math.min(totalPages ?? 1, MAX_ANIMATED_THUMBNAIL_PAGES);
 			transformer = sharp(buffer, { pages }).resize({ width, height, fit: 'inside' });

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -21,7 +21,7 @@ import { Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Cookies } from 'meteor/ostrio:cookies';
 import type { ClientSession, OptionalId } from 'mongodb';
-import sharp from 'sharp';
+import sharp, { type Sharp } from 'sharp';
 import type { WritableStreamBuffer } from 'stream-buffers';
 import streamBuffers from 'stream-buffers';
 
@@ -40,6 +40,9 @@ import { validateAndDecodeJWT, generateJWT } from '../../../utils/lib/JWTHelper'
 import { fileUploadIsValidContentType } from '../../../utils/restrictions';
 
 const cookie = new Cookies();
+
+// Bounds per-frame GIF decode cost; sharp's limitInputPixels alone doesn't catch a huge frame count with tiny per-frame dimensions.
+const MAX_ANIMATED_THUMBNAIL_PAGES = 50;
 let maxFileSize = 0;
 
 settings.watch('FileUpload_MaxFileSize', async (value: string) => {
@@ -326,9 +329,18 @@ export const FileUpload = {
 
 		file = FileUpload.addExtensionTo(file);
 		const store = FileUpload.getStore('Uploads');
-		const image = await store._store.getReadStream(file._id, file);
 
-		let transformer = sharp({ animated: file.type === 'image/gif' }).resize({ width, height, fit: 'inside' });
+		let transformer: Sharp;
+		if (file.type === 'image/gif') {
+			const buffer = await FileUpload.getBuffer(file);
+			const { pages: totalPages } = await sharp(buffer).metadata();
+			const pages = Math.min(totalPages ?? 1, MAX_ANIMATED_THUMBNAIL_PAGES);
+			transformer = sharp(buffer, { pages }).resize({ width, height, fit: 'inside' });
+		} else {
+			const image = await store._store.getReadStream(file._id, file);
+			transformer = sharp().resize({ width, height, fit: 'inside' });
+			image.pipe(transformer);
+		}
 
 		if (file.type === 'image/svg+xml') {
 			transformer = transformer.png();
@@ -341,7 +353,6 @@ export const FileUpload = {
 			thumbFileName: file?.name as string,
 			originalFileId: file?._id as string,
 		}));
-		image.pipe(transformer);
 
 		return result;
 	},

--- a/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
+++ b/apps/meteor/server/lib/media/file-upload/lib/FileUpload.ts
@@ -21,7 +21,7 @@ import { Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Cookies } from 'meteor/ostrio:cookies';
 import type { ClientSession, OptionalId } from 'mongodb';
-import sharp, { type Sharp } from 'sharp';
+import sharp from 'sharp';
 import type { WritableStreamBuffer } from 'stream-buffers';
 import streamBuffers from 'stream-buffers';
 
@@ -41,26 +41,8 @@ import { fileUploadIsValidContentType } from '../../../utils/restrictions';
 
 const cookie = new Cookies();
 
-// Bounds per-frame GIF decode cost; sharp's limitInputPixels alone doesn't catch a huge frame count with tiny per-frame dimensions.
+// Caps GIF frames decoded per thumbnail; limitInputPixels doesn't bound frame count.
 const MAX_ANIMATED_THUMBNAIL_PAGES = 100;
-
-// FileUpload.getBuffer never settles if the underlying store read errors (e.g. a network blip on S3/GCS/WebDAV),
-// which would otherwise hang the sendFileMessage method call indefinitely.
-const GET_BUFFER_TIMEOUT_MS = 30_000;
-
-async function getBufferWithTimeout(file: IUpload): Promise<Buffer> {
-	let timer: ReturnType<typeof setTimeout>;
-	try {
-		return await Promise.race([
-			FileUpload.getBuffer(file),
-			new Promise<never>((_, reject) => {
-				timer = setTimeout(() => reject(new Error('Timed out reading file buffer for thumbnail generation')), GET_BUFFER_TIMEOUT_MS);
-			}),
-		]);
-	} finally {
-		clearTimeout(timer!);
-	}
-}
 
 let maxFileSize = 0;
 
@@ -348,22 +330,17 @@ export const FileUpload = {
 
 		file = FileUpload.addExtensionTo(file);
 		const store = FileUpload.getStore('Uploads');
+		const image = await store._store.getReadStream(file._id, file);
 
-		let transformer: Sharp;
-		if (file.type === 'image/gif') {
-			const buffer = await getBufferWithTimeout(file);
-			const { pages: totalPages } = await sharp(buffer).metadata();
-			const pages = Math.min(totalPages ?? 1, MAX_ANIMATED_THUMBNAIL_PAGES);
-			transformer = sharp(buffer, { pages }).resize({ width, height, fit: 'inside' });
-		} else {
-			const image = await store._store.getReadStream(file._id, file);
-			transformer = sharp().resize({ width, height, fit: 'inside' });
-			image.pipe(transformer);
-		}
+		// GIFs need `pages` to stay animated (capped via Math.min); `sharp()` bare is required so non-GIFs still stream.
+		let transformer = (
+			file.type === 'image/gif' ? sharp({ pages: Math.min(file.identify?.pages ?? 1, MAX_ANIMATED_THUMBNAIL_PAGES) }) : sharp()
+		).resize({ width, height, fit: 'inside' });
 
 		if (file.type === 'image/svg+xml') {
 			transformer = transformer.png();
 		}
+		// pageHeight is the per-frame height; info.height is the full stacked height for animated input.
 		const result = transformer.toBuffer({ resolveWithObject: true }).then(({ data, info: { width, height, pageHeight, format } }) => ({
 			data,
 			width,
@@ -372,6 +349,7 @@ export const FileUpload = {
 			thumbFileName: file?.name as string,
 			originalFileId: file?._id as string,
 		}));
+		image.pipe(transformer);
 
 		return result;
 	},
@@ -421,6 +399,8 @@ export const FileUpload = {
 							height,
 						}
 					: undefined,
+			// Lets thumbnail generation cap frames without re-reading the file.
+			pages: metadata.pages,
 		};
 
 		const shouldRotate = settings.get<boolean>('FileUpload_RotateImages');
@@ -656,7 +636,9 @@ export const FileUpload = {
 			initialSize: file.size,
 		});
 
-		return new Promise((resolve, reject) => {
+		return new Promise<Buffer>((resolve, reject) => {
+			// Settle on write failure instead of hanging.
+			buffer.on('error', reject);
 			buffer.on('finish', () => {
 				const contents = buffer.getContents();
 				if (contents === false) {

--- a/packages/core-typings/src/IUpload.ts
+++ b/packages/core-typings/src/IUpload.ts
@@ -23,6 +23,7 @@ export interface IUpload extends IRocketChatRecord {
 			width: number;
 			height: number;
 		};
+		pages?: number;
 	};
 	store?: string;
 	path?: string;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
After the sharp update from 0.33 to 0.35.3 (#41537), thumbnail generation in `FileUpload.createImageThumbnail` needed two adjustments:

- sharp's animated option defaults to `false`, so thumbnails were only keeping the first frame of GIFs. Passing `{ animated: file.type === 'image/gif' }` to the constructor preserves all frames (and their delay/loop metadata) for GIFs while leaving other formats unaffected.
- The resize output height was using the full stacked "toilet roll" height for multi-frame images rather than the per-frame height, which affected the dimensions stored on the thumbnail attachment. Using `pageHeight ?? height` reports the correct per-frame size.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
https://rocketchat.atlassian.net/browse/CORE-2494

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved animated GIF thumbnail generation by streaming media data reliably and handling read errors.
  * Limited GIF thumbnail processing to a safe number of frames, improving performance for highly animated files.
  * Stored GIF page counts during upload to support more consistent thumbnail generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->