### PR TITLE
test: deflake livechat BH on-agent-created assertions

### DIFF
--- a/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/19-business-hours.ts
@@ -954,10 +954,17 @@ describe('LIVECHAT - business hours', () => {
 		it('should create a new agent and verify if it is assigned to the default business hour which is open', async () => {
 			agent = await createAgent(agent.username);
 
-			const latestAgent: ILivechatAgent = await getMe(agentCredentials);
-			expect(latestAgent).to.be.an('object');
-			expect(latestAgent.openBusinessHours).to.be.an('array').of.length(1);
-			expect(latestAgent?.openBusinessHours?.[0]).to.be.equal(defaultBH._id);
+			// the BH assignment runs on a fire-and-forget callback, so the create-agent request returns before it lands
+			await retry(
+				'agent BH assignment is async, so openBusinessHours may still be unset on the first fetch',
+				async () => {
+					const latestAgent: ILivechatAgent = await getMe(agentCredentials);
+					expect(latestAgent).to.be.an('object');
+					expect(latestAgent.openBusinessHours).to.be.an('array').of.length(1);
+					expect(latestAgent?.openBusinessHours?.[0]).to.be.equal(defaultBH._id);
+				},
+				{ retries: 20, delayMs: 250 },
+			);
 		});
 
 		it('should create a new agent and verify if it is assigned to the default business hour which is closed', async () => {
@@ -978,10 +985,18 @@ describe('LIVECHAT - business hours', () => {
 			const newUserCredentials = await login(newUser.username, password);
 			await createAgent(newUser.username);
 
-			const latestAgent: ILivechatAgent = await getMe(newUserCredentials);
-			expect(latestAgent).to.be.an('object');
-			expect(latestAgent.openBusinessHours).to.be.undefined;
-			expect(latestAgent.statusLivechat).to.be.equal(ILivechatAgentStatus.NOT_AVAILABLE);
+			// createAgent sets the agent as available first and the async callback moves it to not-available, so the
+			// first fetch can still show the intermediate available state
+			await retry(
+				'agent BH assignment is async, so statusLivechat may still be available on the first fetch',
+				async () => {
+					const latestAgent: ILivechatAgent = await getMe(newUserCredentials);
+					expect(latestAgent).to.be.an('object');
+					expect(latestAgent.openBusinessHours).to.be.undefined;
+					expect(latestAgent.statusLivechat).to.be.equal(ILivechatAgentStatus.NOT_AVAILABLE);
+				},
+				{ retries: 20, delayMs: 250 },
+			);
 
 			// cleanup
 			await deleteUser(newUser);


### PR DESCRIPTION
## Proposed changes

Deflakes the two `[CE][BH] On Agent created/removed` tests in `19-business-hours.ts`, which failed on `develop` in [run 30497840427](https://github.com/RocketChat/Rocket.Chat/actions/runs/30497840427):

- `Test API Livechat (FIPS)`: `AssertionError: expected undefined to be an array` at `19-business-hours.ts:959` (`openBusinessHours`)
- `Test API Livechat (CE)`: `AssertionError: expected 'available' to equal 'not-available'` at `19-business-hours.ts:984`

### Why it flakes

`afterAgentAdded` sets the agent as available/not-available and then fires the business-hour logic without awaiting it:

```ts
export async function afterAgentAdded(user: IUser) {
	await setUserStatusLivechat(user._id, user.status !== 'offline' ? ILivechatAgentStatus.AVAILABLE : ILivechatAgentStatus.NOT_AVAILABLE);
	callbacks.runAsync('livechat.onNewAgentCreated', user._id);

	return user;
}
```

`callbacks.runAsync` schedules each callback with `setTimeout(fn, 0)`, so the create-agent request responds before `SingleBusinessHourBehavior.onNewAgentCreated` runs. That callback is what actually:

- fills `openBusinessHours` via `Users.addBusinessHourByAgentIds` when the BH is open, and
- moves the agent to `not-available` via `Users.setLivechatStatus` when the BH is closed, undoing the `available` written a line earlier.

Both tests read the agent right after `createAgent()`, so they can observe the pre-callback state. Which of the two trips depends on timing, which is why CE and FIPS failed on different tests in the same run.

### Change

Wraps both post-`createAgent` assertion blocks in the existing `retry` helper (same pattern already used a few lines below for the BH-close propagation). No production code touched.

## Issue(s)

Follow-up to #41538, which deflaked the BH-close propagation in the same describe block but not the read right after agent creation.

## Steps to test or reproduce

```bash
yarn testapi:livechat --grep "On Agent created/removed"
```

## Further comments

The server-side alternative would be `await callbacks.run('livechat.onNewAgentCreated', ...)` in `afterAgentAdded`, making the endpoint consistent when it returns. That changes POST latency and affects every caller of the hook including the EE `Multiple` behavior, so it is intentionally left out of this test-only fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2319]

[ARCH-2319]: https://rocketchat.atlassian.net/browse/ARCH-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated live chat business-hours coverage to account for asynchronous status updates.
  * Improved test reliability when verifying agent availability after creation under open or closed business hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->