### PR TITLE
refactor(api): migrate remaining groups endpoints to typed router

### DIFF
--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -2,6 +2,9 @@ import { Team, isMeteorError } from '@rocket.chat/core-services';
 import {
 	isRoomNativeFederated,
 	type IIntegration,
+	type IMessage,
+	type ITeam,
+	type IUploadWithUser,
 	type IUser,
 	type IRoom,
 	type RoomType,
@@ -9,11 +12,22 @@ import {
 } from '@rocket.chat/core-typings';
 import { Integrations, Messages, Rooms, Subscriptions, Uploads, Users } from '@rocket.chat/models';
 import {
-	isGroupsOnlineProps,
-	isGroupsMessagesProps,
+	isGroupsConvertToTeamProps,
+	isGroupsCountersProps,
+	isGroupsCreateProps,
+	isGroupsDeleteProps,
 	isGroupsFilesProps,
+	isGroupsHistoryProps,
+	isGroupsInfoProps,
+	isGroupsInviteProps,
+	isGroupsListProps,
+	isGroupsModeratorsProps,
+	isGroupsOnlineProps,
+	isGroupsRolesProps,
 	ajv,
+	ajvQuery,
 	validateBadRequestErrorResponse,
+	validateForbiddenErrorResponse,
 	validateUnauthorizedErrorResponse,
 } from '@rocket.chat/rest-typings';
 import { isTruthy } from '@rocket.chat/tools';
@@ -347,193 +361,306 @@ API.v1.post(
 	},
 );
 
-API.v1.addRoute(
+const countersResponseSchema = ajv.compile<{
+	joined: boolean;
+	members: number | null;
+	unreads: number | null;
+	unreadsFrom: Date | null;
+	msgs: number | null;
+	latest: Date | null;
+	userMentions: number | null;
+}>({
+	type: 'object',
+	properties: {
+		joined: { type: 'boolean' },
+		members: { type: ['number', 'null'] },
+		unreads: { type: ['number', 'null'] },
+		unreadsFrom: { type: ['string', 'null'] },
+		msgs: { type: ['number', 'null'] },
+		latest: { type: ['string', 'null'] },
+		userMentions: { type: ['number', 'null'] },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['joined', 'members', 'unreads', 'unreadsFrom', 'msgs', 'latest', 'userMentions', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
 	'groups.counters',
-	{ authRequired: true },
 	{
-		async get() {
-			const access = await hasPermissionAsync(this.user, 'view-room-administration');
-			const params = this.queryParams;
-			let user = this.userId;
-			let room;
-			let unreads = null;
-			let userMentions = null;
-			let unreadsFrom = null;
-			let joined = false;
-			let msgs = null;
-			let latest = null;
-			let members = null;
-
-			if (('roomId' in params && !params.roomId) || ('roomName' in params && !params.roomName)) {
-				throw new Meteor.Error('error-room-param-not-provided', 'The parameter "roomId" or "roomName" is required');
-			}
-
-			if ('roomId' in params) {
-				room = await Rooms.findOneById(params.roomId || '');
-			} else if ('roomName' in params) {
-				room = await Rooms.findOneByName(params.roomName || '');
-			}
-
-			if (room?.t !== 'p') {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			if (room.archived) {
-				throw new Meteor.Error('error-room-archived', `The private group, ${room.name}, is archived`);
-			}
-
-			if (params.userId) {
-				if (!access) {
-					return API.v1.forbidden();
-				}
-				user = params.userId;
-			}
-			const subscription = await Subscriptions.findOneByRoomIdAndUserId(room._id, user);
-			const lm = room.lm ? room.lm : room._updatedAt;
-
-			if (subscription?.open) {
-				unreads = await Messages.countVisibleByRoomIdBetweenTimestampsInclusive(subscription.rid, subscription.ls || subscription.ts, lm);
-				unreadsFrom = subscription.ls || subscription.ts;
-				userMentions = subscription.userMentions;
-				joined = true;
-			}
-
-			if (access || joined) {
-				msgs = room.msgs;
-				latest = lm;
-				members = await Users.countActiveUsersInNonDMRoom(room._id);
-			}
-
-			return API.v1.success({
-				joined,
-				members,
-				unreads,
-				unreadsFrom,
-				msgs,
-				latest,
-				userMentions,
-			});
+		authRequired: true,
+		query: isGroupsCountersProps,
+		response: {
+			200: countersResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
+	},
+	async function action() {
+		const access = await hasPermissionAsync(this.user, 'view-room-administration');
+		const params = this.queryParams;
+		let user = this.userId;
+		let room;
+		let unreads = null;
+		let userMentions = null;
+		let unreadsFrom = null;
+		let joined = false;
+		let msgs = null;
+		let latest = null;
+		let members = null;
+
+		if (('roomId' in params && !params.roomId) || ('roomName' in params && !params.roomName)) {
+			throw new Meteor.Error('error-room-param-not-provided', 'The parameter "roomId" or "roomName" is required');
+		}
+
+		if ('roomId' in params) {
+			room = await Rooms.findOneById(params.roomId || '');
+		} else if ('roomName' in params) {
+			room = await Rooms.findOneByName(params.roomName || '');
+		}
+
+		if (room?.t !== 'p') {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		if (room.archived) {
+			throw new Meteor.Error('error-room-archived', `The private group, ${room.name}, is archived`);
+		}
+
+		if (params.userId) {
+			if (!access) {
+				return API.v1.forbidden();
+			}
+			user = params.userId;
+		}
+		const subscription = await Subscriptions.findOneByRoomIdAndUserId(room._id, user);
+		const lm = room.lm ? room.lm : room._updatedAt;
+
+		if (subscription?.open) {
+			unreads = await Messages.countVisibleByRoomIdBetweenTimestampsInclusive(subscription.rid, subscription.ls || subscription.ts, lm);
+			unreadsFrom = subscription.ls || subscription.ts;
+			userMentions = subscription.userMentions;
+			joined = true;
+		}
+
+		if (access || joined) {
+			msgs = room.msgs;
+			latest = lm;
+			members = await Users.countActiveUsersInNonDMRoom(room._id);
+		}
+
+		return API.v1.success({
+			joined,
+			members,
+			unreads,
+			unreadsFrom,
+			msgs,
+			latest,
+			userMentions,
+		});
 	},
 );
 
 // Create Private Group
-API.v1.addRoute(
+API.v1.post(
 	'groups.create',
-	{ authRequired: true },
 	{
-		async post() {
-			if (!this.bodyParams.name) {
-				return API.v1.failure('Body param "name" is required');
-			}
-
-			if (this.bodyParams.members && !Array.isArray(this.bodyParams.members)) {
-				return API.v1.failure('Body param "members" must be an array if provided');
-			}
-
-			if (this.bodyParams.customFields && !(typeof this.bodyParams.customFields === 'object')) {
-				return API.v1.failure('Body param "customFields" must be an object if provided');
-			}
-			if (this.bodyParams.extraData && !(typeof this.bodyParams.extraData === 'object')) {
-				return API.v1.failure('Body param "extraData" must be an object if provided');
-			}
-
-			const readOnly = typeof this.bodyParams.readOnly !== 'undefined' ? this.bodyParams.readOnly : false;
-
-			try {
-				const result = await createPrivateGroupMethod(
-					this.user,
-					this.bodyParams.name,
-					this.bodyParams.members ? this.bodyParams.members : [],
-					readOnly,
-					this.bodyParams.customFields,
-					this.bodyParams.extraData,
-					this.bodyParams.excludeSelf ?? false,
-				);
-
-				const room = await Rooms.findOneById(result.rid, { projection: API.v1.defaultFieldsToExclude });
-				if (!room) {
-					throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-				}
-
-				return API.v1.success({
-					group: await composeRoomWithLastMessage(room, this.userId),
-				});
-			} catch (error: unknown) {
-				if (isMeteorError(error) && error.reason === 'error-not-allowed') {
-					return API.v1.forbidden();
-				}
-				throw error;
-			}
+		authRequired: true,
+		body: isGroupsCreateProps,
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
-);
+	async function action() {
+		if (!this.bodyParams.name) {
+			return API.v1.failure('Body param "name" is required');
+		}
 
-API.v1.addRoute(
-	'groups.delete',
-	{ authRequired: true },
-	{
-		async post() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
+		const readOnly = typeof this.bodyParams.readOnly !== 'undefined' ? this.bodyParams.readOnly : false;
 
-			await eraseRoom(findResult.rid, this.user);
+		try {
+			const result = await createPrivateGroupMethod(
+				this.user,
+				this.bodyParams.name,
+				this.bodyParams.members ? this.bodyParams.members : [],
+				readOnly,
+				this.bodyParams.customFields,
+				this.bodyParams.extraData,
+				this.bodyParams.excludeSelf ?? false,
+			);
 
-			return API.v1.success();
-		},
-	},
-);
-
-API.v1.addRoute(
-	'groups.files',
-	{ authRequired: true, validateParams: isGroupsFilesProps },
-	{
-		async get() {
-			const { typeGroup, name, roomId, roomName, onlyConfirmed } = this.queryParams;
-
-			const findResult = await findPrivateGroupByIdOrName({
-				params: roomId ? { roomId } : { roomName },
-				userId: this.userId,
-				checkedArchived: false,
-			});
-
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields, query } = await this.parseJsonQuery();
-
-			const filter = {
-				...query,
-				rid: findResult.rid,
-				...(name ? { name: { $regex: name || '', $options: 'i' } } : {}),
-				...(typeGroup ? { typeGroup } : {}),
-				...(onlyConfirmed && { expiresAt: { $exists: false } }),
-			};
-
-			const { cursor, totalCount } = await Uploads.findPaginatedWithoutThumbs(filter, {
-				sort: sort || { name: 1 },
-				skip: offset,
-				limit: count,
-				projection: fields,
-			});
-
-			const [files, total] = await Promise.all([cursor.toArray(), totalCount]);
+			const room = await Rooms.findOneById(result.rid, { projection: API.v1.defaultFieldsToExclude });
+			if (!room) {
+				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+			}
 
 			return API.v1.success({
-				files: await addUserToFileObj(files),
-				count: files.length,
-				offset,
-				total,
+				group: await composeRoomWithLastMessage(room, this.userId),
 			});
-		},
+		} catch (error: unknown) {
+			if (isMeteorError(error) && error.reason === 'error-not-allowed') {
+				return API.v1.forbidden();
+			}
+			throw error;
+		}
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
+	'groups.delete',
+	{
+		authRequired: true,
+		body: isGroupsDeleteProps,
+		response: {
+			200: successResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
+
+		await eraseRoom(findResult.rid, this.user);
+
+		return API.v1.success();
+	},
+);
+
+// Uploads accept a client-supplied `fields` projection and store `content: null` for non-e2ee files,
+// so items are partial and cannot be validated against $ref IUploadWithUser (required, non-null shape).
+// Validate the array container strictly; leave item props open (only _id is guaranteed).
+const groupsFilesResponseSchema = ajv.compile<{ files: IUploadWithUser[]; count: number; offset: number; total: number }>({
+	type: 'object',
+	properties: {
+		files: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { _id: { type: 'string' } },
+				required: ['_id'],
+				additionalProperties: true,
+			},
+		},
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['files', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
+	'groups.files',
+	{
+		authRequired: true,
+		query: isGroupsFilesProps,
+		response: {
+			200: groupsFilesResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const { typeGroup, name, roomId, roomName, onlyConfirmed } = this.queryParams;
+
+		const findResult = await findPrivateGroupByIdOrName({
+			params: roomId ? { roomId } : { roomName },
+			userId: this.userId,
+			checkedArchived: false,
+		});
+
+		const { offset, count } = await getPaginationItems(this.queryParams);
+		const { sort, fields, query } = await this.parseJsonQuery();
+
+		const filter = {
+			...query,
+			rid: findResult.rid,
+			...(name ? { name: { $regex: name || '', $options: 'i' } } : {}),
+			...(typeGroup ? { typeGroup } : {}),
+			...(onlyConfirmed && { expiresAt: { $exists: false } }),
+		};
+
+		const { cursor, totalCount } = await Uploads.findPaginatedWithoutThumbs(filter, {
+			sort: sort || { name: 1 },
+			skip: offset,
+			limit: count,
+			projection: fields,
+		});
+
+		const [files, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			files: await addUserToFileObj(files),
+			count: files.length,
+			offset,
+			total,
+		});
+	},
+);
+
+// Loose query validator (mirrors channels.getIntegrations): coerces query scalars and accepts pagination/parseJsonQuery params.
+const groupsGetIntegrationsQuery = ajvQuery.compile<{
+	roomId?: string;
+	roomName?: string;
+	includeAllPrivateGroups?: string;
+	offset?: number;
+	count?: number;
+	sort?: string;
+	query?: string;
+	fields?: string;
+}>({
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		roomName: { type: 'string' },
+		includeAllPrivateGroups: { type: 'string' },
+		offset: { type: 'number' },
+		count: { type: 'number' },
+		sort: { type: 'string' },
+		query: { type: 'string' },
+		fields: { type: 'string' },
+	},
+	anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+	additionalProperties: false,
+});
+
+const groupsGetIntegrationsResponseSchema = ajv.compile<{
+	integrations: IIntegration[];
+	count: number;
+	offset: number;
+	total: number;
+}>({
+	type: 'object',
+	properties: {
+		integrations: {
+			type: 'array',
+			items: {
+				oneOf: [{ $ref: '#/components/schemas/IIncomingIntegration' }, { $ref: '#/components/schemas/IOutgoingIntegration' }],
+			},
+		},
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['integrations', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
 	'groups.getIntegrations',
 	{
 		authRequired: true,
+		query: groupsGetIntegrationsQuery,
 		permissionsRequired: {
 			GET: {
 				permissions: [
@@ -545,178 +672,217 @@ API.v1.addRoute(
 				operation: 'hasAny',
 			},
 		},
-	},
-	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
-
-			let includeAllPrivateGroups = true;
-			if (this.queryParams.includeAllPrivateGroups) {
-				includeAllPrivateGroups = this.queryParams.includeAllPrivateGroups === 'true';
-			}
-
-			const channelsToSearch = [`#${findResult.name}`];
-			if (includeAllPrivateGroups) {
-				channelsToSearch.push('all_private_groups');
-			}
-
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields: projection, query } = await this.parseJsonQuery();
-
-			const ourQuery = Object.assign(await mountIntegrationQueryBasedOnPermissions(this.userId), query, {
-				channel: { $in: channelsToSearch },
-			}) as Filter<IIntegration>;
-			const { cursor, totalCount } = await Integrations.findPaginated(ourQuery, {
-				sort: sort || { _createdAt: 1 },
-				skip: offset,
-				limit: count,
-				projection,
-			});
-
-			const [integrations, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				integrations,
-				count: integrations.length,
-				offset,
-				total,
-			});
+		response: {
+			200: groupsGetIntegrationsResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
+
+		let includeAllPrivateGroups = true;
+		if (this.queryParams.includeAllPrivateGroups) {
+			includeAllPrivateGroups = this.queryParams.includeAllPrivateGroups === 'true';
+		}
+
+		const channelsToSearch = [`#${findResult.name}`];
+		if (includeAllPrivateGroups) {
+			channelsToSearch.push('all_private_groups');
+		}
+
+		const { offset, count } = await getPaginationItems(this.queryParams);
+		const { sort, fields: projection, query } = await this.parseJsonQuery();
+
+		// query and channel filters cannot override the permission scope (mountIntegrationQueryBasedOnPermissions).
+		const ourQuery = Object.assign(
+			{},
+			query,
+			{ channel: { $in: channelsToSearch } },
+			await mountIntegrationQueryBasedOnPermissions(this.userId),
+		) as Filter<IIntegration>;
+		const { cursor, totalCount } = await Integrations.findPaginated(ourQuery, {
+			sort: sort || { _createdAt: 1 },
+			skip: offset,
+			limit: count,
+			projection,
+		});
+
+		const [integrations, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			integrations,
+			count: integrations.length,
+			offset,
+			total,
+		});
 	},
 );
 
-API.v1.addRoute(
+const groupsHistoryResponseSchema = ajv.compile<{ messages: IMessage[]; firstUnread?: IMessage; unreadNotLoaded?: number }>({
+	type: 'object',
+	properties: {
+		messages: { type: 'array', items: { $ref: '#/components/schemas/IMessage' } },
+		firstUnread: { $ref: '#/components/schemas/IMessage' },
+		unreadNotLoaded: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['messages', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
 	'groups.history',
-	{ authRequired: true },
 	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
-
-			let latestDate = new Date();
-			if (this.queryParams.latest) {
-				latestDate = new Date(this.queryParams.latest);
-			}
-
-			let oldestDate = undefined;
-			if (this.queryParams.oldest) {
-				oldestDate = new Date(this.queryParams.oldest);
-			}
-
-			const inclusive = this.queryParams.inclusive === 'true';
-
-			let count = 20;
-			if (this.queryParams.count) {
-				count = parseInt(String(this.queryParams.count));
-			}
-
-			let offset = 0;
-			if (this.queryParams.offset) {
-				offset = parseInt(String(this.queryParams.offset));
-			}
-
-			const unreads = this.queryParams.unreads === 'true';
-
-			const showThreadMessages = this.queryParams.showThreadMessages !== 'false';
-
-			const result = await getChannelHistory({
-				rid: findResult.rid,
-				fromUserId: this.userId,
-				latest: latestDate,
-				oldest: oldestDate,
-				inclusive,
-				offset,
-				count,
-				unreads,
-				showThreadMessages,
-			});
-
-			if (!result) {
-				return API.v1.forbidden();
-			}
-
-			return API.v1.success(result);
+		authRequired: true,
+		query: isGroupsHistoryProps,
+		response: {
+			200: groupsHistoryResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
+
+		let latestDate = new Date();
+		if (this.queryParams.latest) {
+			latestDate = new Date(this.queryParams.latest);
+		}
+
+		let oldestDate = undefined;
+		if (this.queryParams.oldest) {
+			oldestDate = new Date(this.queryParams.oldest);
+		}
+
+		const inclusive = this.queryParams.inclusive === 'true';
+
+		let count = 20;
+		if (this.queryParams.count) {
+			count = parseInt(String(this.queryParams.count));
+		}
+
+		let offset = 0;
+		if (this.queryParams.offset) {
+			offset = parseInt(String(this.queryParams.offset));
+		}
+
+		const unreads = this.queryParams.unreads === 'true';
+
+		const showThreadMessages = this.queryParams.showThreadMessages !== 'false';
+
+		const result = await getChannelHistory({
+			rid: findResult.rid,
+			fromUserId: this.userId,
+			latest: latestDate,
+			oldest: oldestDate,
+			inclusive,
+			offset,
+			count,
+			unreads,
+			showThreadMessages,
+		});
+
+		if (!result || typeof result !== 'object' || Array.isArray(result)) {
+			return API.v1.forbidden();
+		}
+
+		return API.v1.success(result);
 	},
 );
 
-API.v1.addRoute(
+API.v1.get(
 	'groups.info',
-	{ authRequired: true },
 	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-				checkedArchived: false,
-			});
-
-			const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
+		authRequired: true,
+		query: isGroupsInfoProps,
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+			checkedArchived: false,
+		});
+
+		const room = await Rooms.findOneById(findResult.rid, { projection: API.v1.defaultFieldsToExclude });
+
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
-API.v1.addRoute(
+API.v1.post(
 	'groups.invite',
-	{ authRequired: true },
 	{
-		async post() {
-			const roomId = 'roomId' in this.bodyParams ? this.bodyParams.roomId : '';
-			const roomName = 'roomName' in this.bodyParams ? this.bodyParams.roomName : '';
-			const idOrName = roomId || roomName;
-
-			if (!idOrName?.trim()) {
-				throw new Meteor.Error('error-room-param-not-provided', 'The parameter "roomId" or "roomName" is required');
-			}
-
-			const groupRoom = await Rooms.findOneByIdOrName(idOrName);
-			const { _id: rid, t: type } = groupRoom || {};
-
-			if (!rid || type !== 'p') {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			// Federated rooms invite by raw username: the federated user record is created
-			// lazily inside addUsersToRoomMethod, so we must not require it to exist locally yet.
-			if (groupRoom && isRoomNativeFederated(groupRoom)) {
-				const usernames = await getUsernameListFromParams(this.bodyParams);
-
-				await addUsersToRoomMethod(this.userId, { rid, users: usernames }, this.user);
-			} else {
-				const users = await getUserListFromParams(this.bodyParams);
-
-				if (!users.length) {
-					throw new Meteor.Error('error-empty-invite-list', 'Cannot invite if no valid users are provided');
-				}
-
-				await addUsersToRoomMethod(this.userId, { rid, users: users.map((u) => u.username).filter(isTruthy) }, this.user);
-			}
-
-			const room = await Rooms.findOneById(rid, { projection: API.v1.defaultFieldsToExclude });
-
-			if (!room) {
-				throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
-			}
-
-			return API.v1.success({
-				group: await composeRoomWithLastMessage(room, this.userId),
-			});
+		authRequired: true,
+		body: isGroupsInviteProps,
+		response: {
+			200: groupResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const roomId = 'roomId' in this.bodyParams ? this.bodyParams.roomId : '';
+		const roomName = 'roomName' in this.bodyParams ? this.bodyParams.roomName : '';
+		const idOrName = roomId || roomName;
+
+		if (!idOrName?.trim()) {
+			throw new Meteor.Error('error-room-param-not-provided', 'The parameter "roomId" or "roomName" is required');
+		}
+
+		const groupRoom = await Rooms.findOneByIdOrName(idOrName);
+		const { _id: rid, t: type } = groupRoom || {};
+
+		if (!rid || type !== 'p') {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		// Federated rooms invite by raw username: the federated user record is created
+		// lazily inside addUsersToRoomMethod, so we must not require it to exist locally yet.
+		if (groupRoom && isRoomNativeFederated(groupRoom)) {
+			const usernames = await getUsernameListFromParams(this.bodyParams);
+
+			await addUsersToRoomMethod(this.userId, { rid, users: usernames }, this.user);
+		} else {
+			const users = await getUserListFromParams(this.bodyParams);
+
+			if (!users.length) {
+				throw new Meteor.Error('error-empty-invite-list', 'Cannot invite if no valid users are provided');
+			}
+
+			await addUsersToRoomMethod(this.userId, { rid, users: users.map((u) => u.username).filter(isTruthy) }, this.user);
+		}
+
+		const room = await Rooms.findOneById(rid, { projection: API.v1.defaultFieldsToExclude });
+
+		if (!room) {
+			throw new Meteor.Error('error-room-not-found', 'The required "roomId" or "roomName" param provided does not match any group');
+		}
+
+		return API.v1.success({
+			group: await composeRoomWithLastMessage(room, this.userId),
+		});
 	},
 );
 
@@ -773,221 +939,384 @@ API.v1.post(
 );
 
 // List Private Groups a user has access to
-API.v1.addRoute(
+const groupsListResponseSchema = ajv.compile<{ groups: IRoom[]; count: number; offset: number; total: number }>({
+	type: 'object',
+	properties: {
+		groups: { type: 'array', items: { $ref: '#/components/schemas/IRoom' } },
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['groups', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
 	'groups.list',
-	{ authRequired: true },
 	{
-		async get() {
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields } = await this.parseJsonQuery();
-
-			const subs = await Subscriptions.findByUserIdAndTypes(this.userId, ['p'], { projection: { rid: 1 } }).toArray();
-			const rids = subs.map(({ rid }) => rid).filter(Boolean);
-
-			if (rids.length === 0) {
-				return API.v1.success({
-					groups: [],
-					offset,
-					count: 0,
-					total: 0,
-				});
-			}
-
-			const { cursor, totalCount } = await Rooms.findPaginatedByTypeAndIds('p', rids, {
-				sort: sort || { name: 1 },
-				skip: offset,
-				limit: count,
-				projection: fields,
-			});
-
-			const [groups, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				groups: await Promise.all(groups.map((room) => composeRoomWithLastMessage(room, this.userId))),
-				offset,
-				count: groups.length,
-				total,
-			});
+		authRequired: true,
+		query: isGroupsListProps,
+		response: {
+			200: groupsListResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const { offset, count } = await getPaginationItems(this.queryParams);
+		const { sort, fields } = await this.parseJsonQuery();
+
+		const subs = await Subscriptions.findByUserIdAndTypes(this.userId, ['p'], { projection: { rid: 1 } }).toArray();
+		const rids = subs.map(({ rid }) => rid).filter(Boolean);
+
+		if (rids.length === 0) {
+			return API.v1.success({
+				groups: [],
+				offset,
+				count: 0,
+				total: 0,
+			});
+		}
+
+		const { cursor, totalCount } = await Rooms.findPaginatedByTypeAndIds('p', rids, {
+			sort: sort || { name: 1 },
+			skip: offset,
+			limit: count,
+			projection: fields,
+		});
+
+		const [groups, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			groups: await Promise.all(groups.map((room) => composeRoomWithLastMessage(room, this.userId))),
+			offset,
+			count: groups.length,
+			total,
+		});
 	},
 );
 
-API.v1.addRoute(
+API.v1.get(
 	'groups.listAll',
-	{ authRequired: true, permissionsRequired: ['view-room-administration'] },
 	{
-		async get() {
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields, query } = await this.parseJsonQuery();
-			const ourQuery = Object.assign({}, query, { t: 'p' as RoomType });
-
-			const { cursor, totalCount } = await Rooms.findPaginated(ourQuery, {
-				sort: sort || { name: 1 },
-				skip: offset,
-				limit: count,
-				projection: fields,
-			});
-
-			const [rooms, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				groups: await Promise.all(rooms.map((room) => composeRoomWithLastMessage(room, this.userId))),
-				offset,
-				count: rooms.length,
-				total,
-			});
+		authRequired: true,
+		query: isGroupsListProps,
+		permissionsRequired: ['view-room-administration'],
+		response: {
+			200: groupsListResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
+	},
+	async function action() {
+		const { offset, count } = await getPaginationItems(this.queryParams);
+		const { sort, fields, query } = await this.parseJsonQuery();
+		const ourQuery = Object.assign({}, query, { t: 'p' as RoomType });
+
+		const { cursor, totalCount } = await Rooms.findPaginated(ourQuery, {
+			sort: sort || { name: 1 },
+			skip: offset,
+			limit: count,
+			projection: fields,
+		});
+
+		const [rooms, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			groups: await Promise.all(rooms.map((room) => composeRoomWithLastMessage(room, this.userId))),
+			offset,
+			count: rooms.length,
+			total,
+		});
 	},
 );
 
-API.v1.addRoute(
-	'groups.members',
-	{ authRequired: true },
-	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-			});
-
-			if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult.rid))) {
-				return API.v1.forbidden();
-			}
-
-			const { offset: skip, count: limit } = await getPaginationItems(this.queryParams);
-			const { sort = {} } = await this.parseJsonQuery();
-
-			check(
-				this.queryParams,
-				Match.ObjectIncluding({
-					status: Match.Maybe([String]),
-					filter: Match.Maybe(String),
-				}),
-			);
-
-			const { status, filter } = this.queryParams;
-
-			const { cursor, totalCount } = await findUsersOfRoom({
-				rid: findResult.rid,
-				...(status && { status: { $in: status as UserStatus[] } }),
-				skip,
-				limit,
-				filter,
-				...(sort?.username && { sort: { username: sort.username } }),
-			});
-
-			const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				members,
-				count: members.length,
-				offset: skip,
-				total,
-			});
-		},
+// Loose query validator (mirrors channels.members): coerces single status value to array and accepts filter/sort/pagination.
+const groupsMembersQuery = ajvQuery.compile<{
+	roomId?: string;
+	roomName?: string;
+	filter?: string;
+	status?: string[];
+	offset?: number;
+	count?: number;
+	sort?: string;
+}>({
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		roomName: { type: 'string' },
+		filter: { type: 'string' },
+		status: { type: 'array', items: { type: 'string' } },
+		offset: { type: 'number' },
+		count: { type: 'number' },
+		sort: { type: 'string' },
 	},
-);
+	anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+	additionalProperties: false,
+});
 
-API.v1.addRoute(
-	'groups.messages',
-	{ authRequired: true, validateParams: isGroupsMessagesProps },
-	{
-		async get() {
-			const { roomId, roomName, mentionIds, starredIds, pinned } = this.queryParams;
-
-			const findResult = await findPrivateGroupByIdOrName({
-				params: {
-					...(roomId && { roomId }),
-					...(roomName && { roomName }),
+// findUsersOfRoom returns a fixed projection (not a full IUser), so validate against the projected
+// shape rather than $ref IUser (which would require createdAt/roles/type/active and reject real data).
+const groupsMembersResponseSchema = ajv.compile<{ members: IUser[]; count: number; offset: number; total: number }>({
+	type: 'object',
+	properties: {
+		members: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					_id: { type: 'string' },
+					name: { type: 'string' },
+					username: { type: 'string' },
+					nickname: { type: 'string' },
+					status: { type: 'string' },
+					avatarETag: { type: 'string' },
+					federated: { type: 'boolean' },
+					_updatedAt: { type: 'string' },
 				},
-				userId: this.userId,
-			});
-			const { offset, count } = await getPaginationItems(this.queryParams);
-			const { sort, fields, query } = await this.parseJsonQuery();
+				required: ['_id'],
+				additionalProperties: true,
+			},
+		},
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['members', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
 
-			const parseIds = (ids: string | undefined, field: string) =>
-				typeof ids === 'string' && ids ? { [field]: { $in: ids.split(',').map((id) => id.trim()) } } : {};
-
-			const ourQuery = {
-				...query,
-				rid: findResult.rid,
-				...parseIds(mentionIds, 'mentions._id'),
-				...parseIds(starredIds, 'starred._id'),
-				...(pinned?.toLowerCase() === 'true' ? { pinned: true } : {}),
-				_hidden: { $ne: true },
-			};
-
-			const { cursor, totalCount } = Messages.findPaginated(ourQuery, {
-				sort: sort || { ts: -1 },
-				skip: offset,
-				limit: count,
-				projection: fields,
-			});
-
-			const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
-
-			return API.v1.success({
-				messages: await normalizeMessagesForUser(messages, this.userId),
-				count: messages.length,
-				offset,
-				total,
-			});
+API.v1.get(
+	'groups.members',
+	{
+		authRequired: true,
+		query: groupsMembersQuery,
+		response: {
+			200: groupsMembersResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+		});
+
+		if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult.rid))) {
+			return API.v1.forbidden();
+		}
+
+		const { offset: skip, count: limit } = await getPaginationItems(this.queryParams);
+		const { sort = {} } = await this.parseJsonQuery();
+
+		check(
+			this.queryParams,
+			Match.ObjectIncluding({
+				status: Match.Maybe([String]),
+				filter: Match.Maybe(String),
+			}),
+		);
+
+		const { status, filter } = this.queryParams;
+
+		const { cursor, totalCount } = await findUsersOfRoom({
+			rid: findResult.rid,
+			...(status && { status: { $in: status as UserStatus[] } }),
+			skip,
+			limit,
+			filter,
+			...(sort?.username && { sort: { username: sort.username } }),
+		});
+
+		const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			members,
+			count: members.length,
+			offset: skip,
+			total,
+		});
+	},
 );
+
+// Flat query shape so roomId/roomName both destructure and pinned stays a string; oneOf rejects passing both room params (400).
+const groupsMessagesQuery = ajvQuery.compile<{
+	roomId?: string;
+	roomName?: string;
+	mentionIds?: string;
+	starredIds?: string;
+	pinned?: string;
+	offset?: number;
+	count?: number;
+	sort?: string;
+	query?: string;
+	fields?: string;
+}>({
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		roomName: { type: 'string' },
+		mentionIds: { type: 'string' },
+		starredIds: { type: 'string' },
+		pinned: { type: 'string' },
+		offset: { type: 'number' },
+		count: { type: 'number' },
+		sort: { type: 'string' },
+		query: { type: 'string' },
+		fields: { type: 'string' },
+	},
+	oneOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+	additionalProperties: false,
+});
+
+const groupsMessagesResponseSchema = ajv.compile<{ messages: IMessage[]; count: number; offset: number; total: number }>({
+	type: 'object',
+	properties: {
+		messages: { type: 'array', items: { $ref: '#/components/schemas/IMessage' } },
+		count: { type: 'number' },
+		offset: { type: 'number' },
+		total: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['messages', 'count', 'offset', 'total', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
+	'groups.messages',
+	{
+		authRequired: true,
+		query: groupsMessagesQuery,
+		response: {
+			200: groupsMessagesResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const { roomId, roomName, mentionIds, starredIds, pinned } = this.queryParams;
+
+		const findResult = await findPrivateGroupByIdOrName({
+			params: {
+				...(roomId && { roomId }),
+				...(roomName && { roomName }),
+			},
+			userId: this.userId,
+		});
+		const { offset, count } = await getPaginationItems(this.queryParams);
+		const { sort, fields, query } = await this.parseJsonQuery();
+
+		const parseIds = (ids: string | undefined, field: string) =>
+			typeof ids === 'string' && ids ? { [field]: { $in: ids.split(',').map((id) => id.trim()) } } : {};
+
+		const ourQuery = {
+			...query,
+			rid: findResult.rid,
+			...parseIds(mentionIds, 'mentions._id'),
+			...parseIds(starredIds, 'starred._id'),
+			...(pinned?.toLowerCase() === 'true' ? { pinned: true } : {}),
+			_hidden: { $ne: true },
+		};
+
+		const { cursor, totalCount } = Messages.findPaginated(ourQuery, {
+			sort: sort || { ts: -1 },
+			skip: offset,
+			limit: count,
+			projection: fields,
+		});
+
+		const [messages, total] = await Promise.all([cursor.toArray(), totalCount]);
+
+		return API.v1.success({
+			messages: await normalizeMessagesForUser(messages, this.userId),
+			count: messages.length,
+			offset,
+			total,
+		});
+	},
+);
+
+const groupsOnlineResponseSchema = ajv.compile<{ online: Pick<IUser, '_id' | 'username'>[] }>({
+	type: 'object',
+	properties: {
+		online: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { _id: { type: 'string' }, username: { type: 'string' } },
+				required: ['_id'],
+				additionalProperties: false,
+			},
+		},
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['online', 'success'],
+	additionalProperties: false,
+});
 
 // TODO: CACHE: same as channels.online
-API.v1.addRoute(
+API.v1.get(
 	'groups.online',
-	{ authRequired: true, validateParams: isGroupsOnlineProps },
 	{
-		async get() {
-			const { query } = await this.parseJsonQuery();
-			const { _id } = this.queryParams;
-
-			if ((!query || Object.keys(query).length === 0) && !_id) {
-				return API.v1.failure('Invalid query');
-			}
-
-			const filter = {
-				...query,
-				...(_id ? { _id } : {}),
-				t: 'p',
-			};
-
-			const room = await Rooms.findOne(filter as Record<string, any>);
-			if (!room) {
-				return API.v1.failure('Group does not exists');
-			}
-
-			if (!(await canAccessRoomAsync(room, this.user))) {
-				throw new Meteor.Error('error-not-allowed', 'Not Allowed');
-			}
-
-			const online: Pick<IUser, '_id' | 'username'>[] = await Users.findUsersNotOffline({
-				projection: {
-					username: 1,
-				},
-			}).toArray();
-
-			const onlineInRoom = await Promise.all(
-				online.map(async (user) => {
-					const subscription = await Subscriptions.findOneByRoomIdAndUserId(room._id, user._id, {
-						projection: { _id: 1, username: 1 },
-					});
-					if (subscription) {
-						return {
-							_id: user._id,
-							username: user.username,
-						};
-					}
-				}),
-			);
-
-			return API.v1.success({
-				online: onlineInRoom.filter(Boolean) as IUser[],
-			});
+		authRequired: true,
+		query: isGroupsOnlineProps,
+		response: {
+			200: groupsOnlineResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
 		},
+	},
+	async function action() {
+		const { query } = await this.parseJsonQuery();
+		const { _id } = this.queryParams;
+
+		if ((!query || Object.keys(query).length === 0) && !_id) {
+			return API.v1.failure('Invalid query');
+		}
+
+		const filter = {
+			...query,
+			...(_id ? { _id } : {}),
+			t: 'p',
+		};
+
+		const room = await Rooms.findOne(filter as Record<string, any>);
+		if (!room) {
+			return API.v1.failure('Group does not exists');
+		}
+
+		if (!(await canAccessRoomAsync(room, this.user))) {
+			throw new Meteor.Error('error-not-allowed', 'Not Allowed');
+		}
+
+		const online: Pick<IUser, '_id' | 'username'>[] = await Users.findUsersNotOffline({
+			projection: {
+				username: 1,
+			},
+		}).toArray();
+
+		const onlineInRoom = await Promise.all(
+			online.map(async (user) => {
+				const subscription = await Subscriptions.findOneByRoomIdAndUserId(room._id, user._id, {
+					projection: { _id: 1, username: 1 },
+				});
+				if (subscription) {
+					return {
+						_id: user._id,
+						username: user.username,
+					};
+				}
+			}),
+		);
+
+		return API.v1.success({
+			online: onlineInRoom.filter(Boolean) as IUser[],
+		});
 	},
 );
 
@@ -1363,45 +1692,105 @@ API.v1.post(
 	},
 );
 
-API.v1.addRoute(
-	'groups.roles',
-	{ authRequired: true },
-	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-			});
-
-			const roles = await executeGetRoomRoles(findResult.rid, this.user);
-
-			return API.v1.success({
-				roles,
-			});
+const groupsRolesResponseSchema = ajv.compile<{
+	roles: { rid: string; u: { _id: string; username: string; name?: string }; roles: string[] }[];
+}>({
+	type: 'object',
+	properties: {
+		roles: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					_id: { type: 'string' },
+					rid: { type: 'string' },
+					u: {
+						type: 'object',
+						properties: { _id: { type: 'string' }, username: { type: 'string' }, name: { type: 'string' } },
+						required: ['_id', 'username'],
+						additionalProperties: false,
+					},
+					roles: { type: 'array', items: { type: 'string' } },
+				},
+				required: ['_id', 'rid', 'u', 'roles'],
+				additionalProperties: false,
+			},
 		},
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['roles', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
+	'groups.roles',
+	{
+		authRequired: true,
+		query: isGroupsRolesProps,
+		response: {
+			200: groupsRolesResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+		});
+
+		const roles = await executeGetRoomRoles(findResult.rid, this.user);
+
+		return API.v1.success({
+			roles,
+		});
 	},
 );
 
-API.v1.addRoute(
-	'groups.moderators',
-	{ authRequired: true },
-	{
-		async get() {
-			const findResult = await findPrivateGroupByIdOrName({
-				params: this.queryParams,
-				userId: this.userId,
-			});
-
-			const moderators = await Subscriptions.findByRoomIdAndRoles(findResult.rid, ['moderator'], {
-				projection: { u: 1, _id: 0 },
-			})
-				.map((sub) => sub.u)
-				.toArray();
-
-			return API.v1.success({
-				moderators,
-			});
+const groupsModeratorsResponseSchema = ajv.compile<{ moderators: { _id: string; username?: string; name?: string }[] }>({
+	type: 'object',
+	properties: {
+		moderators: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: { _id: { type: 'string' }, username: { type: 'string' }, name: { type: 'string' } },
+				required: ['_id'],
+				additionalProperties: false,
+			},
 		},
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['moderators', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.get(
+	'groups.moderators',
+	{
+		authRequired: true,
+		query: isGroupsModeratorsProps,
+		response: {
+			200: groupsModeratorsResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+		},
+	},
+	async function action() {
+		const findResult = await findPrivateGroupByIdOrName({
+			params: this.queryParams,
+			userId: this.userId,
+		});
+
+		const moderators = await Subscriptions.findByRoomIdAndRoles(findResult.rid, ['moderator'], {
+			projection: { u: 1, _id: 0 },
+		})
+			.map((sub) => sub.u)
+			.toArray();
+
+		return API.v1.success({
+			moderators,
+		});
 	},
 );
 
@@ -1438,49 +1827,66 @@ API.v1.post(
 	},
 );
 
-API.v1.addRoute(
+const groupsConvertToTeamResponseSchema = ajv.compile<{ team: ITeam }>({
+	type: 'object',
+	properties: {
+		team: { $ref: '#/components/schemas/ITeam' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['team', 'success'],
+	additionalProperties: false,
+});
+
+API.v1.post(
 	'groups.convertToTeam',
-	{ authRequired: true },
 	{
-		async post() {
-			if (('roomId' in this.bodyParams && !this.bodyParams.roomId) || ('roomName' in this.bodyParams && !this.bodyParams.roomName)) {
-				return API.v1.failure('The parameter "roomId" or "roomName" is required');
-			}
-
-			const room = await findPrivateGroupByIdOrName({
-				params: this.bodyParams,
-				userId: this.userId,
-			});
-
-			if (!room) {
-				return API.v1.failure('Private group not found');
-			}
-
-			if (!(await hasAllPermissionAsync(this.user, ['create-team', 'edit-room'], room.rid))) {
-				return API.v1.forbidden();
-			}
-
-			const subscriptions = await Subscriptions.findByRoomId(room.rid, {
-				projection: { 'u._id': 1 },
-			}).toArray();
-
-			const members = subscriptions.map((s) => s.u?._id);
-
-			const teamData = {
-				team: {
-					name: room.name,
-					type: 1,
-				},
-				members,
-				room: {
-					name: room.name,
-					id: room.rid,
-				},
-			};
-
-			const team = await Team.create(this.userId, teamData);
-
-			return API.v1.success({ team });
+		authRequired: true,
+		body: isGroupsConvertToTeamProps,
+		response: {
+			200: groupsConvertToTeamResponseSchema,
+			400: validateBadRequestErrorResponse,
+			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
+	},
+	async function action() {
+		if (('roomId' in this.bodyParams && !this.bodyParams.roomId) || ('roomName' in this.bodyParams && !this.bodyParams.roomName)) {
+			return API.v1.failure('The parameter "roomId" or "roomName" is required');
+		}
+
+		const room = await findPrivateGroupByIdOrName({
+			params: this.bodyParams,
+			userId: this.userId,
+		});
+
+		if (!room) {
+			return API.v1.failure('Private group not found');
+		}
+
+		if (!(await hasAllPermissionAsync(this.user, ['create-team', 'edit-room'], room.rid))) {
+			return API.v1.forbidden();
+		}
+
+		const subscriptions = await Subscriptions.findByRoomId(room.rid, {
+			projection: { 'u._id': 1 },
+		}).toArray();
+
+		const members = subscriptions.map((s) => s.u?._id);
+
+		const teamData = {
+			team: {
+				name: room.name,
+				type: 1,
+			},
+			members,
+			room: {
+				name: room.name,
+				id: room.rid,
+			},
+		};
+
+		const team = await Team.create(this.userId, teamData);
+
+		return API.v1.success({ team });
 	},
 );

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -667,7 +667,7 @@ describe('[Groups]', () => {
 					.expect(400)
 					.expect((res) => {
 						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'invalid-params');
+						expect(res.body).to.have.property('errorType', 'error-invalid-params');
 					});
 			} finally {
 				await Promise.all([deleteGroup({ roomName: secondGroup.name }), deleteGroup({ roomName: thirdGroup.name })]);

--- a/packages/rest-typings/src/v1/groups/GroupsCreateProps.ts
+++ b/packages/rest-typings/src/v1/groups/GroupsCreateProps.ts
@@ -28,6 +28,10 @@ const GroupsCreatePropsSchema = {
 			type: 'boolean',
 			nullable: true,
 		},
+		excludeSelf: {
+			type: 'boolean',
+			nullable: true,
+		},
 		customFields: {
 			type: 'object',
 			nullable: true,


### PR DESCRIPTION
## Proposal

Migrates the 16 remaining `API.v1.addRoute` endpoints in `groups.ts` to the typed router (`API.v1.get/post`), mirroring the already-migrated `channels.ts` twins. Completes the groups migration started in #41422.

### Endpoints
counters, create, delete, files, getIntegrations, history, info, invite, list, listAll, members, messages, online, roles, moderators, convertToTeam

### Notes
- Strong response schemas (`$ref` IRoom/IMessage/IIntegration/ITeam) or explicit projected shapes where the handler returns a partial document (uploads/members are projected, documented inline).
- Handlers just throw `Meteor.Error`; the global route wrapper maps to the declared 4xx. `groups.create` keeps its load-bearing catch (`error-not-allowed` → forbidden).
- `getIntegrations` applies the permission scope **last** in the query merge so a crafted `query` cannot override it.
- Loose inline query validators for `members`/`getIntegrations` (`ajvQuery`) so a single `status` coerces to an array and `offset/count/sort/query/fields` are accepted — matching the channels contract.

No changeset (pure conversion).

Task: [ARCH-2317](https://rocketchat.atlassian.net/browse/ARCH-2317)

/jira ARCH-2317

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the Groups REST API to use consistent request validation and structured response payloads across listings, membership, messaging, integrations, counters, roles, moderators, and team conversion.
  * Preserved existing permission and authorization behavior.
* **Bug Fixes**
  * Updated the groups messages endpoint to return the correct error type when both room ID and room name are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ARCH-2317]: https://rocketchat.atlassian.net/browse/ARCH-2317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ