### PR TITLE
test: migrate API tests from callback style to async/await

### DIFF
--- a/apps/meteor/tests/end-to-end/api/assets2.ts
+++ b/apps/meteor/tests/end-to-end/api/assets2.ts
@@ -13,8 +13,8 @@ describe('[Assets]', () => {
 	after(() => updatePermission('manage-assets', ['admin']));
 
 	describe('[/assets.setAsset]', () => {
-		it('should set the "logo" asset', (done) => {
-			void request
+		it('should set the "logo" asset', async () => {
+			const res = await request
 				.post(api('assets.setAsset'))
 				.set(credentials)
 				.attach('asset', imgURL)
@@ -22,54 +22,48 @@ describe('[Assets]', () => {
 					assetName: 'logo',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should throw an error when we try set an invalid asset', (done) => {
-			void request
+
+		it('should throw an error when we try set an invalid asset', async () => {
+			const res = await request
 				.post(api('assets.setAsset'))
 				.set(credentials)
 				.attach('invalidAsset', imgURL)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 
 	describe('[/assets.unsetAsset]', () => {
-		it('should unset the "logo" asset', (done) => {
-			void request
+		it('should unset the "logo" asset', async () => {
+			const res = await request
 				.post(api('assets.unsetAsset'))
 				.set(credentials)
 				.send({
 					assetName: 'logo',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should throw an error when we try set an invalid asset', (done) => {
-			void request
+
+		it('should throw an error when we try set an invalid asset', async () => {
+			const res = await request
 				.post(api('assets.unsetAsset'))
 				.set(credentials)
 				.send({
 					assetName: 'invalidAsset',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/autotranslate.ts
+++ b/apps/meteor/tests/end-to-end/api/autotranslate.ts
@@ -32,40 +32,36 @@ describe('AutoTranslate', () => {
 			before(() => resetAutoTranslateDefaults());
 			after(() => resetAutoTranslateDefaults());
 
-			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', (done) => {
-				void request
+			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', async () => {
+				const res = await request
 					.get(api('autotranslate.getSupportedLanguages'))
 					.set(credentials)
 					.query({
 						targetLanguage: 'en',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
 			});
-			it('should throw an error when the user does not have the "auto-translate" permission', (done) => {
-				void updateSetting('AutoTranslate_Enabled', true).then(() => {
-					void updatePermission('auto-translate', []).then(() => {
-						void request
-							.get(api('autotranslate.getSupportedLanguages'))
-							.set(credentials)
-							.query({
-								targetLanguage: 'en',
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(400)
-							.expect((res) => {
-								expect(res.body).to.have.a.property('success', false);
-								expect(res.body.errorType).to.be.equal('error-action-not-allowed');
-								expect(res.body.error).to.be.equal('Auto-Translate is not allowed [error-action-not-allowed]');
-							})
-							.end(done);
-					});
-				});
+			it('should throw an error when the user does not have the "auto-translate" permission', async () => {
+				await updateSetting('AutoTranslate_Enabled', true);
+
+				await updatePermission('auto-translate', []);
+
+				const res = await request
+					.get(api('autotranslate.getSupportedLanguages'))
+					.set(credentials)
+					.query({
+						targetLanguage: 'en',
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.errorType).to.be.equal('error-action-not-allowed');
+				expect(res.body.error).to.be.equal('Auto-Translate is not allowed [error-action-not-allowed]');
 			});
 
 			it('should return a list of languages', async () => {
@@ -109,8 +105,8 @@ describe('AutoTranslate', () => {
 				]);
 			});
 
-			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', (done) => {
-				void request
+			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -120,66 +116,58 @@ describe('AutoTranslate', () => {
 						value: true,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
+			});
+			it('should throw an error when the user does not have the "auto-translate" permission', async () => {
+				await updateSetting('AutoTranslate_Enabled', true);
+
+				await updatePermission('auto-translate', []);
+
+				const res = await request
+					.post(api('autotranslate.saveSettings'))
+					.set(credentials)
+					.send({
+						roomId: testChannelId,
+						defaultLanguage: 'en',
+						field: 'autoTranslateLanguage',
+						value: 'en',
 					})
-					.end(done);
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.errorType).to.be.equal('error-action-not-allowed');
+				expect(res.body.error).to.be.equal('Auto-Translate is not allowed [error-action-not-allowed]');
 			});
-			it('should throw an error when the user does not have the "auto-translate" permission', (done) => {
-				void updateSetting('AutoTranslate_Enabled', true).then(() => {
-					void updatePermission('auto-translate', []).then(() => {
-						void request
-							.post(api('autotranslate.saveSettings'))
-							.set(credentials)
-							.send({
-								roomId: testChannelId,
-								defaultLanguage: 'en',
-								field: 'autoTranslateLanguage',
-								value: 'en',
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(400)
-							.expect((res) => {
-								expect(res.body).to.have.a.property('success', false);
-								expect(res.body.errorType).to.be.equal('error-action-not-allowed');
-								expect(res.body.error).to.be.equal('Auto-Translate is not allowed [error-action-not-allowed]');
-							})
-							.end(done);
-					});
-				});
+			it('should throw an error when the bodyParam "roomId" is not provided', async () => {
+				await updatePermission('auto-translate', ['admin']);
+
+				const res = await request
+					.post(api('autotranslate.saveSettings'))
+					.set(credentials)
+					.send({})
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "roomId" is not provided', (done) => {
-				void updatePermission('auto-translate', ['admin']).then(() => {
-					void request
-						.post(api('autotranslate.saveSettings'))
-						.set(credentials)
-						.send({})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.a.property('success', false);
-						})
-						.end(done);
-				});
-			});
-			it('should throw an error when the bodyParam "field" is not provided', (done) => {
-				void request
+			it('should throw an error when the bodyParam "field" is not provided', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
 						roomId: testChannelId,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "value" is not provided', (done) => {
-				void request
+			it('should throw an error when the bodyParam "value" is not provided', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -187,14 +175,12 @@ describe('AutoTranslate', () => {
 						field: 'autoTranslate',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "autoTranslate" is not a boolean', (done) => {
-				void request
+			it('should throw an error when the bodyParam "autoTranslate" is not a boolean', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -203,14 +189,12 @@ describe('AutoTranslate', () => {
 						value: 'test',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "autoTranslateLanguage" is not a string', (done) => {
-				void request
+			it('should throw an error when the bodyParam "autoTranslateLanguage" is not a string', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -219,14 +203,12 @@ describe('AutoTranslate', () => {
 						value: 12,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "field" is invalid', (done) => {
-				void request
+			it('should throw an error when the bodyParam "field" is invalid', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -235,14 +217,12 @@ describe('AutoTranslate', () => {
 						value: 12,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "roomId" is invalid or the user is not subscribed', (done) => {
-				void request
+			it('should throw an error when the bodyParam "roomId" is invalid or the user is not subscribed', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -251,13 +231,11 @@ describe('AutoTranslate', () => {
 						value: 'en',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body.errorType).to.be.equal('error-invalid-subscription');
-						expect(res.body.error).to.be.equal('Invalid subscription [error-invalid-subscription]');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.errorType).to.be.equal('error-invalid-subscription');
+				expect(res.body.error).to.be.equal('Invalid subscription [error-invalid-subscription]');
 			});
 			it('should throw an error when E2E encryption is enabled', async () => {
 				await request
@@ -276,8 +254,8 @@ describe('AutoTranslate', () => {
 						expect(res.body).to.have.property('errorType', 'error-e2e-enabled');
 					});
 			});
-			it('should return success when the setting is saved correctly', (done) => {
-				void request
+			it('should return success when the setting is saved correctly', async () => {
+				const res = await request
 					.post(api('autotranslate.saveSettings'))
 					.set(credentials)
 					.send({
@@ -286,11 +264,9 @@ describe('AutoTranslate', () => {
 						value: 'en',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.a.property('success', true);
 			});
 		});
 
@@ -313,8 +289,8 @@ describe('AutoTranslate', () => {
 				await Promise.all([resetAutoTranslateDefaults(), deleteRoom({ type: 'c', roomId: testChannelId })]);
 			});
 
-			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', (done) => {
-				void request
+			it('should throw an error when the "AutoTranslate_Enabled" setting is disabled', async () => {
+				const res = await request
 					.post(api('autotranslate.translateMessage'))
 					.set(credentials)
 					.send({
@@ -322,57 +298,49 @@ describe('AutoTranslate', () => {
 						targetLanguage: 'en',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.error).to.be.equal('AutoTranslate is disabled.');
 			});
-			it('should throw an error when the bodyParam "messageId" is not provided', (done) => {
-				void updateSetting('AutoTranslate_Enabled', true).then(() => {
-					void updatePermission('auto-translate', ['admin']).then(() => {
-						void request
-							.post(api('autotranslate.translateMessage'))
-							.set(credentials)
-							.send({})
-							.expect('Content-Type', 'application/json')
-							.expect(400)
-							.expect((res) => {
-								expect(res.body).to.have.a.property('success', false);
-							})
-							.end(done);
-					});
-				});
+			it('should throw an error when the bodyParam "messageId" is not provided', async () => {
+				await updateSetting('AutoTranslate_Enabled', true);
+
+				await updatePermission('auto-translate', ['admin']);
+
+				const res = await request
+					.post(api('autotranslate.translateMessage'))
+					.set(credentials)
+					.send({})
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
 			});
-			it('should throw an error when the bodyParam "messageId" is invalid', (done) => {
-				void request
+			it('should throw an error when the bodyParam "messageId" is invalid', async () => {
+				const res = await request
 					.post(api('autotranslate.translateMessage'))
 					.set(credentials)
 					.send({
 						messageId: 'invalid',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body.error).to.be.equal('Message not found.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body.error).to.be.equal('Message not found.');
 			});
-			it('should return success when the translate is successful', (done) => {
-				void request
+			it('should return success when the translate is successful', async () => {
+				const res = await request
 					.post(api('autotranslate.translateMessage'))
 					.set(credentials)
 					.send({
 						messageId: messageSent._id,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.a.property('success', true);
 			});
 
 			describe('room access check', () => {
@@ -417,19 +385,17 @@ describe('AutoTranslate', () => {
 					]);
 				});
 
-				it('should return 403 forbidden when the user is not a member of the room', (done) => {
-					void request
+				it('should return 403 forbidden when the user is not a member of the room', async () => {
+					const res = await request
 						.post(api('autotranslate.translateMessage'))
 						.set(credB)
 						.send({
 							messageId: privateMessage._id,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(403)
-						.expect((res) => {
-							expect(res.body).to.have.a.property('success', false);
-						})
-						.end(done);
+						.expect(403);
+
+					expect(res.body).to.have.a.property('success', false);
 				});
 			});
 		});
@@ -476,8 +442,8 @@ describe('AutoTranslate', () => {
 				]);
 			});
 
-			it('should fail when messageId is not a string', (done) => {
-				void request
+			it('should fail when messageId is not a string', async () => {
+				const res = await request
 					.post(methodCall('autoTranslate.translateMessage'))
 					.set(credA)
 					.send({
@@ -489,17 +455,15 @@ describe('AutoTranslate', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						const parsedBody = JSON.parse(res.body.message);
-						expect(parsedBody).to.have.a.property('error');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				const parsedBody = JSON.parse(res.body.message);
+				expect(parsedBody).to.have.a.property('error');
 			});
 
-			it('should return error-not-allowed when the caller is not a member of the room', (done) => {
-				void request
+			it('should return error-not-allowed when the caller is not a member of the room', async () => {
+				const res = await request
 					.post(methodCall('autoTranslate.translateMessage'))
 					.set(credB)
 					.send({
@@ -511,14 +475,12 @@ describe('AutoTranslate', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						const parsedBody = JSON.parse(res.body.message);
-						expect(parsedBody).to.have.a.property('error');
-						expect(parsedBody.error).to.have.a.property('error', 'error-not-allowed');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.a.property('success', false);
+				const parsedBody = JSON.parse(res.body.message);
+				expect(parsedBody).to.have.a.property('error');
+				expect(parsedBody.error).to.have.a.property('error', 'error-not-allowed');
 			});
 		});
 

--- a/apps/meteor/tests/end-to-end/api/banners.ts
+++ b/apps/meteor/tests/end-to-end/api/banners.ts
@@ -7,59 +7,47 @@ describe('banners', () => {
 	before((done) => getCredentials(done));
 
 	describe('[/banners.dismiss]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(api('banners.dismiss'))
 				.send({
 					bannerId: '123',
 				})
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if missing bannerId key', (done) => {
-			void request
-				.post(api('banners.dismiss'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-				})
-				.end(done);
+		it('should fail if missing bannerId key', async () => {
+			const res = await request.post(api('banners.dismiss')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
 		});
 
-		it('should fail if bannerId is empty', (done) => {
-			void request
+		it('should fail if bannerId is empty', async () => {
+			const res = await request
 				.post(api('banners.dismiss'))
 				.set(credentials)
 				.send({
 					bannerId: '',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should fail if bannerId is invalid', (done) => {
-			void request
+		it('should fail if bannerId is invalid', async () => {
+			const res = await request
 				.post(api('banners.dismiss'))
 				.set(credentials)
 				.send({
 					bannerId: '123',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -3255,22 +3255,40 @@ describe('[Channels]', () => {
 		});
 
 		it('/channels.invite', async () => {
-			await request.post(api('channels.invite')).set(credentials).send({
-				roomId: testChannel._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('channels.invite'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/channels.addModerator', async () => {
-			await request.post(api('channels.addModerator')).set(credentials).send({
-				roomId: testChannel._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('channels.addModerator'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/channels.addLeader', async () => {
-			await request.post(api('channels.addLeader')).set(credentials).send({
-				roomId: testChannel._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('channels.addLeader'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('should return an array of role <-> user relationships in a channel', async () => {
 			const res = await request
@@ -3313,16 +3331,28 @@ describe('[Channels]', () => {
 		});
 
 		it('/channels.invite', async () => {
-			await request.post(api('channels.invite')).set(credentials).send({
-				roomId: testChannel._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('channels.invite'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/channels.addModerator', async () => {
-			await request.post(api('channels.addModerator')).set(credentials).send({
-				roomId: testChannel._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('channels.addModerator'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('should return an array of moderators with rocket.cat as a moderator', async () => {
 			const res = await request

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -84,8 +84,8 @@ describe('[Channels]', () => {
 			});
 	});
 
-	it('/channels.addModerator', (done) => {
-		void request
+	it('/channels.addModerator', async () => {
+		const res = await request
 			.post(api('channels.addModerator'))
 			.set(credentials)
 			.send({
@@ -93,45 +93,39 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.addModerator should fail with missing room Id', (done) => {
-		void request
+	it('/channels.addModerator should fail with missing room Id', async () => {
+		const res = await request
 			.post(api('channels.addModerator'))
 			.set(credentials)
 			.send({
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(400)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', false);
-			})
-			.end(done);
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
 	});
 
-	it('/channels.addModerator should fail with missing user Id', (done) => {
-		void request
+	it('/channels.addModerator should fail with missing user Id', async () => {
+		const res = await request
 			.post(api('channels.addModerator'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(400)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', false);
-			})
-			.end(done);
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
 	});
 
-	it('/channels.removeModerator', (done) => {
-		void request
+	it('/channels.removeModerator', async () => {
+		const res = await request
 			.post(api('channels.removeModerator'))
 			.set(credentials)
 			.send({
@@ -139,45 +133,39 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.removeModerator should fail on invalid room id', (done) => {
-		void request
+	it('/channels.removeModerator should fail on invalid room id', async () => {
+		const res = await request
 			.post(api('channels.removeModerator'))
 			.set(credentials)
 			.send({
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(400)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', false);
-			})
-			.end(done);
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
 	});
 
-	it('/channels.removeModerator should fail on invalid user id', (done) => {
-		void request
+	it('/channels.removeModerator should fail on invalid user id', async () => {
+		const res = await request
 			.post(api('channels.removeModerator'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(400)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', false);
-			})
-			.end(done);
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
 	});
 
-	it('/channels.addOwner', (done) => {
-		void request
+	it('/channels.addOwner', async () => {
+		const res = await request
 			.post(api('channels.addOwner'))
 			.set(credentials)
 			.send({
@@ -185,15 +173,13 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.removeOwner', (done) => {
-		void request
+	it('/channels.removeOwner', async () => {
+		const res = await request
 			.post(api('channels.removeOwner'))
 			.set(credentials)
 			.send({
@@ -201,11 +187,9 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
 	it('/channels.kick', async () => {
@@ -250,8 +234,8 @@ describe('[Channels]', () => {
 			});
 	});
 
-	it('/channels.addOwner', (done) => {
-		void request
+	it('/channels.addOwner', async () => {
+		const res = await request
 			.post(api('channels.addOwner'))
 			.set(credentials)
 			.send({
@@ -259,87 +243,75 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.archive', (done) => {
-		void request
+	it('/channels.archive', async () => {
+		const res = await request
 			.post(api('channels.archive'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.unarchive', (done) => {
-		void request
+	it('/channels.unarchive', async () => {
+		const res = await request
 			.post(api('channels.unarchive'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.close', (done) => {
-		void request
+	it('/channels.close', async () => {
+		const res = await request
 			.post(api('channels.close'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
-	it('/channels.close', (done) => {
-		void request
+	it('/channels.close', async () => {
+		const res = await request
 			.post(api('channels.close'))
 			.set(credentials)
 			.send({
 				roomName: apiPublicChannelName,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(400)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', false);
-				expect(res.body).to.have.property('error', `The channel, ${apiPublicChannelName}, is already closed to the sender`);
-			})
-			.end(done);
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('error', `The channel, ${apiPublicChannelName}, is already closed to the sender`);
 	});
 
-	it('/channels.open', (done) => {
-		void request
+	it('/channels.open', async () => {
+		const res = await request
 			.post(api('channels.open'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
 	describe('/channels.list', () => {
@@ -444,21 +416,19 @@ describe('[Channels]', () => {
 		});
 	});
 
-	it('/channels.list.joined', (done) => {
-		void request
+	it('/channels.list.joined', async () => {
+		const res = await request
 			.get(api('channels.list.joined'))
 			.set(credentials)
 			.query({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('count');
-				expect(res.body).to.have.property('total');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('count');
+		expect(res.body).to.have.property('total');
 	});
 
 	describe('/channels.counters', () => {
@@ -546,8 +516,8 @@ describe('[Channels]', () => {
 		const roomInfo = await getRoomInfo(channel._id);
 
 		function failRenameChannel(name: string) {
-			it(`should not rename a channel to the reserved name ${name}`, (done) => {
-				void request
+			it(`should not rename a channel to the reserved name ${name}`, async () => {
+				const res = await request
 					.post(api('channels.rename'))
 					.set(credentials)
 					.send({
@@ -555,12 +525,10 @@ describe('[Channels]', () => {
 						name,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', `${name} is already in use :( [error-field-unavailable]`);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', `${name} is already in use :( [error-field-unavailable]`);
 			});
 		}
 
@@ -586,26 +554,24 @@ describe('[Channels]', () => {
 			});
 	});
 
-	it('/channels.addAll', (done) => {
-		void request
+	it('/channels.addAll', async () => {
+		const res = await request
 			.post(api('channels.addAll'))
 			.set(credentials)
 			.send({
 				roomId: channel._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.nested.property('channel._id');
-				expect(res.body).to.have.nested.property('channel.name', `EDITED${apiPublicChannelName}`);
-				expect(res.body).to.have.nested.property('channel.t', 'c');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.nested.property('channel._id');
+		expect(res.body).to.have.nested.property('channel.name', `EDITED${apiPublicChannelName}`);
+		expect(res.body).to.have.nested.property('channel.t', 'c');
 	});
 
-	it('/channels.addLeader', (done) => {
-		void request
+	it('/channels.addLeader', async () => {
+		const res = await request
 			.post(api('channels.addLeader'))
 			.set(credentials)
 			.send({
@@ -613,14 +579,12 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.a.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.a.property('success', true);
 	});
-	it('/channels.removeLeader', (done) => {
-		void request
+	it('/channels.removeLeader', async () => {
+		const res = await request
 			.post(api('channels.removeLeader'))
 			.set(credentials)
 			.send({
@@ -628,11 +592,9 @@ describe('[Channels]', () => {
 				userId: 'rocket.cat',
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
 	it('/channels.setJoinCode', async () => {
@@ -833,58 +795,52 @@ describe('[Channels]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
-		it('creating new channel...', (done) => {
-			void request
+		it('creating new channel...', async () => {
+			const res = await request
 				.post(api('channels.create'))
 				.set(credentials)
 				.send({
 					name: testChannelName,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					testChannel = res.body.channel;
-				})
-				.end(done);
+				.expect(200);
+
+			testChannel = res.body.channel;
 		});
-		it('should fail to create the same channel twice', (done) => {
-			void request
+		it('should fail to create the same channel twice', async () => {
+			const res = await request
 				.post(api('channels.create'))
 				.set(credentials)
 				.send({
 					name: testChannelName,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.contain('error-duplicate-channel-name');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.contain('error-duplicate-channel-name');
 		});
-		it('should return channel basic structure', (done) => {
-			void request
+		it('should return channel basic structure', async () => {
+			const res = await request
 				.get(api('channels.info'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('channel._id');
-					expect(res.body).to.have.nested.property('channel.name', testChannelName);
-					expect(res.body).to.have.nested.property('channel.t', 'c');
-					expect(res.body).to.have.nested.property('channel.msgs', 0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('channel._id');
+			expect(res.body).to.have.nested.property('channel.name', testChannelName);
+			expect(res.body).to.have.nested.property('channel.t', 'c');
+			expect(res.body).to.have.nested.property('channel.msgs', 0);
 		});
 
 		let channelMessage: IMessage;
 
-		it('sending a message...', (done) => {
-			void request
+		it('sending a message...', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -894,15 +850,13 @@ describe('[Channels]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					channelMessage = res.body.message;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			channelMessage = res.body.message;
 		});
-		it('REACTing with last message', (done) => {
-			void request
+		it('REACTing with last message', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -910,83 +864,73 @@ describe('[Channels]', () => {
 					messageId: channelMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('STARring last message', (done) => {
-			void request
+		it('STARring last message', async () => {
+			const res = await request
 				.post(api('chat.starMessage'))
 				.set(credentials)
 				.send({
 					messageId: channelMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('PINning last message', (done) => {
-			void request
+		it('PINning last message', async () => {
+			const res = await request
 				.post(api('chat.pinMessage'))
 				.set(credentials)
 				.send({
 					messageId: channelMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return channel structure with "lastMessage" object including pin, reactions and star(should be an array) infos', (done) => {
-			void request
+		it('should return channel structure with "lastMessage" object including pin, reactions and star(should be an array) infos', async () => {
+			const res = await request
 				.get(api('channels.info'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('channel').and.to.be.an('object');
-					const { channel } = res.body;
-					expect(channel).to.have.property('lastMessage').and.to.be.an('object');
-					expect(channel.lastMessage).to.have.property('reactions').and.to.be.an('object');
-					expect(channel.lastMessage).to.have.property('pinned').and.to.be.a('boolean');
-					expect(channel.lastMessage).to.have.property('pinnedAt').and.to.be.a('string');
-					expect(channel.lastMessage).to.have.property('pinnedBy').and.to.be.an('object');
-					expect(channel.lastMessage).to.have.property('starred').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('channel').and.to.be.an('object');
+			const { channel } = res.body;
+			expect(channel).to.have.property('lastMessage').and.to.be.an('object');
+			expect(channel.lastMessage).to.have.property('reactions').and.to.be.an('object');
+			expect(channel.lastMessage).to.have.property('pinned').and.to.be.a('boolean');
+			expect(channel.lastMessage).to.have.property('pinnedAt').and.to.be.a('string');
+			expect(channel.lastMessage).to.have.property('pinnedBy').and.to.be.an('object');
+			expect(channel.lastMessage).to.have.property('starred').and.to.be.an('array');
 		});
-		it('should return all channels messages where the last message of array should have the "star" array with USERS star ONLY', (done) => {
-			void request
+		it('should return all channels messages where the last message of array should have the "star" array with USERS star ONLY', async () => {
+			const res = await request
 				.get(api('channels.messages'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages').and.to.be.an('array');
-					const messages = res.body.messages as IMessage[];
-					const lastMessage = messages.filter((message) => message._id === channelMessage._id)[0];
-					expect(lastMessage).to.have.property('starred').and.to.be.an('array');
-					expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('array');
+			const messages = res.body.messages as IMessage[];
+			const lastMessage = messages.filter((message) => message._id === channelMessage._id)[0];
+			expect(lastMessage).to.have.property('starred').and.to.be.an('array');
+			expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
 		});
-		it('should return all channels messages where the last message of array should have the "star" array with USERS star ONLY even requested with count and offset params', (done) => {
-			void request
+		it('should return all channels messages where the last message of array should have the "star" array with USERS star ONLY even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('channels.messages'))
 				.set(credentials)
 				.query({
@@ -995,16 +939,14 @@ describe('[Channels]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages').and.to.be.an('array');
-					const messages = res.body.messages as IMessage[];
-					const lastMessage = messages.filter((message) => message._id === channelMessage._id)[0];
-					expect(lastMessage).to.have.property('starred').and.to.be.an('array');
-					expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('array');
+			const messages = res.body.messages as IMessage[];
+			const lastMessage = messages.filter((message) => message._id === channelMessage._id)[0];
+			expect(lastMessage).to.have.property('starred').and.to.be.an('array');
+			expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
 		});
 		describe('Additional Visibility Tests', () => {
 			let outsiderUser: IUser;
@@ -1467,37 +1409,33 @@ describe('[Channels]', () => {
 				.end(done);
 		});
 
-		it('should fail if invalid channel', (done) => {
-			void request
+		it('should fail if invalid channel', async () => {
+			const res = await request
 				.post(api('channels.join'))
 				.set(credentials)
 				.send({
 					roomId: 'invalid',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-room-not-found');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-room-not-found');
 		});
 
 		describe('code-free channel', () => {
-			it('should succeed when joining code-free channel without join code', (done) => {
-				void request
+			it('should succeed when joining code-free channel without join code', async () => {
+				const res = await request
 					.post(api('channels.join'))
 					.set(credentials)
 					.send({
 						roomId: testChannelNoCode._id,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('channel._id', testChannelNoCode._id);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.nested.property('channel._id', testChannelNoCode._id);
 			});
 		});
 
@@ -1507,24 +1445,22 @@ describe('[Channels]', () => {
 					await updatePermission('join-without-join-code', []);
 				});
 
-				it('should fail when joining code-needed channel without join code and no join-without-join-code permission', (done) => {
-					void request
+				it('should fail when joining code-needed channel without join code and no join-without-join-code permission', async () => {
+					const res = await request
 						.post(api('channels.join'))
 						.set(credentials)
 						.send({
 							roomId: testChannelWithCode._id,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body).to.have.nested.property('errorType', 'error-code-required');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.nested.property('errorType', 'error-code-required');
 				});
 
-				it('should fail when joining code-needed channel with incorrect join code and no join-without-join-code permission', (done) => {
-					void request
+				it('should fail when joining code-needed channel with incorrect join code and no join-without-join-code permission', async () => {
+					const res = await request
 						.post(api('channels.join'))
 						.set(credentials)
 						.send({
@@ -1532,16 +1468,14 @@ describe('[Channels]', () => {
 							joinCode: 'WRONG_CODE',
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body).to.have.nested.property('errorType', 'error-code-invalid');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.nested.property('errorType', 'error-code-invalid');
 				});
 
-				it('should succeed when joining code-needed channel with join code', (done) => {
-					void request
+				it('should succeed when joining code-needed channel with join code', async () => {
+					const res = await request
 						.post(api('channels.join'))
 						.set(credentials)
 						.send({
@@ -1549,12 +1483,10 @@ describe('[Channels]', () => {
 							joinCode: '123',
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.nested.property('channel._id', testChannelWithCode._id);
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('channel._id', testChannelWithCode._id);
 				});
 			});
 
@@ -1578,28 +1510,26 @@ describe('[Channels]', () => {
 						.end(done);
 				});
 
-				it('should succeed when joining code-needed channel without join code and with join-without-join-code permission', (done) => {
-					void request
+				it('should succeed when joining code-needed channel without join code and with join-without-join-code permission', async () => {
+					const res = await request
 						.post(api('channels.join'))
 						.set(credentials)
 						.send({
 							roomId: testChannelWithCode._id,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.nested.property('channel._id', testChannelWithCode._id);
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.nested.property('channel._id', testChannelWithCode._id);
 				});
 			});
 		});
 	});
 
 	describe('/channels.setDescription', () => {
-		it('should set the description of the channel with a string', (done) => {
-			void request
+		it('should set the description of the channel with a string', async () => {
+			const res = await request
 				.post(api('channels.setDescription'))
 				.set(credentials)
 				.send({
@@ -1607,15 +1537,13 @@ describe('[Channels]', () => {
 					description: 'this is a description for a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('description', 'this is a description for a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('description', 'this is a description for a channel for api tests');
 		});
-		it('should set the description of the channel with an empty string(remove the description)', (done) => {
-			void request
+		it('should set the description of the channel with an empty string(remove the description)', async () => {
+			const res = await request
 				.post(api('channels.setDescription'))
 				.set(credentials)
 				.send({
@@ -1623,18 +1551,16 @@ describe('[Channels]', () => {
 					description: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('description', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('description', '');
 		});
 	});
 
 	describe('/channels.setTopic', () => {
-		it('should set the topic of the channel with a string', (done) => {
-			void request
+		it('should set the topic of the channel with a string', async () => {
+			const res = await request
 				.post(api('channels.setTopic'))
 				.set(credentials)
 				.send({
@@ -1642,15 +1568,13 @@ describe('[Channels]', () => {
 					topic: 'this is a topic of a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', 'this is a topic of a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', 'this is a topic of a channel for api tests');
 		});
-		it('should set the topic of the channel with an empty string(remove the topic)', (done) => {
-			void request
+		it('should set the topic of the channel with an empty string(remove the topic)', async () => {
+			const res = await request
 				.post(api('channels.setTopic'))
 				.set(credentials)
 				.send({
@@ -1658,18 +1582,16 @@ describe('[Channels]', () => {
 					topic: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', '');
 		});
 	});
 
 	describe('/channels.setAnnouncement', () => {
-		it('should set the announcement of the channel with a string', (done) => {
-			void request
+		it('should set the announcement of the channel with a string', async () => {
+			const res = await request
 				.post(api('channels.setAnnouncement'))
 				.set(credentials)
 				.send({
@@ -1677,15 +1599,13 @@ describe('[Channels]', () => {
 					announcement: 'this is an announcement of a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('announcement', 'this is an announcement of a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('announcement', 'this is an announcement of a channel for api tests');
 		});
-		it('should set the announcement of the channel with an empty string(remove the announcement)', (done) => {
-			void request
+		it('should set the announcement of the channel with an empty string(remove the announcement)', async () => {
+			const res = await request
 				.post(api('channels.setAnnouncement'))
 				.set(credentials)
 				.send({
@@ -1693,18 +1613,16 @@ describe('[Channels]', () => {
 					announcement: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('announcement', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('announcement', '');
 		});
 	});
 
 	describe('/channels.setPurpose', () => {
-		it('should set the purpose of the channel with a string', (done) => {
-			void request
+		it('should set the purpose of the channel with a string', async () => {
+			const res = await request
 				.post(api('channels.setPurpose'))
 				.set(credentials)
 				.send({
@@ -1712,15 +1630,13 @@ describe('[Channels]', () => {
 					purpose: 'this is a purpose of a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('purpose', 'this is a purpose of a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('purpose', 'this is a purpose of a channel for api tests');
 		});
-		it('should set the announcement of channel with an empty string(remove the purpose)', (done) => {
-			void request
+		it('should set the announcement of channel with an empty string(remove the purpose)', async () => {
+			const res = await request
 				.post(api('channels.setPurpose'))
 				.set(credentials)
 				.send({
@@ -1728,34 +1644,30 @@ describe('[Channels]', () => {
 					purpose: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('purpose', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('purpose', '');
 		});
 	});
 
 	describe('/channels.history', () => {
-		it('should return an array of members by channel', (done) => {
-			void request
+		it('should return an array of members by channel', async () => {
+			const res = await request
 				.get(api('channels.history'))
 				.set(credentials)
 				.query({
 					roomId: channel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
 		});
 
-		it('should return an array of members by channel even requested with count and offset params', (done) => {
-			void request
+		it('should return an array of members by channel even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('channels.history'))
 				.set(credentials)
 				.query({
@@ -1764,12 +1676,10 @@ describe('[Channels]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
 		});
 
 		describe('inclusive parameter', () => {
@@ -1894,27 +1804,25 @@ describe('[Channels]', () => {
 			await Promise.all([updateSetting('Accounts_SearchFields', 'username, name, bio, nickname'), deleteUser(testUser)]);
 		});
 
-		it('should return an array of members by channel', (done) => {
-			void request
+		it('should return an array of members by channel', async () => {
+			const res = await request
 				.get(api('channels.members'))
 				.set(credentials)
 				.query({
 					roomId: channel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('members').and.to.be.an('array');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('members').and.to.be.an('array');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
 		});
 
-		it('should return an array of members by channel even requested with count and offset params', (done) => {
-			void request
+		it('should return an array of members by channel even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('channels.members'))
 				.set(credentials)
 				.query({
@@ -1923,19 +1831,17 @@ describe('[Channels]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('members').and.to.be.an('array');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('members').and.to.be.an('array');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
 		});
 
-		it('should return an filtered array of members by channel', (done) => {
-			void request
+		it('should return an filtered array of members by channel', async () => {
+			const res = await request
 				.get(api('channels.members'))
 				.set(credentials)
 				.query({
@@ -1943,17 +1849,15 @@ describe('[Channels]', () => {
 					filter: testUser.username,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('members').and.to.be.an('array');
-					expect(res.body).to.have.property('count', 1);
-					expect(res.body.members[0]._id).to.be.equal(testUser._id);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('members').and.to.be.an('array');
+			expect(res.body).to.have.property('count', 1);
+			expect(res.body.members[0]._id).to.be.equal(testUser._id);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
 		});
 
 		describe('Additional Visibility Tests', () => {
@@ -2707,20 +2611,18 @@ describe('[Channels]', () => {
 					done();
 				});
 		});
-		it('get customFields using channels.info', (done) => {
-			void request
+		it('get customFields using channels.info', async () => {
+			const res = await request
 				.get(api('channels.info'))
 				.set(credentials)
 				.query({
 					roomId: withCFChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('channel.customFields.field0', 'value0');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('channel.customFields.field0', 'value0');
 		});
 		it('change customFields', async () => {
 			const customFields = { field9: 'value9' };
@@ -2742,34 +2644,30 @@ describe('[Channels]', () => {
 					expect(res.body).to.have.not.nested.property('channel.customFields.field0', 'value0');
 				});
 		});
-		it('get customFields using channels.info', (done) => {
-			void request
+		it('get customFields using channels.info', async () => {
+			const res = await request
 				.get(api('channels.info'))
 				.set(credentials)
 				.query({
 					roomId: withCFChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('channel.customFields.field9', 'value9');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('channel.customFields.field9', 'value9');
 		});
-		it('delete channels with customFields', (done) => {
-			void request
+		it('delete channels with customFields', async () => {
+			const res = await request
 				.post(api('channels.delete'))
 				.set(credentials)
 				.send({
 					roomName: withCFChannel.name,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('create channel without customFields', (done) => {
 			void request
@@ -2865,19 +2763,17 @@ describe('[Channels]', () => {
 				})
 				.end(done);
 		});
-		it('delete channel with empty customFields', (done) => {
-			void request
+		it('delete channel with empty customFields', async () => {
+			const res = await request
 				.post(api('channels.delete'))
 				.set(credentials)
 				.send({
 					roomName: withoutCFChannel.name,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -3311,26 +3207,24 @@ describe('[Channels]', () => {
 	});
 
 	describe('/channels.getAllUserMentionsByChannel', () => {
-		it('should return an array of mentions by channel', (done) => {
-			void request
+		it('should return an array of mentions by channel', async () => {
+			const res = await request
 				.get(api('channels.getAllUserMentionsByChannel'))
 				.set(credentials)
 				.query({
 					roomId: channel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('mentions').and.to.be.an('array');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('mentions').and.to.be.an('array');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
 		});
-		it('should return an array of mentions by channel even requested with count and offset params', (done) => {
-			void request
+		it('should return an array of mentions by channel even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('channels.getAllUserMentionsByChannel'))
 				.set(credentials)
 				.query({
@@ -3339,15 +3233,13 @@ describe('[Channels]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('mentions').and.to.be.an('array');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('mentions').and.to.be.an('array');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
 		});
 	});
 
@@ -3362,64 +3254,50 @@ describe('[Channels]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
-		it('/channels.invite', (done) => {
-			void request
-				.post(api('channels.invite'))
-				.set(credentials)
-				.send({
-					roomId: testChannel._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/channels.invite', async () => {
+			await request.post(api('channels.invite')).set(credentials).send({
+				roomId: testChannel._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/channels.addModerator', (done) => {
-			void request
-				.post(api('channels.addModerator'))
-				.set(credentials)
-				.send({
-					roomId: testChannel._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/channels.addModerator', async () => {
+			await request.post(api('channels.addModerator')).set(credentials).send({
+				roomId: testChannel._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/channels.addLeader', (done) => {
-			void request
-				.post(api('channels.addLeader'))
-				.set(credentials)
-				.send({
-					roomId: testChannel._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/channels.addLeader', async () => {
+			await request.post(api('channels.addLeader')).set(credentials).send({
+				roomId: testChannel._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('should return an array of role <-> user relationships in a channel', (done) => {
-			void request
+		it('should return an array of role <-> user relationships in a channel', async () => {
+			const res = await request
 				.get(api('channels.roles'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('roles').that.is.an('array').that.has.lengthOf(2);
+				.expect(200);
 
-					expect(res.body.roles[0]).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[0]).to.have.a.property('rid').that.is.equal(testChannel._id);
-					expect(res.body.roles[0]).to.have.a.property('roles').that.is.an('array').that.includes('moderator', 'leader');
-					expect(res.body.roles[0]).to.have.a.property('u').that.is.an('object');
-					expect(res.body.roles[0].u).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[0].u).to.have.a.property('username').that.is.a('string');
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('roles').that.is.an('array').that.has.lengthOf(2);
 
-					expect(res.body.roles[1]).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[1]).to.have.a.property('rid').that.is.equal(testChannel._id);
-					expect(res.body.roles[1]).to.have.a.property('roles').that.is.an('array').that.includes('owner');
-					expect(res.body.roles[1]).to.have.a.property('u').that.is.an('object');
-					expect(res.body.roles[1].u).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[1].u).to.have.a.property('username').that.is.a('string');
-				})
-				.end(done);
+			expect(res.body.roles[0]).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[0]).to.have.a.property('rid').that.is.equal(testChannel._id);
+			expect(res.body.roles[0]).to.have.a.property('roles').that.is.an('array').that.includes('moderator', 'leader');
+			expect(res.body.roles[0]).to.have.a.property('u').that.is.an('object');
+			expect(res.body.roles[0].u).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[0].u).to.have.a.property('username').that.is.a('string');
+
+			expect(res.body.roles[1]).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[1]).to.have.a.property('rid').that.is.equal(testChannel._id);
+			expect(res.body.roles[1]).to.have.a.property('roles').that.is.an('array').that.includes('owner');
+			expect(res.body.roles[1]).to.have.a.property('u').that.is.an('object');
+			expect(res.body.roles[1].u).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[1].u).to.have.a.property('username').that.is.a('string');
 		});
 	});
 
@@ -3434,41 +3312,31 @@ describe('[Channels]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
-		it('/channels.invite', (done) => {
-			void request
-				.post(api('channels.invite'))
-				.set(credentials)
-				.send({
-					roomId: testChannel._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/channels.invite', async () => {
+			await request.post(api('channels.invite')).set(credentials).send({
+				roomId: testChannel._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/channels.addModerator', (done) => {
-			void request
-				.post(api('channels.addModerator'))
-				.set(credentials)
-				.send({
-					roomId: testChannel._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/channels.addModerator', async () => {
+			await request.post(api('channels.addModerator')).set(credentials).send({
+				roomId: testChannel._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('should return an array of moderators with rocket.cat as a moderator', (done) => {
-			void request
+		it('should return an array of moderators with rocket.cat as a moderator', async () => {
+			const res = await request
 				.get(api('channels.moderators'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('moderators').that.is.an('array').that.has.lengthOf(1);
-					expect(res.body.moderators[0].username).to.be.equal('rocket.cat');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('moderators').that.is.an('array').that.has.lengthOf(1);
+			expect(res.body.moderators[0].username).to.be.equal('rocket.cat');
 		});
 
 		describe('Additional Visibility Tests', () => {
@@ -3794,55 +3662,49 @@ describe('[Channels]', () => {
 			await Promise.all([updateSetting('Accounts_AllowAnonymousRead', false), deleteRoom({ type: 'c', roomId: testChannel._id })]);
 		});
 
-		it('should return an error when the setting "Accounts_AllowAnonymousRead" is disabled', (done) => {
-			void updateSetting('Accounts_AllowAnonymousRead', false).then(() => {
-				void request
-					.get(api('channels.anonymousread'))
-					.query({
-						roomId: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(401)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body).to.have.a.property('error', 'You must be logged in to do this.');
-					})
-					.end(done);
-			});
+		it('should return an error when the setting "Accounts_AllowAnonymousRead" is disabled', async () => {
+			await updateSetting('Accounts_AllowAnonymousRead', false);
+
+			const res = await request
+				.get(api('channels.anonymousread'))
+				.query({
+					roomId: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(401);
+
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('error', 'You must be logged in to do this.');
 		});
-		it('should return the messages list when the setting "Accounts_AllowAnonymousRead" is enabled', (done) => {
-			void updateSetting('Accounts_AllowAnonymousRead', true).then(() => {
-				void request
-					.get(api('channels.anonymousread'))
-					.query({
-						roomId: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-						expect(res.body).to.have.a.property('messages').that.is.an('array');
-					})
-					.end(done);
-			});
+		it('should return the messages list when the setting "Accounts_AllowAnonymousRead" is enabled', async () => {
+			await updateSetting('Accounts_AllowAnonymousRead', true);
+
+			const res = await request
+				.get(api('channels.anonymousread'))
+				.query({
+					roomId: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('messages').that.is.an('array');
 		});
-		it('should return the messages list when the setting "Accounts_AllowAnonymousRead" is enabled even requested with count and offset params', (done) => {
-			void updateSetting('Accounts_AllowAnonymousRead', true).then(() => {
-				void request
-					.get(api('channels.anonymousread'))
-					.query({
-						roomId: testChannel._id,
-						count: 5,
-						offset: 0,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-						expect(res.body).to.have.a.property('messages').that.is.an('array');
-					})
-					.end(done);
-			});
+		it('should return the messages list when the setting "Accounts_AllowAnonymousRead" is enabled even requested with count and offset params', async () => {
+			await updateSetting('Accounts_AllowAnonymousRead', true);
+
+			const res = await request
+				.get(api('channels.anonymousread'))
+				.query({
+					roomId: testChannel._id,
+					count: 5,
+					offset: 0,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('messages').that.is.an('array');
 		});
 		describe('Additional Visibility Tests', () => {
 			let outsiderUser: IUser;
@@ -4021,20 +3883,18 @@ describe('[Channels]', () => {
 			});
 		});
 
-		it(`should return an error when the channel's name and id are sent as parameter`, (done) => {
-			void request
+		it(`should return an error when the channel's name and id are sent as parameter`, async () => {
+			const res = await request
 				.post(api('channels.convertToTeam'))
 				.set(credentials)
 				.send({
 					channelName: testChannel.name,
 					channelId: testChannel._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').include(`must match exactly one schema in oneOf`);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').include(`must match exactly one schema in oneOf`);
 		});
 
 		it(`should successfully convert a channel to a team when the channel's id is sent as parameter`, async () => {
@@ -4075,16 +3935,10 @@ describe('[Channels]', () => {
 			void request.post(api('channels.convertToTeam')).set(credentials).send({}).expect(400).end(done);
 		});
 
-		it("should fail to convert channel if it's already taken", (done) => {
-			void request
-				.post(api('channels.convertToTeam'))
-				.set(credentials)
-				.send({ channelId: testChannel._id })
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-				})
-				.end(done);
+		it("should fail to convert channel if it's already taken", async () => {
+			const res = await request.post(api('channels.convertToTeam')).set(credentials).send({ channelId: testChannel._id }).expect(400);
+
+			expect(res.body).to.have.a.property('success', false);
 		});
 	});
 
@@ -4134,42 +3988,34 @@ describe('[Channels]', () => {
 			]);
 		});
 
-		it('should return the last message user real name', (done) => {
-			void request
+		it('should return the last message user real name', async () => {
+			const res = await request
 				.get(api('channels.info'))
 				.query({
 					roomId: testChannel._id,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					const { channel } = res.body;
+				.expect(200);
 
-					expect(channel._id).to.be.equal(testChannel._id);
-					expect(channel).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
-				})
-				.end(done);
+			expect(res.body).to.have.property('success', true);
+			const { channel } = res.body;
+
+			expect(channel._id).to.be.equal(testChannel._id);
+			expect(channel).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
 		});
 
-		it('/channels.list.joined', (done) => {
-			void request
-				.get(api('channels.list.joined'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('channels').and.to.be.an('array');
+		it('/channels.list.joined', async () => {
+			const res = await request.get(api('channels.list.joined')).set(credentials).expect('Content-Type', 'application/json').expect(200);
 
-					const retChannel = (res.body.channels as IRoom[]).find(({ _id }) => _id === testChannel._id);
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('channels').and.to.be.an('array');
 
-					expect(retChannel).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
-				})
-				.end(done);
+			const retChannel = (res.body.channels as IRoom[]).find(({ _id }) => _id === testChannel._id);
+
+			expect(retChannel).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
 		});
 
 		it('/channels.list.join should return empty list when member of no group', async () => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -58,8 +58,8 @@ describe('[Chat]', () => {
 	});
 
 	describe('/chat.postMessage', () => {
-		it('should throw an error when at least one of required parameters(channel, roomId) is not sent', (done) => {
-			void request
+		it('should throw an error when at least one of required parameters(channel, roomId) is not sent', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -69,15 +69,13 @@ describe('[Chat]', () => {
 					avatar: 'http://res.guggy.com/logo_128.png',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should throw an error when it has some properties with the wrong type(attachments.title_link_download, attachments.fields, message_link)', (done) => {
-			void request
+		it('should throw an error when it has some properties with the wrong type(attachments.title_link_download, attachments.fields, message_link)', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -108,12 +106,10 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
 		describe('should throw an error when the sensitive properties contain malicious XSS values', () => {
@@ -440,8 +436,8 @@ describe('[Chat]', () => {
 					}));
 		});
 
-		it('should throw an error when the properties (attachments.fields.title, attachments.fields.value) are with the wrong type', (done) => {
-			void request
+		it('should throw an error when the properties (attachments.fields.title, attachments.fields.value) are with the wrong type', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -478,16 +474,14 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should throw an error when the properties (attachments.fields.title) is missing', (done) => {
-			void request
+		it('should throw an error when the properties (attachments.fields.title) is missing', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -523,16 +517,14 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should throw an error when the properties (attachments.fields.value) is missing', (done) => {
-			void request
+		it('should throw an error when the properties (attachments.fields.value) is missing', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -568,16 +560,14 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('attachment.fields should work fine when value and title are provided', (done) => {
-			void request
+		it('attachment.fields should work fine when value and title are provided', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -592,18 +582,16 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.not.have.property('error');
-					expect(res.body).to.have.nested.property('message.msg', 'Sample message');
-					expect(res.body).to.have.nested.property('message.attachments').to.be.an('array');
-					expect(res.body).to.have.nested.property('message.attachments[0].fields').to.be.an('array');
-					expect(res.body).to.have.nested.property('message.attachments[0].fields[0].short', true);
-					expect(res.body).to.have.nested.property('message.attachments[0].fields[0].value', 'This is value');
-					expect(res.body).to.have.nested.property('message.attachments[0].fields[0].title', 'This is title');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.property('error');
+			expect(res.body).to.have.nested.property('message.msg', 'Sample message');
+			expect(res.body).to.have.nested.property('message.attachments').to.be.an('array');
+			expect(res.body).to.have.nested.property('message.attachments[0].fields').to.be.an('array');
+			expect(res.body).to.have.nested.property('message.attachments[0].fields[0].short', true);
+			expect(res.body).to.have.nested.property('message.attachments[0].fields[0].value', 'This is value');
+			expect(res.body).to.have.nested.property('message.attachments[0].fields[0].title', 'This is title');
 		});
 
 		it('should allow forwarding a message into the same password protected room', async () => {
@@ -634,8 +622,8 @@ describe('[Chat]', () => {
 			expect(forwardResponse.body).to.have.nested.property('message.rid', protectedChannel._id);
 		});
 
-		it('should return statusCode 200 when postMessage successfully', (done) => {
-			void request
+		it('should return statusCode 200 when postMessage successfully', async () => {
+			const res = await request
 				.post(api('chat.postMessage'))
 				.set(credentials)
 				.send({
@@ -675,13 +663,11 @@ describe('[Chat]', () => {
 					],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('message.msg', 'Sample message');
-					message = { _id: res.body.message._id };
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('message.msg', 'Sample message');
+			message = { _id: res.body.message._id };
 		});
 
 		it('should not parse urls when parseUrls=false is provided', async () => {
@@ -747,8 +733,8 @@ describe('[Chat]', () => {
 				await updateSetting('Message_MaxAllowedSize', 5000);
 			});
 
-			it('should return an error if text parameter surpasses the maximum allowed size', (done) => {
-				void request
+			it('should return an error if text parameter surpasses the maximum allowed size', async () => {
+				const res = await request
 					.post(api('chat.postMessage'))
 					.set(credentials)
 					.send({
@@ -759,16 +745,14 @@ describe('[Chat]', () => {
 						avatar: 'http://res.guggy.com/logo_128.png',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'error-message-size-exceeded');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'error-message-size-exceeded');
 			});
 
-			it('should return an error if text parameter in the first attachment surpasses the maximum allowed size', (done) => {
-				void request
+			it('should return an error if text parameter in the first attachment surpasses the maximum allowed size', async () => {
+				const res = await request
 					.post(api('chat.postMessage'))
 					.set(credentials)
 					.send({
@@ -797,16 +781,14 @@ describe('[Chat]', () => {
 						],
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'error-message-size-exceeded');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'error-message-size-exceeded');
 			});
 
-			it('should return an error if text parameter in any of the attachments surpasses the maximum allowed size', (done) => {
-				void request
+			it('should return an error if text parameter in any of the attachments surpasses the maximum allowed size', async () => {
+				const res = await request
 					.post(api('chat.postMessage'))
 					.set(credentials)
 					.send({
@@ -853,16 +835,14 @@ describe('[Chat]', () => {
 						],
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'error-message-size-exceeded');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'error-message-size-exceeded');
 			});
 
-			it('should pass if any text parameter length does not surpasses the maximum allowed size', (done) => {
-				void request
+			it('should pass if any text parameter length does not surpasses the maximum allowed size', async () => {
+				const res = await request
 					.post(api('chat.postMessage'))
 					.set(credentials)
 					.send({
@@ -902,12 +882,10 @@ describe('[Chat]', () => {
 						],
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('message.msg', 'Sample');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.nested.property('message.msg', 'Sample');
 			});
 		});
 
@@ -924,8 +902,8 @@ describe('[Chat]', () => {
 				await deleteRoom({ type: 'c', roomId: archivedChannel._id });
 			});
 
-			it('should fail to post a message to an archived room', (done) => {
-				void request
+			it('should fail to post a message to an archived room', async () => {
+				const res = await request
 					.post(api('chat.postMessage'))
 					.set(credentials)
 					.send({
@@ -933,37 +911,33 @@ describe('[Chat]', () => {
 						text: 'This message should not be posted',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'room_is_archived');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'room_is_archived');
 			});
 		});
 	});
 
 	describe('/chat.getMessage', () => {
-		it('should retrieve the message successfully', (done) => {
-			void request
+		it('should retrieve the message successfully', async () => {
+			const res = await request
 				.get(api('chat.getMessage'))
 				.set(credentials)
 				.query({
 					msgId: message._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('message._id', message._id);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('message._id', message._id);
 		});
 	});
 
 	describe('/chat.sendMessage', () => {
-		it("should throw an error when the required param 'rid' is not sent", (done) => {
-			void request
+		it("should throw an error when the required param 'rid' is not sent", async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -975,12 +949,10 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', "The 'rid' property on the message object is missing.");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', "The 'rid' property on the message object is missing.");
 		});
 
 		describe('should throw an error when the sensitive properties contain malicious XSS values', () => {
@@ -1100,8 +1072,8 @@ describe('[Chat]', () => {
 					}));
 		});
 
-		it('should throw an error when it has some properties with the wrong type(attachments.title_link_download, attachments.fields, message_link)', (done) => {
-			void request
+		it('should throw an error when it has some properties with the wrong type(attachments.title_link_download, attachments.fields, message_link)', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -1134,12 +1106,10 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
 		it('should send a message successfully', (done) => {
@@ -1242,8 +1212,8 @@ describe('[Chat]', () => {
 				await deleteRoom({ type: 'c', roomId: archivedChannel._id });
 			});
 
-			it('should fail to send a message to an archived room', (done) => {
-				void request
+			it('should fail to send a message to an archived room', async () => {
+				const res = await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
 					.send({
@@ -1253,12 +1223,10 @@ describe('[Chat]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'room_is_archived');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'room_is_archived');
 			});
 		});
 
@@ -1655,8 +1623,8 @@ describe('[Chat]', () => {
 				]),
 			);
 
-			it('Creating a read-only channel', (done) => {
-				void request
+			it('Creating a read-only channel', async () => {
+				const res = await request
 					.post(api('channels.create'))
 					.set(credentials)
 					.send({
@@ -1664,15 +1632,13 @@ describe('[Chat]', () => {
 						readOnly: true,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						readOnlyChannel = res.body.channel;
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				readOnlyChannel = res.body.channel;
 			});
-			it('should send a message when the user is the owner of a readonly channel', (done) => {
-				void request
+			it('should send a message when the user is the owner of a readonly channel', async () => {
+				const res = await request
 					.post(api('chat.sendMessage'))
 					.set(credentials)
 					.send({
@@ -1682,12 +1648,10 @@ describe('[Chat]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('message').and.to.be.an('object');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('message').and.to.be.an('object');
 			});
 			it('Inviting regular user to read-only channel', (done) => {
 				void request
@@ -1707,8 +1671,8 @@ describe('[Chat]', () => {
 					});
 			});
 
-			it('should fail to send message when the user lacks permission', (done) => {
-				void request
+			it('should fail to send message when the user lacks permission', async () => {
+				const res = await request
 					.post(api('chat.sendMessage'))
 					.set(userCredentials)
 					.send({
@@ -1718,12 +1682,10 @@ describe('[Chat]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error');
 			});
 
 			it('should send a message when the user has permission to send messages on readonly channels', async () => {
@@ -1747,8 +1709,8 @@ describe('[Chat]', () => {
 			});
 		});
 
-		it('should fail if user does not have the message-impersonate permission and tries to send message with alias param', (done) => {
-			void request
+		it('should fail if user does not have the message-impersonate permission and tries to send message with alias param', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -1759,16 +1721,14 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'Not enough permission');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'Not enough permission');
 		});
 
-		it('should fail if user does not have the message-impersonate permission and tries to send message with avatar param', (done) => {
-			void request
+		it('should fail if user does not have the message-impersonate permission and tries to send message with avatar param', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -1779,12 +1739,10 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'Not enough permission');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'Not enough permission');
 		});
 
 		it('should fail if message is a system message', () => {
@@ -2154,8 +2112,8 @@ describe('[Chat]', () => {
 				});
 		});
 
-		it('should fail updating a message with "content" if it is not encrypted', (done) => {
-			void request
+		it('should fail updating a message with "content" if it is not encrypted', async () => {
+			const res = await request
 				.post(api('chat.update'))
 				.set(credentials)
 				.send({
@@ -2167,16 +2125,14 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'Only encrypted messages can have content updated.');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'Only encrypted messages can have content updated.');
 		});
 
-		it('should update a message successfully', (done) => {
-			void request
+		it('should update a message successfully', async () => {
+			const res = await request
 				.post(api('chat.update'))
 				.set(credentials)
 				.send({
@@ -2185,12 +2141,10 @@ describe('[Chat]', () => {
 					text: 'This message was edited via API',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('message.msg', 'This message was edited via API');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('message.msg', 'This message was edited via API');
 		});
 
 		it('should add quote attachments to a message', async () => {
@@ -2450,8 +2404,8 @@ describe('[Chat]', () => {
 					expect(res.body).to.have.property('error', `No message found with the id of "invalid-id".`);
 				});
 		});
-		it('should delete a message successfully', (done) => {
-			void request
+		it('should delete a message successfully', async () => {
+			const res = await request
 				.post(api('chat.delete'))
 				.set(credentials)
 				.send({
@@ -2459,14 +2413,12 @@ describe('[Chat]', () => {
 					msgId,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('sending message as another user...', (done) => {
-			void request
+		it('sending message as another user...', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(userCredentials)
 				.send({
@@ -2476,15 +2428,13 @@ describe('[Chat]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					msgId = res.body.message._id;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			msgId = res.body.message._id;
 		});
-		it('should delete a message successfully when the user deletes a message send by another user', (done) => {
-			void request
+		it('should delete a message successfully when the user deletes a message send by another user', async () => {
+			const res = await request
 				.post(api('chat.delete'))
 				.set(credentials)
 				.send({
@@ -2493,11 +2443,9 @@ describe('[Chat]', () => {
 					asUser: true,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
 		describe('when deleting by fileId', () => {
@@ -2777,8 +2725,8 @@ describe('[Chat]', () => {
 			await sendMessage('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!');
 		});
 
-		it('should return a list of messages when execute successfully', (done) => {
-			void request
+		it('should return a list of messages when execute successfully', async () => {
+			const res = await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
@@ -2786,15 +2734,13 @@ describe('[Chat]', () => {
 					searchText: 'msg1',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
 		});
-		it('should return a list of messages(length=1) when is provided "count" query parameter execute successfully', (done) => {
-			void request
+		it('should return a list of messages(length=1) when is provided "count" query parameter execute successfully', async () => {
+			const res = await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
@@ -2803,16 +2749,14 @@ describe('[Chat]', () => {
 					count: 1,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-					expect(res.body.messages.length).to.equal(1);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
+			expect(res.body.messages.length).to.equal(1);
 		});
-		it('should return a list of messages(length=3) when is provided "count" and "offset" query parameters are executed successfully', (done) => {
-			void request
+		it('should return a list of messages(length=3) when is provided "count" and "offset" query parameters are executed successfully', async () => {
+			const res = await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
@@ -2822,17 +2766,15 @@ describe('[Chat]', () => {
 					count: 3,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-					expect(res.body.messages.length).to.equal(3);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
+			expect(res.body.messages.length).to.equal(3);
 		});
 
-		it('should return a empty list of messages when is provided a huge offset value', (done) => {
-			void request
+		it('should return a empty list of messages when is provided a huge offset value', async () => {
+			const res = await request
 				.get(api('chat.search'))
 				.set(credentials)
 				.query({
@@ -2842,13 +2784,11 @@ describe('[Chat]', () => {
 					count: 3,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-					expect(res.body.messages.length).to.equal(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
+			expect(res.body.messages.length).to.equal(0);
 		});
 
 		it('should return an empty array of messages with status 200 if the regexp starts with an invalid quantifier', async () => {
@@ -2917,8 +2857,8 @@ describe('[Chat]', () => {
 	});
 
 	describe('[/chat.react]', () => {
-		it("should return statusCode: 200 and success when try unreact a message that's no reacted yet", (done) => {
-			void request
+		it("should return statusCode: 200 and success when try unreact a message that's no reacted yet", async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -2927,14 +2867,12 @@ describe('[Chat]', () => {
 					shouldReact: false,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should react a message successfully', (done) => {
-			void request
+		it('should react a message successfully', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -2942,15 +2880,13 @@ describe('[Chat]', () => {
 					messageId: message._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return statusCode: 200 when the emoji is valid', (done) => {
-			void request
+		it('should return statusCode: 200 when the emoji is valid', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -2958,14 +2894,12 @@ describe('[Chat]', () => {
 					messageId: message._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it("should return statusCode: 200 and success when try react a message that's already reacted", (done) => {
-			void request
+		it("should return statusCode: 200 and success when try react a message that's already reacted", async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -2974,14 +2908,12 @@ describe('[Chat]', () => {
 					shouldReact: true,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return statusCode: 200 when unreact a message with flag, shouldReact: false', (done) => {
-			void request
+		it('should return statusCode: 200 when unreact a message with flag, shouldReact: false', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -2990,14 +2922,12 @@ describe('[Chat]', () => {
 					shouldReact: false,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return statusCode: 200 when react a message with flag, shouldReact: true', (done) => {
-			void request
+		it('should return statusCode: 200 when react a message with flag, shouldReact: true', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -3006,14 +2936,12 @@ describe('[Chat]', () => {
 					shouldReact: true,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return statusCode: 200 when the emoji is valid and has no colons', (done) => {
-			void request
+		it('should return statusCode: 200 when the emoji is valid and has no colons', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -3021,14 +2949,12 @@ describe('[Chat]', () => {
 					messageId: message._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return statusCode: 200 for reaction property when the emoji is valid', (done) => {
-			void request
+		it('should return statusCode: 200 for reaction property when the emoji is valid', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -3036,11 +2962,9 @@ describe('[Chat]', () => {
 					messageId: message._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -3113,8 +3037,8 @@ describe('[Chat]', () => {
 
 	describe('[/chat.reportMessage]', () => {
 		describe('when execute successfully', () => {
-			it('should return the statusCode 200', (done) => {
-				void request
+			it('should return the statusCode 200', async () => {
+				const res = await request
 					.post(api('chat.reportMessage'))
 					.set(credentials)
 					.send({
@@ -3122,29 +3046,25 @@ describe('[Chat]', () => {
 						description: 'test',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
 		});
 
 		describe('when an error occurs', () => {
-			it('should return statusCode 400 and an error', (done) => {
-				void request
+			it('should return statusCode 400 and an error', async () => {
+				const res = await request
 					.post(api('chat.reportMessage'))
 					.set(credentials)
 					.send({
 						messageId: message._id,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error');
 			});
 		});
 	});
@@ -3166,8 +3086,8 @@ describe('[Chat]', () => {
 		after(() => deleteRoom({ type: 'c', roomId }));
 
 		describe('when execute successfully', () => {
-			it('should return a list of deleted messages', (done) => {
-				void request
+			it('should return a list of deleted messages', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3175,16 +3095,14 @@ describe('[Chat]', () => {
 						since: new Date('20 December 2018 17:51 UTC').toISOString(),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
-			it('should return a list of deleted messages when the user sets count query parameter', (done) => {
-				void request
+			it('should return a list of deleted messages when the user sets count query parameter', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3193,16 +3111,14 @@ describe('[Chat]', () => {
 						count: 1,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
-			it('should return a list of deleted messages when the user sets count and offset query parameters', (done) => {
-				void request
+			it('should return a list of deleted messages when the user sets count and offset query parameters', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3212,19 +3128,17 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
 		});
 
 		describe('when an error occurs', () => {
-			it('should return statusCode 400', (done) => {
-				void request
+			it('should return statusCode 400', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3233,14 +3147,12 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
-			it('should return statusCode 400 and an error when "since" is not provided', (done) => {
-				void request
+			it('should return statusCode 400 and an error when "since" is not provided', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3249,14 +3161,12 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
-			it('should return statusCode 400 and an error when "since" is provided but it is invalid ISODate', (done) => {
-				void request
+			it('should return statusCode 400 and an error when "since" is provided but it is invalid ISODate', async () => {
+				const res = await request
 					.get(api('chat.getDeletedMessages'))
 					.set(credentials)
 					.query({
@@ -3266,11 +3176,9 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
 		});
 	});
@@ -3280,42 +3188,38 @@ describe('[Chat]', () => {
 			Promise.all([updateSetting('Message_AllowPinning', true), updatePermission('pin-message', ['owner', 'moderator', 'admin'])]),
 		);
 
-		it('should return an error when pinMessage is not allowed in this server', (done) => {
-			void updateSetting('Message_AllowPinning', false).then(() => {
-				void request
-					.post(api('chat.pinMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
-			});
+		it('should return an error when pinMessage is not allowed in this server', async () => {
+			await updateSetting('Message_AllowPinning', false);
+
+			const res = await request
+				.post(api('chat.pinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should return an error when pinMessage is allowed in server but user dont have permission', (done) => {
-			void updateSetting('Message_AllowPinning', true).then(() => {
-				void updatePermission('pin-message', []).then(() => {
-					void request
-						.post(api('chat.pinMessage'))
-						.set(credentials)
-						.send({
-							messageId: message._id,
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body).to.have.property('error');
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when pinMessage is allowed in server but user dont have permission', async () => {
+			await updateSetting('Message_AllowPinning', true);
+
+			await updatePermission('pin-message', []);
+
+			const res = await request
+				.post(api('chat.pinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
 		it('should return an error when messageId does not exist', async () => {
@@ -3333,22 +3237,20 @@ describe('[Chat]', () => {
 				});
 		});
 
-		it('should pin Message successfully', (done) => {
-			void updatePermission('pin-message', ['admin']).then(() => {
-				void request
-					.post(api('chat.pinMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.property('error');
-					})
-					.end(done);
-			});
+		it('should pin Message successfully', async () => {
+			await updatePermission('pin-message', ['admin']);
+
+			const res = await request
+				.post(api('chat.pinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.property('error');
 		});
 
 		it('should return message when its already pinned', async () => {
@@ -3372,140 +3274,126 @@ describe('[Chat]', () => {
 			Promise.all([updateSetting('Message_AllowPinning', true), updatePermission('pin-message', ['owner', 'moderator', 'admin'])]),
 		);
 
-		it('should return an error when pinMessage is not allowed in this server', (done) => {
-			void updateSetting('Message_AllowPinning', false).then(() => {
-				void request
-					.post(api('chat.unPinMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
-			});
+		it('should return an error when pinMessage is not allowed in this server', async () => {
+			await updateSetting('Message_AllowPinning', false);
+
+			const res = await request
+				.post(api('chat.unPinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should return an error when pinMessage is allowed in server but users dont have permission', (done) => {
-			void updateSetting('Message_AllowPinning', true).then(() => {
-				void updatePermission('pin-message', []).then(() => {
-					void request
-						.post(api('chat.unPinMessage'))
-						.set(credentials)
-						.send({
-							messageId: message._id,
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body).to.have.property('error');
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when pinMessage is allowed in server but users dont have permission', async () => {
+			await updateSetting('Message_AllowPinning', true);
+
+			await updatePermission('pin-message', []);
+
+			const res = await request
+				.post(api('chat.unPinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should unpin Message successfully', (done) => {
-			void updatePermission('pin-message', ['admin']).then(() => {
-				void request
-					.post(api('chat.unPinMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.property('error');
-					})
-					.end(done);
-			});
+		it('should unpin Message successfully', async () => {
+			await updatePermission('pin-message', ['admin']);
+
+			const res = await request
+				.post(api('chat.unPinMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.property('error');
 		});
 	});
 
 	describe('[/chat.unStarMessage]', () => {
 		after(() => updateSetting('Message_AllowStarring', true));
 
-		it('should return an error when starMessage is not allowed in this server', (done) => {
-			void updateSetting('Message_AllowStarring', false).then(() => {
-				void request
-					.post(api('chat.unStarMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
-			});
+		it('should return an error when starMessage is not allowed in this server', async () => {
+			await updateSetting('Message_AllowStarring', false);
+
+			const res = await request
+				.post(api('chat.unStarMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should unstar Message successfully', (done) => {
-			void updateSetting('Message_AllowStarring', true).then(() => {
-				void request
-					.post(api('chat.unStarMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.property('error');
-					})
-					.end(done);
-			});
+		it('should unstar Message successfully', async () => {
+			await updateSetting('Message_AllowStarring', true);
+
+			const res = await request
+				.post(api('chat.unStarMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.property('error');
 		});
 	});
 
 	describe('[/chat.starMessage]', () => {
 		after(() => updateSetting('Message_AllowStarring', true));
 
-		it('should return an error when starMessage is not allowed in this server', (done) => {
-			void updateSetting('Message_AllowStarring', false).then(() => {
-				void request
-					.post(api('chat.starMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error');
-					})
-					.end(done);
-			});
+		it('should return an error when starMessage is not allowed in this server', async () => {
+			await updateSetting('Message_AllowStarring', false);
+
+			const res = await request
+				.post(api('chat.starMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should star Message successfully', (done) => {
-			void updateSetting('Message_AllowStarring', true).then(() => {
-				void request
-					.post(api('chat.starMessage'))
-					.set(credentials)
-					.send({
-						messageId: message._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.property('error');
-					})
-					.end(done);
-			});
+		it('should star Message successfully', async () => {
+			await updateSetting('Message_AllowStarring', true);
+
+			const res = await request
+				.post(api('chat.starMessage'))
+				.set(credentials)
+				.send({
+					messageId: message._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.property('error');
 		});
 	});
 
@@ -3622,24 +3510,22 @@ describe('[Chat]', () => {
 		after(() => deleteRoom({ type: 'c', roomId }));
 
 		describe('when execute successfully', () => {
-			it('should return a list of pinned messages', (done) => {
-				void request
+			it('should return a list of pinned messages', async () => {
+				const res = await request
 					.get(api('chat.getPinnedMessages'))
 					.set(credentials)
 					.query({
 						roomId,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
-			it('should return a list of pinned messages when the user sets count query parameter', (done) => {
-				void request
+			it('should return a list of pinned messages when the user sets count query parameter', async () => {
+				const res = await request
 					.get(api('chat.getPinnedMessages'))
 					.set(credentials)
 					.query({
@@ -3647,16 +3533,14 @@ describe('[Chat]', () => {
 						count: 1,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
-			it('should return a list of pinned messages when the user sets count and offset query parameters', (done) => {
-				void request
+			it('should return a list of pinned messages when the user sets count and offset query parameters', async () => {
+				const res = await request
 					.get(api('chat.getPinnedMessages'))
 					.set(credentials)
 					.query({
@@ -3665,19 +3549,17 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body.messages.length).to.be.equal(1);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body.messages.length).to.be.equal(1);
 			});
 		});
 
 		describe('when an error occurs', () => {
-			it('should return statusCode 400 and an error when "roomId" is not provided', (done) => {
-				void request
+			it('should return statusCode 400 and an error when "roomId" is not provided', async () => {
+				const res = await request
 					.get(api('chat.getPinnedMessages'))
 					.set(credentials)
 					.query({
@@ -3685,11 +3567,9 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
 		});
 	});
@@ -3708,48 +3588,42 @@ describe('[Chat]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return an error when the required "roomId" parameter is not sent', (done) => {
-			void request
+		it('should return an error when the required "roomId" parameter is not sent', async () => {
+			const res = await request
 				.get(api('chat.getMentionedMessages'))
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-invalid-params');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-invalid-params');
 		});
 
-		it('should return an error when the roomId is invalid', (done) => {
-			void request
+		it('should return an error when the roomId is invalid', async () => {
+			const res = await request
 				.get(api('chat.getMentionedMessages'))
 				.query({ roomId: 'invalid-room' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('error-not-allowed');
 		});
 
-		it('should return the mentioned messages', (done) => {
-			void request
+		it('should return the mentioned messages', async () => {
+			const res = await request
 				.get(api('chat.getMentionedMessages'))
 				.query({ roomId: testChannel._id })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.messages).to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
 	});
 
@@ -3767,48 +3641,38 @@ describe('[Chat]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return an error when the required "roomId" parameter is not sent', (done) => {
-			void request
-				.get(api('chat.getStarredMessages'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-invalid-params');
-				})
-				.end(done);
+		it('should return an error when the required "roomId" parameter is not sent', async () => {
+			const res = await request.get(api('chat.getStarredMessages')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-invalid-params');
 		});
 
-		it('should return an error when the roomId is invalid', (done) => {
-			void request
+		it('should return an error when the roomId is invalid', async () => {
+			const res = await request
 				.get(api('chat.getStarredMessages'))
 				.query({ roomId: 'invalid-room' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('error-not-allowed');
 		});
 
-		it('should return the starred messages', (done) => {
-			void request
+		it('should return the starred messages', async () => {
+			const res = await request
 				.get(api('chat.getStarredMessages'))
 				.query({ roomId: testChannel._id })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.messages).to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
 	});
 
@@ -3843,50 +3707,40 @@ describe('[Chat]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return an error when the required "roomId" parameter is not sent', (done) => {
-			void request
-				.get(api('chat.getDiscussions'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+		it('should return an error when the required "roomId" parameter is not sent', async () => {
+			const res = await request.get(api('chat.getDiscussions')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should return an error when the roomId is invalid', (done) => {
-			void request
+		it('should return an error when the roomId is invalid', async () => {
+			const res = await request
 				.get(api('chat.getDiscussions'))
 				.query({ roomId: 'invalid-room' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('error-not-allowed');
 		});
 
-		it('should return the discussions of a room', (done) => {
-			void request
+		it('should return the discussions of a room', async () => {
+			const res = await request
 				.get(api('chat.getDiscussions'))
 				.query({ roomId: testChannel._id })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.messages).to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return the discussions of a room even requested with count and offset params', (done) => {
-			void request
+		it('should return the discussions of a room even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('chat.getDiscussions'))
 				.set(credentials)
 				.query({
@@ -3895,20 +3749,18 @@ describe('[Chat]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.messages).to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
 
 		function filterDiscussionsByText(text: string) {
-			it(`should return the room's discussion list filtered by the text '${text}'`, (done) => {
-				void request
+			it(`should return the room's discussion list filtered by the text '${text}'`, async () => {
+				const res = await request
 					.get(api('chat.getDiscussions'))
 					.set(credentials)
 					.query({
@@ -3916,21 +3768,19 @@ describe('[Chat]', () => {
 						text,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.messages).to.have.lengthOf(1);
-						expect(res.body.messages[0].drid).to.be.equal(discussionRoom.rid);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body).to.have.property('total');
+				expect(res.body).to.have.property('offset');
+				expect(res.body).to.have.property('count');
+				expect(res.body.messages).to.have.lengthOf(1);
+				expect(res.body.messages[0].drid).to.be.equal(discussionRoom.rid);
 			});
 
-			it(`should return the room's discussion list filtered by the text '${text}' even requested with count and offset params`, (done) => {
-				void request
+			it(`should return the room's discussion list filtered by the text '${text}' even requested with count and offset params`, async () => {
+				const res = await request
 					.get(api('chat.getDiscussions'))
 					.set(credentials)
 					.query({
@@ -3940,17 +3790,15 @@ describe('[Chat]', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.messages).to.have.lengthOf(1);
-						expect(res.body.messages[0].drid).to.be.equal(discussionRoom.rid);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('messages').and.to.be.an('array');
+				expect(res.body).to.have.property('total');
+				expect(res.body).to.have.property('offset');
+				expect(res.body).to.have.property('count');
+				expect(res.body.messages).to.have.lengthOf(1);
+				expect(res.body.messages[0].drid).to.be.equal(discussionRoom.rid);
 			});
 		}
 
@@ -3968,78 +3816,64 @@ describe('[Chat]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return an error when the required "roomId" parameter is not sent', (done) => {
-			void request
-				.get(api('chat.syncMessages'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-invalid-params');
-					expect(res.body.error).to.include(`must have required property 'roomId'`);
-				})
-				.end(done);
+		it('should return an error when the required "roomId" parameter is not sent', async () => {
+			const res = await request.get(api('chat.syncMessages')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-invalid-params');
+			expect(res.body.error).to.include(`must have required property 'roomId'`);
 		});
 
-		it('should return an error when the neither "lastUpdate" or "type" parameter is sent', (done) => {
-			void request
+		it('should return an error when the neither "lastUpdate" or "type" parameter is sent', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-param-required');
-					expect(res.body.error).to.include('The "type" or "lastUpdate" parameters must be provided');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-param-required');
+			expect(res.body.error).to.include('The "type" or "lastUpdate" parameters must be provided');
 		});
 
-		it('should return an error when the "lastUpdate" parameter is invalid', (done) => {
-			void request
+		it('should return an error when the "lastUpdate" parameter is invalid', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: 'invalid-room', lastUpdate: 'invalid-date' })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-lastUpdate-param-invalid');
-					expect(res.body.error).to.include('The "lastUpdate" query parameter must be a valid date');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-lastUpdate-param-invalid');
+			expect(res.body.error).to.include('The "lastUpdate" query parameter must be a valid date');
 		});
 
-		it('should return an error when user provides an invalid roomId', (done) => {
-			void request
+		it('should return an error when user provides an invalid roomId', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: 'invalid-room', lastUpdate: new Date().toISOString() })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-not-allowed');
-					expect(res.body.error).to.include('Not allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-not-allowed');
+			expect(res.body.error).to.include('Not allowed');
 		});
 
-		it('should return an error when the "type" parameter is not supported', (done) => {
-			void request
+		it('should return an error when the "type" parameter is not supported', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id, type: 'invalid-type', next: new Date().toISOString() })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-invalid-params');
-					expect(res.body.error).to.include('must be equal to one of the allowed values');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-invalid-params');
+			expect(res.body.error).to.include('must be equal to one of the allowed values');
 		});
 
 		it('should return an error when the "next" or "previous" parameter is sent without the "type" parameter', async () => {
@@ -4064,66 +3898,58 @@ describe('[Chat]', () => {
 			expect(previousResponse.body.error).to.include('The "type" or "lastUpdate" parameters must be provided');
 		});
 
-		it('should return an error when both "next" and "previous" are sent', (done) => {
-			void request
+		it('should return an error when both "next" and "previous" are sent', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id, type: 'UPDATED', next: new Date().toISOString(), previous: new Date().toISOString() })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-cursor-conflict');
-					expect(res.body.error).to.include('You cannot provide both "next" and "previous" parameters');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-cursor-conflict');
+			expect(res.body.error).to.include('You cannot provide both "next" and "previous" parameters');
 		});
 
-		it('should return an error when both "next" or "previous" and "lastUpdate" are sent', (done) => {
-			void request
+		it('should return an error when both "next" or "previous" and "lastUpdate" are sent', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id, type: 'UPDATED', next: new Date().toISOString(), lastUpdate: new Date().toISOString() })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-cursor-and-lastUpdate-conflict');
-					expect(res.body.error).to.include('The attributes "next", "previous" and "lastUpdate" cannot be used together');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-cursor-and-lastUpdate-conflict');
+			expect(res.body.error).to.include('The attributes "next", "previous" and "lastUpdate" cannot be used together');
 		});
 
-		it('should return an error when neither "type" or "lastUpdate" are sent', (done) => {
-			void request
+		it('should return an error when neither "type" or "lastUpdate" are sent', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-param-required');
-					expect(res.body.error).to.include('The "type" or "lastUpdate" parameters must be provided');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-param-required');
+			expect(res.body.error).to.include('The "type" or "lastUpdate" parameters must be provided');
 		});
 
-		it('should return an empty response when there are no messages to sync', (done) => {
-			void request
+		it('should return an empty response when there are no messages to sync', async () => {
+			const res = await request
 				.get(api('chat.syncMessages'))
 				.set(credentials)
 				.query({ roomId: testChannel._id, lastUpdate: new Date().toISOString() })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.result).to.have.property('updated').and.to.be.an('array');
-					expect(res.body.result).to.have.property('deleted').and.to.be.an('array');
-					expect(res.body.result.updated).to.have.lengthOf(0);
-					expect(res.body.result.deleted).to.have.lengthOf(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.result).to.have.property('updated').and.to.be.an('array');
+			expect(res.body.result).to.have.property('deleted').and.to.be.an('array');
+			expect(res.body.result.updated).to.have.lengthOf(0);
+			expect(res.body.result.deleted).to.have.lengthOf(0);
 		});
 
 		it('should return all updated and deleted messages since "lastUpdate" parameter date', async () => {
@@ -4333,23 +4159,21 @@ describe('Threads', () => {
 			]),
 		);
 
-		it('should return an error for chat.getThreadsList when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.get(api('chat.getThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.getThreadsList when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.get(api('chat.getThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -4378,27 +4202,25 @@ describe('Threads', () => {
 			});
 		});
 
-		it("should return the room's thread list", (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.getThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.threads).to.have.lengthOf(1);
-						expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
-					})
-					.end(done);
-			});
+		it("should return the room's thread list", async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.getThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('threads').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body.threads).to.have.lengthOf(1);
+			expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
 		});
 
 		it("should fail returning a room's thread list if no roomId is provided", async () => {
@@ -4451,34 +4273,32 @@ describe('Threads', () => {
 				});
 		});
 
-		it("should return the room's thread list even requested with count and offset params", (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.getThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-						count: 5,
-						offset: 0,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.threads).to.have.lengthOf(1);
-						expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
-					})
-					.end(done);
-			});
+		it("should return the room's thread list even requested with count and offset params", async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.getThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+					count: 5,
+					offset: 0,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('threads').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body.threads).to.have.lengthOf(1);
+			expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
 		});
 
 		function filterThreadsByText(text: string) {
-			it(`should return the room's thread list filtered by the text '${text}'`, (done) => {
-				void request
+			it(`should return the room's thread list filtered by the text '${text}'`, async () => {
+				const res = await request
 					.get(api('chat.getThreadsList'))
 					.set(credentials)
 					.query({
@@ -4486,20 +4306,18 @@ describe('Threads', () => {
 						text,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.threads).to.have.lengthOf(1);
-						expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('threads').and.to.be.an('array');
+				expect(res.body).to.have.property('total');
+				expect(res.body).to.have.property('offset');
+				expect(res.body).to.have.property('count');
+				expect(res.body.threads).to.have.lengthOf(1);
+				expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
 			});
-			it(`should return the room's thread list filtered by the text '${text}' even requested with count and offset params`, (done) => {
-				void request
+			it(`should return the room's thread list filtered by the text '${text}' even requested with count and offset params`, async () => {
+				const res = await request
 					.get(api('chat.getThreadsList'))
 					.set(credentials)
 					.query({
@@ -4509,17 +4327,15 @@ describe('Threads', () => {
 						offset: 0,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.threads).to.have.lengthOf(1);
-						expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('threads').and.to.be.an('array');
+				expect(res.body).to.have.property('total');
+				expect(res.body).to.have.property('offset');
+				expect(res.body).to.have.property('count');
+				expect(res.body.threads).to.have.lengthOf(1);
+				expect(res.body.threads[0]._id).to.be.equal(threadMessage.tmid);
 			});
 		}
 
@@ -4527,27 +4343,25 @@ describe('Threads', () => {
 			filterThreadsByText(text);
 		});
 
-		it('should return an empty thread list', (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.getThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-						text: 'missing',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('array');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.threads).to.have.lengthOf(0);
-					})
-					.end(done);
-			});
+		it('should return an empty thread list', async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.getThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+					text: 'missing',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('threads').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body.threads).to.have.lengthOf(0);
 		});
 	});
 
@@ -4581,76 +4395,68 @@ describe('Threads', () => {
 			]),
 		);
 
-		it('should return an error for chat.getThreadsList when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.get(api('chat.getThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.getThreadsList when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.get(api('chat.getThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
 		});
 
-		it('should return an error when the required param "rid" is missing', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadsList'))
-					.set(credentials)
-					.query({})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the required param "rid" is missing', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadsList'))
+				.set(credentials)
+				.query({})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
-		it('should return an error when the required param "updatedSince" is missing', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the required param "updatedSince" is missing', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
-		it('should return an error when the param "updatedSince" is an invalid date', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-						updatedSince: 'invalid-date',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the param "updatedSince" is an invalid date', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+					updatedSince: 'invalid-date',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -4678,28 +4484,26 @@ describe('Threads', () => {
 			});
 		});
 
-		it("should return the room's thread synced list", (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.syncThreadsList'))
-					.set(credentials)
-					.query({
-						rid: testChannel._id,
-						updatedSince: new Date('2019-04-01').toISOString(),
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('threads').and.to.be.an('object');
-						expect(res.body.threads).to.have.property('update').and.to.be.an('array');
-						expect(res.body.threads).to.have.property('remove').and.to.be.an('array');
-						expect(res.body.threads.update).to.have.lengthOf(1);
-						expect(res.body.threads.remove).to.have.lengthOf(0);
-						expect(res.body.threads.update[0]._id).to.be.equal(threadMessage.tmid);
-					})
-					.end(done);
-			});
+		it("should return the room's thread synced list", async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.syncThreadsList'))
+				.set(credentials)
+				.query({
+					rid: testChannel._id,
+					updatedSince: new Date('2019-04-01').toISOString(),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('threads').and.to.be.an('object');
+			expect(res.body.threads).to.have.property('update').and.to.be.an('array');
+			expect(res.body.threads).to.have.property('remove').and.to.be.an('array');
+			expect(res.body.threads.update).to.have.lengthOf(1);
+			expect(res.body.threads.remove).to.have.lengthOf(0);
+			expect(res.body.threads.update[0]._id).to.be.equal(threadMessage.tmid);
 		});
 	});
 
@@ -4736,23 +4540,21 @@ describe('Threads', () => {
 			]),
 		);
 
-		it('should return an error for chat.getThreadMessages when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.get(api('chat.getThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.getThreadMessages when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.get(api('chat.getThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -4781,27 +4583,25 @@ describe('Threads', () => {
 			});
 		});
 
-		it("should return the thread's message list", (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.getThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('array');
-						expect(res.body).to.have.property('total').and.to.be.equal(1);
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('count');
-						expect(res.body.messages).to.have.lengthOf(1);
-						expect(res.body.messages[0].tmid).to.be.equal(createdThreadMessage._id);
-					})
-					.end(done);
-			});
+		it("should return the thread's message list", async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.getThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('array');
+			expect(res.body).to.have.property('total').and.to.be.equal(1);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body.messages).to.have.lengthOf(1);
+			expect(res.body.messages[0].tmid).to.be.equal(createdThreadMessage._id);
 		});
 	});
 
@@ -4930,77 +4730,69 @@ describe('Threads', () => {
 			]),
 		);
 
-		it('should return an error for chat.syncThreadMessages when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.get(api('chat.syncThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-						updatedSince: new Date().toISOString(),
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.syncThreadMessages when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.get(api('chat.syncThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+					updatedSince: new Date().toISOString(),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'Threads Disabled [error-not-allowed]');
 		});
 
-		it('should return an error when the required param "tmid" is missing', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadMessages'))
-					.set(credentials)
-					.query({})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the required param "tmid" is missing', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadMessages'))
+				.set(credentials)
+				.query({})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
-		it('should return an error when the required param "updatedSince" is missing', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the required param "updatedSince" is missing', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
-		it('should return an error when the param "updatedSince" is an invalid date', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.get(api('chat.syncThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-						updatedSince: 'invalid-date',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-params');
-					})
-					.end(done);
-			});
+		it('should return an error when the param "updatedSince" is an invalid date', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.get(api('chat.syncThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+					updatedSince: 'invalid-date',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-params');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -5028,28 +4820,26 @@ describe('Threads', () => {
 			});
 		});
 
-		it("should return the thread's message list", (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.get(api('chat.syncThreadMessages'))
-					.set(credentials)
-					.query({
-						tmid: threadMessage.tmid,
-						updatedSince: new Date('2019-04-01').toISOString(),
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('messages').and.to.be.an('object');
-						expect(res.body.messages).to.have.property('update').and.to.be.an('array');
-						expect(res.body.messages).to.have.property('remove').and.to.be.an('array');
-						expect(res.body.messages.update).to.have.lengthOf(1);
-						expect(res.body.messages.remove).to.have.lengthOf(0);
-						expect(res.body.messages.update[0].id).to.be.equal(createdThreadMessage.tmid);
-					})
-					.end(done);
-			});
+		it("should return the thread's message list", async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.get(api('chat.syncThreadMessages'))
+				.set(credentials)
+				.query({
+					tmid: threadMessage.tmid,
+					updatedSince: new Date('2019-04-01').toISOString(),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('object');
+			expect(res.body.messages).to.have.property('update').and.to.be.an('array');
+			expect(res.body.messages).to.have.property('remove').and.to.be.an('array');
+			expect(res.body.messages.update).to.have.lengthOf(1);
+			expect(res.body.messages.remove).to.have.lengthOf(0);
+			expect(res.body.messages.update[0].id).to.be.equal(createdThreadMessage.tmid);
 		});
 	});
 
@@ -5083,42 +4873,38 @@ describe('Threads', () => {
 			]),
 		);
 
-		it('should return an error for chat.followMessage when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.post(api('chat.followMessage'))
-					.set(credentials)
-					.send({
-						mid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'not-allowed [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.followMessage when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.post(api('chat.followMessage'))
+				.set(credentials)
+				.send({
+					mid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'not-allowed [error-not-allowed]');
 		});
 
-		it('should return an error when the message does not exist', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.post(api('chat.followMessage'))
-					.set(credentials)
-					.send({
-						mid: 'invalid-message-id',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-message');
-						expect(res.body).to.have.property('error', 'Invalid message [error-invalid-message]');
-					})
-					.end(done);
-			});
+		it('should return an error when the message does not exist', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.post(api('chat.followMessage'))
+				.set(credentials)
+				.send({
+					mid: 'invalid-message-id',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-message');
+			expect(res.body).to.have.property('error', 'Invalid message [error-invalid-message]');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -5145,21 +4931,19 @@ describe('Threads', () => {
 			});
 		});
 
-		it('should return success: true when it execute successfully', (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.post(api('chat.followMessage'))
-					.set(credentials)
-					.send({
-						mid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
-			});
+		it('should return success: true when it execute successfully', async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.post(api('chat.followMessage'))
+				.set(credentials)
+				.send({
+					mid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -5192,42 +4976,38 @@ describe('Threads', () => {
 				deleteUser(user),
 			]),
 		);
-		it('should return an error for chat.unfollowMessage when threads are not allowed in this server', (done) => {
-			void updateSetting('Threads_enabled', false).then(() => {
-				void request
-					.post(api('chat.unfollowMessage'))
-					.set(credentials)
-					.send({
-						mid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-						expect(res.body).to.have.property('error', 'not-allowed [error-not-allowed]');
-					})
-					.end(done);
-			});
+		it('should return an error for chat.unfollowMessage when threads are not allowed in this server', async () => {
+			await updateSetting('Threads_enabled', false);
+
+			const res = await request
+				.post(api('chat.unfollowMessage'))
+				.set(credentials)
+				.send({
+					mid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
+			expect(res.body).to.have.property('error', 'not-allowed [error-not-allowed]');
 		});
 
-		it('should return an error when the message does not exist', (done) => {
-			void updateSetting('Threads_enabled', true).then(() => {
-				void request
-					.post(api('chat.unfollowMessage'))
-					.set(credentials)
-					.send({
-						mid: 'invalid-message-id',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-message');
-						expect(res.body).to.have.property('error', 'Invalid message [error-invalid-message]');
-					})
-					.end(done);
-			});
+		it('should return an error when the message does not exist', async () => {
+			await updateSetting('Threads_enabled', true);
+
+			const res = await request
+				.post(api('chat.unfollowMessage'))
+				.set(credentials)
+				.send({
+					mid: 'invalid-message-id',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-message');
+			expect(res.body).to.have.property('error', 'Invalid message [error-invalid-message]');
 		});
 
 		it('should return an error when the user is not allowed access the room', (done) => {
@@ -5254,21 +5034,19 @@ describe('Threads', () => {
 			});
 		});
 
-		it('should return success: true when it execute successfully', (done) => {
-			void updatePermission('view-c-room', ['admin', 'user']).then(() => {
-				void request
-					.post(api('chat.unfollowMessage'))
-					.set(credentials)
-					.send({
-						mid: threadMessage.tmid,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
-			});
+		it('should return success: true when it execute successfully', async () => {
+			await updatePermission('view-c-room', ['admin', 'user']);
+
+			const res = await request
+				.post(api('chat.unfollowMessage'))
+				.set(credentials)
+				.send({
+					mid: threadMessage.tmid,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/commands.ts
+++ b/apps/meteor/tests/end-to-end/api/commands.ts
@@ -15,83 +15,67 @@ describe('[Commands]', () => {
 	before((done) => getCredentials(done));
 
 	describe('[/commands.get]', () => {
-		it('should return an error when call the endpoint without "command" required parameter', (done) => {
-			void request
-				.get(api('commands.get'))
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal(`must have required property 'command'`);
-				})
-				.end(done);
+		it('should return an error when call the endpoint without "command" required parameter', async () => {
+			const res = await request.get(api('commands.get')).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal(`must have required property 'command'`);
 		});
-		it('should return an error when call the endpoint with an invalid command', (done) => {
-			void request
+		it('should return an error when call the endpoint with an invalid command', async () => {
+			const res = await request
 				.get(api('commands.get'))
 				.set(credentials)
 				.query({
 					command: 'invalid-command',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('There is no command in the system by the name of: invalid-command');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('There is no command in the system by the name of: invalid-command');
 		});
-		it('should return success when parameters are correct', (done) => {
-			void request
+		it('should return success when parameters are correct', async () => {
+			const res = await request
 				.get(api('commands.get'))
 				.set(credentials)
 				.query({
 					command: 'help',
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('command');
-					expect(res.body.command).to.have.property('command');
-					expect(res.body.command).to.have.property('description');
-					expect(res.body.command).to.have.property('clientOnly');
-					expect(res.body.command).to.have.property('providesPreview');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('command');
+			expect(res.body.command).to.have.property('command');
+			expect(res.body.command).to.have.property('description');
+			expect(res.body.command).to.have.property('clientOnly');
+			expect(res.body.command).to.have.property('providesPreview');
 		});
 	});
 
 	describe('[/commands.list]', () => {
-		it('should return a list of commands', (done) => {
-			void request
-				.get(api('commands.list'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('commands').and.to.be.an('array');
-				})
-				.end(done);
+		it('should return a list of commands', async () => {
+			const res = await request.get(api('commands.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('commands').and.to.be.an('array');
 		});
-		it('should return a list of commands even requested with count and offset params', (done) => {
-			void request
+		it('should return a list of commands even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('commands.list'))
 				.set(credentials)
 				.query({
 					count: 5,
 					offset: 0,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('commands').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('commands').and.to.be.an('array');
 		});
 	});
 
@@ -117,20 +101,15 @@ describe('[Commands]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return an error when call the endpoint without "command" required parameter', (done) => {
-			void request
-				.post(api('commands.run'))
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal("must have required property 'command'");
-				})
-				.end(done);
+		it('should return an error when call the endpoint without "command" required parameter', async () => {
+			const res = await request.post(api('commands.run')).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal("must have required property 'command'");
 		});
 
-		it('should coerce non-string "params" to string via ajv coercion', (done) => {
-			void request
+		it('should coerce non-string "params" to string via ajv coercion', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -138,29 +117,25 @@ describe('[Commands]', () => {
 					roomId: 'GENERAL',
 					params: true,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return an error when call the endpoint without "roomId" required parameter', (done) => {
-			void request
+		it('should return an error when call the endpoint without "roomId" required parameter', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
 					command: 'help',
 					params: 'params',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal("must have required property 'roomId'");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal("must have required property 'roomId'");
 		});
-		it('should coerce non-string "tmid" to string via ajv coercion and fail with invalid thread', (done) => {
-			void request
+		it('should coerce non-string "tmid" to string via ajv coercion and fail with invalid thread', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -169,15 +144,13 @@ describe('[Commands]', () => {
 					roomId: 'GENERAL',
 					tmid: true,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('Invalid thread.');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('Invalid thread.');
 		});
-		it('should return an error when call the endpoint with the invalid "command" param', (done) => {
-			void request
+		it('should return an error when call the endpoint with the invalid "command" param', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -185,15 +158,13 @@ describe('[Commands]', () => {
 					params: 'params',
 					roomId: 'GENERAL',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('The command provided does not exist (or is disabled).');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('The command provided does not exist (or is disabled).');
 		});
-		it('should return an error when call the endpoint with an invalid thread id', (done) => {
-			void request
+		it('should return an error when call the endpoint with an invalid thread id', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -202,15 +173,13 @@ describe('[Commands]', () => {
 					roomId: 'GENERAL',
 					tmid: 'invalid-thread',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('Invalid thread.');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('Invalid thread.');
 		});
-		it('should return an error when call the endpoint with a valid thread id of wrong channel', (done) => {
-			void request
+		it('should return an error when call the endpoint with a valid thread id of wrong channel', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -219,15 +188,13 @@ describe('[Commands]', () => {
 					roomId: 'GENERAL',
 					tmid: threadMessage.tmid,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('Invalid thread.');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('Invalid thread.');
 		});
-		it('should return success when parameters are correct', (done) => {
-			void request
+		it('should return success when parameters are correct', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(credentials)
 				.send({
@@ -236,11 +203,9 @@ describe('[Commands]', () => {
 					roomId: threadMessage.rid,
 					tmid: threadMessage.tmid,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -529,17 +494,15 @@ describe('[Commands]', () => {
 			await Promise.all([deleteUser(user1)]);
 		});
 
-		it('should fail when trying to kick a user from a direct message room', (done) => {
-			void request
+		it('should fail when trying to kick a user from a direct message room', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(user1Credentials)
 				.send({ command: 'kick', roomId: directMessageRoom._id, params: user1.username })
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.is.a('string');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.is.a('string');
 		});
 	});
 	describe('Command "leave"', function () {
@@ -566,17 +529,15 @@ describe('[Commands]', () => {
 			await Promise.all([deleteUser(user1), deleteUser(user2)]);
 		});
 
-		it('should fail when trying to leave a direct message room', (done) => {
-			void request
+		it('should fail when trying to leave a direct message room', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(user1Credentials)
 				.send({ command: 'leave', roomId: directMessageRoom._id })
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.is.a('string');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.is.a('string');
 		});
 	});
 
@@ -605,18 +566,16 @@ describe('[Commands]', () => {
 			await Promise.all([deleteUser(user1), deleteUser(user2)]);
 		});
 
-		it('should fail when trying to invite a user to a direct message room', (done) => {
-			void request
+		it('should fail when trying to invite a user to a direct message room', async () => {
+			const res = await request
 				.post(api('commands.run'))
 				.set(user1Credentials)
 				.send({ command: 'invite', roomId: directMessageRoom._id, params: 'g1' })
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.is.a('string');
-					expect(res.body.error).to.equal('unauthorized');
-				})
-				.end(done);
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.is.a('string');
+			expect(res.body.error).to.equal('unauthorized');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/cors.ts
+++ b/apps/meteor/tests/end-to-end/api/cors.ts
@@ -23,12 +23,12 @@ describe('[CORS]', () => {
 	});
 
 	describe('[/meteor_runtime_config.js]', () => {
-		it('should return 404 when hash is missing', (done) => {
-			void request.get('/meteor_runtime_config.js').expect(404).end(done);
+		it('should return 404 when hash is missing', async () => {
+			await request.get('/meteor_runtime_config.js').expect(404);
 		});
 
-		it('should return 404 when hash is invalid', (done) => {
-			void request.get('/meteor_runtime_config.js').query({ hash: 'invalid_hash' }).expect(404).end(done);
+		it('should return 404 when hash is invalid', async () => {
+			await request.get('/meteor_runtime_config.js').query({ hash: 'invalid_hash' }).expect(404);
 		});
 
 		it('should return runtime config when hash matches', async () => {
@@ -47,9 +47,9 @@ describe('[CORS]', () => {
 				});
 		});
 
-		it('should return 404 when hash does not match', (done) => {
+		it('should return 404 when hash does not match', async () => {
 			// First get the root page to extract the hash
-			void request.get('/meteor_runtime_config.js').query({ hash: 'invalidHash' }).expect(404).end(done);
+			await request.get('/meteor_runtime_config.js').query({ hash: 'invalidHash' }).expect(404);
 		});
 
 		it('should update hash when ROOT_URL changes', async () => {

--- a/apps/meteor/tests/end-to-end/api/custom-sounds.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-sounds.ts
@@ -416,38 +416,27 @@ describe('[CustomSounds]', () => {
 	});
 
 	describe('[/custom-sounds.list]', () => {
-		it('should return custom sounds', (done) => {
-			void request
-				.get(api('custom-sounds.list'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('sounds').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return custom sounds', async () => {
+			const res = await request.get(api('custom-sounds.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('sounds').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return custom sounds even requested with count and offset params', (done) => {
-			void request
-				.get(api('custom-sounds.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					count: 5,
-					offset: 0,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('sounds').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return custom sounds even requested with count and offset params', async () => {
+			const res = await request.get(api('custom-sounds.list')).set(credentials).expect(200).query({
+				count: 5,
+				offset: 0,
+			});
+
+			expect(res.body).to.have.property('sounds').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return custom sounds filtering it using the `name` parameter', (done) => {
-			void request
+		it('should return custom sounds filtering it using the `name` parameter', async () => {
+			const res = await request
 				.get(api('custom-sounds.list'))
 				.set(credentials)
 				.expect(200)
@@ -455,15 +444,13 @@ describe('[CustomSounds]', () => {
 					name: `${fileName}-2`,
 					count: 5,
 					offset: 0,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('sounds').and.to.be.an('array');
-					expect(res.body).to.have.property('total').to.equal(1);
-					expect(res.body).to.have.property('offset').to.equal(0);
-					expect(res.body).to.have.property('count').to.equal(1);
-					expect(res.body.sounds[0]._id).to.be.equal(fileId2);
-				})
-				.end(done);
+				});
+
+			expect(res.body).to.have.property('sounds').and.to.be.an('array');
+			expect(res.body).to.have.property('total').to.equal(1);
+			expect(res.body).to.have.property('offset').to.equal(0);
+			expect(res.body).to.have.property('count').to.equal(1);
+			expect(res.body.sounds[0]._id).to.be.equal(fileId2);
 		});
 	});
 
@@ -540,58 +527,41 @@ describe('[CustomSounds]', () => {
 	});
 
 	describe('Accessing custom sounds', () => {
-		it('should return forbidden if the there is no fileId on the url', (done) => {
-			void request
-				.get('/custom-sounds/')
-				.set(credentials)
-				.expect(403)
-				.expect((res) => {
-					expect(res.text).to.be.equal('Forbidden');
-				})
-				.end(done);
+		it('should return forbidden if the there is no fileId on the url', async () => {
+			const res = await request.get('/custom-sounds/').set(credentials).expect(403);
+
+			expect(res.text).to.be.equal('Forbidden');
 		});
 
-		it('should return not found if the the requested file does not exists', (done) => {
-			void request
-				.get('/custom-sounds/invalid.mp3')
-				.set(credentials)
-				.expect(404)
-				.expect((res) => {
-					expect(res.text).to.be.equal('Not found');
-				})
-				.end(done);
+		it('should return not found if the the requested file does not exists', async () => {
+			const res = await request.get('/custom-sounds/invalid.mp3').set(credentials).expect(404);
+
+			expect(res.text).to.be.equal('Not found');
 		});
 
-		it('should return success if the the requested exists', (done) => {
-			void request
-				.get(`/custom-sounds/${fileId}.wav`)
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified');
-					expect(res.headers).to.have.property('content-type', 'audio/wav');
-					expect(res.headers).to.have.property('cache-control', 'public, max-age=0');
-					expect(res.headers).to.have.property('expires', '-1');
-					uploadDate = res.headers['last-modified'];
-				})
-				.end(done);
+		it('should return success if the the requested exists', async () => {
+			const res = await request.get(`/custom-sounds/${fileId}.wav`).set(credentials).expect(200);
+
+			expect(res.headers).to.have.property('last-modified');
+			expect(res.headers).to.have.property('content-type', 'audio/wav');
+			expect(res.headers).to.have.property('cache-control', 'public, max-age=0');
+			expect(res.headers).to.have.property('expires', '-1');
+			uploadDate = res.headers['last-modified'];
 		});
 
-		it('should return not modified if the the requested file contains a valid-since equal to the upload date', (done) => {
-			void request
+		it('should return not modified if the the requested file contains a valid-since equal to the upload date', async () => {
+			const res = await request
 				.get(`/custom-sounds/${fileId}.wav`)
 				.set(credentials)
 				.set({
 					'if-modified-since': uploadDate,
 				})
-				.expect(304)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified', uploadDate);
-					expect(res.headers).not.to.have.property('content-type');
-					expect(res.headers).not.to.have.property('cache-control');
-					expect(res.headers).not.to.have.property('expires');
-				})
-				.end(done);
+				.expect(304);
+
+			expect(res.headers).to.have.property('last-modified', uploadDate);
+			expect(res.headers).not.to.have.property('content-type');
+			expect(res.headers).not.to.have.property('cache-control');
+			expect(res.headers).not.to.have.property('expires');
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/custom-user-status.ts
+++ b/apps/meteor/tests/end-to-end/api/custom-user-status.ts
@@ -44,87 +44,58 @@ describe('[CustomUserStatus]', () => {
 			await deleteCustomUserStatus(customUserStatusId);
 		});
 
-		it('should return custom user status', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return custom user status', async () => {
+			const res = await request.get(api('custom-user-status.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('statuses').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
 
-		it('should return custom user status even requested with count and offset params', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					count: 5,
-					offset: 0,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return custom user status even requested with count and offset params', async () => {
+			const res = await request.get(api('custom-user-status.list')).set(credentials).expect(200).query({
+				count: 5,
+				offset: 0,
+			});
+
+			expect(res.body).to.have.property('statuses').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
 
-		it('should return one custom user status when requested with id param', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					_id: customUserStatusId,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('total').and.to.equal(1);
-					expect(res.body).to.have.property('offset').and.to.equal(0);
-					expect(res.body).to.have.property('count').and.to.equal(1);
-				})
-				.end(done);
+		it('should return one custom user status when requested with id param', async () => {
+			const res = await request.get(api('custom-user-status.list')).set(credentials).expect(200).query({
+				_id: customUserStatusId,
+			});
+
+			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+			expect(res.body).to.have.property('total').and.to.equal(1);
+			expect(res.body).to.have.property('offset').and.to.equal(0);
+			expect(res.body).to.have.property('count').and.to.equal(1);
 		});
 
-		it('should return empty array when requested with an existing name param', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					name: customUserStatusName,
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('total').and.to.equal(1);
-					expect(res.body).to.have.property('offset').and.to.equal(0);
-					expect(res.body).to.have.property('count').and.to.equal(1);
-				})
-				.end(done);
+		it('should return empty array when requested with an existing name param', async () => {
+			const res = await request.get(api('custom-user-status.list')).set(credentials).expect(200).query({
+				name: customUserStatusName,
+			});
+
+			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(1);
+			expect(res.body).to.have.property('total').and.to.equal(1);
+			expect(res.body).to.have.property('offset').and.to.equal(0);
+			expect(res.body).to.have.property('count').and.to.equal(1);
 		});
 
-		it('should return empty array when requested with unknown name param', (done) => {
-			void request
-				.get(api('custom-user-status.list'))
-				.set(credentials)
-				.expect(200)
-				.query({
-					name: 'testxxx',
-				})
-				.expect((res) => {
-					expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(0);
-					expect(res.body).to.have.property('total').and.to.equal(0);
-					expect(res.body).to.have.property('offset').and.to.equal(0);
-					expect(res.body).to.have.property('count').and.to.equal(0);
-				})
-				.end(done);
+		it('should return empty array when requested with unknown name param', async () => {
+			const res = await request.get(api('custom-user-status.list')).set(credentials).expect(200).query({
+				name: 'testxxx',
+			});
+
+			expect(res.body).to.have.property('statuses').and.to.be.an('array').and.to.have.lengthOf(0);
+			expect(res.body).to.have.property('total').and.to.equal(0);
+			expect(res.body).to.have.property('offset').and.to.equal(0);
+			expect(res.body).to.have.property('count').and.to.equal(0);
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/direct-message.ts
+++ b/apps/meteor/tests/end-to-end/api/direct-message.ts
@@ -1058,8 +1058,11 @@ describe('[Direct Messages]', () => {
 					data: {
 						name: updatedName,
 					},
-				});
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
 
+			expect(res.body).to.have.property('success', true);
 			expect(res.body.user).to.have.property('name', updatedName);
 		});
 

--- a/apps/meteor/tests/end-to-end/api/direct-message.ts
+++ b/apps/meteor/tests/end-to-end/api/direct-message.ts
@@ -116,8 +116,8 @@ describe('[Direct Messages]', () => {
 	});
 
 	describe('/im.setTopic', () => {
-		it('should set the topic of the DM with a string', (done) => {
-			void request
+		it('should set the topic of the DM with a string', async () => {
+			const res = await request
 				.post(api('im.setTopic'))
 				.set(credentials)
 				.send({
@@ -125,15 +125,13 @@ describe('[Direct Messages]', () => {
 					topic: `a direct message with ${user.username}`,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', `a direct message with ${user.username}`);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', `a direct message with ${user.username}`);
 		});
-		it('should set the topic of DM with an empty string(remove the topic)', (done) => {
-			void request
+		it('should set the topic of DM with an empty string(remove the topic)', async () => {
+			const res = await request
 				.post(api('im.setTopic'))
 				.set(credentials)
 				.send({
@@ -141,20 +139,18 @@ describe('[Direct Messages]', () => {
 					topic: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', '');
 		});
 	});
 
 	describe('Testing DM info', () => {
 		let dmMessage: IMessage;
 
-		it('sending a message...', (done) => {
-			void request
+		it('sending a message...', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -164,15 +160,13 @@ describe('[Direct Messages]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					dmMessage = res.body.message;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			dmMessage = res.body.message;
 		});
-		it('REACTing with last message', (done) => {
-			void request
+		it('REACTing with last message', async () => {
+			const res = await request
 				.post(api('chat.react'))
 				.set(credentials)
 				.send({
@@ -180,75 +174,65 @@ describe('[Direct Messages]', () => {
 					messageId: dmMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('STARring last message', (done) => {
-			void request
+		it('STARring last message', async () => {
+			const res = await request
 				.post(api('chat.starMessage'))
 				.set(credentials)
 				.send({
 					messageId: dmMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('PINning last message', (done) => {
-			void request
+		it('PINning last message', async () => {
+			const res = await request
 				.post(api('chat.pinMessage'))
 				.set(credentials)
 				.send({
 					messageId: dmMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return all DM messages where the last message of array should have the "star" array with USERS star ONLY', (done) => {
-			void request
+		it('should return all DM messages where the last message of array should have the "star" array with USERS star ONLY', async () => {
+			const res = await request
 				.get(api('im.messages'))
 				.set(credentials)
 				.query({
 					roomId: testDM._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages').and.to.be.an('array');
-					const messages = res.body.messages as IMessage[];
-					const lastMessage = messages.filter((message) => message._id === dmMessage._id)[0];
-					expect(lastMessage).to.have.property('starred').and.to.be.an('array');
-					expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('array');
+			const messages = res.body.messages as IMessage[];
+			const lastMessage = messages.filter((message) => message._id === dmMessage._id)[0];
+			expect(lastMessage).to.have.property('starred').and.to.be.an('array');
+			expect(lastMessage.starred?.[0]._id).to.be.equal(adminUsername);
 		});
 	});
 
-	it('/im.history', (done) => {
-		void request
+	it('/im.history', async () => {
+		const res = await request
 			.get(api('im.history'))
 			.set(credentials)
 			.query({
 				roomId: directMessage._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('messages');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('messages');
 	});
 
 	describe('/im.history inclusive parameter', () => {
@@ -353,28 +337,22 @@ describe('[Direct Messages]', () => {
 		});
 	});
 
-	it('/im.list', (done) => {
-		void request
-			.get(api('im.list'))
-			.set(credentials)
-			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('count');
-				expect(res.body).to.have.property('total');
-				expect(res.body).to.have.property('ims').and.to.be.an('array');
-				const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id);
-				expect(im).to.have.property('_id');
-				expect(im).to.have.property('t').and.to.be.eq('d');
-				expect(im).to.have.property('msgs').and.to.be.a('number');
-				expect(im).to.have.property('usernames').and.to.be.an('array');
-				expect(im).to.have.property('lm');
-				expect(im).to.have.property('_updatedAt');
-				expect(im).to.have.property('ts');
-				expect(im).to.have.property('lastMessage');
-			})
-			.end(done);
+	it('/im.list', async () => {
+		const res = await request.get(api('im.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('count');
+		expect(res.body).to.have.property('total');
+		expect(res.body).to.have.property('ims').and.to.be.an('array');
+		const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id);
+		expect(im).to.have.property('_id');
+		expect(im).to.have.property('t').and.to.be.eq('d');
+		expect(im).to.have.property('msgs').and.to.be.a('number');
+		expect(im).to.have.property('usernames').and.to.be.an('array');
+		expect(im).to.have.property('lm');
+		expect(im).to.have.property('_updatedAt');
+		expect(im).to.have.property('ts');
+		expect(im).to.have.property('lastMessage');
 	});
 
 	describe('/im.list.everyone', () => {
@@ -428,79 +406,65 @@ describe('[Direct Messages]', () => {
 		before(async () => updateSetting('UI_Use_Real_Name', true));
 		after(async () => updateSetting('UI_Use_Real_Name', false));
 
-		it('/im.list', (done) => {
-			void request
-				.get(api('im.list'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('ims').and.to.be.an('array');
+		it('/im.list', async () => {
+			const res = await request.get(api('im.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
 
-					const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id) as IRoom;
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('ims').and.to.be.an('array');
 
-					expect(im).to.have.property('_id');
-					expect(im).to.have.property('t').and.to.be.eq('d');
-					expect(im).to.have.property('msgs').and.to.be.a('number');
-					expect(im).to.have.property('usernames').and.to.be.an('array');
-					expect(im).to.have.property('lm');
-					expect(im).to.have.property('_updatedAt');
-					expect(im).to.have.property('ts');
-					expect(im).to.have.property('lastMessage');
+			const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id) as IRoom;
 
-					const { lastMessage } = im;
+			expect(im).to.have.property('_id');
+			expect(im).to.have.property('t').and.to.be.eq('d');
+			expect(im).to.have.property('msgs').and.to.be.a('number');
+			expect(im).to.have.property('usernames').and.to.be.an('array');
+			expect(im).to.have.property('lm');
+			expect(im).to.have.property('_updatedAt');
+			expect(im).to.have.property('ts');
+			expect(im).to.have.property('lastMessage');
 
-					expect(lastMessage).to.have.nested.property('u.name', 'RocketChat Internal Admin Test');
-				})
-				.end(done);
+			const { lastMessage } = im;
+
+			expect(lastMessage).to.have.nested.property('u.name', 'RocketChat Internal Admin Test');
 		});
 
-		it('/im.list.everyone', (done) => {
-			void request
-				.get(api('im.list.everyone'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('ims').and.to.be.an('array');
-					const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id) as IRoom;
-					expect(im).to.have.property('_id');
-					expect(im).to.have.property('t').and.to.be.eq('d');
-					expect(im).to.have.property('msgs').and.to.be.a('number');
-					expect(im).to.have.property('usernames').and.to.be.an('array');
-					expect(im).to.have.property('ro');
-					expect(im).to.have.property('sysMes');
-					expect(im).to.have.property('_updatedAt');
-					expect(im).to.have.property('ts');
-					expect(im).to.have.property('lastMessage');
+		it('/im.list.everyone', async () => {
+			const res = await request.get(api('im.list.everyone')).set(credentials).expect('Content-Type', 'application/json').expect(200);
 
-					const { lastMessage } = im;
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('ims').and.to.be.an('array');
+			const im = (res.body.ims as IRoom[]).find((dm) => dm._id === testDM._id) as IRoom;
+			expect(im).to.have.property('_id');
+			expect(im).to.have.property('t').and.to.be.eq('d');
+			expect(im).to.have.property('msgs').and.to.be.a('number');
+			expect(im).to.have.property('usernames').and.to.be.an('array');
+			expect(im).to.have.property('ro');
+			expect(im).to.have.property('sysMes');
+			expect(im).to.have.property('_updatedAt');
+			expect(im).to.have.property('ts');
+			expect(im).to.have.property('lastMessage');
 
-					expect(lastMessage).to.have.nested.property('u.name', 'RocketChat Internal Admin Test');
-				})
-				.end(done);
+			const { lastMessage } = im;
+
+			expect(lastMessage).to.have.nested.property('u.name', 'RocketChat Internal Admin Test');
 		});
 	});
 
-	it('/im.open', (done) => {
-		void request
+	it('/im.open', async () => {
+		const res = await request
 			.post(api('im.open'))
 			.set(credentials)
 			.send({
 				roomId: directMessage._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
 	describe('/im.counters', () => {
@@ -523,26 +487,24 @@ describe('[Direct Messages]', () => {
 					expect(res.body).to.have.property('success', false);
 				});
 		});
-		it('should work with all params right', (done) => {
-			void request
+		it('should work with all params right', async () => {
+			const res = await request
 				.get(api('im.counters'))
 				.set(credentials)
 				.query({
 					roomId: directMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('joined', true);
-					expect(res.body).to.have.property('members');
-					expect(res.body).to.have.property('unreads');
-					expect(res.body).to.have.property('unreadsFrom');
-					expect(res.body).to.have.property('msgs');
-					expect(res.body).to.have.property('latest');
-					expect(res.body).to.have.property('userMentions');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('joined', true);
+			expect(res.body).to.have.property('members');
+			expect(res.body).to.have.property('unreads');
+			expect(res.body).to.have.property('unreadsFrom');
+			expect(res.body).to.have.property('msgs');
+			expect(res.body).to.have.property('latest');
+			expect(res.body).to.have.property('userMentions');
 		});
 
 		describe('with valid room id', () => {
@@ -703,20 +665,18 @@ describe('[Direct Messages]', () => {
 
 		after(async () => Promise.all([deleteUser(testUser), deleteUser(testUser2)]));
 
-		it('should return all DM messages that were sent to yourself using your username', (done) => {
-			void request
+		it('should return all DM messages that were sent to yourself using your username', async () => {
+			const res = await request
 				.get(api('im.messages'))
 				.set(testUserCredentials)
 				.query({
 					username: testUser.username,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages').and.to.be.an('array');
 		});
 
 		it('should sort by ts by default', async () => {
@@ -1010,19 +970,17 @@ describe('[Direct Messages]', () => {
 		});
 	});
 
-	it('/im.close', (done) => {
-		void request
+	it('/im.close', async () => {
+		const res = await request
 			.post(api('im.close'))
 			.set(credentials)
 			.send({
 				roomId: directMessage._id,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
 	});
 
 	describe('fname property', () => {
@@ -1076,25 +1034,23 @@ describe('[Direct Messages]', () => {
 
 		after(async () => deleteUser(user));
 
-		it('should have fname property', (done) => {
-			void request
+		it('should have fname property', async () => {
+			const res = await request
 				.get(api('subscriptions.getOne'))
 				.set(credentials)
 				.query({
 					roomId: directMessageId,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.subscription).to.have.property('name', username);
-					expect(res.body.subscription).to.have.property('fname', name);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.subscription).to.have.property('name', username);
+			expect(res.body.subscription).to.have.property('fname', name);
 		});
 
-		it("should update user's name", (done) => {
-			void request
+		it("should update user's name", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -1102,70 +1058,62 @@ describe('[Direct Messages]', () => {
 					data: {
 						name: updatedName,
 					},
-				})
-				.expect((res) => {
-					expect(res.body.user).to.have.property('name', updatedName);
-				})
-				.end(done);
+				});
+
+			expect(res.body.user).to.have.property('name', updatedName);
 		});
 
-		it('should have fname property updated', (done) => {
-			void request
+		it('should have fname property updated', async () => {
+			const res = await request
 				.get(api('subscriptions.getOne'))
 				.set(credentials)
 				.query({
 					roomId: directMessageId,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.subscription).to.have.property('name', username);
-					expect(res.body.subscription).to.have.property('fname', updatedName);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.subscription).to.have.property('name', username);
+			expect(res.body.subscription).to.have.property('fname', updatedName);
 		});
 	});
 
 	describe('/im.members', () => {
-		it('should return and array with two members', (done) => {
-			void request
+		it('should return and array with two members', async () => {
+			const res = await request
 				.get(api('im.members'))
 				.set(credentials)
 				.query({
 					roomId: directMessage._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count').and.to.be.equal(2);
-					expect(res.body).to.have.property('offset').and.to.be.equal(0);
-					expect(res.body).to.have.property('total').and.to.be.equal(2);
-					expect(res.body).to.have.property('members').and.to.have.lengthOf(2);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count').and.to.be.equal(2);
+			expect(res.body).to.have.property('offset').and.to.be.equal(0);
+			expect(res.body).to.have.property('total').and.to.be.equal(2);
+			expect(res.body).to.have.property('members').and.to.have.lengthOf(2);
 		});
-		it('should return and array with one member', (done) => {
-			void request
+		it('should return and array with one member', async () => {
+			const res = await request
 				.get(api('im.members'))
 				.set(credentials)
 				.query({
 					username: user.username,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count').and.to.be.equal(2);
-					expect(res.body).to.have.property('offset').and.to.be.equal(0);
-					expect(res.body).to.have.property('total').and.to.be.equal(2);
-					expect(res.body).to.have.property('members').and.to.have.lengthOf(2);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count').and.to.be.equal(2);
+			expect(res.body).to.have.property('offset').and.to.be.equal(0);
+			expect(res.body).to.have.property('total').and.to.be.equal(2);
+			expect(res.body).to.have.property('members').and.to.have.lengthOf(2);
 		});
-		it('should return and array with one member queried by status', (done) => {
-			void request
+		it('should return and array with one member queried by status', async () => {
+			const res = await request
 				.get(api('im.members'))
 				.set(credentials)
 				.query({
@@ -1173,15 +1121,13 @@ describe('[Direct Messages]', () => {
 					'status[]': ['online'],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count').and.to.be.equal(1);
-					expect(res.body).to.have.property('offset').and.to.be.equal(0);
-					expect(res.body).to.have.property('total').and.to.be.equal(1);
-					expect(res.body).to.have.property('members').and.to.have.lengthOf(1);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count').and.to.be.equal(1);
+			expect(res.body).to.have.property('offset').and.to.be.equal(0);
+			expect(res.body).to.have.property('total').and.to.be.equal(1);
+			expect(res.body).to.have.property('members').and.to.have.lengthOf(1);
 		});
 	});
 
@@ -1219,26 +1165,24 @@ describe('[Direct Messages]', () => {
 			await deleteUser(thirdUser);
 		});
 
-		it('creates a DM between two other parties (including self)', (done) => {
-			void request
+		it('creates a DM between two other parties (including self)', async () => {
+			const res = await request
 				.post(api('im.create'))
 				.set(userCredentials)
 				.send({
 					usernames: [otherUser.username, thirdUser.username].join(','),
 				})
 				.expect(200)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.property('usernames').and.to.have.members([thirdUser.username, user.username, otherUser.username]);
-					roomIds = { ...roomIds, multipleDm: res.body.room._id };
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.property('usernames').and.to.have.members([thirdUser.username, user.username, otherUser.username]);
+			roomIds = { ...roomIds, multipleDm: res.body.room._id };
 		});
 
-		it('creates a DM between two other parties (excluding self)', (done) => {
-			void request
+		it('creates a DM between two other parties (excluding self)', async () => {
+			const res = await request
 				.post(api('im.create'))
 				.set(credentials)
 				.send({
@@ -1246,32 +1190,28 @@ describe('[Direct Messages]', () => {
 					excludeSelf: true,
 				})
 				.expect(200)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username, otherUser.username]);
-					roomIds = { ...roomIds, dm: res.body.room._id };
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username, otherUser.username]);
+			roomIds = { ...roomIds, dm: res.body.room._id };
 		});
 
-		it('should create a self-DM', (done) => {
-			void request
+		it('should create a self-DM', async () => {
+			const res = await request
 				.post(api('im.create'))
 				.set(userCredentials)
 				.send({
 					username: user.username,
 				})
 				.expect(200)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username]);
-					roomIds = { ...roomIds, self: res.body.room._id };
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username]);
+			roomIds = { ...roomIds, self: res.body.room._id };
 		});
 
 		describe('should create dm with correct notification preferences', () => {
@@ -1306,39 +1246,35 @@ describe('[Direct Messages]', () => {
 					.expect(200);
 			});
 
-			it('should create a DM', (done) => {
-				void request
+			it('should create a DM', async () => {
+				const res = await request
 					.post(api('im.create'))
 					.set(userCredentials)
 					.send({
 						usernames: [user.username, otherUser.username].join(','),
 					})
 					.expect(200)
-					.expect('Content-Type', 'application/json')
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('room').and.to.be.an('object');
-						expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username, otherUser.username]);
-						userPrefRoomId = res.body.room._id;
-					})
-					.end(done);
+					.expect('Content-Type', 'application/json');
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('room').and.to.be.an('object');
+				expect(res.body.room).to.have.property('usernames').and.to.have.members([user.username, otherUser.username]);
+				userPrefRoomId = res.body.room._id;
 			});
 
-			it('should return the right user notification preferences in the dm', (done) => {
-				void request
+			it('should return the right user notification preferences in the dm', async () => {
+				const res = await request
 					.get(api('subscriptions.getOne'))
 					.set(userCredentials)
 					.query({
 						roomId: userPrefRoomId,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('subscription').and.to.be.an('object');
-						expect(res.body).to.have.nested.property('subscription.emailNotifications').and.to.be.equal('nothing');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('subscription').and.to.be.an('object');
+				expect(res.body).to.have.nested.property('subscription.emailNotifications').and.to.be.equal('nothing');
 			});
 		});
 
@@ -1377,50 +1313,44 @@ describe('[Direct Messages]', () => {
 	describe('/im.delete', () => {
 		let testDM: IRoom;
 
-		it('/im.create', (done) => {
-			void request
+		it('/im.create', async () => {
+			const res = await request
 				.post(api('im.create'))
 				.set(credentials)
 				.send({
 					username: user.username,
 				})
 				.expect(200)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					testDM = res.body.room;
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			testDM = res.body.room;
 		});
 
-		it('/im.delete', (done) => {
-			void request
+		it('/im.delete', async () => {
+			const res = await request
 				.post(api('im.delete'))
 				.set(credentials)
 				.send({
 					username: user.username,
 				})
 				.expect(200)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('/im.open', (done) => {
-			void request
+		it('/im.open', async () => {
+			const res = await request
 				.post(api('im.open'))
 				.set(credentials)
 				.send({
 					roomId: testDM._id,
 				})
 				.expect(403)
-				.expect('Content-Type', 'application/json')
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'unauthorized');
-				})
-				.end(done);
+				.expect('Content-Type', 'application/json');
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'unauthorized');
 		});
 
 		describe('when authenticated as a non-admin user', () => {
@@ -1436,34 +1366,30 @@ describe('[Direct Messages]', () => {
 				await deleteUser(otherUser);
 			});
 
-			it('/im.create', (done) => {
-				void request
+			it('/im.create', async () => {
+				const res = await request
 					.post(api('im.create'))
 					.set(credentials)
 					.send({
 						username: otherUser.username,
 					})
 					.expect(200)
-					.expect('Content-Type', 'application/json')
-					.expect((res) => {
-						testDM = res.body.room;
-					})
-					.end(done);
+					.expect('Content-Type', 'application/json');
+
+				testDM = res.body.room;
 			});
 
-			it('/im.delete', (done) => {
-				void request
+			it('/im.delete', async () => {
+				const res = await request
 					.post(api('im.delete'))
 					.set(otherCredentials)
 					.send({
 						roomId: testDM._id,
 					})
 					.expect(400)
-					.expect('Content-Type', 'application/json')
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect('Content-Type', 'application/json');
+
+				expect(res.body).to.have.property('success', false);
 			});
 		});
 	});

--- a/apps/meteor/tests/end-to-end/api/emoji-custom.ts
+++ b/apps/meteor/tests/end-to-end/api/emoji-custom.ts
@@ -20,8 +20,8 @@ describe('[EmojiCustom]', () => {
 	);
 
 	describe('[/emoji-custom.create]', () => {
-		it('should create new custom emoji', (done) => {
-			void request
+		it('should create new custom emoji', async () => {
+			const res = await request
 				.post(api('emoji-custom.create'))
 				.set(credentials)
 				.attach('emoji', imgURL)
@@ -30,14 +30,12 @@ describe('[EmojiCustom]', () => {
 					aliases: `${customEmojiName}-alias`,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should create new custom emoji without optional parameter "aliases"', (done) => {
-			void request
+		it('should create new custom emoji without optional parameter "aliases"', async () => {
+			const res = await request
 				.post(api('emoji-custom.create'))
 				.set(credentials)
 				.attach('emoji', imgURL)
@@ -45,14 +43,12 @@ describe('[EmojiCustom]', () => {
 					name: `${customEmojiName}-without-aliases`,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should throw an error when the filename is wrong', (done) => {
-			void request
+		it('should throw an error when the filename is wrong', async () => {
+			const res = await request
 				.post(api('emoji-custom.create'))
 				.set(credentials)
 				.attach('emojiwrong', imgURL)
@@ -61,12 +57,10 @@ describe('[EmojiCustom]', () => {
 					name: 'my-custom-emoji-without-aliases',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('invalid-field');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('invalid-field');
 		});
 	});
 
@@ -97,8 +91,8 @@ describe('[EmojiCustom]', () => {
 				.end(done);
 		});
 		describe('successfully:', () => {
-			it('should update the custom emoji without a file', (done) => {
-				void request
+			it('should update the custom emoji without a file', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.field({
@@ -107,14 +101,12 @@ describe('[EmojiCustom]', () => {
 						aliases: 'alias-my-custom-emoji',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should update the custom emoji without optional parameter "aliases"', (done) => {
-				void request
+			it('should update the custom emoji without optional parameter "aliases"', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.field({
@@ -122,14 +114,12 @@ describe('[EmojiCustom]', () => {
 						name: customEmojiName,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should update the custom emoji with all parameters and with a file', (done) => {
-				void request
+			it('should update the custom emoji with all parameters and with a file', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.attach('emoji', imgURL)
@@ -138,11 +128,9 @@ describe('[EmojiCustom]', () => {
 						name: customEmojiName,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
 
 			it('should change the etag when the custom emoji image is updated', async () => {
@@ -169,8 +157,8 @@ describe('[EmojiCustom]', () => {
 		});
 
 		describe('should throw error when:', () => {
-			it('the fields does not include "_id"', (done) => {
-				void request
+			it('the fields does not include "_id"', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.attach('emoji', imgURL)
@@ -178,15 +166,13 @@ describe('[EmojiCustom]', () => {
 						name: 'my-custom-emoji-without-aliases',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.errorType).to.be.equal('The required "_id" query param is missing.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body.errorType).to.be.equal('The required "_id" query param is missing.');
 			});
-			it('the custom emoji does not exists', (done) => {
-				void request
+			it('the custom emoji does not exists', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.attach('emoji', imgURL)
@@ -195,15 +181,13 @@ describe('[EmojiCustom]', () => {
 						name: 'my-custom-emoji-without-aliases',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.errorType).to.be.equal('Emoji not found.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body.errorType).to.be.equal('Emoji not found.');
 			});
-			it('the emoji file field is wrong', (done) => {
-				void request
+			it('the emoji file field is wrong', async () => {
+				const res = await request
 					.post(api('emoji-custom.update'))
 					.set(credentials)
 					.attach('emojiwrong', imgURL)
@@ -212,207 +196,156 @@ describe('[EmojiCustom]', () => {
 						name: 'my-custom-emoji-without-aliases',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.errorType).to.be.equal('invalid-field');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body.errorType).to.be.equal('invalid-field');
 			});
 		});
 	});
 
 	describe('[/emoji-custom.list]', () => {
-		it('should return emojis', (done) => {
-			void request
-				.get(api('emoji-custom.list'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.a('object');
-					expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.not.have.lengthOf(0);
-					expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
-				})
-				.end(done);
+		it('should return emojis', async () => {
+			const res = await request.get(api('emoji-custom.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('emojis').and.to.be.a('object');
+			expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.not.have.lengthOf(0);
+			expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
 		});
-		it('should return emojis when use "query" query parameter', (done) => {
-			void request
-				.get(api('emoji-custom.list'))
-				.query({ _updatedAt: new Date().toISOString() })
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('emojis').and.to.be.a('object');
-					expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
-					expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
-				})
-				.end(done);
+		it('should return emojis when use "query" query parameter', async () => {
+			const res = await request.get(api('emoji-custom.list')).query({ _updatedAt: new Date().toISOString() }).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('emojis').and.to.be.a('object');
+			expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
+			expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
 		});
-		it('should return emojis when use "updateSince" query parameter', (done) => {
-			void request
+		it('should return emojis when use "updateSince" query parameter', async () => {
+			const res = await request
 				.get(api('emoji-custom.list'))
 				.query({ updatedSince: new Date().toISOString() })
 				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('emojis').and.to.be.a('object');
-					expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
-					expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('emojis').and.to.be.a('object');
+			expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
+			expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
 		});
-		it('should return emojis when use both, "updateSince" and "query" query parameter', (done) => {
-			void request
+		it('should return emojis when use both, "updateSince" and "query" query parameter', async () => {
+			const res = await request
 				.get(api('emoji-custom.list'))
 				.query({ _updatedAt: new Date().toISOString(), updatedSince: new Date().toISOString() })
 				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('emojis').and.to.be.a('object');
-					expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
-					expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('emojis').and.to.be.a('object');
+			expect(res.body.emojis).to.have.property('update').and.to.be.a('array').and.to.have.lengthOf(0);
+			expect(res.body.emojis).to.have.property('remove').and.to.be.a('array').and.to.have.lengthOf(0);
 		});
-		it('should return an error when the "updateSince" query parameter is a invalid date', (done) => {
-			void request
-				.get(api('emoji-custom.list'))
-				.query({ updatedSince: 'invalid-date' })
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('error-roomId-param-invalid');
-				})
-				.end(done);
+		it('should return an error when the "updateSince" query parameter is a invalid date', async () => {
+			const res = await request.get(api('emoji-custom.list')).query({ updatedSince: 'invalid-date' }).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-roomId-param-invalid');
 		});
 	});
 
 	describe('[/emoji-custom.all]', () => {
-		it('should return emojis', (done) => {
-			void request
-				.get(api('emoji-custom.all'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return emojis', async () => {
+			const res = await request.get(api('emoji-custom.all')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('emojis').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return emojis even requested with count and offset params', (done) => {
-			void request
+		it('should return emojis even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('emoji-custom.all'))
 				.set(credentials)
 				.query({
 					count: 5,
 					offset: 0,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('emojis').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return only filtered by name emojis', (done) => {
-			void request
+		it('should return only filtered by name emojis', async () => {
+			const res = await request
 				.get(api('emoji-custom.all'))
 				.set(credentials)
 				.query({
 					name: `${customEmojiName}-without-aliases`,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('emojis').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('emojis').and.to.be.an('array').and.to.have.lengthOf(1);
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('count');
 		});
 	});
 
 	describe('Accessing custom emojis', () => {
 		let uploadDate: string | undefined;
 
-		it('should return forbidden if the there is no fileId on the url', (done) => {
-			void request
-				.get('/emoji-custom/')
-				.set(credentials)
-				.expect(403)
-				.expect((res) => {
-					expect(res.text).to.be.equal('Forbidden');
-				})
-				.end(done);
+		it('should return forbidden if the there is no fileId on the url', async () => {
+			const res = await request.get('/emoji-custom/').set(credentials).expect(403);
+
+			expect(res.text).to.be.equal('Forbidden');
 		});
 
-		it('should return success if the file does not exists with some specific headers', (done) => {
-			void request
-				.get('/emoji-custom/invalid')
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified', 'Thu, 01 Jan 2015 00:00:00 GMT');
-					expect(res.headers).to.have.property('content-type', 'image/svg+xml');
-					expect(res.headers).to.have.property('cache-control', 'public, max-age=0');
-					expect(res.headers).to.have.property('expires', '-1');
-					expect(res.headers).to.have.property('content-disposition', 'inline');
-				})
-				.end(done);
+		it('should return success if the file does not exists with some specific headers', async () => {
+			const res = await request.get('/emoji-custom/invalid').set(credentials).expect(200);
+
+			expect(res.headers).to.have.property('last-modified', 'Thu, 01 Jan 2015 00:00:00 GMT');
+			expect(res.headers).to.have.property('content-type', 'image/svg+xml');
+			expect(res.headers).to.have.property('cache-control', 'public, max-age=0');
+			expect(res.headers).to.have.property('expires', '-1');
+			expect(res.headers).to.have.property('content-disposition', 'inline');
 		});
 
-		it('should return not modified if the file does not exists and if-modified-since is equal to the Thu, 01 Jan 2015 00:00:00 GMT', (done) => {
-			void request
+		it('should return not modified if the file does not exists and if-modified-since is equal to the Thu, 01 Jan 2015 00:00:00 GMT', async () => {
+			const res = await request
 				.get('/emoji-custom/invalid')
 				.set(credentials)
 				.set({
 					'if-modified-since': 'Thu, 01 Jan 2015 00:00:00 GMT',
 				})
-				.expect(304)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified', 'Thu, 01 Jan 2015 00:00:00 GMT');
-				})
-				.end(done);
+				.expect(304);
+
+			expect(res.headers).to.have.property('last-modified', 'Thu, 01 Jan 2015 00:00:00 GMT');
 		});
 
-		it('should return success if the the requested exists', (done) => {
-			void request
-				.get(`/emoji-custom/${customEmojiName}.png`)
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified');
-					expect(res.headers).to.have.property('content-type', 'image/png');
-					expect(res.headers).to.have.property('cache-control', 'public, max-age=31536000');
-					expect(res.headers).to.have.property('content-disposition', 'inline');
-					uploadDate = res.headers['last-modified'];
-				})
-				.end(done);
+		it('should return success if the the requested exists', async () => {
+			const res = await request.get(`/emoji-custom/${customEmojiName}.png`).set(credentials).expect(200);
+
+			expect(res.headers).to.have.property('last-modified');
+			expect(res.headers).to.have.property('content-type', 'image/png');
+			expect(res.headers).to.have.property('cache-control', 'public, max-age=31536000');
+			expect(res.headers).to.have.property('content-disposition', 'inline');
+			uploadDate = res.headers['last-modified'];
 		});
 
-		it('should return not modified if the the requested file contains a valid-since equal to the upload date', (done) => {
-			void request
+		it('should return not modified if the the requested file contains a valid-since equal to the upload date', async () => {
+			const res = await request
 				.get(`/emoji-custom/${customEmojiName}.png`)
 				.set(credentials)
 				.set({
 					'if-modified-since': uploadDate,
 				})
-				.expect(304)
-				.expect((res) => {
-					expect(res.headers).to.have.property('last-modified', uploadDate);
-					expect(res.headers).not.to.have.property('content-type');
-					expect(res.headers).not.to.have.property('content-length');
-					expect(res.headers).not.to.have.property('cache-control');
-				})
-				.end(done);
+				.expect(304);
+
+			expect(res.headers).to.have.property('last-modified', uploadDate);
+			expect(res.headers).not.to.have.property('content-type');
+			expect(res.headers).not.to.have.property('content-length');
+			expect(res.headers).not.to.have.property('cache-control');
 		});
 
 		it('should return the emoji even when no etag is passed (for old emojis)', async () => {
@@ -439,47 +372,41 @@ describe('[EmojiCustom]', () => {
 	});
 
 	describe('[/emoji-custom.delete]', () => {
-		it('should throw an error when trying delete custom emoji without the required param "emojid"', (done) => {
-			void request
+		it('should throw an error when trying delete custom emoji without the required param "emojid"', async () => {
+			const res = await request
 				.post(api('emoji-custom.delete'))
 				.set(credentials)
 				.send({})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal("must have required property 'emojiId'");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal("must have required property 'emojiId'");
 		});
-		it('should throw an error when trying delete custom emoji that does not exists', (done) => {
-			void request
+		it('should throw an error when trying delete custom emoji that does not exists', async () => {
+			const res = await request
 				.post(api('emoji-custom.delete'))
 				.set(credentials)
 				.send({
 					emojiId: 'invalid-id',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('Custom_Emoji_Error_Invalid_Emoji');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('Custom_Emoji_Error_Invalid_Emoji');
 		});
-		it('should delete the custom emoji created before successfully', (done) => {
-			void request
+		it('should delete the custom emoji created before successfully', async () => {
+			const res = await request
 				.post(api('emoji-custom.delete'))
 				.set(credentials)
 				.send({
 					emojiId: createdCustomEmoji._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -776,8 +776,8 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.addModerator', () => {
-		it('should make user a moderator', (done) => {
-			void request
+		it('should make user a moderator', async () => {
+			const res = await request
 				.post(api('groups.addModerator'))
 				.set(credentials)
 				.send({
@@ -785,17 +785,15 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.removeModerator', () => {
-		it('should remove user from moderator', (done) => {
-			void request
+		it('should remove user from moderator', async () => {
+			const res = await request
 				.post(api('groups.removeModerator'))
 				.set(credentials)
 				.send({
@@ -803,17 +801,15 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.addOwner', () => {
-		it('should add user as owner', (done) => {
-			void request
+		it('should add user as owner', async () => {
+			const res = await request
 				.post(api('groups.addOwner'))
 				.set(credentials)
 				.send({
@@ -821,17 +817,15 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.removeOwner', () => {
-		it('should remove user from owner', (done) => {
-			void request
+		it('should remove user from owner', async () => {
+			const res = await request
 				.post(api('groups.removeOwner'))
 				.set(credentials)
 				.send({
@@ -839,17 +833,15 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.addLeader', () => {
-		it('should add user as leader', (done) => {
-			void request
+		it('should add user as leader', async () => {
+			const res = await request
 				.post(api('groups.addLeader'))
 				.set(credentials)
 				.send({
@@ -857,17 +849,15 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
 		});
 	});
 
 	describe('/groups.removeLeader', () => {
-		it('should remove user from leader', (done) => {
-			void request
+		it('should remove user from leader', async () => {
+			const res = await request
 				.post(api('groups.removeLeader'))
 				.set(credentials)
 				.send({
@@ -875,11 +865,9 @@ describe('[Groups]', () => {
 					userId: 'rocket.cat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -1063,8 +1051,8 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.setDescription', () => {
-		it('should set the description of the group with a string', (done) => {
-			void request
+		it('should set the description of the group with a string', async () => {
+			const res = await request
 				.post(api('groups.setDescription'))
 				.set(credentials)
 				.send({
@@ -1072,15 +1060,13 @@ describe('[Groups]', () => {
 					description: 'this is a description for a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('description', 'this is a description for a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('description', 'this is a description for a channel for api tests');
 		});
-		it('should set the description of the group with an empty string(remove the description)', (done) => {
-			void request
+		it('should set the description of the group with an empty string(remove the description)', async () => {
+			const res = await request
 				.post(api('groups.setDescription'))
 				.set(credentials)
 				.send({
@@ -1088,18 +1074,16 @@ describe('[Groups]', () => {
 					description: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('description', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('description', '');
 		});
 	});
 
 	describe('/groups.setTopic', () => {
-		it('should set the topic of the group with a string', (done) => {
-			void request
+		it('should set the topic of the group with a string', async () => {
+			const res = await request
 				.post(api('groups.setTopic'))
 				.set(credentials)
 				.send({
@@ -1107,15 +1091,13 @@ describe('[Groups]', () => {
 					topic: 'this is a topic of a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', 'this is a topic of a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', 'this is a topic of a channel for api tests');
 		});
-		it('should set the topic of the group with an empty string(remove the topic)', (done) => {
-			void request
+		it('should set the topic of the group with an empty string(remove the topic)', async () => {
+			const res = await request
 				.post(api('groups.setTopic'))
 				.set(credentials)
 				.send({
@@ -1123,18 +1105,16 @@ describe('[Groups]', () => {
 					topic: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('topic', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('topic', '');
 		});
 	});
 
 	describe('/groups.setPurpose', () => {
-		it('should set the purpose of the group with a string', (done) => {
-			void request
+		it('should set the purpose of the group with a string', async () => {
+			const res = await request
 				.post(api('groups.setPurpose'))
 				.set(credentials)
 				.send({
@@ -1142,15 +1122,13 @@ describe('[Groups]', () => {
 					purpose: 'this is a purpose of a channel for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('purpose', 'this is a purpose of a channel for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('purpose', 'this is a purpose of a channel for api tests');
 		});
-		it('should set the purpose of the group with an empty string(remove the purpose)', (done) => {
-			void request
+		it('should set the purpose of the group with an empty string(remove the purpose)', async () => {
+			const res = await request
 				.post(api('groups.setPurpose'))
 				.set(credentials)
 				.send({
@@ -1158,33 +1136,29 @@ describe('[Groups]', () => {
 					purpose: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('purpose', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('purpose', '');
 		});
 	});
 
 	describe('/groups.history', () => {
-		it('should return groups history when searching by roomId', (done) => {
-			void request
+		it('should return groups history when searching by roomId', async () => {
+			const res = await request
 				.get(api('groups.history'))
 				.set(credentials)
 				.query({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
 		});
-		it('should return groups history when searching by roomId even requested with count and offset params', (done) => {
-			void request
+		it('should return groups history when searching by roomId even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('groups.history'))
 				.set(credentials)
 				.query({
@@ -1193,12 +1167,10 @@ describe('[Groups]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('messages');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('messages');
 		});
 
 		describe('inclusive parameter', () => {
@@ -1303,86 +1275,76 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.archive', () => {
-		it('should archive the group', (done) => {
-			void request
+		it('should archive the group', async () => {
+			const res = await request
 				.post(api('groups.archive'))
 				.set(credentials)
 				.send({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.unarchive', () => {
-		it('should unarchive the group', (done) => {
-			void request
+		it('should unarchive the group', async () => {
+			const res = await request
 				.post(api('groups.unarchive'))
 				.set(credentials)
 				.send({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.close', () => {
-		it('should close the group', (done) => {
-			void request
+		it('should close the group', async () => {
+			const res = await request
 				.post(api('groups.close'))
 				.set(credentials)
 				.send({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when trying to close a private group that is already closed', (done) => {
-			void request
+		it('should return an error when trying to close a private group that is already closed', async () => {
+			const res = await request
 				.post(api('groups.close'))
 				.set(credentials)
 				.send({
 					roomName: apiPrivateChannelName,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', `The private group, ${apiPrivateChannelName}, is already closed to the sender`);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', `The private group, ${apiPrivateChannelName}, is already closed to the sender`);
 		});
 	});
 
 	describe('/groups.open', () => {
-		it('should open the group', (done) => {
-			void request
+		it('should open the group', async () => {
+			const res = await request
 				.post(api('groups.open'))
 				.set(credentials)
 				.send({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -1513,19 +1475,13 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.list', () => {
-		it('should list the groups the caller is part of', (done) => {
-			void request
-				.get(api('groups.list'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('groups').and.to.be.an('array');
-				})
-				.end(done);
+		it('should list the groups the caller is part of', async () => {
+			const res = await request.get(api('groups.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('groups').and.to.be.an('array');
 		});
 
 		it('should return a list of zero length if not a member of any group', async () => {
@@ -1646,26 +1602,24 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.members', () => {
-		it('should return group members when searching by roomId', (done) => {
-			void request
+		it('should return group members when searching by roomId', async () => {
+			const res = await request
 				.get(api('groups.members'))
 				.set(credentials)
 				.query({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('members').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('members').and.to.be.an('array');
 		});
-		it('should return group members when searching by roomId even requested with count and offset params', (done) => {
-			void request
+		it('should return group members when searching by roomId even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('groups.members'))
 				.set(credentials)
 				.query({
@@ -1674,15 +1628,13 @@ describe('[Groups]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('members').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('members').and.to.be.an('array');
 		});
 	});
 
@@ -1949,8 +1901,8 @@ describe('[Groups]', () => {
 	});
 
 	describe('/groups.setReadOnly', () => {
-		it('should set the group as read only', (done) => {
-			void request
+		it('should set the group as read only', async () => {
+			const res = await request
 				.post(api('groups.setReadOnly'))
 				.set(credentials)
 				.send({
@@ -1958,34 +1910,30 @@ describe('[Groups]', () => {
 					readOnly: true,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe.skip('/groups.leave', () => {
-		it('should allow the user to leave the group', (done) => {
-			void request
+		it('should allow the user to leave the group', async () => {
+			const res = await request
 				.post(api('groups.leave'))
 				.set(credentials)
 				.send({
 					roomId: group._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('/groups.setAnnouncement', () => {
-		it('should set the announcement of the group with a string', (done) => {
-			void request
+		it('should set the announcement of the group with a string', async () => {
+			const res = await request
 				.post(api('groups.setAnnouncement'))
 				.set(credentials)
 				.send({
@@ -1993,15 +1941,13 @@ describe('[Groups]', () => {
 					announcement: 'this is an announcement of a group for api tests',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('announcement', 'this is an announcement of a group for api tests');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('announcement', 'this is an announcement of a group for api tests');
 		});
-		it('should set the announcement of the group with an empty string(remove the announcement)', (done) => {
-			void request
+		it('should set the announcement of the group with an empty string(remove the announcement)', async () => {
+			const res = await request
 				.post(api('groups.setAnnouncement'))
 				.set(credentials)
 				.send({
@@ -2009,12 +1955,10 @@ describe('[Groups]', () => {
 					announcement: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('announcement', '');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('announcement', '');
 		});
 	});
 
@@ -2229,20 +2173,18 @@ describe('[Groups]', () => {
 				.expect(200);
 		});
 
-		it('get customFields using groups.info', (done) => {
-			void request
+		it('get customFields using groups.info', async () => {
+			const res = await request
 				.get(api('groups.info'))
 				.set(credentials)
 				.query({
 					roomId: cfchannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('group.customFields.field0', 'value0');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('group.customFields.field0', 'value0');
 		});
 		it('change customFields', async () => {
 			const customFields = { field9: 'value9' };
@@ -2264,20 +2206,18 @@ describe('[Groups]', () => {
 					expect(res.body).to.have.not.nested.property('group.customFields.field0', 'value0');
 				});
 		});
-		it('get customFields using groups.info', (done) => {
-			void request
+		it('get customFields using groups.info', async () => {
+			const res = await request
 				.get(api('groups.info'))
 				.set(credentials)
 				.query({
 					roomId: cfchannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('group.customFields.field9', 'value9');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('group.customFields.field9', 'value9');
 		});
 
 		it('set customFields with one nested field', async () => {
@@ -2527,64 +2467,50 @@ describe('[Groups]', () => {
 				.expect(200);
 		});
 
-		it('/groups.invite', (done) => {
-			void request
-				.post(api('groups.invite'))
-				.set(credentials)
-				.send({
-					roomId: testGroup._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/groups.invite', async () => {
+			await request.post(api('groups.invite')).set(credentials).send({
+				roomId: testGroup._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/groups.addModerator', (done) => {
-			void request
-				.post(api('groups.addModerator'))
-				.set(credentials)
-				.send({
-					roomId: testGroup._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/groups.addModerator', async () => {
+			await request.post(api('groups.addModerator')).set(credentials).send({
+				roomId: testGroup._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/groups.addLeader', (done) => {
-			void request
-				.post(api('groups.addLeader'))
-				.set(credentials)
-				.send({
-					roomId: testGroup._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/groups.addLeader', async () => {
+			await request.post(api('groups.addLeader')).set(credentials).send({
+				roomId: testGroup._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('should return an array of roles <-> user relationships in a private group', (done) => {
-			void request
+		it('should return an array of roles <-> user relationships in a private group', async () => {
+			const res = await request
 				.get(api('groups.roles'))
 				.set(credentials)
 				.query({
 					roomId: testGroup._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('roles').that.is.an('array').that.has.lengthOf(2);
+				.expect(200);
 
-					expect(res.body.roles[0]).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[0]).to.have.a.property('rid').that.is.equal(testGroup._id);
-					expect(res.body.roles[0]).to.have.a.property('roles').that.is.an('array').that.includes('moderator', 'leader');
-					expect(res.body.roles[0]).to.have.a.property('u').that.is.an('object');
-					expect(res.body.roles[0].u).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[0].u).to.have.a.property('username').that.is.a('string');
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('roles').that.is.an('array').that.has.lengthOf(2);
 
-					expect(res.body.roles[1]).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[1]).to.have.a.property('rid').that.is.equal(testGroup._id);
-					expect(res.body.roles[1]).to.have.a.property('roles').that.is.an('array').that.includes('owner');
-					expect(res.body.roles[1]).to.have.a.property('u').that.is.an('object');
-					expect(res.body.roles[1].u).to.have.a.property('_id').that.is.a('string');
-					expect(res.body.roles[1].u).to.have.a.property('username').that.is.a('string');
-				})
-				.end(done);
+			expect(res.body.roles[0]).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[0]).to.have.a.property('rid').that.is.equal(testGroup._id);
+			expect(res.body.roles[0]).to.have.a.property('roles').that.is.an('array').that.includes('moderator', 'leader');
+			expect(res.body.roles[0]).to.have.a.property('u').that.is.an('object');
+			expect(res.body.roles[0].u).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[0].u).to.have.a.property('username').that.is.a('string');
+
+			expect(res.body.roles[1]).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[1]).to.have.a.property('rid').that.is.equal(testGroup._id);
+			expect(res.body.roles[1]).to.have.a.property('roles').that.is.an('array').that.includes('owner');
+			expect(res.body.roles[1]).to.have.a.property('u').that.is.an('object');
+			expect(res.body.roles[1].u).to.have.a.property('_id').that.is.a('string');
+			expect(res.body.roles[1].u).to.have.a.property('username').that.is.a('string');
 		});
 	});
 
@@ -2615,41 +2541,31 @@ describe('[Groups]', () => {
 				.expect(200);
 		});
 
-		it('/groups.invite', (done) => {
-			void request
-				.post(api('groups.invite'))
-				.set(credentials)
-				.send({
-					roomId: testGroup._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/groups.invite', async () => {
+			await request.post(api('groups.invite')).set(credentials).send({
+				roomId: testGroup._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('/groups.addModerator', (done) => {
-			void request
-				.post(api('groups.addModerator'))
-				.set(credentials)
-				.send({
-					roomId: testGroup._id,
-					userId: 'rocket.cat',
-				})
-				.end(done);
+		it('/groups.addModerator', async () => {
+			await request.post(api('groups.addModerator')).set(credentials).send({
+				roomId: testGroup._id,
+				userId: 'rocket.cat',
+			});
 		});
-		it('should return an array of moderators with rocket.cat as a moderator', (done) => {
-			void request
+		it('should return an array of moderators with rocket.cat as a moderator', async () => {
+			const res = await request
 				.get(api('groups.moderators'))
 				.set(credentials)
 				.query({
 					roomId: testGroup._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('moderators').that.is.an('array').that.has.lengthOf(1);
-					expect(res.body.moderators[0].username).to.be.equal('rocket.cat');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('moderators').that.is.an('array').that.has.lengthOf(1);
+			expect(res.body.moderators[0].username).to.be.equal('rocket.cat');
 		});
 	});
 
@@ -2686,38 +2602,34 @@ describe('[Groups]', () => {
 				.expect(200);
 		});
 
-		it('should return an error when passing no boolean param', (done) => {
-			void request
+		it('should return an error when passing no boolean param', async () => {
+			const res = await request
 				.post(api('groups.setEncrypted'))
 				.set(credentials)
 				.send({
 					roomId: testGroup._id,
 					encrypted: 'no-boolean',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'must be boolean');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'must be boolean');
 		});
 
-		it('should set group as encrypted correctly and return the new data', (done) => {
-			void request
+		it('should set group as encrypted correctly and return the new data', async () => {
+			const res = await request
 				.post(api('groups.setEncrypted'))
 				.set(credentials)
 				.send({
 					roomId: testGroup._id,
 					encrypted: true,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('group');
-					expect(res.body.group).to.have.property('_id', testGroup._id);
-					expect(res.body.group).to.have.property('encrypted', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('group');
+			expect(res.body.group).to.have.property('_id', testGroup._id);
+			expect(res.body.group).to.have.property('encrypted', true);
 		});
 
 		it('should return the updated room encrypted', async () => {
@@ -2727,22 +2639,20 @@ describe('[Groups]', () => {
 			expect(roomInfo.group).to.have.a.property('encrypted', true);
 		});
 
-		it('should set group as unencrypted correctly and return the new data', (done) => {
-			void request
+		it('should set group as unencrypted correctly and return the new data', async () => {
+			const res = await request
 				.post(api('groups.setEncrypted'))
 				.set(credentials)
 				.send({
 					roomId: testGroup._id,
 					encrypted: false,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('group');
-					expect(res.body.group).to.have.property('_id', testGroup._id);
-					expect(res.body.group).to.have.property('encrypted', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('group');
+			expect(res.body.group).to.have.property('_id', testGroup._id);
+			expect(res.body.group).to.have.property('encrypted', false);
 		});
 
 		it('should return the updated room unencrypted', async () => {
@@ -2772,68 +2682,44 @@ describe('[Groups]', () => {
 			return Promise.all([deleteTeam(credentials, newGroup.name), updatePermission('create-team', ['admin', 'user'])]);
 		});
 
-		it('should fail to convert group if lacking edit-room permission', (done) => {
-			void updatePermission('create-team', []).then(() => {
-				void updatePermission('edit-room', ['admin']).then(() => {
-					void request
-						.post(api('groups.convertToTeam'))
-						.set(credentials)
-						.send({ roomId: newGroup._id })
-						.expect(403)
-						.expect((res) => {
-							expect(res.body).to.have.a.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should fail to convert group if lacking edit-room permission', async () => {
+			await updatePermission('create-team', []);
+
+			await updatePermission('edit-room', ['admin']);
+
+			const res = await request.post(api('groups.convertToTeam')).set(credentials).send({ roomId: newGroup._id }).expect(403);
+
+			expect(res.body).to.have.a.property('success', false);
 		});
 
-		it('should fail to convert group if lacking create-team permission', (done) => {
-			void updatePermission('create-team', ['admin']).then(() => {
-				void updatePermission('edit-room', []).then(() => {
-					void request
-						.post(api('groups.convertToTeam'))
-						.set(credentials)
-						.send({ roomId: newGroup._id })
-						.expect(403)
-						.expect((res) => {
-							expect(res.body).to.have.a.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should fail to convert group if lacking create-team permission', async () => {
+			await updatePermission('create-team', ['admin']);
+
+			await updatePermission('edit-room', []);
+
+			const res = await request.post(api('groups.convertToTeam')).set(credentials).send({ roomId: newGroup._id }).expect(403);
+
+			expect(res.body).to.have.a.property('success', false);
 		});
 
-		it('should successfully convert a group to a team', (done) => {
-			void updatePermission('create-team', ['admin']).then(() => {
-				void updatePermission('edit-room', ['admin']).then(() => {
-					void request
-						.post(api('groups.convertToTeam'))
-						.set(credentials)
-						.send({ roomId: newGroup._id })
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.a.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should successfully convert a group to a team', async () => {
+			await updatePermission('create-team', ['admin']);
+
+			await updatePermission('edit-room', ['admin']);
+
+			const res = await request.post(api('groups.convertToTeam')).set(credentials).send({ roomId: newGroup._id }).expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
 		});
 
 		it('should fail to convert group without the required parameters', (done) => {
 			void request.post(api('groups.convertToTeam')).set(credentials).send({}).expect(400).end(done);
 		});
 
-		it("should fail to convert group if it's already taken", (done) => {
-			void request
-				.post(api('groups.convertToTeam'))
-				.set(credentials)
-				.send({ roomId: newGroup._id })
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-				})
-				.end(done);
+		it("should fail to convert group if it's already taken", async () => {
+			const res = await request.post(api('groups.convertToTeam')).set(credentials).send({ roomId: newGroup._id }).expect(400);
+
+			expect(res.body).to.have.a.property('success', false);
 		});
 	});
 
@@ -2883,23 +2769,21 @@ describe('[Groups]', () => {
 				});
 		});
 
-		it('should return the last message user real name', (done) => {
-			void request
+		it('should return the last message user real name', async () => {
+			const res = await request
 				.get(api('groups.info'))
 				.query({
 					roomId: realNameGroup._id,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					const { group } = res.body;
+				.expect(200);
 
-					expect(group._id).to.be.equal(realNameGroup._id);
-					expect(group).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
-				})
-				.end(done);
+			expect(res.body).to.have.property('success', true);
+			const { group } = res.body;
+
+			expect(group._id).to.be.equal(realNameGroup._id);
+			expect(group).to.have.nested.property('lastMessage.u.name', 'RocketChat Internal Admin Test');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -2468,22 +2468,40 @@ describe('[Groups]', () => {
 		});
 
 		it('/groups.invite', async () => {
-			await request.post(api('groups.invite')).set(credentials).send({
-				roomId: testGroup._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('groups.invite'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/groups.addModerator', async () => {
-			await request.post(api('groups.addModerator')).set(credentials).send({
-				roomId: testGroup._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('groups.addModerator'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/groups.addLeader', async () => {
-			await request.post(api('groups.addLeader')).set(credentials).send({
-				roomId: testGroup._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('groups.addLeader'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('should return an array of roles <-> user relationships in a private group', async () => {
 			const res = await request
@@ -2542,16 +2560,28 @@ describe('[Groups]', () => {
 		});
 
 		it('/groups.invite', async () => {
-			await request.post(api('groups.invite')).set(credentials).send({
-				roomId: testGroup._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('groups.invite'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('/groups.addModerator', async () => {
-			await request.post(api('groups.addModerator')).set(credentials).send({
-				roomId: testGroup._id,
-				userId: 'rocket.cat',
-			});
+			const res = await request
+				.post(api('groups.addModerator'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+					userId: 'rocket.cat',
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('should return an array of moderators with rocket.cat as a moderator', async () => {
 			const res = await request

--- a/apps/meteor/tests/end-to-end/api/incoming-integrations.ts
+++ b/apps/meteor/tests/end-to-end/api/incoming-integrations.ts
@@ -62,8 +62,8 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to add an incoming integration', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to add an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.create'))
 					.set(credentials)
 					.send({
@@ -77,16 +77,14 @@ describe('[Incoming Integrations]', () => {
 						channel: '#general',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'not_authorized');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('errorType', 'not_authorized');
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-own-incoming-integrations" to add an incoming integration', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-own-incoming-integrations" to add an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.create'))
 					.set(credentials)
 					.send({
@@ -100,12 +98,10 @@ describe('[Incoming Integrations]', () => {
 						channel: '#general',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'not_authorized');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('errorType', 'not_authorized');
 			});
 		});
 
@@ -183,8 +179,8 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should add the integration successfully when the user ONLY has the permission "manage-own-incoming-integrations" to add an incoming integration', (done) => {
-				void request
+			it('should add the integration successfully when the user ONLY has the permission "manage-own-incoming-integrations" to add an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.create'))
 					.set(credentials)
 					.send({
@@ -198,13 +194,11 @@ describe('[Incoming Integrations]', () => {
 						channel: '#general',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('integration').and.to.be.an('object');
-						integration = res.body.integration;
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('integration').and.to.be.an('object');
+				integration = res.body.integration;
 			});
 		});
 
@@ -236,8 +230,8 @@ describe('[Incoming Integrations]', () => {
 		});
 
 		describe('Incoming Integration execution', () => {
-			it('should return an error when the user sends an invalid type of integration', (done) => {
-				void request
+			it('should return an error when the user sends an invalid type of integration', async () => {
+				const res = await request
 					.post(api('integrations.create'))
 					.set(credentials)
 					.send({
@@ -251,52 +245,45 @@ describe('[Incoming Integrations]', () => {
 						channel: '#general',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'Invalid integration type.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'Invalid integration type.');
 			});
 
-			it('should execute the incoming integration', (done) => {
-				void request
+			it('should execute the incoming integration', async () => {
+				await request
 					.post(`/hooks/${integration._id}/${integration.token}`)
 					.send({
 						text: 'Example message',
 					})
-					.expect(200)
-					.end(done);
+					.expect(200);
 			});
 
-			it("should return an error when sending 'channel' field telling its configuration is disabled", (done) => {
-				void request
+			it("should return an error when sending 'channel' field telling its configuration is disabled", async () => {
+				const res = await request
 					.post(`/hooks/${integration._id}/${integration.token}`)
 					.send({
 						text: 'Example message',
 						channel: [testChannelName],
 					})
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'overriding destination channel is disabled for this integration');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'overriding destination channel is disabled for this integration');
 			});
 
-			it("should return an error when sending 'roomId' field telling its configuration is disabled", (done) => {
-				void request
+			it("should return an error when sending 'roomId' field telling its configuration is disabled", async () => {
+				const res = await request
 					.post(`/hooks/${integration._id}/${integration.token}`)
 					.send({
 						text: 'Example message',
 						roomId: channel._id,
 					})
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'overriding destination channel is disabled for this integration');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'overriding destination channel is disabled for this integration');
 			});
 			it('should send a message for a channel that is specified in the webhooks configuration', (done) => {
 				const successfulMessage = `Message sent successfully at #${Date.now()}`;
@@ -646,20 +633,18 @@ describe('[Incoming Integrations]', () => {
 			]);
 		});
 
-		it('should return an error when trying to get history of incoming integrations if user does NOT have enough permissions', (done) => {
-			void request
+		it('should return an error when trying to get history of incoming integrations if user does NOT have enough permissions', async () => {
+			const res = await request
 				.get(api('integrations.history'))
 				.set(credentials)
 				.query({
 					id: integration._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-				})
-				.end(done);
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
 	});
 
@@ -691,25 +676,19 @@ describe('[Incoming Integrations]', () => {
 			});
 		});
 
-		it('should return the list of incoming integrations', (done) => {
-			void request
-				.get(api('integrations.list'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					const integrationCreatedByAdmin = (res.body.integrations as IIntegration[]).find(
-						(createdIntegration) => createdIntegration._id === integration._id,
-					);
-					assert.isDefined(integrationCreatedByAdmin);
-					expect(integrationCreatedByAdmin).to.be.an('object');
-					expect(integrationCreatedByAdmin._id).to.be.equal(integration._id);
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('items');
-					expect(res.body).to.have.property('total');
-				})
-				.end(done);
+		it('should return the list of incoming integrations', async () => {
+			const res = await request.get(api('integrations.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			const integrationCreatedByAdmin = (res.body.integrations as IIntegration[]).find(
+				(createdIntegration) => createdIntegration._id === integration._id,
+			);
+			assert.isDefined(integrationCreatedByAdmin);
+			expect(integrationCreatedByAdmin).to.be.an('object');
+			expect(integrationCreatedByAdmin._id).to.be.equal(integration._id);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('items');
+			expect(res.body).to.have.property('total');
 		});
 
 		describe('With manage-own-incoming-integrations permission', () => {
@@ -727,23 +706,17 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should return the list of integrations created by the user only', (done) => {
-				void request
-					.get(api('integrations.list'))
-					.set(userCredentials)
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						const integrationCreatedByAdmin = (res.body.integrations as IIntegration[]).find(
-							(createdIntegration) => createdIntegration._id === integration._id,
-						);
-						expect(integrationCreatedByAdmin).to.be.equal(undefined);
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('items');
-						expect(res.body).to.have.property('total');
-					})
-					.end(done);
+			it('should return the list of integrations created by the user only', async () => {
+				const res = await request.get(api('integrations.list')).set(userCredentials).expect('Content-Type', 'application/json').expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				const integrationCreatedByAdmin = (res.body.integrations as IIntegration[]).find(
+					(createdIntegration) => createdIntegration._id === integration._id,
+				);
+				expect(integrationCreatedByAdmin).to.be.equal(undefined);
+				expect(res.body).to.have.property('offset');
+				expect(res.body).to.have.property('items');
+				expect(res.body).to.have.property('total');
 			});
 		});
 
@@ -782,31 +755,23 @@ describe('[Incoming Integrations]', () => {
 
 	describe('[/integrations.get]', () => {
 		describe('Invalid params', () => {
-			it('should return an error when the required "integrationId" query parameters is not sent', (done) => {
-				void request
-					.get(api('integrations.get'))
-					.set(credentials)
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', `must have required property 'integrationId'`);
-					})
-					.end(done);
+			it('should return an error when the required "integrationId" query parameters is not sent', async () => {
+				const res = await request.get(api('integrations.get')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', `must have required property 'integrationId'`);
 			});
 
-			it('should return an error when the user sends an invalid integration', (done) => {
-				void request
+			it('should return an error when the user sends an invalid integration', async () => {
+				const res = await request
 					.get(api('integrations.get'))
 					.query({ integrationId: 'invalid' })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'The integration does not exists.');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'The integration does not exists.');
 			});
 		});
 
@@ -822,32 +787,28 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to get an incoming integration', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to get an incoming integration', async () => {
+				const res = await request
 					.get(api('integrations.get'))
 					.query({ integrationId: integration._id })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'not-authorized');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'not-authorized');
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to get an incoming integration created by another user', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to get an incoming integration created by another user', async () => {
+				const res = await request
 					.get(api('integrations.get'))
 					.query({ integrationId: integrationCreatedByAnUser._id })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'not-authorized');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'not-authorized');
 			});
 		});
 
@@ -856,19 +817,17 @@ describe('[Incoming Integrations]', () => {
 				await updatePermission('manage-incoming-integrations', ['admin']);
 			});
 
-			it('should return the integration successfully', (done) => {
-				void request
+			it('should return the integration successfully', async () => {
+				const res = await request
 					.get(api('integrations.get'))
 					.query({ integrationId: integration._id })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('integration');
-						expect(res.body.integration._id).to.be.equal(integration._id);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('integration');
+				expect(res.body.integration._id).to.be.equal(integration._id);
 			});
 		});
 
@@ -887,19 +846,17 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should return the integration successfully when the user is able to see only your own integrations', (done) => {
-				void request
+			it('should return the integration successfully when the user is able to see only your own integrations', async () => {
+				const res = await request
 					.get(api('integrations.get'))
 					.query({ integrationId: integrationCreatedByAnUser._id })
 					.set(userCredentials)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('integration');
-						expect(res.body.integration._id).to.be.equal(integrationCreatedByAnUser._id);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('integration');
+				expect(res.body.integration._id).to.be.equal(integrationCreatedByAnUser._id);
 			});
 		});
 	});
@@ -923,8 +880,8 @@ describe('[Incoming Integrations]', () => {
 			await deleteUser(senderUser);
 		});
 
-		it('should update an integration by id and return the new data', (done) => {
-			void request
+		it('should update an integration by id and return the new data', async () => {
+			const res = await request
 				.put(api('integrations.update'))
 				.set(credentials)
 				.send({
@@ -939,16 +896,14 @@ describe('[Incoming Integrations]', () => {
 					integrationId: integration._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('integration');
-					expect(res.body.integration._id).to.be.equal(integration._id);
-					expect(res.body.integration.name).to.be.equal('Incoming test updated');
-					expect(res.body.integration.alias).to.be.equal('test updated');
-					integration = res.body.integration;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('integration');
+			expect(res.body.integration._id).to.be.equal(integration._id);
+			expect(res.body.integration.name).to.be.equal('Incoming test updated');
+			expect(res.body.integration.alias).to.be.equal('test updated');
+			integration = res.body.integration;
 		});
 
 		it('should not allow users without a role with the message-impersonate permission to be assigned to existing incoming integrations', async () => {
@@ -975,21 +930,19 @@ describe('[Incoming Integrations]', () => {
 				});
 		});
 
-		it('should have integration updated on subsequent gets', (done) => {
-			void request
+		it('should have integration updated on subsequent gets', async () => {
+			const res = await request
 				.get(api('integrations.get'))
 				.query({ integrationId: integration._id })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('integration');
-					expect(res.body.integration._id).to.be.equal(integration._id);
-					expect(res.body.integration.name).to.be.equal('Incoming test updated');
-					expect(res.body.integration.alias).to.be.equal('test updated');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('integration');
+			expect(res.body.integration._id).to.be.equal(integration._id);
+			expect(res.body.integration.name).to.be.equal('Incoming test updated');
+			expect(res.body.integration.alias).to.be.equal('test updated');
 		});
 
 		it("should update an integration's username and associated userId correctly and return the new data", async () => {
@@ -1067,8 +1020,8 @@ describe('[Incoming Integrations]', () => {
 				]);
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to remove an incoming integration', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-incoming-integrations" to remove an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.remove'))
 					.set(credentials)
 					.send({
@@ -1076,16 +1029,14 @@ describe('[Incoming Integrations]', () => {
 						type: 'webhook-incoming',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
+					.expect(403);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 			});
 
-			it('should return an error when the user DOES NOT have the permission "manage-own-incoming-integrations" to remove an incoming integration', (done) => {
-				void request
+			it('should return an error when the user DOES NOT have the permission "manage-own-incoming-integrations" to remove an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.remove'))
 					.set(credentials)
 					.send({
@@ -1093,12 +1044,10 @@ describe('[Incoming Integrations]', () => {
 						type: 'webhook-incoming',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
+					.expect(403);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 			});
 		});
 
@@ -1107,8 +1056,8 @@ describe('[Incoming Integrations]', () => {
 				await updatePermission('manage-own-incoming-integrations', ['admin']);
 			});
 
-			it('should return an error when the user sends an invalid type of integration', (done) => {
-				void request
+			it('should return an error when the user sends an invalid type of integration', async () => {
+				const res = await request
 					.post(api('integrations.remove'))
 					.set(credentials)
 					.send({
@@ -1116,12 +1065,10 @@ describe('[Incoming Integrations]', () => {
 						type: 'invalid-type',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error').include(`must match exactly one schema in oneOf`);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error').include(`must match exactly one schema in oneOf`);
 			});
 		});
 
@@ -1130,8 +1077,8 @@ describe('[Incoming Integrations]', () => {
 				await updatePermission('manage-incoming-integrations', ['admin']);
 			});
 
-			it('should remove the integration successfully when the user at least one of the necessary permission to remove an incoming integration', (done) => {
-				void request
+			it('should remove the integration successfully when the user at least one of the necessary permission to remove an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.remove'))
 					.set(credentials)
 					.send({
@@ -1139,11 +1086,9 @@ describe('[Incoming Integrations]', () => {
 						type: integration.type,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
 		});
 
@@ -1156,8 +1101,8 @@ describe('[Incoming Integrations]', () => {
 				await updatePermission('manage-own-incoming-integrations', ['admin']);
 			});
 
-			it('the normal user should remove the integration successfully when the user have the "manage-own-incoming-integrations" to remove an incoming integration', (done) => {
-				void request
+			it('the normal user should remove the integration successfully when the user have the "manage-own-incoming-integrations" to remove an incoming integration', async () => {
+				const res = await request
 					.post(api('integrations.remove'))
 					.set(userCredentials)
 					.send({
@@ -1165,11 +1110,9 @@ describe('[Incoming Integrations]', () => {
 						type: integrationCreatedByAnUser.type,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
 		});
 	});

--- a/apps/meteor/tests/end-to-end/api/invites.ts
+++ b/apps/meteor/tests/end-to-end/api/invites.ts
@@ -14,24 +14,22 @@ describe('Invites', () => {
 
 	before((done) => getCredentials(done));
 	describe('POST [/findOrCreateInvite]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(api('findOrCreateInvite'))
 				.send({
 					rid: 'GENERAL',
 					days: 1,
 					maxUses: 10,
 				})
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if invalid roomid', (done) => {
-			void request
+		it('should fail if invalid roomid', async () => {
+			const res = await request
 				.post(api('findOrCreateInvite'))
 				.set(credentials)
 				.send({
@@ -39,16 +37,14 @@ describe('Invites', () => {
 					days: 1,
 					maxUses: 10,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-invalid-room');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-room');
 		});
 
-		it('should create an invite for GENERAL', (done) => {
-			void request
+		it('should create an invite for GENERAL', async () => {
+			const res = await request
 				.post(api('findOrCreateInvite'))
 				.set(credentials)
 				.send({
@@ -56,20 +52,18 @@ describe('Invites', () => {
 					days: 1,
 					maxUses: 10,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('days', 1);
-					expect(res.body).to.have.property('maxUses', 10);
-					expect(res.body).to.have.property('uses');
-					expect(res.body).to.have.property('_id');
-					testInviteID = res.body._id;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('days', 1);
+			expect(res.body).to.have.property('maxUses', 10);
+			expect(res.body).to.have.property('uses');
+			expect(res.body).to.have.property('_id');
+			testInviteID = res.body._id;
 		});
 
-		it('should return an existing invite for GENERAL', (done) => {
-			void request
+		it('should return an existing invite for GENERAL', async () => {
+			const res = await request
 				.post(api('findOrCreateInvite'))
 				.set(credentials)
 				.send({
@@ -77,126 +71,97 @@ describe('Invites', () => {
 					days: 1,
 					maxUses: 10,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('days', 1);
-					expect(res.body).to.have.property('maxUses', 10);
-					expect(res.body).to.have.property('uses');
-					expect(res.body).to.have.property('_id', testInviteID);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('days', 1);
+			expect(res.body).to.have.property('maxUses', 10);
+			expect(res.body).to.have.property('uses');
+			expect(res.body).to.have.property('_id', testInviteID);
 		});
 	});
 
 	describe('GET [/listInvites]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
-				.get(api('listInvites'))
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should fail if not logged in', async () => {
+			const res = await request.get(api('listInvites')).expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return the existing invite for GENERAL', (done) => {
-			void request
-				.get(api('listInvites'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body[0]).to.have.property('_id', testInviteID);
-				})
-				.end(done);
+		it('should return the existing invite for GENERAL', async () => {
+			const res = await request.get(api('listInvites')).set(credentials).expect(200);
+
+			expect(res.body[0]).to.have.property('_id', testInviteID);
 		});
 	});
 
 	describe('POST [/useInviteToken]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
-				.post(api('useInviteToken'))
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should fail if not logged in', async () => {
+			const res = await request.post(api('useInviteToken')).expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if invalid token', (done) => {
-			void request
+		it('should fail if invalid token', async () => {
+			const res = await request
 				.post(api('useInviteToken'))
 				.set(credentials)
 				.send({
 					token: 'invalid',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-invalid-token');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-token');
 		});
 
-		it('should fail if missing token', (done) => {
-			void request
-				.post(api('useInviteToken'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-				})
-				.end(done);
+		it('should fail if missing token', async () => {
+			const res = await request.post(api('useInviteToken')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
 		});
 
-		it('should use the existing invite for GENERAL', (done) => {
-			void request
+		it('should use the existing invite for GENERAL', async () => {
+			const res = await request
 				.post(api('useInviteToken'))
 				.set(credentials)
 				.send({
 					token: testInviteID,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
 	describe('POST [/validateInviteToken]', () => {
-		it('should warn if invalid token', (done) => {
-			void request
+		it('should warn if invalid token', async () => {
+			const res = await request
 				.post(api('validateInviteToken'))
 				.set(credentials)
 				.send({
 					token: 'invalid',
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('valid', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('valid', false);
 		});
 
-		it('should succeed when valid token', (done) => {
-			void request
+		it('should succeed when valid token', async () => {
+			const res = await request
 				.post(api('validateInviteToken'))
 				.set(credentials)
 				.send({
 					token: testInviteID,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('valid', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('valid', true);
 		});
 	});
 
@@ -259,50 +224,37 @@ describe('Invites', () => {
 	});
 
 	describe('DELETE [/removeInvite]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
-				.delete(api(`removeInvite/${testInviteID}`))
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should fail if not logged in', async () => {
+			const res = await request.delete(api(`removeInvite/${testInviteID}`)).expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if invalid token', (done) => {
-			void request
-				.delete(api('removeInvite/invalid'))
-				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-invitation-id');
-				})
-				.end(done);
+		it('should fail if invalid token', async () => {
+			const res = await request.delete(api('removeInvite/invalid')).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-invitation-id');
 		});
 
-		it('should succeed when valid token', (done) => {
-			void request
+		it('should succeed when valid token', async () => {
+			const res = await request
 				.delete(api(`removeInvite/${testInviteID}`))
 				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.equal(true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.equal(true);
 		});
 
-		it('should fail when deleting the same invite again', (done) => {
-			void request
+		it('should fail when deleting the same invite again', async () => {
+			const res = await request
 				.delete(api(`removeInvite/${testInviteID}`))
 				.set(credentials)
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-invitation-id');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-invitation-id');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/licenses.ts
+++ b/apps/meteor/tests/end-to-end/api/licenses.ts
@@ -22,97 +22,78 @@ describe('licenses', () => {
 	after(() => deleteUser(createdUser));
 
 	describe('[/licenses.add]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(api('licenses.add'))
 				.send({
 					license: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if user is unauthorized', (done) => {
-			void request
+		it('should fail if user is unauthorized', async () => {
+			const res = await request
 				.post(api('licenses.add'))
 				.set(unauthorizedUserCredentials)
 				.send({
 					license: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-				})
-				.end(done);
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
 
-		it('should fail if license is invalid', (done) => {
-			void request
+		it('should fail if license is invalid', async () => {
+			const res = await request
 				.post(api('licenses.add'))
 				.set(credentials)
 				.send({
 					license: '',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 	});
 
 	describe('[/licenses.info]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
-				.get(api('licenses.info'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should fail if not logged in', async () => {
+			const res = await request.get(api('licenses.info')).expect('Content-Type', 'application/json').expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return limited information if user is unauthorized', (done) => {
-			void request
+		it('should return limited information if user is unauthorized', async () => {
+			const res = await request
 				.get(api('licenses.info'))
 				.set(unauthorizedUserCredentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('license').and.to.be.an('object');
-					expect(res.body.license).to.not.have.property('license');
-					expect(res.body.license).to.have.property('tags').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('license').and.to.be.an('object');
+			expect(res.body.license).to.not.have.property('license');
+			expect(res.body.license).to.have.property('tags').and.to.be.an('array');
 		});
 
-		it('should return unrestricted info if user is logged in and is authorized', (done) => {
-			void request
-				.get(api('licenses.info'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('license').and.to.be.an('object');
-					if (process.env.IS_EE) {
-						expect(res.body.license).to.have.property('license').and.to.be.an('object');
-					}
-					expect(res.body.license).to.have.property('tags').and.to.be.an('array');
-				})
+		it('should return unrestricted info if user is logged in and is authorized', async () => {
+			const res = await request.get(api('licenses.info')).set(credentials).expect(200);
 
-				.end(done);
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('license').and.to.be.an('object');
+			if (process.env.IS_EE) {
+				expect(res.body.license).to.have.property('license').and.to.be.an('object');
+			}
+			expect(res.body.license).to.have.property('tags').and.to.be.an('array');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/methods.ts
+++ b/apps/meteor/tests/end-to-end/api/methods.ts
@@ -86,8 +86,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('getThreadMessages'))
 				.send({
 					message: JSON.stringify({
@@ -98,16 +98,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return message thread', (done) => {
-			void request
+		it('should return message thread', async () => {
+			const res = await request
 				.post(methodCall('getThreadMessages'))
 				.set(credentials)
 				.send({
@@ -119,16 +117,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-					expect(data.result.length).to.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
+			expect(data.result.length).to.equal(2);
 		});
 	});
 
@@ -544,8 +540,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('getMessages'))
 				.send({
 					message: JSON.stringify({
@@ -556,16 +552,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if msgIds not specified', (done) => {
-			void request
+		it('should fail if msgIds not specified', async () => {
+			const res = await request
 				.post(methodCall('getMessages'))
 				.set(credentials)
 				.send({
@@ -577,21 +571,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(400);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('error').that.is.an('object');
-					expect(data.error).to.have.a.property('sanitizedError');
-					expect(data.error.sanitizedError).to.have.property('error', 400);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('error').that.is.an('object');
+			expect(data.error).to.have.a.property('sanitizedError');
+			expect(data.error.sanitizedError).to.have.property('error', 400);
 		});
 
-		it('should return the first message', (done) => {
-			void request
+		it('should return the first message', async () => {
+			const res = await request
 				.post(methodCall('getMessages'))
 				.set(credentials)
 				.send({
@@ -603,20 +595,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-					expect(data.result.length).to.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
+			expect(data.result.length).to.equal(1);
 		});
 
-		it('should return both messages', (done) => {
-			void request
+		it('should return both messages', async () => {
+			const res = await request
 				.post(methodCall('getMessages'))
 				.set(credentials)
 				.send({
@@ -628,16 +618,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-					expect(data.result.length).to.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
+			expect(data.result.length).to.equal(2);
 		});
 	});
 
@@ -871,8 +859,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.send({
 					message: JSON.stringify({
@@ -883,16 +871,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if roomId not specified', (done) => {
-			void request
+		it('should fail if roomId not specified', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.set(credentials)
 				.send({
@@ -904,21 +890,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(400);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('error').that.is.an('object');
-					expect(data.error).to.have.a.property('sanitizedError');
-					expect(data.error.sanitizedError).to.have.property('error', 400);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('error').that.is.an('object');
+			expect(data.error).to.have.a.property('sanitizedError');
+			expect(data.error.sanitizedError).to.have.property('error', 400);
 		});
 
-		it('should return all messages for the specified room', (done) => {
-			void request
+		it('should return all messages for the specified room', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.set(credentials)
 				.send({
@@ -930,21 +914,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(2);
 		});
 
-		it('should return only the first message', (done) => {
-			void request
+		it('should return only the first message', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.set(credentials)
 				.send({
@@ -956,21 +938,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(1);
 		});
 
-		it('should return only one message when limit = 1', (done) => {
-			void request
+		it('should return only one message when limit = 1', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.set(credentials)
 				.send({
@@ -982,21 +962,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(1);
 		});
 
-		it('should return the messages since the last one', (done) => {
-			void request
+		it('should return the messages since the last one', async () => {
+			const res = await request
 				.post(methodCall('loadHistory'))
 				.set(credentials)
 				.send({
@@ -1008,17 +986,15 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(2);
 		});
 	});
 
@@ -1089,8 +1065,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('loadNextMessages'))
 				.send({
 					message: JSON.stringify({
@@ -1101,16 +1077,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if roomId not specified', (done) => {
-			void request
+		it('should fail if roomId not specified', async () => {
+			const res = await request
 				.post(methodCall('loadNextMessages'))
 				.set(credentials)
 				.send({
@@ -1122,21 +1096,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(400);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('error').that.is.an('object');
-					expect(data.error).to.have.a.property('sanitizedError');
-					expect(data.error.sanitizedError).to.have.property('error', 400);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('error').that.is.an('object');
+			expect(data.error).to.have.a.property('sanitizedError');
+			expect(data.error.sanitizedError).to.have.property('error', 400);
 		});
 
-		it('should return all messages for the specified room', (done) => {
-			void request
+		it('should return all messages for the specified room', async () => {
+			const res = await request
 				.post(methodCall('loadNextMessages'))
 				.set(credentials)
 				.send({
@@ -1148,21 +1120,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(2);
 		});
 
-		it('should return only the latest message', (done) => {
-			void request
+		it('should return only the latest message', async () => {
+			const res = await request
 				.post(methodCall('loadNextMessages'))
 				.set(credentials)
 				.send({
@@ -1174,21 +1144,19 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(1);
 		});
 
-		it('should return only one message when limit = 1', (done) => {
-			void request
+		it('should return only one message when limit = 1', async () => {
+			const res = await request
 				.post(methodCall('loadNextMessages'))
 				.set(credentials)
 				.send({
@@ -1200,17 +1168,15 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('messages').that.is.an('array');
-					expect(data.result.messages.length).to.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('messages').that.is.an('array');
+			expect(data.result.messages.length).to.equal(1);
 		});
 	});
 
@@ -1269,8 +1235,8 @@ describe('Meteor.methods', () => {
 
 		after(() => Promise.all([deleteRoom({ type: 'p', roomId: rid }), deleteUser(testUser)]));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('getUsersOfRoom'))
 				.send({
 					message: JSON.stringify({
@@ -1281,16 +1247,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should fail if roomId not specified', (done) => {
-			void request
+		it('should fail if roomId not specified', async () => {
+			const res = await request
 				.post(methodCall('getUsersOfRoom'))
 				.set(credentials)
 				.send({
@@ -1302,20 +1266,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(400);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('error').that.is.an('object');
-					expect(data.error).to.have.a.property('error', 'error-invalid-room');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('error').that.is.an('object');
+			expect(data.error).to.have.a.property('error', 'error-invalid-room');
 		});
 
-		it('should return the users for the specified room', (done) => {
-			void request
+		it('should return the users for the specified room', async () => {
+			const res = await request
 				.post(methodCall('getUsersOfRoom'))
 				.set(credentials)
 				.send({
@@ -1327,22 +1289,20 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('total', 2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('total', 2);
 		});
 	});
 
 	describe('[@listCustomUserStatus]', () => {
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('listCustomUserStatus'))
 				.send({
 					message: JSON.stringify({
@@ -1353,16 +1313,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return custom status for the current user', (done) => {
-			void request
+		it('should return custom status for the current user', async () => {
+			const res = await request
 				.post(methodCall('listCustomUserStatus'))
 				.set(credentials)
 				.send({
@@ -1374,15 +1332,13 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
 		});
 	});
 
@@ -1391,8 +1347,8 @@ describe('Meteor.methods', () => {
 			$date: new Date().getTime(),
 		};
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('permissions:get'))
 				.send({
 					message: JSON.stringify({
@@ -1403,16 +1359,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return all permissions', (done) => {
-			void request
+		it('should return all permissions', async () => {
+			const res = await request
 				.post(methodCall('permissions:get'))
 				.set(credentials)
 				.send({
@@ -1424,20 +1378,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-					expect(data.result.length).to.be.above(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
+			expect(data.result.length).to.be.above(1);
 		});
 
-		it('should return all permissions after the given date', (done) => {
-			void request
+		it('should return all permissions after the given date', async () => {
+			const res = await request
 				.post(methodCall('permissions:get'))
 				.set(credentials)
 				.send({
@@ -1449,16 +1401,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('update').that.is.an('array');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('update').that.is.an('array');
 		});
 	});
 
@@ -1530,8 +1480,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.send({
 					message: JSON.stringify({
@@ -1542,16 +1492,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return an error if the rid param is empty', (done) => {
-			void request
+		it('should return an error if the rid param is empty', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.set(credentials)
 				.send({
@@ -1563,16 +1511,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.include('error-invalid-room');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.include('error-invalid-room');
 		});
 
-		it('should return an error if the start param is missing', (done) => {
-			void request
+		it('should return an error if the start param is missing', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.set(credentials)
 				.send({
@@ -1584,16 +1530,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', false);
-					expect(res.body).to.have.a.property('message').that.include('Match error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.a.property('success', false);
+			expect(res.body).to.have.a.property('message').that.include('Match error');
 		});
 
-		it('should return and empty list if using current time', (done) => {
-			void request
+		it('should return and empty list if using current time', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.set(credentials)
 				.send({
@@ -1605,20 +1549,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.a('array');
-					expect(data.result.length).to.be.equal(0);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.a('array');
+			expect(data.result.length).to.be.equal(0);
 		});
 
-		it('should return two messages if using a time from before the first msg was sent', (done) => {
-			void request
+		it('should return two messages if using a time from before the first msg was sent', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.set(credentials)
 				.send({
@@ -1630,20 +1572,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.a('array');
-					expect(data.result.length).to.be.equal(2);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.a('array');
+			expect(data.result.length).to.be.equal(2);
 		});
 
-		it('should return a single message if using a time from in between the messages', (done) => {
-			void request
+		it('should return a single message if using a time from in between the messages', async () => {
+			const res = await request
 				.post(methodCall('loadMissedMessages'))
 				.set(credentials)
 				.send({
@@ -1655,16 +1595,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.a('array');
-					expect(data.result.length).to.be.equal(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.a('array');
+			expect(data.result.length).to.be.equal(1);
 		});
 	});
 
@@ -1673,8 +1611,8 @@ describe('Meteor.methods', () => {
 			$date: new Date().getTime(),
 		};
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('public-settings:get'))
 				.send({
 					message: JSON.stringify({
@@ -1685,16 +1623,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return the list of public settings', (done) => {
-			void request
+		it('should return the list of public settings', async () => {
+			const res = await request
 				.post(methodCall('public-settings:get'))
 				.set(credentials)
 				.send({
@@ -1706,15 +1642,13 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
 		});
 	});
 
@@ -1731,8 +1665,8 @@ describe('Meteor.methods', () => {
 			]),
 		);
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('private-settings:get'))
 				.send({
 					message: JSON.stringify({
@@ -1743,12 +1677,10 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
 		it('should return nothing when user doesnt have any permission', (done) => {
@@ -1781,32 +1713,30 @@ describe('Meteor.methods', () => {
 				});
 		});
 
-		it('should return properties when user has any related permissions', (done) => {
-			void updatePermission('view-privileged-setting', ['admin']).then(() => {
-				void request
-					.post(methodCall('private-settings:get'))
-					.set(credentials)
-					.send({
-						message: JSON.stringify({
-							method: 'private-settings/get',
-							params: [date],
-							id: 'id',
-							msg: 'method',
-						}),
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-						expect(res.body).to.have.a.property('message').that.is.a('string');
+		it('should return properties when user has any related permissions', async () => {
+			await updatePermission('view-privileged-setting', ['admin']);
 
-						const data = JSON.parse(res.body.message);
-						expect(data).to.have.a.property('result').that.is.an('object');
-						expect(data.result).to.have.a.property('update').that.is.an('array');
-						expect(data.result.update.length).to.not.equal(0);
-					})
-					.end(done);
-			});
+			const res = await request
+				.post(methodCall('private-settings:get'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'private-settings/get',
+						params: [date],
+						id: 'id',
+						msg: 'method',
+					}),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('update').that.is.an('array');
+			expect(data.result.update.length).to.not.equal(0);
 		});
 
 		it('should return properties when user has all related permissions', (done) => {
@@ -1846,8 +1776,8 @@ describe('Meteor.methods', () => {
 			$date: new Date().getTime(),
 		};
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.post(methodCall('subscriptions:get'))
 				.send({
 					message: JSON.stringify({
@@ -1858,16 +1788,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return all subscriptions', (done) => {
-			void request
+		it('should return all subscriptions', async () => {
+			const res = await request
 				.post(methodCall('subscriptions:get'))
 				.set(credentials)
 				.send({
@@ -1879,20 +1807,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('array');
-					expect(data.result.length).to.be.above(1);
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('array');
+			expect(data.result.length).to.be.above(1);
 		});
 
-		it('should return all subscriptions after the given date', (done) => {
-			void request
+		it('should return all subscriptions after the given date', async () => {
+			const res = await request
 				.post(methodCall('subscriptions:get'))
 				.set(credentials)
 				.send({
@@ -1904,16 +1830,14 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('update').that.is.an('array');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('update').that.is.an('array');
 		});
 	});
 
@@ -1944,8 +1868,8 @@ describe('Meteor.methods', () => {
 
 		after(() => deleteRoom({ type: 'p', roomId: rid }));
 
-		it('should send a message', (done) => {
-			void request
+		it('should send a message', async () => {
+			const res = await request
 				.post(methodCall('sendMessage'))
 				.set(credentials)
 				.send({
@@ -1957,20 +1881,18 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result.msg).to.equal('test message');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result.msg).to.equal('test message');
 		});
 
-		it('should parse correctly urls sent in message', (done) => {
-			void request
+		it('should parse correctly urls sent in message', async () => {
+			const res = await request
 				.post(methodCall('sendMessage'))
 				.set(credentials)
 				.send({
@@ -1988,17 +1910,15 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.a.property('success', true);
-					expect(res.body).to.have.a.property('message').that.is.a('string');
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('urls').that.is.an('array');
-					expect(data.result.urls[0].url).to.equal('https://github.com');
-				})
-				.end(done);
+			expect(res.body).to.have.a.property('success', true);
+			expect(res.body).to.have.a.property('message').that.is.a('string');
+
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('urls').that.is.an('array');
+			expect(data.result.urls[0].url).to.equal('https://github.com');
 		});
 
 		it('should not send message if it is a system message', async () => {
@@ -2041,8 +1961,8 @@ describe('Meteor.methods', () => {
 				});
 		});
 
-		it('should return an error if request includes unallowed parameters', (done) => {
-			void request
+		it('should return an error if request includes unallowed parameters', async () => {
+			const res = await request
 				.post(methodCall('sendMessage'))
 				.set(credentials)
 				.send({
@@ -2054,18 +1974,16 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					const data = JSON.parse(res.body.message);
-					expect(data).to.have.a.property('error').that.is.an('object');
-					expect(data.error.sanitizedError).to.have.a.property('reason', 'Match failed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			const data = JSON.parse(res.body.message);
+			expect(data).to.have.a.property('error').that.is.an('object');
+			expect(data.error.sanitizedError).to.have.a.property('reason', 'Match failed');
 		});
 
-		it('should accept message sent by js.SDK', (done) => {
-			void request
+		it('should accept message sent by js.SDK', async () => {
+			const res = await request
 				.post(methodCall('sendMessage'))
 				.set(credentials)
 				.send({
@@ -2077,17 +1995,15 @@ describe('Meteor.methods', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
+				.expect(200);
 
-					const data = JSON.parse(res.body.message);
+			expect(res.body).to.have.property('success', true);
 
-					expect(data).to.have.a.property('result').that.is.an('object');
-					expect(data.result).to.have.a.property('bot').that.is.an('object');
-					expect(data.result.bot).to.have.a.property('i', 'js.SDK');
-				})
-				.end(done);
+			const data = JSON.parse(res.body.message);
+
+			expect(data).to.have.a.property('result').that.is.an('object');
+			expect(data.result).to.have.a.property('bot').that.is.an('object');
+			expect(data.result.bot).to.have.a.property('i', 'js.SDK');
 		});
 	});
 
@@ -2498,8 +2414,8 @@ describe('Meteor.methods', () => {
 		});
 
 		['tshow', 'alias', 'attachments', 'avatar', 'emoji', 'msg'].forEach((prop) => {
-			it(`should allow to update a message changing property '${prop}'`, (done) => {
-				void request
+			it(`should allow to update a message changing property '${prop}'`, async () => {
+				const res = await request
 					.post(methodCall('updateMessage'))
 					.set(credentials)
 					.send({
@@ -2511,20 +2427,18 @@ describe('Meteor.methods', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', true);
-						expect(res.body).to.have.a.property('message').that.is.a('string');
-						const data = JSON.parse(res.body.message);
-						expect(data).to.have.a.property('msg').that.is.a('string');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.a.property('success', true);
+				expect(res.body).to.have.a.property('message').that.is.a('string');
+				const data = JSON.parse(res.body.message);
+				expect(data).to.have.a.property('msg').that.is.a('string');
 			});
 		});
 
 		['tmid', '_hidden', 'rid'].forEach((prop) => {
-			it(`should fail to update a message changing invalid property '${prop}'`, (done) => {
-				void request
+			it(`should fail to update a message changing invalid property '${prop}'`, async () => {
+				const res = await request
 					.post(methodCall('updateMessage'))
 					.set(credentials)
 					.send({
@@ -2536,16 +2450,14 @@ describe('Meteor.methods', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.a.property('success', false);
-						expect(res.body).to.have.a.property('message').that.is.a('string');
+					.expect(400);
 
-						const data = JSON.parse(res.body.message);
-						expect(data).to.have.a.property('error').that.is.an('object');
-						expect(data.error).to.have.a.property('error', 'error-invalid-update-key');
-					})
-					.end(done);
+				expect(res.body).to.have.a.property('success', false);
+				expect(res.body).to.have.a.property('message').that.is.a('string');
+
+				const data = JSON.parse(res.body.message);
+				expect(data).to.have.a.property('error').that.is.an('object');
+				expect(data.error).to.have.a.property('error', 'error-invalid-update-key');
 			});
 		});
 	});
@@ -3124,8 +3036,8 @@ describe('Meteor.methods', () => {
 				]),
 			);
 
-			it('should fail when trying to add a user to a direct message room', (done) => {
-				void request
+			it('should fail when trying to add a user to a direct message room', async () => {
+				const res = await request
 					.post(methodCall('addUsersToRoom'))
 					.set(credentials)
 					.send({
@@ -3137,12 +3049,10 @@ describe('Meteor.methods', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('message').that.is.an('string');
-						expect(res.body.message).to.include('error-cant-invite-for-direct-room');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('message').that.is.an('string');
+				expect(res.body.message).to.include('error-cant-invite-for-direct-room');
 			});
 		});
 
@@ -3162,16 +3072,11 @@ describe('Meteor.methods', () => {
 				Promise.all([...createdRooms.map((r) => deleteRoom({ type: 'c', roomId: r._id })), deleteUser(user), deleteUser(guestUser)]),
 			);
 
-			it('should fail if not logged in', (done) => {
-				void request
-					.post(methodCall('addUsersToRoom'))
-					.expect('Content-Type', 'application/json')
-					.expect(401)
-					.expect((res) => {
-						expect(res.body).to.have.property('status', 'error');
-						expect(res.body).to.have.property('message');
-					})
-					.end(done);
+			it('should fail if not logged in', async () => {
+				const res = await request.post(methodCall('addUsersToRoom')).expect('Content-Type', 'application/json').expect(401);
+
+				expect(res.body).to.have.property('status', 'error');
+				expect(res.body).to.have.property('message');
 			});
 
 			it('should add a single user to a room', (done) => {

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -21,33 +21,22 @@ describe('miscellaneous', () => {
 		// Required by mobile apps
 		describe('/info', () => {
 			let version: string;
-			it('should return "version", "build", "commit" and "marketplaceApiVersion" when the user is logged in', (done) => {
-				void request
-					.get('/api/info')
-					.set(credentials)
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('version').and.to.be.a('string');
-						expect(res.body.info).to.have.property('version').and.to.be.a('string');
-						expect(res.body.info).to.have.property('build').and.to.be.an('object');
-						expect(res.body.info).to.have.property('commit').and.to.be.an('object');
-						expect(res.body.info).to.have.property('marketplaceApiVersion').and.to.be.a('string');
-						version = res.body.info.version;
-					})
-					.end(done);
+			it('should return "version", "build", "commit" and "marketplaceApiVersion" when the user is logged in', async () => {
+				const res = await request.get('/api/info').set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+				expect(res.body).to.have.property('version').and.to.be.a('string');
+				expect(res.body.info).to.have.property('version').and.to.be.a('string');
+				expect(res.body.info).to.have.property('build').and.to.be.an('object');
+				expect(res.body.info).to.have.property('commit').and.to.be.an('object');
+				expect(res.body.info).to.have.property('marketplaceApiVersion').and.to.be.a('string');
+				version = res.body.info.version;
 			});
-			it('should return only "version" and the version should not have patch info when the user is not logged in', (done) => {
-				void request
-					.get('/api/info')
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('version');
-						expect(res.body).to.not.have.property('info');
-						expect(res.body.version).to.be.equal(version.replace(/(\d+\.\d+).*/, '$1'));
-					})
-					.end(done);
+			it('should return only "version" and the version should not have patch info when the user is not logged in', async () => {
+				const res = await request.get('/api/info').expect('Content-Type', 'application/json').expect(200);
+
+				expect(res.body).to.have.property('version');
+				expect(res.body).to.not.have.property('info');
+				expect(res.body.version).to.be.equal(version.replace(/(\d+\.\d+).*/, '$1'));
 			});
 		});
 	});
@@ -57,8 +46,8 @@ describe('miscellaneous', () => {
 		expect(credentials).to.have.property('X-User-Id').with.lengthOf.at.least(1);
 	});
 
-	it('/login (wrapper username)', (done) => {
-		void request
+	it('/login (wrapper username)', async () => {
+		const res = await request
 			.post(api('login'))
 			.send({
 				user: {
@@ -67,19 +56,17 @@ describe('miscellaneous', () => {
 				password: adminPassword,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('status', 'success');
-				expect(res.body).to.have.property('data').and.to.be.an('object');
-				expect(res.body.data).to.have.property('userId');
-				expect(res.body.data).to.have.property('authToken');
-				expect(res.body.data).to.have.property('me');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('status', 'success');
+		expect(res.body).to.have.property('data').and.to.be.an('object');
+		expect(res.body.data).to.have.property('userId');
+		expect(res.body.data).to.have.property('authToken');
+		expect(res.body.data).to.have.property('me');
 	});
 
-	it('/login (wrapper email)', (done) => {
-		void request
+	it('/login (wrapper email)', async () => {
+		const res = await request
 			.post(api('login'))
 			.send({
 				user: {
@@ -88,57 +75,51 @@ describe('miscellaneous', () => {
 				password: adminPassword,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('status', 'success');
-				expect(res.body).to.have.property('data').and.to.be.an('object');
-				expect(res.body.data).to.have.property('userId');
-				expect(res.body.data).to.have.property('authToken');
-				expect(res.body.data).to.have.property('me');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('status', 'success');
+		expect(res.body).to.have.property('data').and.to.be.an('object');
+		expect(res.body.data).to.have.property('userId');
+		expect(res.body.data).to.have.property('authToken');
+		expect(res.body.data).to.have.property('me');
 	});
 
-	it('/login by user', (done) => {
-		void request
+	it('/login by user', async () => {
+		const res = await request
 			.post(api('login'))
 			.send({
 				user: adminEmail,
 				password: adminPassword,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('status', 'success');
-				expect(res.body).to.have.property('data').and.to.be.an('object');
-				expect(res.body.data).to.have.property('userId');
-				expect(res.body.data).to.have.property('authToken');
-				expect(res.body.data).to.have.property('me');
-				expect(res.body.data.me.services).to.not.have.nested.property('password.bcrypt');
-				expect(res.body.data.me.services).to.have.nested.property('password.exists', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('status', 'success');
+		expect(res.body).to.have.property('data').and.to.be.an('object');
+		expect(res.body.data).to.have.property('userId');
+		expect(res.body.data).to.have.property('authToken');
+		expect(res.body.data).to.have.property('me');
+		expect(res.body.data.me.services).to.not.have.nested.property('password.bcrypt');
+		expect(res.body.data.me.services).to.have.nested.property('password.exists', true);
 	});
 
-	it('/login by username', (done) => {
-		void request
+	it('/login by username', async () => {
+		const res = await request
 			.post(api('login'))
 			.send({
 				username: adminUsername,
 				password: adminPassword,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('status', 'success');
-				expect(res.body).to.have.property('data').and.to.be.an('object');
-				expect(res.body.data).to.have.property('userId');
-				expect(res.body.data).to.have.property('authToken');
-				expect(res.body.data).to.have.property('me');
-				expect(res.body.data.me.services).to.not.have.nested.property('password.bcrypt');
-				expect(res.body.data.me.services).to.have.nested.property('password.exists', true);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('status', 'success');
+		expect(res.body).to.have.property('data').and.to.be.an('object');
+		expect(res.body.data).to.have.property('userId');
+		expect(res.body.data).to.have.property('authToken');
+		expect(res.body.data).to.have.property('me');
+		expect(res.body.data.me.services).to.not.have.nested.property('password.bcrypt');
+		expect(res.body.data.me.services).to.have.nested.property('password.exists', true);
 	});
 
 	it('/me', async () => {
@@ -242,8 +223,8 @@ describe('miscellaneous', () => {
 			]);
 		});
 
-		it('should return an array(result) when search by user and execute successfully', (done) => {
-			void request
+		it('should return an array(result) when search by user and execute successfully', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
@@ -251,24 +232,22 @@ describe('miscellaneous', () => {
 					type: 'users',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('result').and.to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-					expect(res.body.result[0]).to.have.property('_id');
-					expect(res.body.result[0]).to.have.property('createdAt');
-					expect(res.body.result[0]).to.have.property('username');
-					expect(res.body.result[0]).to.have.property('emails').and.to.be.an('array');
-					expect(res.body.result[0]).to.have.property('name');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('result').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
+			expect(res.body.result[0]).to.have.property('_id');
+			expect(res.body.result[0]).to.have.property('createdAt');
+			expect(res.body.result[0]).to.have.property('username');
+			expect(res.body.result[0]).to.have.property('emails').and.to.be.an('array');
+			expect(res.body.result[0]).to.have.property('name');
 		});
 
-		it('should not return the emails field for non admins', (done) => {
-			void request
+		it('should not return the emails field for non admins', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(normalUserCredentials)
 				.query({
@@ -276,23 +255,21 @@ describe('miscellaneous', () => {
 					type: 'users',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('result').and.to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-					expect(res.body.result[0]).to.have.property('_id');
-					expect(res.body.result[0]).to.have.property('createdAt');
-					expect(res.body.result[0]).to.have.property('username');
-					expect(res.body.result[0]).to.not.have.property('emails');
-					expect(res.body.result[0]).to.have.property('name');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('result').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
+			expect(res.body.result[0]).to.have.property('_id');
+			expect(res.body.result[0]).to.have.property('createdAt');
+			expect(res.body.result[0]).to.have.property('username');
+			expect(res.body.result[0]).to.not.have.property('emails');
+			expect(res.body.result[0]).to.have.property('name');
 		});
-		it('should return an array(result) when search by channel and execute successfully', (done) => {
-			void request
+		it('should return an array(result) when search by channel and execute successfully', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
@@ -300,19 +277,17 @@ describe('miscellaneous', () => {
 					type: 'channels',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('result').and.to.be.an('array');
-					expect(res.body.result[0]).to.have.property('_id');
-					expect(res.body.result[0]).to.have.property('name');
-					expect(res.body.result[0]).to.have.property('usersCount').and.to.be.an('number');
-					expect(res.body.result[0]).to.have.property('ts');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('result').and.to.be.an('array');
+			expect(res.body.result[0]).to.have.property('_id');
+			expect(res.body.result[0]).to.have.property('name');
+			expect(res.body.result[0]).to.have.property('usersCount').and.to.be.an('number');
+			expect(res.body.result[0]).to.have.property('ts');
 		});
 
 		it('should return private group when search by channel and execute successfully', async () => {
@@ -339,8 +314,8 @@ describe('miscellaneous', () => {
 				});
 		});
 
-		it('should return an array(result) when search by channel with sort params correctly and execute successfully', (done) => {
-			void request
+		it('should return an array(result) when search by channel with sort params correctly and execute successfully', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
@@ -351,22 +326,20 @@ describe('miscellaneous', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('result').and.to.be.an('array');
-					expect(res.body.result[0]).to.have.property('_id');
-					expect(res.body.result[0]).to.have.property('name');
-					expect(res.body.result[0]).to.have.property('usersCount').and.to.be.an('number');
-					expect(res.body.result[0]).to.have.property('ts');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('result').and.to.be.an('array');
+			expect(res.body.result[0]).to.have.property('_id');
+			expect(res.body.result[0]).to.have.property('name');
+			expect(res.body.result[0]).to.have.property('usersCount').and.to.be.an('number');
+			expect(res.body.result[0]).to.have.property('ts');
 		});
-		it('should return an error when send invalid query', (done) => {
-			void request
+		it('should return an error when send invalid query', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
@@ -374,14 +347,12 @@ describe('miscellaneous', () => {
 					type: 'invalid',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
-		it('should return an error when have more than one sort parameter', (done) => {
-			void request
+		it('should return an error when have more than one sort parameter', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
@@ -393,15 +364,13 @@ describe('miscellaneous', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should return an object containing rooms and totalCount from teams', (done) => {
-			void request
+		it('should return an object containing rooms and totalCount from teams', async () => {
+			const res = await request
 				.get(api('directory'))
 				.set(normalUserCredentials)
 				.query({
@@ -412,24 +381,22 @@ describe('miscellaneous', () => {
 					}),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('result');
-					expect(res.body.result).to.be.an(`array`);
-					expect(res.body).to.have.property('total');
-					expect(res.body.total).to.be.an('number');
-					expect(res.body.result[0]).to.have.property('_id', teamCreated.roomId);
-					expect(res.body.result[0]).to.have.property('fname');
-					expect(res.body.result[0]).to.have.property('teamMain');
-					expect(res.body.result[0]).to.have.property('name');
-					expect(res.body.result[0]).to.have.property('t');
-					expect(res.body.result[0]).to.have.property('usersCount');
-					expect(res.body.result[0]).to.have.property('ts');
-					expect(res.body.result[0]).to.have.property('teamId');
-					expect(res.body.result[0]).to.have.property('default');
-					expect(res.body.result[0]).to.have.property('roomsCount');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('result');
+			expect(res.body.result).to.be.an(`array`);
+			expect(res.body).to.have.property('total');
+			expect(res.body.total).to.be.an('number');
+			expect(res.body.result[0]).to.have.property('_id', teamCreated.roomId);
+			expect(res.body.result[0]).to.have.property('fname');
+			expect(res.body.result[0]).to.have.property('teamMain');
+			expect(res.body.result[0]).to.have.property('name');
+			expect(res.body.result[0]).to.have.property('t');
+			expect(res.body.result[0]).to.have.property('usersCount');
+			expect(res.body.result[0]).to.have.property('ts');
+			expect(res.body.result[0]).to.have.property('teamId');
+			expect(res.body.result[0]).to.have.property('default');
+			expect(res.body.result[0]).to.have.property('roomsCount');
 		});
 	});
 
@@ -459,98 +426,84 @@ describe('miscellaneous', () => {
 			]);
 		});
 
-		it('should fail when does not have query param', (done) => {
-			void request
-				.get(api('spotlight'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+		it('should fail when does not have query param', async () => {
+			const res = await request.get(api('spotlight')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
-		it('should return object inside users array when search by a valid user', (done) => {
-			void request
+		it('should return object inside users array when search by a valid user', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `@${adminUsername}`,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-					expect(res.body.users[0]).to.have.property('_id');
-					expect(res.body.users[0]).to.have.property('name');
-					expect(res.body.users[0]).to.have.property('username');
-					expect(res.body.users[0]).to.have.property('status');
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array');
+			expect(res.body.users[0]).to.have.property('_id');
+			expect(res.body.users[0]).to.have.property('name');
+			expect(res.body.users[0]).to.have.property('username');
+			expect(res.body.users[0]).to.have.property('status');
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
 		});
-		it('must return the object inside the room array when searching for a valid room and that user is not a member of it', (done) => {
-			void request
+		it('must return the object inside the room array when searching for a valid room and that user is not a member of it', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `#${testChannel.name}`,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms[0]).to.have.property('_id');
-					expect(res.body.rooms[0]).to.have.property('name');
-					expect(res.body.rooms[0]).to.have.property('t');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array');
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms[0]).to.have.property('_id');
+			expect(res.body.rooms[0]).to.have.property('name');
+			expect(res.body.rooms[0]).to.have.property('t');
 		});
-		it('must return the teamMain property when searching for a valid team that the user is not a member of', (done) => {
-			void request
+		it('must return the teamMain property when searching for a valid team that the user is not a member of', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `${testTeam.name}`,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms[0]).to.have.property('_id');
-					expect(res.body.rooms[0]).to.have.property('name');
-					expect(res.body.rooms[0]).to.have.property('t');
-					expect(res.body.rooms[0]).to.have.property('teamMain');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array');
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms[0]).to.have.property('_id');
+			expect(res.body.rooms[0]).to.have.property('name');
+			expect(res.body.rooms[0]).to.have.property('t');
+			expect(res.body.rooms[0]).to.have.property('teamMain');
 		});
-		it('must return rooms when searching for a valid fname', (done) => {
-			void request
+		it('must return rooms when searching for a valid fname', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `#${fnameSpecialCharsRoom}`,
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms[0]).to.have.property('_id', testChannelSpecialChars._id);
-					expect(res.body.rooms[0]).to.have.property('name', testChannelSpecialChars.name);
-					expect(res.body.rooms[0]).to.have.property('t', testChannelSpecialChars.t);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array');
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms[0]).to.have.property('_id', testChannelSpecialChars._id);
+			expect(res.body.rooms[0]).to.have.property('name', testChannelSpecialChars.name);
+			expect(res.body.rooms[0]).to.have.property('t', testChannelSpecialChars.t);
 		});
-		it('should not return users when the type param disables user search', (done) => {
-			void request
+		it('should not return users when the type param disables user search', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `${adminUsername}`,
@@ -558,16 +511,14 @@ describe('miscellaneous', () => {
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
 		});
-		it('should exclude usernames passed in the usernames param from the results', (done) => {
-			void request
+		it('should exclude usernames passed in the usernames param from the results', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					// Use a non-exact (prefix) query so the regex search path runs; the exact-username
@@ -577,28 +528,24 @@ describe('miscellaneous', () => {
 				})
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-					expect(res.body.users.map((u: { username: string }) => u.username)).to.not.include(adminUsername);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('users').and.to.be.an('array');
+			expect(res.body.users.map((u: { username: string }) => u.username)).to.not.include(adminUsername);
 		});
-		it('should allow anonymous (unauthenticated) requests', (done) => {
-			void request
+		it('should allow anonymous (unauthenticated) requests', async () => {
+			const res = await request
 				.get(api('spotlight'))
 				.query({
 					query: `#${testChannel.name}`,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body).to.have.property('users').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body).to.have.property('users').and.to.be.an('array');
 		});
 	});
 
@@ -609,76 +556,62 @@ describe('miscellaneous', () => {
 			unauthorizedUserCredentials = await doLogin(createdUser.username, password);
 		});
 
-		it('should fail if user is logged in but is unauthorized', (done) => {
-			void request
+		it('should fail if user is logged in but is unauthorized', async () => {
+			const res = await request
 				.get(api('instances.get'))
 				.set(unauthorizedUserCredentials)
 				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-				})
-				.end(done);
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
 
-		it('should fail if not logged in', (done) => {
-			void request
-				.get(api('instances.get'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should fail if not logged in', async () => {
+			const res = await request.get(api('instances.get')).expect('Content-Type', 'application/json').expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return instances if user is logged in and is authorized', (done) => {
-			void request
-				.get(api('instances.get'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
+		it('should return instances if user is logged in and is authorized', async () => {
+			const res = await request.get(api('instances.get')).set(credentials).expect(200);
 
-					expect(res.body).to.have.property('instances').and.to.be.an('array').with.lengthOf(1);
+			expect(res.body).to.have.property('success', true);
 
-					const instances = res.body.instances as IInstance[];
+			expect(res.body).to.have.property('instances').and.to.be.an('array').with.lengthOf(1);
 
-					const instanceName = IS_EE ? 'ddp-streamer' : 'rocket.chat';
+			const instances = res.body.instances as IInstance[];
 
-					const instance = instances.find(
-						(i): i is IInstance & { instanceRecord: IInstanceStatus } => i.instanceRecord?.name === instanceName,
-					);
+			const instanceName = IS_EE ? 'ddp-streamer' : 'rocket.chat';
 
-					if (!instance) throw new AssertionError(`no instance named "${instanceName}"`);
+			const instance = instances.find((i): i is IInstance & { instanceRecord: IInstanceStatus } => i.instanceRecord?.name === instanceName);
 
-					expect(instance).to.have.property('instanceRecord');
-					expect(instance).to.have.property('currentStatus');
+			if (!instance) throw new AssertionError(`no instance named "${instanceName}"`);
 
-					expect(instance.currentStatus).to.have.property('connected');
+			expect(instance).to.have.property('instanceRecord');
+			expect(instance).to.have.property('currentStatus');
 
-					expect(instance.instanceRecord).to.have.property('_id');
-					expect(instance.instanceRecord).to.have.property('extraInformation');
-					expect(instance.instanceRecord).to.have.property('name');
-					expect(instance.instanceRecord).to.have.property('pid');
+			expect(instance.currentStatus).to.have.property('connected');
 
-					if (!IS_EE) {
-						expect(instance).to.have.property('address');
+			expect(instance.instanceRecord).to.have.property('_id');
+			expect(instance.instanceRecord).to.have.property('extraInformation');
+			expect(instance.instanceRecord).to.have.property('name');
+			expect(instance.instanceRecord).to.have.property('pid');
 
-						expect(instance.currentStatus).to.have.property('lastHeartbeatTime');
-						expect(instance.currentStatus).to.have.property('local');
+			if (!IS_EE) {
+				expect(instance).to.have.property('address');
 
-						const { extraInformation } = instance.instanceRecord;
+				expect(instance.currentStatus).to.have.property('lastHeartbeatTime');
+				expect(instance.currentStatus).to.have.property('local');
 
-						expect(extraInformation).to.have.property('host');
-						expect(extraInformation).to.have.property('port');
-						expect(extraInformation).to.have.property('os').and.to.have.property('cpus').to.be.a('number');
-						expect(extraInformation).to.have.property('nodeVersion');
-					}
-				})
-				.end(done);
+				const { extraInformation } = instance.instanceRecord;
+
+				expect(extraInformation).to.have.property('host');
+				expect(extraInformation).to.have.property('port');
+				expect(extraInformation).to.have.property('os').and.to.have.property('cpus').to.be.a('number');
+				expect(extraInformation).to.have.property('nodeVersion');
+			}
 		});
 	});
 
@@ -687,8 +620,8 @@ describe('miscellaneous', () => {
 
 		after(() => updateSetting('API_Enable_Shields', true));
 
-		it('should fail if API_Enable_Shields is disabled', (done) => {
-			void request
+		it('should fail if API_Enable_Shields is disabled', async () => {
+			const res = await request
 				.get(api('shield.svg'))
 				.query({
 					type: 'online',
@@ -697,44 +630,35 @@ describe('miscellaneous', () => {
 					name: 'Rocket.Chat',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-endpoint-disabled');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-endpoint-disabled');
 		});
 
-		it('should succeed if API_Enable_Shields is enabled', (done) => {
-			void updateSetting('API_Enable_Shields', true).then(() => {
-				void request
-					.get(api('shield.svg'))
-					.query({
-						type: 'online',
-						icon: true,
-						channel: 'general',
-						name: 'Rocket.Chat',
-					})
-					.expect('Content-Type', 'image/svg+xml;charset=utf-8')
-					.expect(200)
-					.end(done);
-			});
+		it('should succeed if API_Enable_Shields is enabled', async () => {
+			await updateSetting('API_Enable_Shields', true);
+
+			await request
+				.get(api('shield.svg'))
+				.query({
+					type: 'online',
+					icon: true,
+					channel: 'general',
+					name: 'Rocket.Chat',
+				})
+				.expect('Content-Type', 'image/svg+xml;charset=utf-8')
+				.expect(200);
 		});
 	});
 
 	describe('/pw.getPolicy', () => {
-		it('should return policies', (done) => {
-			void request
-				.get(api('pw.getPolicy'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('enabled');
-					expect(res.body).to.have.property('policy').and.to.be.an('array');
-				})
-				.end(done);
+		it('should return policies', async () => {
+			const res = await request.get(api('pw.getPolicy')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('enabled');
+			expect(res.body).to.have.property('policy').and.to.be.an('array');
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/oauthapps.ts
+++ b/apps/meteor/tests/end-to-end/api/oauthapps.ts
@@ -22,31 +22,22 @@ describe('[OAuthApps]', () => {
 	);
 
 	describe('[/oauth-apps.list]', () => {
-		it('should return an error when the user does not have the necessary permission', (done) => {
-			void updatePermission('manage-oauth-apps', []).then(() => {
-				void request
-					.get(api('oauth-apps.list'))
-					.set(credentials)
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.error).to.be.equal('User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
-			});
+		it('should return an error when the user does not have the necessary permission', async () => {
+			await updatePermission('manage-oauth-apps', []);
+
+			const res = await request.get(api('oauth-apps.list')).set(credentials).expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('User does not have the permissions required for this action [error-unauthorized]');
 		});
-		it('should return an array of oauth apps', (done) => {
-			void updatePermission('manage-oauth-apps', ['admin']).then(() => {
-				void request
-					.get(api('oauth-apps.list'))
-					.set(credentials)
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('oauthApps').and.to.be.an('array');
-					})
-					.end(done);
-			});
+
+		it('should return an array of oauth apps', async () => {
+			await updatePermission('manage-oauth-apps', ['admin']);
+
+			const res = await request.get(api('oauth-apps.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('oauthApps').and.to.be.an('array');
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/permissions.ts
+++ b/apps/meteor/tests/end-to-end/api/permissions.ts
@@ -15,46 +15,36 @@ describe('[Permissions]', () => {
 	after(() => updatePermission('add-oauth-service', ['admin']));
 
 	describe('[/permissions.listAll]', () => {
-		it('should return an array with update and remove properties', (done) => {
-			void request
-				.get(api('permissions.listAll'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('update').and.to.be.an('array');
-					expect(res.body).to.have.property('remove').and.to.be.an('array');
-				})
-				.end(done);
+		it('should return an array with update and remove properties', async () => {
+			const res = await request.get(api('permissions.listAll')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('update').and.to.be.an('array');
+			expect(res.body).to.have.property('remove').and.to.be.an('array');
 		});
 
-		it('should return an array with update and remov properties when search by "updatedSince" query parameter', (done) => {
-			void request
+		it('should return an array with update and remov properties when search by "updatedSince" query parameter', async () => {
+			const res = await request
 				.get(api('permissions.listAll'))
 				.query({ updatedSince: '2018-11-27T13:52:01Z' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('update').and.to.be.an('array');
-					expect(res.body).to.have.property('remove').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('update').and.to.be.an('array');
+			expect(res.body).to.have.property('remove').and.to.be.an('array');
 		});
 
-		it('should return an error when updatedSince query parameter is not a valid ISODate string', (done) => {
-			void request
+		it('should return an error when updatedSince query parameter is not a valid ISODate string', async () => {
+			const res = await request
 				.get(api('permissions.listAll'))
 				.query({ updatedSince: 'fsafdf' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 
@@ -72,78 +62,77 @@ describe('[Permissions]', () => {
 			await deleteUser(testUser);
 		});
 
-		it('should change the permissions on the server', (done) => {
+		it('should change the permissions on the server', async () => {
 			const permissions = [
 				{
 					_id: 'add-oauth-service',
 					roles: ['admin', 'user'],
 				},
 			];
-			void request
+
+			const res = await request
 				.post(api('permissions.update'))
 				.set(credentials)
 				.send({ permissions })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('permissions');
+				.expect(200);
 
-					const firstElement = res.body.permissions[0];
-					expect(firstElement).to.have.property('_id');
-					expect(firstElement).to.have.property('roles').and.to.be.a('array');
-					expect(firstElement).to.have.property('_updatedAt');
-				})
-				.end(done);
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('permissions');
+
+			const firstElement = res.body.permissions[0];
+			expect(firstElement).to.have.property('_id');
+			expect(firstElement).to.have.property('roles').and.to.be.a('array');
+			expect(firstElement).to.have.property('_updatedAt');
 		});
-		it('should 400 when trying to set an unknown permission', (done) => {
+
+		it('should 400 when trying to set an unknown permission', async () => {
 			const permissions = [
 				{
 					_id: 'this-permission-does-not-exist',
 					roles: ['admin'],
 				},
 			];
-			void request
+
+			const res = await request
 				.post(api('permissions.update'))
 				.set(credentials)
 				.send({ permissions })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
-		it('should 400 when trying to assign a permission to an unknown role', (done) => {
+
+		it('should 400 when trying to assign a permission to an unknown role', async () => {
 			const permissions = [
 				{
 					_id: 'add-oauth-service',
 					roles: ['this-role-does-not-exist'],
 				},
 			];
-			void request
+
+			const res = await request
 				.post(api('permissions.update'))
 				.set(credentials)
 				.send({ permissions })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
-		it('should 400 when trying to set permissions to a string', (done) => {
+
+		it('should 400 when trying to set permissions to a string', async () => {
 			const permissions = '';
-			void request
+
+			const res = await request
 				.post(api('permissions.update'))
 				.set(credentials)
 				.send({ permissions })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 		it('should fail updating permission if user does NOT have the access-permissions permission', async () => {
 			const permissions = [

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -44,33 +44,26 @@ const svgLogoFileName = 'logo.svg';
 describe('[Rooms]', () => {
 	before((done) => getCredentials(done));
 
-	it('/rooms.get', (done) => {
-		void request
-			.get(api('rooms.get'))
-			.set(credentials)
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('update');
-				expect(res.body).to.have.property('remove');
-			})
-			.end(done);
+	it('/rooms.get', async () => {
+		const res = await request.get(api('rooms.get')).set(credentials).expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('update');
+		expect(res.body).to.have.property('remove');
 	});
 
-	it('/rooms.get?updatedSince', (done) => {
-		void request
+	it('/rooms.get?updatedSince', async () => {
+		const res = await request
 			.get(api('rooms.get'))
 			.set(credentials)
 			.query({
 				updatedSince: new Date(),
 			})
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('update').that.have.lengthOf(0);
-				expect(res.body).to.have.property('remove').that.have.lengthOf(0);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('update').that.have.lengthOf(0);
+		expect(res.body).to.have.property('remove').that.have.lengthOf(0);
 	});
 
 	describe('/rooms.saveNotification:', () => {
@@ -82,8 +75,8 @@ describe('[Rooms]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('/rooms.saveNotification:', (done) => {
-			void request
+		it('/rooms.saveNotification:', async () => {
+			const res = await request
 				.post(api('rooms.saveNotification'))
 				.set(credentials)
 				.send({
@@ -97,11 +90,9 @@ describe('[Rooms]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 	});
 
@@ -431,46 +422,40 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		it("don't upload a file to room with file field other than file", (done) => {
-			void request
+		it("don't upload a file to room with file field other than file", async () => {
+			const res = await request
 				.post(api(`rooms.media/${testChannel._id}`))
 				.set(credentials)
 				.attach('test', imgURL)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', '[invalid-field]');
-					expect(res.body).to.have.property('errorType', 'invalid-field');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', '[invalid-field]');
+			expect(res.body).to.have.property('errorType', 'invalid-field');
 		});
-		it("don't upload a file to room with empty file", (done) => {
-			void request
+		it("don't upload a file to room with empty file", async () => {
+			const res = await request
 				.post(api(`rooms.media/${testChannel._id}`))
 				.set(credentials)
 				.attach('file', '')
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
-		it("don't upload a file to room with more than 1 file", (done) => {
-			void request
+		it("don't upload a file to room with more than 1 file", async () => {
+			const res = await request
 				.post(api(`rooms.media/${testChannel._id}`))
 				.set(credentials)
 				.attach('file', imgURL)
 				.attach('file', imgURL)
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-too-many-files');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-too-many-files');
 		});
 
 		let fileNewUrl: string;
@@ -903,78 +888,68 @@ describe('[Rooms]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should favorite the room when send favorite: true by roomName', (done) => {
-			void request
+		it('should favorite the room when send favorite: true by roomName', async () => {
+			const res = await request
 				.post(api('rooms.favorite'))
 				.set(credentials)
 				.send({
 					roomName: testChannelName,
 					favorite: true,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should unfavorite the room when send favorite: false by roomName', (done) => {
-			void request
+		it('should unfavorite the room when send favorite: false by roomName', async () => {
+			const res = await request
 				.post(api('rooms.favorite'))
 				.set(credentials)
 				.send({
 					roomName: testChannelName,
 					favorite: false,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should favorite the room when send favorite: true by roomId', (done) => {
-			void request
+		it('should favorite the room when send favorite: true by roomId', async () => {
+			const res = await request
 				.post(api('rooms.favorite'))
 				.set(credentials)
 				.send({
 					roomId: testChannel._id,
 					favorite: true,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should unfavorite room when send favorite: false by roomId', (done) => {
-			void request
+		it('should unfavorite room when send favorite: false by roomId', async () => {
+			const res = await request
 				.post(api('rooms.favorite'))
 				.set(credentials)
 				.send({
 					roomId: testChannel._id,
 					favorite: false,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when send an invalid room', (done) => {
-			void request
+		it('should return an error when send an invalid room', async () => {
+			const res = await request
 				.post(api('rooms.favorite'))
 				.set(credentials)
 				.send({
 					roomId: 'foo',
 					favorite: false,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 	});
 
@@ -988,60 +963,49 @@ describe('[Rooms]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should return 401 unauthorized when user is not logged in', (done) => {
-			void request
-				.get(api('rooms.nameExists'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should return 401 unauthorized when user is not logged in', async () => {
+			const res = await request.get(api('rooms.nameExists')).expect('Content-Type', 'application/json').expect(401);
+
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return true if this room name exists', (done) => {
-			void request
+		it('should return true if this room name exists', async () => {
+			const res = await request
 				.get(api('rooms.nameExists'))
 				.set(credentials)
 				.query({
 					roomName: testChannelName,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('exists', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('exists', true);
 		});
 
-		it('should return false if this room name does not exist', (done) => {
-			void request
+		it('should return false if this room name does not exist', async () => {
+			const res = await request
 				.get(api('rooms.nameExists'))
 				.set(credentials)
 				.query({
 					roomName: 'foo',
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('exists', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('exists', false);
 		});
 
-		it('should return an error when the require parameter (roomName) is not provided', (done) => {
-			void request
+		it('should return an error when the require parameter (roomName) is not provided', async () => {
+			const res = await request
 				.get(api('rooms.nameExists'))
 				.set(credentials)
 				.query({
 					roomId: 'foo',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 	});
 
@@ -1073,8 +1037,8 @@ describe('[Rooms]', () => {
 
 		after(() => updateSetting('Message_ShowDeletedStatus', false));
 
-		it('should return success when send a valid public channel', (done) => {
-			void request
+		it('should return success when send a valid public channel', async () => {
+			const res = await request
 				.post(api('rooms.cleanHistory'))
 				.set(credentials)
 				.send({
@@ -1083,11 +1047,9 @@ describe('[Rooms]', () => {
 					oldest: '2016-08-30T13:42:25.304Z',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 		it('should not count hidden or deleted messages when limit param is not sent', async () => {
 			const res = await sendSimpleMessage({ roomId: publicChannel._id });
@@ -1282,8 +1244,8 @@ describe('[Rooms]', () => {
 				});
 		});
 
-		it('should return success when send a valid private channel', (done) => {
-			void request
+		it('should return success when send a valid private channel', async () => {
+			const res = await request
 				.post(api('rooms.cleanHistory'))
 				.set(credentials)
 				.send({
@@ -1292,14 +1254,12 @@ describe('[Rooms]', () => {
 					oldest: '2016-08-30T13:42:25.304Z',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return success when send a valid Direct Message channel', (done) => {
-			void request
+		it('should return success when send a valid Direct Message channel', async () => {
+			const res = await request
 				.post(api('rooms.cleanHistory'))
 				.set(credentials)
 				.send({
@@ -1308,14 +1268,12 @@ describe('[Rooms]', () => {
 					oldest: '2016-08-30T13:42:25.304Z',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should return not allowed error when try deleting messages with user without permission', (done) => {
-			void request
+		it('should return not allowed error when try deleting messages with user without permission', async () => {
+			const res = await request
 				.post(api('rooms.cleanHistory'))
 				.set(userCredentials)
 				.send({
@@ -1324,12 +1282,10 @@ describe('[Rooms]', () => {
 					oldest: '2016-08-30T13:42:25.304Z',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
 		});
 		describe('test user is not part of room', async () => {
 			beforeEach(async () => {
@@ -1385,79 +1341,69 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		it('should return the info about the created channel correctly searching by roomId', (done) => {
-			void request
+		it('should return the info about the created channel correctly searching by roomId', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.keys(expectedKeys);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.keys(expectedKeys);
 		});
-		it('should return the info about the created channel correctly searching by roomName', (done) => {
-			void request
+		it('should return the info about the created channel correctly searching by roomName', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomName: testChannel.name,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.all.keys(expectedKeys);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.all.keys(expectedKeys);
 		});
-		it('should return the info about the created group correctly searching by roomId', (done) => {
-			void request
+		it('should return the info about the created group correctly searching by roomId', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomId: testGroup._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.all.keys(expectedKeys);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.all.keys(expectedKeys);
 		});
-		it('should return the info about the created group correctly searching by roomName', (done) => {
-			void request
+		it('should return the info about the created group correctly searching by roomName', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomName: testGroup.name,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-					expect(res.body.room).to.have.all.keys(expectedKeys);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+			expect(res.body.room).to.have.all.keys(expectedKeys);
 		});
-		it('should return the info about the created DM correctly searching by roomId', (done) => {
-			void request
+		it('should return the info about the created DM correctly searching by roomId', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomId: testDM._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
 		});
 
 		it('should not return parent & team for room thats not on a team nor is a discussion', async () => {
@@ -1702,79 +1648,69 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		it('should return an Error when trying leave a DM room', (done) => {
-			void request
+		it('should return an Error when trying leave a DM room', async () => {
+			const res = await request
 				.post(api('rooms.leave'))
 				.set(credentials)
 				.send({
 					roomId: testDM._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
 		});
-		it('should return an Error when trying to leave a public channel and you are the last owner', (done) => {
-			void request
+		it('should return an Error when trying to leave a public channel and you are the last owner', async () => {
+			const res = await request
 				.post(api('rooms.leave'))
 				.set(credentials)
 				.send({
 					roomId: testChannel._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-you-are-last-owner');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-you-are-last-owner');
 		});
-		it('should return an Error when trying to leave a private group and you are the last owner', (done) => {
-			void request
+		it('should return an Error when trying to leave a private group and you are the last owner', async () => {
+			const res = await request
 				.post(api('rooms.leave'))
 				.set(credentials)
 				.send({
 					roomId: testGroup._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-you-are-last-owner');
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-you-are-last-owner');
+		});
+		it('should return an Error when trying to leave a public channel and not have the necessary permission(leave-c)', async () => {
+			await updatePermission('leave-c', []);
+
+			const res = await request
+				.post(api('rooms.leave'))
+				.set(credentials)
+				.send({
+					roomId: testChannel._id,
 				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
 		});
-		it('should return an Error when trying to leave a public channel and not have the necessary permission(leave-c)', (done) => {
-			void updatePermission('leave-c', []).then(() => {
-				void request
-					.post(api('rooms.leave'))
-					.set(credentials)
-					.send({
-						roomId: testChannel._id,
-					})
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-					})
-					.end(done);
-			});
-		});
-		it('should return an Error when trying to leave a private group and not have the necessary permission(leave-p)', (done) => {
-			void updatePermission('leave-p', []).then(() => {
-				void request
-					.post(api('rooms.leave'))
-					.set(credentials)
-					.send({
-						roomId: testGroup._id,
-					})
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-not-allowed');
-					})
-					.end(done);
-			});
+		it('should return an Error when trying to leave a private group and not have the necessary permission(leave-p)', async () => {
+			await updatePermission('leave-p', []);
+
+			const res = await request
+				.post(api('rooms.leave'))
+				.set(credentials)
+				.send({
+					roomId: testGroup._id,
+				})
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
 		});
 		it('should leave the public channel when the room has at least another owner and the user has the necessary permission(leave-c)', async () => {
 			await updatePermission('leave-c', ['admin']);
@@ -1890,34 +1826,26 @@ describe('[Rooms]', () => {
 				});
 			});
 		});
-		it('should throw an error when the user tries to create a discussion without the required parameter "prid"', (done) => {
-			void request
-				.post(api('rooms.createDiscussion'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.includes("must have required property 'prid'");
-				})
-				.end(done);
+		it('should throw an error when the user tries to create a discussion without the required parameter "prid"', async () => {
+			const res = await request.post(api('rooms.createDiscussion')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.includes("must have required property 'prid'");
 		});
-		it('should throw an error when the user tries to create a discussion without the required parameter "t_name"', (done) => {
-			void request
+		it('should throw an error when the user tries to create a discussion without the required parameter "t_name"', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
 					prid: testChannel._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.includes("must have required property 't_name'");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.includes("must have required property 't_name'");
 		});
-		it('should throw an error when the user tries to create a discussion with the required parameter invalid "users"(different from an array)', (done) => {
-			void request
+		it('should throw an error when the user tries to create a discussion with the required parameter invalid "users"(different from an array)', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
@@ -1925,30 +1853,26 @@ describe('[Rooms]', () => {
 					t_name: 'valid name',
 					users: 'invalid-type-of-users',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').that.includes('must be array');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').that.includes('must be array');
 		});
-		it("should throw an error when the user tries to create a discussion with the channel's id invalid", (done) => {
-			void request
+		it("should throw an error when the user tries to create a discussion with the channel's id invalid", async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
 					prid: 'invalid-id',
 					t_name: 'valid name',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-invalid-room');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-room');
 		});
-		it("should throw an error when the user tries to create a discussion with the message's id invalid", (done) => {
-			void request
+		it("should throw an error when the user tries to create a discussion with the message's id invalid", async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
@@ -1956,32 +1880,28 @@ describe('[Rooms]', () => {
 					t_name: 'valid name',
 					pmid: 'invalid-message',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-invalid-message');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-invalid-message');
 		});
-		it('should create a discussion successfully when send only the required parameters', (done) => {
-			void request
+		it('should create a discussion successfully when send only the required parameters', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
 					prid: testChannel._id,
 					t_name: `discussion-create-from-tests-${testChannel.name}`,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('discussion').and.to.be.an('object');
-					expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
-					expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('discussion').and.to.be.an('object');
+			expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
+			expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
 		});
-		it('should create a discussion successfully when send the required parameters plus the optional parameter "reply"', (done) => {
-			void request
+		it('should create a discussion successfully when send the required parameters plus the optional parameter "reply"', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
@@ -1989,17 +1909,15 @@ describe('[Rooms]', () => {
 					t_name: `discussion-create-from-tests-${testChannel.name}`,
 					reply: 'reply from discussion tests',
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('discussion').and.to.be.an('object');
-					expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
-					expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('discussion').and.to.be.an('object');
+			expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
+			expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
 		});
-		it('should create a discussion successfully when send the required parameters plus the optional parameter "users"', (done) => {
-			void request
+		it('should create a discussion successfully when send the required parameters plus the optional parameter "users"', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
@@ -2008,17 +1926,15 @@ describe('[Rooms]', () => {
 					reply: 'reply from discussion tests',
 					users: ['rocket.cat'],
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('discussion').and.to.be.an('object');
-					expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
-					expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('discussion').and.to.be.an('object');
+			expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
+			expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
 		});
-		it('should create a discussion successfully when send the required parameters plus the optional parameter "pmid"', (done) => {
-			void request
+		it('should create a discussion successfully when send the required parameters plus the optional parameter "pmid"', async () => {
+			const res = await request
 				.post(api('rooms.createDiscussion'))
 				.set(credentials)
 				.send({
@@ -2028,19 +1944,17 @@ describe('[Rooms]', () => {
 					users: ['rocket.cat'],
 					pmid: messageSent._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('discussion').and.to.be.an('object');
-					expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
-					expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('discussion').and.to.be.an('object');
+			expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
+			expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}`);
 		});
 
 		describe('it should create a *private* discussion if the parent channel is public and inside a private team', async () => {
-			it('should create a team', (done) => {
-				void request
+			it('should create a team', async () => {
+				const res = await request
 					.post(api('teams.create'))
 					.set(credentials)
 					.send({
@@ -2048,18 +1962,16 @@ describe('[Rooms]', () => {
 						type: 1,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('team');
-						expect(res.body).to.have.nested.property('team._id');
-						privateTeam = res.body.team;
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('team');
+				expect(res.body).to.have.nested.property('team._id');
+				privateTeam = res.body.team;
 			});
 
-			it('should add the public channel to the team', (done) => {
-				void request
+			it('should add the public channel to the team', async () => {
+				const res = await request
 					.post(api('teams.addRooms'))
 					.set(credentials)
 					.send({
@@ -2067,30 +1979,26 @@ describe('[Rooms]', () => {
 						teamId: privateTeam._id,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success');
 			});
 
-			it('should create a private discussion inside the public channel', (done) => {
-				void request
+			it('should create a private discussion inside the public channel', async () => {
+				const res = await request
 					.post(api('rooms.createDiscussion'))
 					.set(credentials)
 					.send({
 						prid: testChannel._id,
 						t_name: `discussion-create-from-tests-${testChannel.name}-team`,
 					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('discussion').and.to.be.an('object');
-						expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
-						expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}-team`);
-						expect(res.body.discussion).to.have.property('t').and.to.be.equal('p');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('discussion').and.to.be.an('object');
+				expect(res.body.discussion).to.have.property('prid').and.to.be.equal(testChannel._id);
+				expect(res.body.discussion).to.have.property('fname').and.to.be.equal(`discussion-create-from-tests-${testChannel.name}-team`);
+				expect(res.body.discussion).to.have.property('t').and.to.be.equal('p');
 			});
 		});
 	});
@@ -2117,17 +2025,11 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		it('should throw an error when the user tries to gets a list of discussion without a required parameter "roomId"', (done) => {
-			void request
-				.get(api('rooms.getDiscussions'))
-				.set(credentials)
-				.query({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'The parameter "roomId" or "roomName" is required [error-roomid-param-not-provided]');
-				})
-				.end(done);
+		it('should throw an error when the user tries to gets a list of discussion without a required parameter "roomId"', async () => {
+			const res = await request.get(api('rooms.getDiscussions')).set(credentials).query({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'The parameter "roomId" or "roomName" is required [error-roomid-param-not-provided]');
 		});
 		it('should throw an error when the user tries to gets a list of discussion and he cannot access the room', (done) => {
 			void updatePermission('view-c-room', []).then(() => {
@@ -2143,20 +2045,18 @@ describe('[Rooms]', () => {
 					.end(() => updatePermission('view-c-room', ['admin', 'user', 'bot', 'anonymous']).then(done));
 			});
 		});
-		it('should return a list of discussions with ONE discussion', (done) => {
-			void request
+		it('should return a list of discussions with ONE discussion', async () => {
+			const res = await request
 				.get(api('rooms.getDiscussions'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('discussions').and.to.be.an('array');
-					expect(res.body.discussions).to.have.lengthOf(1);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('discussions').and.to.be.an('array');
+			expect(res.body.discussions).to.have.lengthOf(1);
 		});
 	});
 
@@ -2192,75 +2092,65 @@ describe('[Rooms]', () => {
 			]),
 		);
 
-		it('should fail when the room does not exist', (done) => {
-			void request
+		it('should fail when the room does not exist', async () => {
+			const res = await request
 				.post(api('rooms.join'))
 				.set(testUserCredentials)
 				.send({ roomId: 'invalid-room-id' })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-room-not-found');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-room-not-found');
 		});
 
-		it('should join a public channel by roomId', (done) => {
-			void request
+		it('should join a public channel by roomId', async () => {
+			const res = await request
 				.post(api('rooms.join'))
 				.set(testUserCredentials)
 				.send({ roomId: testChannel._id })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('room._id', testChannel._id);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('room._id', testChannel._id);
 		});
 
-		it('should join a public channel by roomName', (done) => {
-			void request
+		it('should join a public channel by roomName', async () => {
+			const res = await request
 				.post(api('rooms.join'))
 				.set(testUserCredentials)
 				.send({ roomName: testChannel.name })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('room._id', testChannel._id);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('room._id', testChannel._id);
 		});
 
-		it('should join a discussion (a room with a parent room) by roomId', (done) => {
-			void request
+		it('should join a discussion (a room with a parent room) by roomId', async () => {
+			const res = await request
 				.post(api('rooms.join'))
 				.set(testUserCredentials)
 				.send({ roomId: testDiscussion._id })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('room._id', testDiscussion._id);
-					expect(res.body).to.have.nested.property('room.prid', testChannel._id);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('room._id', testDiscussion._id);
+			expect(res.body).to.have.nested.property('room.prid', testChannel._id);
 		});
 
-		it('should fail to join a private group the user cannot access', (done) => {
-			void request
+		it('should fail to join a private group the user cannot access', async () => {
+			const res = await request
 				.post(api('rooms.join'))
 				.set(testUserCredentials)
 				.send({ roomId: testGroup._id })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'error-not-allowed');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'error-not-allowed');
 		});
 
 		describe('with a join code', () => {
@@ -2269,46 +2159,40 @@ describe('[Rooms]', () => {
 				await updatePermission('join-without-join-code', []);
 			});
 
-			it('should fail to join without a join code', (done) => {
-				void request
+			it('should fail to join without a join code', async () => {
+				const res = await request
 					.post(api('rooms.join'))
 					.set(testUserCredentials)
 					.send({ roomId: testChannelWithCode._id })
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-code-required');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('errorType', 'error-code-required');
 			});
 
-			it('should fail to join with an incorrect join code', (done) => {
-				void request
+			it('should fail to join with an incorrect join code', async () => {
+				const res = await request
 					.post(api('rooms.join'))
 					.set(testUserCredentials)
 					.send({ roomId: testChannelWithCode._id, joinCode: 'WRONG' })
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-code-invalid');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('errorType', 'error-code-invalid');
 			});
 
-			it('should join with the correct join code', (done) => {
-				void request
+			it('should join with the correct join code', async () => {
+				const res = await request
 					.post(api('rooms.join'))
 					.set(testUserCredentials)
 					.send({ roomId: testChannelWithCode._id, joinCode: '123' })
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('room._id', testChannelWithCode._id);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.nested.property('room._id', testChannelWithCode._id);
 			});
 		});
 	});
@@ -2326,79 +2210,69 @@ describe('[Rooms]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
-		it('should return an error when the required parameter "selector" is not provided', (done) => {
-			void request
+		it('should return an error when the required parameter "selector" is not provided', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate'))
 				.set(credentials)
 				.query({})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.include("must have required property 'selector'");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.include("must have required property 'selector'");
 		});
-		it('should return the rooms to fill auto complete', (done) => {
-			void request
+		it('should return the rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate'))
 				.query({ selector: '{}' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
 		});
-		it('should return the rooms with cyrillic characters in channel name', (done) => {
-			void request
+		it('should return the rooms with cyrillic characters in channel name', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate'))
 				.query({ selector: '{ "name": "тест" }' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-					expect(res.body.items).to.have.lengthOf(1);
-					expect(res.body.items[0].fname).to.be.equal('тест');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
+			expect(res.body.items).to.have.lengthOf(1);
+			expect(res.body.items[0].fname).to.be.equal('тест');
 		});
 	});
 
 	describe('[/rooms.autocomplete.channelAndPrivate.withPagination]', () => {
-		it('should return an error when the required parameter "selector" is not provided', (done) => {
-			void request
+		it('should return an error when the required parameter "selector" is not provided', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate.withPagination'))
 				.set(credentials)
 				.query({})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.include("must have required property 'selector'");
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.include("must have required property 'selector'");
 		});
-		it('should return the rooms to fill auto complete', (done) => {
-			void request
+		it('should return the rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate.withPagination'))
 				.query({ selector: '{}' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
 		});
-		it('should return the rooms to fill auto complete even requested with count and offset params', (done) => {
-			void request
+		it('should return the rooms to fill auto complete even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.channelAndPrivate.withPagination'))
 				.query({ selector: '{}' })
 				.set(credentials)
@@ -2407,41 +2281,35 @@ describe('[Rooms]', () => {
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-					expect(res.body).to.have.property('total');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
+			expect(res.body).to.have.property('total');
 		});
 	});
 
 	describe('[/rooms.autocomplete.availableForTeams]', () => {
-		it('should return the rooms to fill auto complete', (done) => {
-			void request
+		it('should return the rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.availableForTeams'))
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
 		});
-		it('should return the filtered rooms to fill auto complete', (done) => {
-			void request
+		it('should return the filtered rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.availableForTeams'))
 				.query({ name: 'group' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
 		});
 	});
 
@@ -2480,34 +2348,30 @@ describe('[Rooms]', () => {
 					.end(done);
 			});
 		});
-		it('should return the rooms to fill auto complete', (done) => {
-			void request
+		it('should return the rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.adminRooms'))
 				.query({ selector: '{}' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
 		});
-		it('should return the rooms to fill auto complete', (done) => {
-			void request
+		it('should return the rooms to fill auto complete', async () => {
+			const res = await request
 				.get(api('rooms.autocomplete.adminRooms'))
 				.set(credentials)
 				.query({
 					selector: JSON.stringify(name),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('items').and.to.be.an('array');
-					expect(res.body).to.have.property('items').that.have.lengthOf(2);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('items').and.to.be.an('array');
+			expect(res.body).to.have.property('items').that.have.lengthOf(2);
 		});
 	});
 
@@ -2549,149 +2413,130 @@ describe('[Rooms]', () => {
 					.end(() => updatePermission('view-room-administration', ['admin']).then(done));
 			});
 		});
-		it('should return a list of admin rooms', (done) => {
-			void request
-				.get(api('rooms.adminRooms'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return a list of admin rooms', async () => {
+			const res = await request.get(api('rooms.adminRooms')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return a list of admin rooms even requested with count and offset params', (done) => {
-			void request
+		it('should return a list of admin rooms even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
 					count: 5,
 					offset: 0,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body).to.have.property('offset');
-					expect(res.body).to.have.property('total');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should search the list of admin rooms using non-latin characters when UI_Allow_room_names_with_special_chars setting is toggled', (done) => {
-			void updateSetting('UI_Allow_room_names_with_special_chars', true).then(() => {
-				void request
-					.get(api('rooms.adminRooms'))
-					.set(credentials)
-					.query({
-						filter: fnameRoom,
-					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('rooms').and.to.be.an('array');
-						expect(res.body.rooms).to.have.lengthOf(1);
-						expect(res.body.rooms[0].fname).to.be.equal(fnameRoom);
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('count');
-					})
-					.end(done);
-			});
-		});
-		it('should search the list of admin rooms using latin characters only when UI_Allow_room_names_with_special_chars setting is disabled', (done) => {
-			void updateSetting('UI_Allow_room_names_with_special_chars', false).then(() => {
-				void request
-					.get(api('rooms.adminRooms'))
-					.set(credentials)
-					.query({
-						filter: nameRoom,
-					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('rooms').and.to.be.an('array');
-						expect(res.body.rooms).to.have.lengthOf(1);
-						expect(res.body.rooms[0].name).to.be.equal(nameRoom);
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('count');
-					})
-					.end(done);
-			});
-		});
-		it('should filter by only rooms types', (done) => {
-			void request
+		it('should search the list of admin rooms using non-latin characters when UI_Allow_room_names_with_special_chars setting is toggled', async () => {
+			await updateSetting('UI_Allow_room_names_with_special_chars', true);
+
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
-					types: ['p'],
+					filter: fnameRoom,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms).to.have.lengthOf.at.least(1);
-					expect(res.body.rooms[0].t).to.be.equal('p');
-					expect((res.body.rooms as IRoom[]).find((room) => room.name === nameRoom)).to.exist;
-					expect((res.body.rooms as IRoom[]).find((room) => room.name === discussionRoomName)).to.not.exist;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf(1);
+			expect(res.body.rooms[0].fname).to.be.equal(fnameRoom);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should filter by only name', (done) => {
-			void request
+		it('should search the list of admin rooms using latin characters only when UI_Allow_room_names_with_special_chars setting is disabled', async () => {
+			await updateSetting('UI_Allow_room_names_with_special_chars', false);
+
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
 					filter: nameRoom,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms).to.have.lengthOf(1);
-					expect(res.body.rooms[0].name).to.be.equal(nameRoom);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf(1);
+			expect(res.body.rooms[0].name).to.be.equal(nameRoom);
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should filter by type and name at the same query', (done) => {
-			void request
+		it('should filter by only rooms types', async () => {
+			const res = await request
+				.get(api('rooms.adminRooms'))
+				.set(credentials)
+				.query({
+					types: ['p'],
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf.at.least(1);
+			expect(res.body.rooms[0].t).to.be.equal('p');
+			expect((res.body.rooms as IRoom[]).find((room) => room.name === nameRoom)).to.exist;
+			expect((res.body.rooms as IRoom[]).find((room) => room.name === discussionRoomName)).to.not.exist;
+		});
+		it('should filter by only name', async () => {
+			const res = await request
+				.get(api('rooms.adminRooms'))
+				.set(credentials)
+				.query({
+					filter: nameRoom,
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf(1);
+			expect(res.body.rooms[0].name).to.be.equal(nameRoom);
+		});
+		it('should filter by type and name at the same query', async () => {
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
 					filter: nameRoom,
 					types: ['p'],
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms).to.have.lengthOf(1);
-					expect(res.body.rooms[0].name).to.be.equal(nameRoom);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf(1);
+			expect(res.body.rooms[0].name).to.be.equal(nameRoom);
 		});
-		it('should return an empty array when filter by wrong type and correct room name', (done) => {
-			void request
+		it('should return an empty array when filter by wrong type and correct room name', async () => {
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
 					filter: nameRoom,
 					types: ['c'],
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms).to.have.lengthOf(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf(0);
 		});
-		it('should return an array sorted by "ts" property', (done) => {
-			void request
+		it('should return an array sorted by "ts" property', async () => {
+			const res = await request
 				.get(api('rooms.adminRooms'))
 				.set(credentials)
 				.query({
@@ -2699,14 +2544,12 @@ describe('[Rooms]', () => {
 						ts: -1,
 					}),
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms').and.to.be.an('array');
-					expect(res.body.rooms).to.have.lengthOf.at.least(1);
-					expect(res.body.rooms[0]).to.have.property('ts').that.is.a('string');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('rooms').and.to.be.an('array');
+			expect(res.body.rooms).to.have.lengthOf.at.least(1);
+			expect(res.body.rooms[0]).to.have.property('ts').that.is.a('string');
 		});
 		it('should return the customFields of a private room', async () => {
 			const roomCustomFields = { department: 'engineering', priority: 'high' };
@@ -2981,56 +2824,43 @@ describe('[Rooms]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
-		it('should throw an error when roomId is not provided', (done) => {
-			void request
-				.post(api('rooms.delete'))
-				.set(credentials)
-				.send({})
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-					expect(res.body).to.have.property('error').include("must have required property 'roomId'");
-				})
-				.end(done);
+		it('should throw an error when roomId is not provided', async () => {
+			const res = await request.post(api('rooms.delete')).set(credentials).send({}).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
+			expect(res.body).to.have.property('error').include("must have required property 'roomId'");
 		});
 
-		it('should delete a room when the request is correct', (done) => {
-			void request
+		it('should delete a room when the request is correct', async () => {
+			const res = await request
 				.post(api('rooms.delete'))
 				.set(credentials)
 				.send({ roomId: testChannel._id })
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
-		it('should throw an error when the room id doesn exist', (done) => {
-			void request
+		it('should throw an error when the room id doesn exist', async () => {
+			const res = await request
 				.post(api('rooms.delete'))
 				.set(credentials)
 				.send({ roomId: 'invalid' })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
-		it('should throw an error when room is a main team room', (done) => {
-			void request
+		it('should throw an error when room is a main team room', async () => {
+			const res = await request
 				.post(api('rooms.delete'))
 				.set(credentials)
 				.send({ roomId: testTeam.roomId })
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 
@@ -3094,31 +2924,29 @@ describe('[Rooms]', () => {
 				.end(done);
 		});
 
-		it('should have reflected on rooms.info', (done) => {
-			void request
+		it('should have reflected on rooms.info', async () => {
+			const res = await request
 				.get(api('rooms.info'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room').and.to.be.an('object');
+				.expect(200);
 
-					expect(res.body.room).to.have.property('_id', testChannel._id);
-					expect(res.body.room).to.have.property('name', randomString);
-					expect(res.body.room).to.have.property('topic', randomString);
-					expect(res.body.room).to.have.property('announcement', randomString);
-					expect(res.body.room).to.have.property('description', randomString);
-					expect(res.body.room).to.have.property('t', 'p');
-					expect(res.body.room).to.have.property('featured', true);
-					expect(res.body.room).to.have.property('ro', true);
-					expect(res.body.room).to.have.property('default', true);
-					expect(res.body.room).to.have.property('favorite', true);
-					expect(res.body.room).to.have.property('reactWhenReadOnly', true);
-				})
-				.end(done);
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('room').and.to.be.an('object');
+
+			expect(res.body.room).to.have.property('_id', testChannel._id);
+			expect(res.body.room).to.have.property('name', randomString);
+			expect(res.body.room).to.have.property('topic', randomString);
+			expect(res.body.room).to.have.property('announcement', randomString);
+			expect(res.body.room).to.have.property('description', randomString);
+			expect(res.body.room).to.have.property('t', 'p');
+			expect(res.body.room).to.have.property('featured', true);
+			expect(res.body.room).to.have.property('ro', true);
+			expect(res.body.room).to.have.property('default', true);
+			expect(res.body.room).to.have.property('favorite', true);
+			expect(res.body.room).to.have.property('reactWhenReadOnly', true);
 		});
 
 		it('should be able to update the discussion name with spaces', async () => {

--- a/apps/meteor/tests/end-to-end/api/settings.ts
+++ b/apps/meteor/tests/end-to-end/api/settings.ts
@@ -10,96 +10,77 @@ describe('[Settings]', () => {
 	before((done) => getCredentials(done));
 
 	describe('[/settings.public]', () => {
-		it('should return public settings', (done) => {
-			void request
-				.get(api('settings.public'))
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('settings');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return public settings', async () => {
+			const res = await request.get(api('settings.public')).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('settings');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return public settings even requested with count and offset params', (done) => {
-			void request
+		it('should return public settings even requested with count and offset params', async () => {
+			const res = await request
 				.get(api('settings.public'))
 				.query({
 					count: 5,
 					offset: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success').and.to.be.true;
-					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(5);
-					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(5);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success').and.to.be.true;
+			expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(5);
+			expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(5);
 		});
-		it('should return public settings even requested with _id param', (done) => {
-			void request
+		it('should return public settings even requested with _id param', async () => {
+			const res = await request
 				.get(api('settings.public'))
 				.query({
 					_id: 'Site_Url',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success').and.to.be.true;
-					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(1);
-					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(1);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success').and.to.be.true;
+			expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(1);
+			expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(1);
 		});
-		it('should return public settings even requested with _id param as an array', (done) => {
-			void request
+		it('should return public settings even requested with _id param as an array', async () => {
+			const res = await request
 				.get(api('settings.public'))
 				.query({
 					_id: 'Site_Url,LDAP_Enable',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success').and.to.be.true;
-					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(2);
-					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(2);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success').and.to.be.true;
+			expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.have.lengthOf(2);
+			expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(2);
 		});
-		it('should return an empty response when requesting public settings with a broken _id param', (done) => {
-			void request
+		it('should return an empty response when requesting public settings with a broken _id param', async () => {
+			const res = await request
 				.get(api('settings.public'))
 				.query({
 					_id: 10,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success').and.to.be.true;
-					expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.be.empty;
-					expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(0);
-					expect(res.body).to.have.property('offset').and.to.be.a('number').and.to.equal(0);
-					expect(res.body).to.have.property('total').and.to.be.a('number').and.to.equal(0);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success').and.to.be.true;
+			expect(res.body).to.have.property('settings').and.to.be.an('array').and.to.be.empty;
+			expect(res.body).to.have.property('count').and.to.be.a('number').and.to.equal(0);
+			expect(res.body).to.have.property('offset').and.to.be.a('number').and.to.equal(0);
+			expect(res.body).to.have.property('total').and.to.be.a('number').and.to.equal(0);
 		});
 	});
 
 	describe('[/settings]', () => {
-		it('should return private settings', (done) => {
-			void request
-				.get(api('settings'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('settings');
-					expect(res.body).to.have.property('count');
-				})
-				.end(done);
+		it('should return private settings', async () => {
+			const res = await request.get(api('settings')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('settings');
+			expect(res.body).to.have.property('count');
 		});
 		it('should return the default values of the settings when includeDefaults is true', async () => {
 			return request
@@ -327,17 +308,11 @@ describe('[Settings]', () => {
 	});
 
 	describe('[/service.configurations]', () => {
-		it('should return service configurations', (done) => {
-			void request
-				.get(api('service.configurations'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('configurations');
-				})
-				.end(done);
+		it('should return service configurations', async () => {
+			const res = await request.get(api('service.configurations')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('configurations');
 		});
 
 		describe('With OAuth enabled', () => {
@@ -390,29 +365,18 @@ describe('[Settings]', () => {
 	});
 
 	describe('/settings.oauth', () => {
-		it('should have return list of available oauth services when user is not logged', (done) => {
-			void request
-				.get(api('settings.oauth'))
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('services').and.to.be.an('array');
-				})
-				.end(done);
+		it('should have return list of available oauth services when user is not logged', async () => {
+			const res = await request.get(api('settings.oauth')).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('services').and.to.be.an('array');
 		});
 
-		it('should have return list of available oauth services when user is logged', (done) => {
-			void request
-				.get(api('settings.oauth'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('services').and.to.be.an('array');
-				})
-				.end(done);
+		it('should have return list of available oauth services when user is logged', async () => {
+			const res = await request.get(api('settings.oauth')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('services').and.to.be.an('array');
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/statistics.ts
+++ b/apps/meteor/tests/end-to-end/api/statistics.ts
@@ -11,99 +11,76 @@ describe('[Statistics]', () => {
 
 	describe('[/statistics]', () => {
 		let lastUptime: unknown;
-		it('should return an error when the user does not have the necessary permission', (done) => {
-			void updatePermission('view-statistics', []).then(() => {
-				void request
-					.get(api('statistics'))
-					.set(credentials)
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.error).to.be.equal('error-not-allowed');
-					})
-					.end(done);
-			});
+		it('should return an error when the user does not have the necessary permission', async () => {
+			await updatePermission('view-statistics', []);
+
+			const res = await request.get(api('statistics')).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('error-not-allowed');
 		});
-		it('should return an object with the statistics', (done) => {
-			void updatePermission('view-statistics', ['admin']).then(() => {
-				void request
-					.get(api('statistics'))
-					.set(credentials)
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('process');
-						expect(res.body.process).to.have.property('uptime');
-						lastUptime = res.body.process.uptime;
-					})
-					.end(done);
-			});
+
+		it('should return an object with the statistics', async () => {
+			await updatePermission('view-statistics', ['admin']);
+
+			const res = await request.get(api('statistics')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('process');
+			expect(res.body.process).to.have.property('uptime');
+
+			lastUptime = res.body.process.uptime;
 		});
-		it('should update the statistics when is provided the "refresh:true" query parameter', (done) => {
-			void request
-				.get(api('statistics'))
-				.query({ refresh: 'true' })
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('process');
-					expect(res.body.process).to.have.property('uptime');
-					expect(lastUptime).to.not.be.equal(res.body.process.uptime);
-				})
-				.end(done);
+
+		it('should update the statistics when is provided the "refresh:true" query parameter', async () => {
+			const res = await request.get(api('statistics')).query({ refresh: 'true' }).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('process');
+			expect(res.body.process).to.have.property('uptime');
+			expect(lastUptime).to.not.be.equal(res.body.process.uptime);
 		});
 	});
 
 	describe('[/statistics.list]', () => {
-		it('should return an error when the user does not have the necessary permission', (done) => {
-			void updatePermission('view-statistics', []).then(() => {
-				void request
-					.get(api('statistics.list'))
-					.set(credentials)
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.error).to.be.equal('error-not-allowed');
-					})
-					.end(done);
-			});
+		it('should return an error when the user does not have the necessary permission', async () => {
+			await updatePermission('view-statistics', []);
+
+			const res = await request.get(api('statistics.list')).set(credentials).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('error-not-allowed');
 		});
-		it('should return an array with the statistics', (done) => {
-			void updatePermission('view-statistics', ['admin']).then(() => {
-				void request
-					.get(api('statistics.list'))
-					.set(credentials)
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('statistics').and.to.be.an('array');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('count');
-					})
-					.end(done);
-			});
+
+		it('should return an array with the statistics', async () => {
+			await updatePermission('view-statistics', ['admin']);
+
+			const res = await request.get(api('statistics.list')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('statistics').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
-		it('should return an array with the statistics even requested with count and offset params', (done) => {
-			void updatePermission('view-statistics', ['admin']).then(() => {
-				void request
-					.get(api('statistics.list'))
-					.set(credentials)
-					.query({
-						count: 5,
-						offset: 0,
-					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('statistics').and.to.be.an('array');
-						expect(res.body).to.have.property('offset');
-						expect(res.body).to.have.property('total');
-						expect(res.body).to.have.property('count');
-					})
-					.end(done);
-			});
+
+		it('should return an array with the statistics even requested with count and offset params', async () => {
+			await updatePermission('view-statistics', ['admin']);
+
+			const res = await request
+				.get(api('statistics.list'))
+				.set(credentials)
+				.query({
+					count: 5,
+					offset: 0,
+				})
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('statistics').and.to.be.an('array');
+			expect(res.body).to.have.property('offset');
+			expect(res.body).to.have.property('total');
+			expect(res.body).to.have.property('count');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/subscriptions.ts
+++ b/apps/meteor/tests/end-to-end/api/subscriptions.ts
@@ -20,79 +20,61 @@ describe('[Subscriptions]', () => {
 
 	after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-	it('/subscriptions.get', (done) => {
-		void request
-			.get(api('subscriptions.get'))
-			.set(credentials)
-			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('update');
-				expect(res.body).to.have.property('remove');
-			})
-			.end(done);
+	it('/subscriptions.get', async () => {
+		const res = await request.get(api('subscriptions.get')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('update');
+		expect(res.body).to.have.property('remove');
 	});
 
-	it('/subscriptions.get?updatedSince', (done) => {
-		void request
+	it('/subscriptions.get?updatedSince', async () => {
+		const res = await request
 			.get(api('subscriptions.get'))
 			.set(credentials)
 			.query({
 				updatedSince: new Date(),
 			})
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('update').that.have.lengthOf(0);
-				expect(res.body).to.have.property('remove').that.have.lengthOf(0);
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('update').that.have.lengthOf(0);
+		expect(res.body).to.have.property('remove').that.have.lengthOf(0);
 	});
 
 	describe('/subscriptions.getOne', () => {
-		it('should fail if no roomId provided', (done) => {
-			void request
-				.get(api('subscriptions.getOne'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', "must have required property 'roomId'");
-				})
-				.end(done);
+		it('should fail if no roomId provided', async () => {
+			const res = await request.get(api('subscriptions.getOne')).set(credentials).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', "must have required property 'roomId'");
 		});
 
-		it('should fail if not logged in', (done) => {
-			void request
+		it('should fail if not logged in', async () => {
+			const res = await request
 				.get(api('subscriptions.getOne'))
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+				.expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return the subscription with success', (done) => {
-			void request
+		it('should return the subscription with success', async () => {
+			const res = await request
 				.get(api('subscriptions.getOne'))
 				.set(credentials)
 				.query({
 					roomId: testChannel._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('subscription').and.to.be.an('object');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('subscription').and.to.be.an('object');
 		});
 
 		it('should keep subscription as read after sending a message', async () => {
@@ -164,135 +146,113 @@ describe('[Subscriptions]', () => {
 			]),
 		);
 
-		it('should mark public channels as read', (done) => {
-			void request
+		it('should mark public channels as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: testChannel._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should mark groups as read', (done) => {
-			void request
+		it('should mark groups as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: testGroup._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should mark DMs as read', (done) => {
-			void request
+		it('should mark DMs as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: testDM._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should fail on two params with different ids', (done) => {
-			void request
+		it('should fail on two params with different ids', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: testDM._id,
 					roomId: testChannel._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
 		});
 
-		it('should fail on mark inexistent public channel as read', (done) => {
-			void request
+		it('should fail on mark inexistent public channel as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: 'foobar123-somechannel',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'error-invalid-subscription');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'error-invalid-subscription');
 		});
 
-		it('should fail on mark inexistent group as read', (done) => {
-			void request
+		it('should fail on mark inexistent group as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: 'foobar123-somegroup',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'error-invalid-subscription');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'error-invalid-subscription');
 		});
 
-		it('should fail on mark inexistent DM as read', (done) => {
-			void request
+		it('should fail on mark inexistent DM as read', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: 'foobar123-somedm',
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'error-invalid-subscription');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'error-invalid-subscription');
 		});
 
-		it('should fail on invalid params', (done) => {
-			void request
+		it('should fail on invalid params', async () => {
+			const res = await request
 				.post(api('subscriptions.read'))
 				.set(credentials)
 				.send({
 					rid: 12345,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'error-invalid-subscription');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'error-invalid-subscription');
 		});
 
-		it('should fail on empty params', (done) => {
-			void request
-				.post(api('subscriptions.read'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-				})
-				.end(done);
+		it('should fail on empty params', async () => {
+			const res = await request.post(api('subscriptions.read')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
 		});
 
 		describe('should handle threads correctly', () => {
@@ -406,23 +366,22 @@ describe('[Subscriptions]', () => {
 
 		after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
 
-		it('should fail when there are no messages on an channel', (done) => {
-			void request
+		it('should fail when there are no messages on an channel', async () => {
+			const res = await request
 				.post(api('subscriptions.unread'))
 				.set(credentials)
 				.send({
 					roomId: testChannel._id,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body).to.have.property('errorType', 'error-no-message-for-unread');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
+			expect(res.body).to.have.property('errorType', 'error-no-message-for-unread');
 		});
-		it('sending message', (done) => {
-			void request
+
+		it('sending message', async () => {
+			const res = await request
 				.post(api('chat.sendMessage'))
 				.set(credentials)
 				.send({
@@ -432,53 +391,42 @@ describe('[Subscriptions]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('message').and.to.be.an('object');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('message').and.to.be.an('object');
 		});
-		it('should return success: true when make as unread successfully', (done) => {
-			void request
+
+		it('should return success: true when make as unread successfully', async () => {
+			const res = await request
 				.post(api('subscriptions.unread'))
 				.set(credentials)
 				.send({
 					roomId: testChannel._id,
 				})
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should fail on invalid params', (done) => {
-			void request
+		it('should fail on invalid params', async () => {
+			const res = await request
 				.post(api('subscriptions.unread'))
 				.set(credentials)
 				.send({
 					roomId: 12345,
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should fail on empty params', (done) => {
-			void request
-				.post(api('subscriptions.unread'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+		it('should fail on empty params', async () => {
+			const res = await request.post(api('subscriptions.unread')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/teams.ts
+++ b/apps/meteor/tests/end-to-end/api/teams.ts
@@ -67,8 +67,8 @@ describe('[Teams]', () => {
 			return updatePermission('create-team', ['admin', 'user']);
 		});
 
-		it('should create a public team', (done) => {
-			void request
+		it('should create a public team', async () => {
+			const res = await request
 				.post(api('teams.create'))
 				.set(credentials)
 				.send({
@@ -76,14 +76,12 @@ describe('[Teams]', () => {
 					type: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('team');
-					expect(res.body).to.have.nested.property('team._id');
-					createdTeams.push(res.body.team);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('team');
+			expect(res.body).to.have.nested.property('team._id');
+			createdTeams.push(res.body.team);
 		});
 
 		it('should create a public team with a member', (done) => {
@@ -171,8 +169,8 @@ describe('[Teams]', () => {
 				.catch(done);
 		});
 
-		it('should throw an error if the team already exists', (done) => {
-			void request
+		it('should throw an error if the team already exists', async () => {
+			const res = await request
 				.post(api('teams.create'))
 				.set(credentials)
 				.send({
@@ -180,13 +178,11 @@ describe('[Teams]', () => {
 					type: 0,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.be.equal('team-name-already-exists');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
+			expect(res.body.error).to.be.equal('team-name-already-exists');
 		});
 
 		it('should not create a team with no associated room', async () => {
@@ -691,34 +687,32 @@ describe('/teams.members', () => {
 
 	after(() => Promise.all([deleteUser(testUser), deleteUser(testUser2), deleteTeam(credentials, teamName)]));
 
-	it('should list all the members from a public team', (done) => {
-		void request
+	it('should list all the members from a public team', async () => {
+		const res = await request
 			.get(api('teams.members'))
 			.set(credentials)
 			.query({
 				teamName: testTeam.name,
 			})
 			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('count', 3);
-				expect(res.body).to.have.property('offset', 0);
-				expect(res.body).to.have.property('total', 3);
-				expect(res.body).to.have.property('members');
-				expect(res.body.members).to.have.length(3);
-				expect(res.body.members[0]).to.have.property('user');
-				expect(res.body.members[0]).to.have.property('roles');
-				expect(res.body.members[0]).to.have.property('createdBy');
-				expect(res.body.members[0]).to.have.property('createdAt');
-				expect(res.body.members[0].user).to.have.property('_id');
-				expect(res.body.members[0].user).to.have.property('username');
-				expect(res.body.members[0].user).to.have.property('name');
-				expect(res.body.members[0].user).to.have.property('status');
-				expect(res.body.members[0].createdBy).to.have.property('_id');
-				expect(res.body.members[0].createdBy).to.have.property('username');
-			})
-			.end(done);
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('count', 3);
+		expect(res.body).to.have.property('offset', 0);
+		expect(res.body).to.have.property('total', 3);
+		expect(res.body).to.have.property('members');
+		expect(res.body.members).to.have.length(3);
+		expect(res.body.members[0]).to.have.property('user');
+		expect(res.body.members[0]).to.have.property('roles');
+		expect(res.body.members[0]).to.have.property('createdBy');
+		expect(res.body.members[0]).to.have.property('createdAt');
+		expect(res.body.members[0].user).to.have.property('_id');
+		expect(res.body.members[0].user).to.have.property('username');
+		expect(res.body.members[0].user).to.have.property('name');
+		expect(res.body.members[0].user).to.have.property('status');
+		expect(res.body.members[0].createdBy).to.have.property('_id');
+		expect(res.body.members[0].createdBy).to.have.property('username');
 	});
 });
 
@@ -781,32 +775,26 @@ describe('/teams.list', () => {
 
 	after('delete test users', () => deleteUser(testUser1));
 
-	it('should list all teams', (done) => {
-		void request
-			.get(api('teams.list'))
-			.set(credentials)
-			.expect('Content-Type', 'application/json')
-			.expect(200)
-			.expect((res) => {
-				expect(res.body).to.have.property('success', true);
-				expect(res.body).to.have.property('count');
-				expect(res.body).to.have.property('offset', 0);
-				expect(res.body).to.have.property('total');
-				expect(res.body).to.have.property('teams');
-				expect(res.body.teams.length).to.be.gte(1);
-				expect(res.body.teams[0]).to.have.property('_id');
-				expect(res.body.teams[0]).to.have.property('_updatedAt');
-				expect(res.body.teams[0]).to.have.property('name');
-				expect(res.body.teams[0]).to.have.property('type');
-				expect(res.body.teams[0]).to.have.property('roomId');
-				expect(res.body.teams[0]).to.have.property('createdBy');
-				expect(res.body.teams[0].createdBy).to.have.property('_id');
-				expect(res.body.teams[0].createdBy).to.have.property('username');
-				expect(res.body.teams[0]).to.have.property('createdAt');
-				expect(res.body.teams[0]).to.have.property('rooms');
-				expect(res.body.teams[0]).to.have.property('numberOfUsers');
-			})
-			.end(done);
+	it('should list all teams', async () => {
+		const res = await request.get(api('teams.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('count');
+		expect(res.body).to.have.property('offset', 0);
+		expect(res.body).to.have.property('total');
+		expect(res.body).to.have.property('teams');
+		expect(res.body.teams.length).to.be.gte(1);
+		expect(res.body.teams[0]).to.have.property('_id');
+		expect(res.body.teams[0]).to.have.property('_updatedAt');
+		expect(res.body.teams[0]).to.have.property('name');
+		expect(res.body.teams[0]).to.have.property('type');
+		expect(res.body.teams[0]).to.have.property('roomId');
+		expect(res.body.teams[0]).to.have.property('createdBy');
+		expect(res.body.teams[0].createdBy).to.have.property('_id');
+		expect(res.body.teams[0].createdBy).to.have.property('username');
+		expect(res.body.teams[0]).to.have.property('createdAt');
+		expect(res.body.teams[0]).to.have.property('rooms');
+		expect(res.body.teams[0]).to.have.property('numberOfUsers');
 	});
 
 	it("should prevent users from accessing unrelated teams via 'query' parameter", () => {
@@ -1730,95 +1718,87 @@ describe('/teams.addRooms', () => {
 		]);
 	});
 
-	it('should throw an error if no permission', (done) => {
-		void updatePermission('move-room-to-team', []).then(() => {
-			void request
-				.post(api('teams.addRooms'))
-				.set(credentials)
-				.send({
-					rooms: [publicRoom._id],
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.be.equal('error-no-permission-team-channel');
-				})
-				.end(done);
-		});
+	it('should throw an error if no permission', async () => {
+		await updatePermission('move-room-to-team', []);
+
+		const res = await request
+			.post(api('teams.addRooms'))
+			.set(credentials)
+			.send({
+				rooms: [publicRoom._id],
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(403);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('error');
+		expect(res.body.error).to.be.equal('error-no-permission-team-channel');
 	});
 
-	it('should add public and private rooms to team', (done) => {
-		void updatePermission('move-room-to-team', ['admin']).then(() => {
-			void request
-				.post(api('teams.addRooms'))
-				.set(credentials)
-				.send({
-					rooms: [publicRoom._id, privateRoom._id],
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms).to.have.length(2);
-					expect(res.body.rooms[0]).to.have.property('_id');
-					expect(res.body.rooms[0]).to.have.property('teamId', publicTeam._id);
-					expect(res.body.rooms[1]).to.have.property('_id');
-					expect(res.body.rooms[1]).to.have.property('teamId', publicTeam._id);
+	it('should add public and private rooms to team', async () => {
+		await updatePermission('move-room-to-team', ['admin']);
 
-					const rids = (res.body.rooms as IRoom[]).map(({ _id }) => _id);
+		const res = await request
+			.post(api('teams.addRooms'))
+			.set(credentials)
+			.send({
+				rooms: [publicRoom._id, privateRoom._id],
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
 
-					expect(rids).to.include(publicRoom._id);
-					expect(rids).to.include(privateRoom._id);
-				})
-				.end(done);
-		});
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.have.length(2);
+		expect(res.body.rooms[0]).to.have.property('_id');
+		expect(res.body.rooms[0]).to.have.property('teamId', publicTeam._id);
+		expect(res.body.rooms[1]).to.have.property('_id');
+		expect(res.body.rooms[1]).to.have.property('teamId', publicTeam._id);
+
+		const rids = (res.body.rooms as IRoom[]).map(({ _id }) => _id);
+
+		expect(rids).to.include(publicRoom._id);
+		expect(rids).to.include(privateRoom._id);
 	});
 
-	it('should add public room to private team', (done) => {
-		void updatePermission('move-room-to-team', ['admin']).then(() => {
-			void request
-				.post(api('teams.addRooms'))
-				.set(credentials)
-				.send({
-					rooms: [publicRoom2._id],
-					teamId: privateTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms[0]).to.have.property('teamId', privateTeam._id);
-					expect(res.body.rooms[0]).to.not.have.property('teamDefault');
-				})
-				.end(done);
-		});
+	it('should add public room to private team', async () => {
+		await updatePermission('move-room-to-team', ['admin']);
+
+		const res = await request
+			.post(api('teams.addRooms'))
+			.set(credentials)
+			.send({
+				rooms: [publicRoom2._id],
+				teamId: privateTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms[0]).to.have.property('teamId', privateTeam._id);
+		expect(res.body.rooms[0]).to.not.have.property('teamDefault');
 	});
 
-	it('should add private room to team', (done) => {
-		void updatePermission('move-room-to-team', ['admin']).then(() => {
-			void request
-				.post(api('teams.addRooms'))
-				.set(credentials)
-				.send({
-					rooms: [privateRoom2._id],
-					teamId: privateTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms[0]).to.have.property('teamId', privateTeam._id);
-					expect(res.body.rooms[0]).to.not.have.property('teamDefault');
-				})
-				.end(done);
-		});
+	it('should add private room to team', async () => {
+		await updatePermission('move-room-to-team', ['admin']);
+
+		const res = await request
+			.post(api('teams.addRooms'))
+			.set(credentials)
+			.send({
+				rooms: [privateRoom2._id],
+				teamId: privateTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms[0]).to.have.property('teamId', privateTeam._id);
+		expect(res.body.rooms[0]).to.not.have.property('teamDefault');
 	});
 
 	it('should fail if the user cannot access the channel', (done) => {
@@ -1937,130 +1917,118 @@ describe('/teams.listRooms', () => {
 		]),
 	);
 
-	it('should throw an error if team is private and no permission', (done) => {
-		void updatePermission('view-all-teams', []).then(() => {
-			void request
-				.get(api('teams.listRooms'))
-				.set(testUserCredentials)
-				.query({
-					teamId: privateTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.be.equal('user-not-on-private-team');
-				})
-				.end(done);
-		});
+	it('should throw an error if team is private and no permission', async () => {
+		await updatePermission('view-all-teams', []);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(testUserCredentials)
+			.query({
+				teamId: privateTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('error');
+		expect(res.body.error).to.be.equal('user-not-on-private-team');
 	});
 
-	it('should return only public rooms for public team', (done) => {
-		void updatePermission('view-all-team-channels', []).then(() => {
-			void request
-				.get(api('teams.listRooms'))
-				.set(testUserCredentials)
-				.query({
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms).to.be.an('array');
-					// main room should not be returned here
-					expect(res.body.rooms.length).to.equal(1);
-				})
-				.end(done);
-		});
+	it('should return only public rooms for public team', async () => {
+		await updatePermission('view-all-team-channels', []);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(testUserCredentials)
+			.query({
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.be.an('array');
+		// main room should not be returned here
+		expect(res.body.rooms.length).to.equal(1);
 	});
 
-	it('should return all rooms for public team', (done) => {
-		void updatePermission('view-all-team-channels', ['user']).then(() => {
-			void request
-				.get(api('teams.listRooms'))
-				.set(testUserCredentials)
-				.query({
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms).to.be.an('array');
-					expect(res.body.rooms.length).to.equal(2);
-				})
-				.end(done);
-		});
+	it('should return all rooms for public team', async () => {
+		await updatePermission('view-all-team-channels', ['user']);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(testUserCredentials)
+			.query({
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.be.an('array');
+		expect(res.body.rooms.length).to.equal(2);
 	});
-	it('should return all rooms for public team even requested with count and offset params', (done) => {
-		void updatePermission('view-all-team-channels', ['user']).then(() => {
-			void request
-				.get(api('teams.listRooms'))
-				.set(testUserCredentials)
-				.query({
-					teamId: publicTeam._id,
-					count: 5,
-					offset: 0,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('rooms');
-					expect(res.body.rooms).to.be.an('array');
-					expect(res.body.rooms.length).to.equal(2);
-				})
-				.end(done);
-		});
+	it('should return all rooms for public team even requested with count and offset params', async () => {
+		await updatePermission('view-all-team-channels', ['user']);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(testUserCredentials)
+			.query({
+				teamId: publicTeam._id,
+				count: 5,
+				offset: 0,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.be.an('array');
+		expect(res.body.rooms.length).to.equal(2);
 	});
 
-	it('should return public rooms for private team', (done) => {
-		void updatePermission('view-all-team-channels', []).then(() => {
-			void updatePermission('view-all-teams', ['admin']).then(() => {
-				void request
-					.get(api('teams.listRooms'))
-					.set(credentials)
-					.query({
-						teamId: privateTeam._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('rooms');
-						expect(res.body.rooms).to.be.an('array');
-						expect(res.body.rooms.length).to.equal(1);
-					})
-					.end(done);
-			});
-		});
+	it('should return public rooms for private team', async () => {
+		await updatePermission('view-all-team-channels', []);
+
+		await updatePermission('view-all-teams', ['admin']);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(credentials)
+			.query({
+				teamId: privateTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.be.an('array');
+		expect(res.body.rooms.length).to.equal(1);
 	});
-	it('should return public rooms for private team even requested with count and offset params', (done) => {
-		void updatePermission('view-all-team-channels', []).then(() => {
-			void updatePermission('view-all-teams', ['admin']).then(() => {
-				void request
-					.get(api('teams.listRooms'))
-					.set(credentials)
-					.query({
-						teamId: privateTeam._id,
-						count: 5,
-						offset: 0,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('rooms');
-						expect(res.body.rooms).to.be.an('array');
-						expect(res.body.rooms.length).to.equal(1);
-					})
-					.end(done);
-			});
-		});
+	it('should return public rooms for private team even requested with count and offset params', async () => {
+		await updatePermission('view-all-team-channels', []);
+
+		await updatePermission('view-all-teams', ['admin']);
+
+		const res = await request
+			.get(api('teams.listRooms'))
+			.set(credentials)
+			.query({
+				teamId: privateTeam._id,
+				count: 5,
+				offset: 0,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('rooms');
+		expect(res.body.rooms).to.be.an('array');
+		expect(res.body.rooms.length).to.equal(1);
 	});
 
 	describe('[teams.listChildren]', () => {
@@ -2410,45 +2378,41 @@ describe('/teams.updateRoom', () => {
 		]);
 	});
 
-	it('should throw an error if no permission', (done) => {
-		void updatePermission('edit-team-channel', []).then(() => {
-			void request
-				.post(api('teams.updateRoom'))
-				.set(credentials)
-				.send({
-					roomId: publicRoom._id,
-					isDefault: true,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.be.equal('unauthorized');
-				})
-				.end(done);
-		});
+	it('should throw an error if no permission', async () => {
+		await updatePermission('edit-team-channel', []);
+
+		const res = await request
+			.post(api('teams.updateRoom'))
+			.set(credentials)
+			.send({
+				roomId: publicRoom._id,
+				isDefault: true,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(403);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('error');
+		expect(res.body.error).to.be.equal('unauthorized');
 	});
 
-	it('should set room to team default', (done) => {
-		void updatePermission('edit-team-channel', ['admin']).then(() => {
-			void request
-				.post(api('teams.updateRoom'))
-				.set(credentials)
-				.send({
-					roomId: publicRoom._id,
-					isDefault: true,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room');
-					expect(res.body.room).to.have.property('teamId', publicTeam._id);
-					expect(res.body.room).to.have.property('teamDefault', true);
-				})
-				.end(done);
-		});
+	it('should set room to team default', async () => {
+		await updatePermission('edit-team-channel', ['admin']);
+
+		const res = await request
+			.post(api('teams.updateRoom'))
+			.set(credentials)
+			.send({
+				roomId: publicRoom._id,
+				isDefault: true,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('room');
+		expect(res.body.room).to.have.property('teamId', publicTeam._id);
+		expect(res.body.room).to.have.property('teamDefault', true);
 	});
 
 	describe('team auto-join', () => {
@@ -2796,45 +2760,41 @@ describe('/teams.removeRoom', () => {
 		]),
 	);
 
-	it('should throw an error if no permission', (done) => {
-		void updatePermission('remove-team-channel', []).then(() => {
-			void request
-				.post(api('teams.removeRoom'))
-				.set(credentials)
-				.send({
-					roomId: publicRoom._id,
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-					expect(res.body.error).to.be.equal('unauthorized');
-				})
-				.end(done);
-		});
+	it('should throw an error if no permission', async () => {
+		await updatePermission('remove-team-channel', []);
+
+		const res = await request
+			.post(api('teams.removeRoom'))
+			.set(credentials)
+			.send({
+				roomId: publicRoom._id,
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(403);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('error');
+		expect(res.body.error).to.be.equal('unauthorized');
 	});
 
-	it('should remove room from team', (done) => {
-		void updatePermission('remove-team-channel', ['admin']).then(() => {
-			void request
-				.post(api('teams.removeRoom'))
-				.set(credentials)
-				.send({
-					roomId: publicRoom._id,
-					teamId: publicTeam._id,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('room');
-					expect(res.body.room).to.not.have.property('teamId');
-					expect(res.body.room).to.not.have.property('teamDefault');
-				})
-				.end(done);
-		});
+	it('should remove room from team', async () => {
+		await updatePermission('remove-team-channel', ['admin']);
+
+		const res = await request
+			.post(api('teams.removeRoom'))
+			.set(credentials)
+			.send({
+				roomId: publicRoom._id,
+				teamId: publicTeam._id,
+			})
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body).to.have.property('room');
+		expect(res.body.room).to.not.have.property('teamId');
+		expect(res.body.room).to.not.have.property('teamDefault');
 	});
 });
 
@@ -3018,8 +2978,8 @@ describe('/teams.update', () => {
 				.expect(200);
 		});
 
-		it('should add user with prefs to team', (done) => {
-			void request
+		it('should add user with prefs to team', async () => {
+			await request
 				.post(api('teams.addMembers'))
 				.set(credentials)
 				.send({
@@ -3030,8 +2990,7 @@ describe('/teams.update', () => {
 							roles: ['member'],
 						},
 					],
-				})
-				.end(done);
+				});
 		});
 
 		it('should update team channel to auto-join', async () => {
@@ -3042,21 +3001,19 @@ describe('/teams.update', () => {
 			expect(response.body).to.have.property('success', true);
 		});
 
-		it('should return the user subscription with the right notification preferences', (done) => {
-			void request
+		it('should return the user subscription with the right notification preferences', async () => {
+			const res = await request
 				.get(api('subscriptions.getOne'))
 				.set(userCredentials)
 				.query({
 					roomId: createdRoom._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('subscription').and.to.be.an('object');
-					expect(res.body).to.have.nested.property('subscription.emailNotifications').and.to.be.equal('nothing');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('subscription').and.to.be.an('object');
+			expect(res.body).to.have.nested.property('subscription.emailNotifications').and.to.be.equal('nothing');
 		});
 	});
 });

--- a/apps/meteor/tests/end-to-end/api/users.ts
+++ b/apps/meteor/tests/end-to-end/api/users.ts
@@ -307,8 +307,8 @@ describe('[Users]', () => {
 		});
 
 		function failCreateUser(name: string) {
-			it(`should not create a new user if username is the reserved word ${name}`, (done) => {
-				void request
+			it(`should not create a new user if username is the reserved word ${name}`, async () => {
+				const res = await request
 					.post(api('users.create'))
 					.set(credentials)
 					.send({
@@ -322,12 +322,10 @@ describe('[Users]', () => {
 						verified: true,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', `${name} is blocked and can't be used! [error-blocked-username]`);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', `${name} is blocked and can't be used! [error-blocked-username]`);
 			});
 		}
 
@@ -857,8 +855,8 @@ describe('[Users]', () => {
 			await Promise.all(users.map((user) => deleteUser(user)));
 		});
 
-		it('should register new user', (done) => {
-			void request
+		it('should register new user', async () => {
+			const res = await request
 				.post(api('users.register'))
 				.send({
 					email,
@@ -867,19 +865,17 @@ describe('[Users]', () => {
 					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.username', username);
-					expect(res.body).to.have.nested.property('user.active', true);
-					expect(res.body).to.have.nested.property('user.name', 'name');
-					users.push(res.body.user);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.username', username);
+			expect(res.body).to.have.nested.property('user.active', true);
+			expect(res.body).to.have.nested.property('user.name', 'name');
+			users.push(res.body.user);
 		});
 
-		it('should return an error when trying register new user with an invalid username', (done) => {
-			void request
+		it('should return an error when trying register new user with an invalid username', async () => {
+			const res = await request
 				.post(api('users.register'))
 				.send({
 					email,
@@ -888,16 +884,14 @@ describe('[Users]', () => {
 					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').and.to.be.equal('The username provided is not valid');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').and.to.be.equal('The username provided is not valid');
 		});
 
-		it('should return an error when trying register new user with an existing username', (done) => {
-			void request
+		it('should return an error when trying register new user with an existing username', async () => {
+			const res = await request
 				.post(api('users.register'))
 				.send({
 					email,
@@ -906,15 +900,13 @@ describe('[Users]', () => {
 					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').and.to.be.equal('Username is already in use');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').and.to.be.equal('Username is already in use');
 		});
-		it("should return an error when registering a user's name with invalid characters: >, <, /, or \\", (done) => {
-			void request
+		it("should return an error when registering a user's name with invalid characters: >, <, /, or \\", async () => {
+			const res = await request
 				.post(api('users.register'))
 				.send({
 					email,
@@ -923,16 +915,14 @@ describe('[Users]', () => {
 					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').and.to.be.equal('Name contains invalid characters');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').and.to.be.equal('Name contains invalid characters');
 		});
 
-		it('should return an error when logged in user tries to register', (done) => {
-			void request
+		it('should return an error when logged in user tries to register', async () => {
+			const res = await request
 				.post(api('users.register'))
 				.set(credentials)
 				.send({
@@ -942,12 +932,10 @@ describe('[Users]', () => {
 					pass: password,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error').and.to.be.equal('Logged in users can not register again.');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error').and.to.be.equal('Logged in users can not register again.');
 		});
 
 		describe('registration form setting', () => {
@@ -1329,43 +1317,39 @@ describe('[Users]', () => {
 			});
 		});
 
-		it('should return an error when the user does not exist', (done) => {
-			void request
+		it('should return an error when the user does not exist', async () => {
+			const res = await request
 				.get(api('users.info'))
 				.set(credentials)
 				.query({
 					username: 'invalid-username',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 
-		it('should query information about a user by userId', (done) => {
-			void request
+		it('should query information about a user by userId', async () => {
+			const res = await request
 				.get(api('users.info'))
 				.set(credentials)
 				.query({
 					userId: targetUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.username', targetUser.username);
-					expect(res.body).to.have.nested.property('user.active', true);
-					expect(res.body).to.have.nested.property('user.name', targetUser.username);
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.username', targetUser.username);
+			expect(res.body).to.have.nested.property('user.active', true);
+			expect(res.body).to.have.nested.property('user.name', targetUser.username);
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it('should return "rooms" property when user request it and the user has the necessary permission (admin, "view-other-user-channels")', (done) => {
-			void request
+		it('should return "rooms" property when user request it and the user has the necessary permission (admin, "view-other-user-channels")', async () => {
+			const res = await request
 				.get(api('users.info'))
 				.set(credentials)
 				.query({
@@ -1373,104 +1357,92 @@ describe('[Users]', () => {
 					includeUserRooms: true,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.rooms').and.to.be.an('array');
-					const createdRoom = (res.body.user.rooms as ISubscription[]).find((room) => room.rid === infoRoom._id);
-					expect(createdRoom).to.have.property('unread');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.rooms').and.to.be.an('array');
+			const createdRoom = (res.body.user.rooms as ISubscription[]).find((room) => room.rid === infoRoom._id);
+			expect(createdRoom).to.have.property('unread');
 		});
 
-		it('should NOT return "rooms" property when user NOT request it but the user has the necessary permission (admin, "view-other-user-channels")', (done) => {
-			void request
+		it('should NOT return "rooms" property when user NOT request it but the user has the necessary permission (admin, "view-other-user-channels")', async () => {
+			const res = await request
 				.get(api('users.info'))
 				.set(credentials)
 				.query({
 					userId: targetUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.not.have.nested.property('user.rooms');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.nested.property('user.rooms');
 		});
 
-		it('should return the rooms when the user requests their own rooms but they do NOT have the necessary permission', (done) => {
-			void updatePermission('view-other-user-channels', []).then(() => {
-				void request
-					.get(api('users.info'))
-					.set(credentials)
-					.query({
-						userId: credentials['X-User-Id'],
-						includeUserRooms: true,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('user.rooms');
-						expect(res.body.user.rooms).with.lengthOf.at.least(1);
-						expect(res.body.user.rooms[0]).to.have.property('unread');
-					})
-					.end(done);
-			});
+		it('should return the rooms when the user requests their own rooms but they do NOT have the necessary permission', async () => {
+			await updatePermission('view-other-user-channels', []);
+
+			const res = await request
+				.get(api('users.info'))
+				.set(credentials)
+				.query({
+					userId: credentials['X-User-Id'],
+					includeUserRooms: true,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.rooms');
+			expect(res.body.user.rooms).with.lengthOf.at.least(1);
+			expect(res.body.user.rooms[0]).to.have.property('unread');
 		});
-		it("should NOT return the rooms when the user requests another user's rooms WITHOUT having the necessary permission", (done) => {
-			void updatePermission('view-other-user-channels', []).then(() => {
-				void request
-					.get(api('users.info'))
-					.set(credentials)
-					.query({
-						userId: targetUser._id,
-						fields: JSON.stringify({ userRooms: 1 }),
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.nested.property('user.rooms');
-					})
-					.end(done);
-			});
+		it("should NOT return the rooms when the user requests another user's rooms WITHOUT having the necessary permission", async () => {
+			await updatePermission('view-other-user-channels', []);
+
+			const res = await request
+				.get(api('users.info'))
+				.set(credentials)
+				.query({
+					userId: targetUser._id,
+					fields: JSON.stringify({ userRooms: 1 }),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.nested.property('user.rooms');
 		});
-		it("should NOT return any services fields when requesting another user's info, even if the user has the necessary permission", (done) => {
-			void updatePermission('view-full-other-user-info', ['admin']).then(() => {
-				void request
-					.get(api('users.info'))
-					.set(credentials)
-					.query({
-						userId: targetUser._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.not.have.nested.property('user.services.emailCode');
-						expect(res.body).to.not.have.nested.property('user.services');
-					})
-					.end(done);
-			});
+		it("should NOT return any services fields when requesting another user's info, even if the user has the necessary permission", async () => {
+			await updatePermission('view-full-other-user-info', ['admin']);
+
+			const res = await request
+				.get(api('users.info'))
+				.set(credentials)
+				.query({
+					userId: targetUser._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.not.have.nested.property('user.services.emailCode');
+			expect(res.body).to.not.have.nested.property('user.services');
 		});
-		it('should return all services fields when request for myself data even without privileged permission', (done) => {
-			void updatePermission('view-full-other-user-info', []).then(() => {
-				void request
-					.get(api('users.info'))
-					.set(credentials)
-					.query({
-						userId: credentials['X-User-Id'],
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('user.services.password');
-					})
-					.end(done);
-			});
+		it('should return all services fields when request for myself data even without privileged permission', async () => {
+			await updatePermission('view-full-other-user-info', []);
+
+			const res = await request
+				.get(api('users.info'))
+				.set(credentials)
+				.query({
+					userId: credentials['X-User-Id'],
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.services.password');
 		});
 
 		it('should correctly route users that have `ufs` in their username', async () => {
@@ -1502,23 +1474,21 @@ describe('[Users]', () => {
 			await deleteUser(user);
 		});
 
-		it("should NOT return sensitive fields on services even though it's the same user requesting its info", (done) => {
-			void request
+		it("should NOT return sensitive fields on services even though it's the same user requesting its info", async () => {
+			const res = await request
 				.get(api('users.info'))
 				.set(credentials)
 				.query({
 					userId: credentials['X-User-Id'],
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.services.password').and.to.be.a('boolean');
-					expect(res.body).to.not.have.nested.property('user.services.email');
-					expect(res.body).to.not.have.nested.property('user.services.resume');
-					expect(res.body).to.not.have.nested.property('user.services.passwordHistory');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.services.password').and.to.be.a('boolean');
+			expect(res.body).to.not.have.nested.property('user.services.email');
+			expect(res.body).to.not.have.nested.property('user.services.resume');
+			expect(res.body).to.not.have.nested.property('user.services.passwordHistory');
 		});
 
 		describe('querying by user email', () => {
@@ -1679,20 +1649,18 @@ describe('[Users]', () => {
 		});
 	});
 	describe('[/users.getPresence]', () => {
-		it("should query a user's presence by userId", (done) => {
-			void request
+		it("should query a user's presence by userId", async () => {
+			const res = await request
 				.get(api('users.getPresence'))
 				.set(credentials)
 				.query({
 					userId: targetUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('presence', 'offline');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('presence', 'offline');
 		});
 
 		describe('Logging in with type: "resume"', () => {
@@ -1743,48 +1711,35 @@ describe('[Users]', () => {
 
 	describe('[/users.presence]', () => {
 		describe('Not logged in:', () => {
-			it('should return 401 unauthorized', (done) => {
-				void request
-					.get(api('users.presence'))
-					.expect('Content-Type', 'application/json')
-					.expect(401)
-					.expect((res) => {
-						expect(res.body).to.have.property('message');
-					})
-					.end(done);
+			it('should return 401 unauthorized', async () => {
+				const res = await request.get(api('users.presence')).expect('Content-Type', 'application/json').expect(401);
+
+				expect(res.body).to.have.property('message');
 			});
 		});
 		describe('Logged in:', () => {
-			it('should return online users full list', (done) => {
-				void request
-					.get(api('users.presence'))
-					.set(credentials)
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('full', true);
+			it('should return online users full list', async () => {
+				const res = await request.get(api('users.presence')).set(credentials).expect('Content-Type', 'application/json').expect(200);
 
-						const user = (res.body.users as IUser[]).find((user) => user.username === 'rocket.cat');
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('full', true);
 
-						expect(user).to.have.all.keys('_id', 'avatarETag', 'username', 'name', 'status', 'utcOffset');
-					})
-					.end(done);
+				const user = (res.body.users as IUser[]).find((user) => user.username === 'rocket.cat');
+
+				expect(user).to.have.all.keys('_id', 'avatarETag', 'username', 'name', 'status', 'utcOffset');
 			});
 
-			it('should return no online users updated after now', (done) => {
-				void request
+			it('should return no online users updated after now', async () => {
+				const res = await request
 					.get(api('users.presence'))
 					.query({ from: new Date().toISOString() })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('full', false);
-						expect(res.body).to.have.property('users').that.is.an('array').that.has.lengthOf(0);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('full', false);
+				expect(res.body).to.have.property('users').that.is.an('array').that.has.lengthOf(0);
 			});
 
 			it('should return presence for a single id', async () => {
@@ -1988,20 +1943,14 @@ describe('[Users]', () => {
 			]),
 		);
 
-		it('should query all users in the system', (done) => {
-			void request
-				.get(api('users.list'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('count');
-					expect(res.body).to.have.property('total');
-					const myself = (res.body.users as IUser[]).find((user) => user.username === adminUsername);
-					expect(myself).to.not.have.property('e2e');
-				})
-				.end(done);
+		it('should query all users in the system', async () => {
+			const res = await request.get(api('users.list')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+			const myself = (res.body.users as IUser[]).find((user) => user.username === adminUsername);
+			expect(myself).to.not.have.property('e2e');
 		});
 
 		it('should sort for user statuses and check if deactivated user is correctly sorted', (done) => {
@@ -2212,91 +2161,79 @@ describe('[Users]', () => {
 		);
 
 		describe('[/users.setAvatar]', () => {
-			it('should set the avatar of the logged user by a local image', (done) => {
-				void request
+			it('should set the avatar of the logged user by a local image', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(userCredentials)
 					.attach('image', imgURL)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should reject non-renderable image types (e.g. TIFF)', (done) => {
-				void request
+			it('should reject non-renderable image types (e.g. TIFF)', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(userCredentials)
 					.attach('image', tiffURL)
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('errorType', 'error-invalid-file-type');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('errorType', 'error-invalid-file-type');
 			});
-			it('should update the avatar of another user by userId when the logged user has the necessary permission (edit-other-user-avatar)', (done) => {
-				void request
+			it('should update the avatar of another user by userId when the logged user has the necessary permission (edit-other-user-avatar)', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(userCredentials)
 					.attach('image', imgURL)
 					.field({ userId: credentials['X-User-Id'] })
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should set the avatar of another user by username and local image when the logged user has the necessary permission (edit-other-user-avatar)', (done) => {
-				void request
+			it('should set the avatar of another user by username and local image when the logged user has the necessary permission (edit-other-user-avatar)', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(credentials)
 					.attach('image', imgURL)
 					.field({ username: adminUsername })
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it("should prevent from updating someone else's avatar when the logged user doesn't have the necessary permission(edit-other-user-avatar)", (done) => {
-				void updatePermission('edit-other-user-avatar', []).then(() => {
-					void request
-						.post(api('users.setAvatar'))
-						.set(userCredentials)
-						.attach('image', imgURL)
-						.field({ userId: credentials['X-User-Id'] })
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
+			it("should prevent from updating someone else's avatar when the logged user doesn't have the necessary permission(edit-other-user-avatar)", async () => {
+				await updatePermission('edit-other-user-avatar', []);
+
+				const res = await request
+					.post(api('users.setAvatar'))
+					.set(userCredentials)
+					.attach('image', imgURL)
+					.field({ userId: credentials['X-User-Id'] })
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
-			it('should allow users with the edit-other-user-avatar permission to update avatars when the Accounts_AllowUserAvatarChange setting is off', (done) => {
-				void updateSetting('Accounts_AllowUserAvatarChange', false).then(() => {
-					void updatePermission('edit-other-user-avatar', ['admin']).then(() => {
-						void request
-							.post(api('users.setAvatar'))
-							.set(credentials)
-							.attach('image', imgURL)
-							.field({ userId: userCredentials['X-User-Id'] })
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('success', true);
-							})
-							.end(done);
-					});
-				});
+			it('should allow users with the edit-other-user-avatar permission to update avatars when the Accounts_AllowUserAvatarChange setting is off', async () => {
+				await updateSetting('Accounts_AllowUserAvatarChange', false);
+
+				await updatePermission('edit-other-user-avatar', ['admin']);
+
+				const res = await request
+					.post(api('users.setAvatar'))
+					.set(credentials)
+					.attach('image', imgURL)
+					.field({ userId: userCredentials['X-User-Id'] })
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should prevent users from passing server-side request forgery (SSRF) payloads as avatarUrl', (done) => {
-				void request
+			it('should prevent users from passing server-side request forgery (SSRF) payloads as avatarUrl', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(credentials)
 					.send({
@@ -2304,11 +2241,9 @@ describe('[Users]', () => {
 						avatarUrl: 'http://169.254.169.254/',
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
 
 			it('should return 401 when not authenticated', async () => {
@@ -2330,93 +2265,81 @@ describe('[Users]', () => {
 				]);
 			});
 
-			it('should set the avatar of the logged user by a local image', (done) => {
-				void request
+			it('should set the avatar of the logged user by a local image', async () => {
+				const res = await request
 					.post(api('users.setAvatar'))
 					.set(userCredentials)
 					.attach('image', imgURL)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should reset the avatar of the logged user', (done) => {
-				void request
+			it('should reset the avatar of the logged user', async () => {
+				const res = await request
 					.post(api('users.resetAvatar'))
 					.set(userCredentials)
 					.expect('Content-Type', 'application/json')
 					.send({
 						userId: userCredentials['X-User-Id'],
 					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should reset the avatar of another user by userId when the logged user has the necessary permission (edit-other-user-avatar)', (done) => {
-				void request
+			it('should reset the avatar of another user by userId when the logged user has the necessary permission (edit-other-user-avatar)', async () => {
+				const res = await request
 					.post(api('users.resetAvatar'))
 					.set(userCredentials)
 					.send({
 						userId: credentials['X-User-Id'],
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
-			it('should reset the avatar of another user by username and local image when the logged user has the necessary permission (edit-other-user-avatar)', (done) => {
-				void request
+			it('should reset the avatar of another user by username and local image when the logged user has the necessary permission (edit-other-user-avatar)', async () => {
+				const res = await request
 					.post(api('users.resetAvatar'))
 					.set(credentials)
 					.send({
 						username: adminUsername,
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+			});
+			it("should prevent from resetting someone else's avatar when the logged user doesn't have the necessary permission(edit-other-user-avatar)", async () => {
+				await updatePermission('edit-other-user-avatar', []);
+
+				const res = await request
+					.post(api('users.resetAvatar'))
+					.set(userCredentials)
+					.send({
+						userId: credentials['X-User-Id'],
 					})
-					.end(done);
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
-			it("should prevent from resetting someone else's avatar when the logged user doesn't have the necessary permission(edit-other-user-avatar)", (done) => {
-				void updatePermission('edit-other-user-avatar', []).then(() => {
-					void request
-						.post(api('users.resetAvatar'))
-						.set(userCredentials)
-						.send({
-							userId: credentials['X-User-Id'],
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
-			it('should allow users with the edit-other-user-avatar permission to reset avatars when the Accounts_AllowUserAvatarChange setting is off', (done) => {
-				void updateSetting('Accounts_AllowUserAvatarChange', false).then(() => {
-					void updatePermission('edit-other-user-avatar', ['admin']).then(() => {
-						void request
-							.post(api('users.resetAvatar'))
-							.set(credentials)
-							.send({
-								userId: userCredentials['X-User-Id'],
-							})
-							.expect('Content-Type', 'application/json')
-							.expect(200)
-							.expect((res) => {
-								expect(res.body).to.have.property('success', true);
-							})
-							.end(done);
-					});
-				});
+			it('should allow users with the edit-other-user-avatar permission to reset avatars when the Accounts_AllowUserAvatarChange setting is off', async () => {
+				await updateSetting('Accounts_AllowUserAvatarChange', false);
+
+				await updatePermission('edit-other-user-avatar', ['admin']);
+
+				const res = await request
+					.post(api('users.resetAvatar'))
+					.set(credentials)
+					.send({
+						userId: userCredentials['X-User-Id'],
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
 			});
 
 			it('should return 401 when not authenticated', async () => {
@@ -2431,25 +2354,23 @@ describe('[Users]', () => {
 		});
 
 		describe('[/users.getAvatar]', () => {
-			it('should get the url of the avatar of the logged user via userId', (done) => {
-				void request
+			it('should get the url of the avatar of the logged user via userId', async () => {
+				await request
 					.get(api('users.getAvatar'))
 					.set(userCredentials)
 					.query({
 						userId: userCredentials['X-User-Id'],
 					})
-					.expect(307)
-					.end(done);
+					.expect(307);
 			});
-			it('should get the url of the avatar of the logged user via username', (done) => {
-				void request
+			it('should get the url of the avatar of the logged user via username', async () => {
+				await request
 					.get(api('users.getAvatar'))
 					.set(userCredentials)
 					.query({
 						username: user.username,
 					})
-					.expect(307)
-					.end(done);
+					.expect(307);
 			});
 		});
 
@@ -2458,19 +2379,17 @@ describe('[Users]', () => {
 				void request.get(api('users.getAvatarSuggestion')).expect('Content-Type', 'application/json').expect(401).end(done);
 			});
 
-			it('should get avatar suggestion of the logged user via userId', (done) => {
-				void request
+			it('should get avatar suggestion of the logged user via userId', async () => {
+				const res = await request
 					.get(api('users.getAvatarSuggestion'))
 					.set(userCredentials)
 					.query({
 						userId: userCredentials['X-User-Id'],
 					})
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('suggestions').and.to.be.an('object');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('suggestions').and.to.be.an('object');
 			});
 		});
 	});
@@ -2499,8 +2418,8 @@ describe('[Users]', () => {
 			]),
 		);
 
-		it("should update a user's info by userId", (done) => {
-			void request
+		it("should update a user's info by userId", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2515,20 +2434,18 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.username', `edited${apiUsername}`);
-					expect(res.body).to.have.nested.property('user.emails[0].address', apiEmail);
-					expect(res.body).to.have.nested.property('user.active', true);
-					expect(res.body).to.have.nested.property('user.name', `edited${apiUsername}`);
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.username', `edited${apiUsername}`);
+			expect(res.body).to.have.nested.property('user.emails[0].address', apiEmail);
+			expect(res.body).to.have.nested.property('user.active', true);
+			expect(res.body).to.have.nested.property('user.name', `edited${apiUsername}`);
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it("should update a user's email by userId", (done) => {
-			void request
+		it("should update a user's email by userId", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2538,18 +2455,16 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.emails[0].address', `edited${apiEmail}`);
-					expect(res.body).to.have.nested.property('user.emails[0].verified', false);
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.emails[0].address', `edited${apiEmail}`);
+			expect(res.body).to.have.nested.property('user.emails[0].verified', false);
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it("should update a user's bio by userId", (done) => {
-			void request
+		it("should update a user's bio by userId", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2559,17 +2474,15 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.bio', 'edited-bio-test');
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.bio', 'edited-bio-test');
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it("should update a user's nickname by userId", (done) => {
-			void request
+		it("should update a user's nickname by userId", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2579,17 +2492,15 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.nickname', 'edited-nickname-test');
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.nickname', 'edited-nickname-test');
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it(`should return an error when trying to set a nickname longer than ${MAX_NICKNAME_LENGTH} characters`, (done) => {
-			void request
+		it(`should return an error when trying to set a nickname longer than ${MAX_NICKNAME_LENGTH} characters`, async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2599,19 +2510,14 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property(
-						'error',
-						`Nickname size exceeds ${MAX_NICKNAME_LENGTH} characters [error-nickname-size-exceeded]`,
-					);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', `Nickname size exceeds ${MAX_NICKNAME_LENGTH} characters [error-nickname-size-exceeded]`);
 		});
 
-		it(`should return an error when trying to set a bio longer than ${MAX_BIO_LENGTH} characters`, (done) => {
-			void request
+		it(`should return an error when trying to set a bio longer than ${MAX_BIO_LENGTH} characters`, async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2621,12 +2527,10 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', `Bio size exceeds ${MAX_BIO_LENGTH} characters [error-bio-size-exceeded]`);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', `Bio size exceeds ${MAX_BIO_LENGTH} characters [error-bio-size-exceeded]`);
 		});
 
 		it('should return an error when trying to upsert a user by sending an empty userId', () => {
@@ -2665,8 +2569,8 @@ describe('[Users]', () => {
 				});
 		});
 
-		it("should update a bot's email", (done) => {
-			void request
+		it("should update a bot's email", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2674,15 +2578,13 @@ describe('[Users]', () => {
 					data: { email: 'nouser@rocket.cat' },
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it("should verify user's email by userId", (done) => {
-			void request
+		it("should verify user's email by userId", async () => {
+			const res = await request
 				.post(api('users.update'))
 				.set(credentials)
 				.send({
@@ -2692,35 +2594,31 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.emails[0].verified', true);
-					expect(res.body).to.not.have.nested.property('user.e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.emails[0].verified', true);
+			expect(res.body).to.not.have.nested.property('user.e2e');
 		});
 
-		it('should return an error when trying update username and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-info', ['user']).then(() => {
-				void updateSetting('Accounts_AllowUsernameChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								username: 'fake.name',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update username and it is not allowed', async () => {
+			await updatePermission('edit-other-user-info', ['user']);
+
+			await updateSetting('Accounts_AllowUsernameChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						username: 'fake.name',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
 		it('should update the user name when the required permission is applied', async () => {
@@ -2742,224 +2640,204 @@ describe('[Users]', () => {
 				});
 		});
 
-		it('should return an error when trying update user real name and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-info', ['user']).then(() => {
-				void updateSetting('Accounts_AllowRealNameChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								name: 'Fake name',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update user real name and it is not allowed', async () => {
+			await updatePermission('edit-other-user-info', ['user']);
+
+			await updateSetting('Accounts_AllowRealNameChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						name: 'Fake name',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should update user real name when the required permission is applied', (done) => {
-			void updatePermission('edit-other-user-info', ['admin']).then(() => {
-				void updateSetting('Accounts_AllowRealNameChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								name: 'Fake name',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should update user real name when the required permission is applied', async () => {
+			await updatePermission('edit-other-user-info', ['admin']);
+
+			await updateSetting('Accounts_AllowRealNameChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						name: 'Fake name',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when trying update user status message and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-info', ['user']).then(() => {
-				void updateSetting('Accounts_AllowUserStatusMessageChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								statusMessage: 'a new status',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update user status message and it is not allowed', async () => {
+			await updatePermission('edit-other-user-info', ['user']);
+
+			await updateSetting('Accounts_AllowUserStatusMessageChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						statusMessage: 'a new status',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should update user status message when the required permission is applied', (done) => {
-			void updatePermission('edit-other-user-info', ['admin']).then(() => {
-				void updateSetting('Accounts_AllowUserStatusMessageChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								name: 'a new status',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should update user status message when the required permission is applied', async () => {
+			await updatePermission('edit-other-user-info', ['admin']);
+
+			await updateSetting('Accounts_AllowUserStatusMessageChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						name: 'a new status',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when trying update user email and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-info', ['user']).then(() => {
-				void updateSetting('Accounts_AllowEmailChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								email: 'itsnotworking@email.com',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update user email and it is not allowed', async () => {
+			await updatePermission('edit-other-user-info', ['user']);
+
+			await updateSetting('Accounts_AllowEmailChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						email: 'itsnotworking@email.com',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should update user email when the required permission is applied', (done) => {
-			void updatePermission('edit-other-user-info', ['admin']).then(() => {
-				void updateSetting('Accounts_AllowEmailChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								email: apiEmail,
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should update user email when the required permission is applied', async () => {
+			await updatePermission('edit-other-user-info', ['admin']);
+
+			await updateSetting('Accounts_AllowEmailChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						email: apiEmail,
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when trying update user password and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-password', ['user']).then(() => {
-				void updateSetting('Accounts_AllowPasswordChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								password: '1tsn0tw0rkingP@ssw0rd1234.!',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update user password and it is not allowed', async () => {
+			await updatePermission('edit-other-user-password', ['user']);
+
+			await updateSetting('Accounts_AllowPasswordChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						password: '1tsn0tw0rkingP@ssw0rd1234.!',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should update user password when the required permission is applied', (done) => {
-			void updatePermission('edit-other-user-password', ['admin']).then(() => {
-				void updateSetting('Accounts_AllowPasswordChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								password: '1tsn0tw0rkingP@ssw0rd1234.!',
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should update user password when the required permission is applied', async () => {
+			await updatePermission('edit-other-user-password', ['admin']);
+
+			await updateSetting('Accounts_AllowPasswordChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						password: '1tsn0tw0rkingP@ssw0rd1234.!',
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when trying update profile and it is not allowed', (done) => {
-			void updatePermission('edit-other-user-info', ['user']).then(() => {
-				void updateSetting('Accounts_AllowUserProfileChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								verified: true,
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
-				});
-			});
+		it('should return an error when trying update profile and it is not allowed', async () => {
+			await updatePermission('edit-other-user-info', ['user']);
+
+			await updateSetting('Accounts_AllowUserProfileChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						verified: true,
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it('should update profile when the required permission is applied', (done) => {
-			void updatePermission('edit-other-user-info', ['admin']).then(() => {
-				void updateSetting('Accounts_AllowUserProfileChange', false).then(() => {
-					void request
-						.post(api('users.update'))
-						.set(credentials)
-						.send({
-							userId: targetUser._id,
-							data: {
-								verified: true,
-							},
-						})
-						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
-				});
-			});
+		it('should update profile when the required permission is applied', async () => {
+			await updatePermission('edit-other-user-info', ['admin']);
+
+			await updateSetting('Accounts_AllowUserProfileChange', false);
+
+			const res = await request
+				.post(api('users.update'))
+				.set(credentials)
+				.send({
+					userId: targetUser._id,
+					data: {
+						verified: true,
+					},
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
 		it('should delete requirePasswordChangeReason when requirePasswordChange is set to false', async () => {
@@ -3025,8 +2903,8 @@ describe('[Users]', () => {
 					});
 			});
 
-			it("should update user's email verified even if email is not changed", (done) => {
-				void request
+			it("should update user's email verified even if email is not changed", async () => {
+				const res = await request
 					.post(api('users.update'))
 					.set(userCredentials)
 					.send({
@@ -3037,19 +2915,17 @@ describe('[Users]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.nested.property('user.emails[0].verified', true);
-						expect(res.body).to.not.have.nested.property('user.e2e');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.nested.property('user.emails[0].verified', true);
+				expect(res.body).to.not.have.nested.property('user.e2e');
 			});
 		});
 
 		function failUpdateUser(name: string) {
-			it(`should not update an user if the new username is the reserved word ${name}`, (done) => {
-				void request
+			it(`should not update an user if the new username is the reserved word ${name}`, async () => {
+				const res = await request
 					.post(api('users.update'))
 					.set(credentials)
 					.send({
@@ -3059,12 +2935,10 @@ describe('[Users]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'Could not save user identity [error-could-not-save-identity]');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'Could not save user identity [error-could-not-save-identity]');
 			});
 		}
 
@@ -3340,26 +3214,24 @@ describe('[Users]', () => {
 		const editedName = `basic-info-test-name${+new Date()}`;
 		const editedEmail = `test${+new Date()}@mail.com`;
 
-		it('enabling E2E in server and generating keys to user...', (done) => {
-			void updateSetting('E2E_Enable', true).then(() => {
-				void request
-					.post(api('e2e.setUserPublicAndPrivateKeys'))
-					.set(userCredentials)
-					.send({
-						private_key: 'test',
-						public_key: 'test',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
-			});
+		it('enabling E2E in server and generating keys to user...', async () => {
+			await updateSetting('E2E_Enable', true);
+
+			const res = await request
+				.post(api('e2e.setUserPublicAndPrivateKeys'))
+				.set(userCredentials)
+				.send({
+					private_key: 'test',
+					public_key: 'test',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should update the user own basic information', (done) => {
-			void request
+		it('should update the user own basic information', async () => {
+			const res = await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)
 				.send({
@@ -3371,19 +3243,17 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					const { user } = res.body;
-					expect(res.body).to.have.property('success', true);
-					expect(user.username).to.be.equal(editedUsername);
-					expect(user.name).to.be.equal(editedName);
-					expect(user).to.not.have.property('e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			const { user } = res.body;
+			expect(res.body).to.have.property('success', true);
+			expect(user.username).to.be.equal(editedUsername);
+			expect(user.name).to.be.equal(editedName);
+			expect(user).to.not.have.property('e2e');
 		});
 
-		it('should update the user name only', (done) => {
-			void request
+		it('should update the user name only', async () => {
+			const res = await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)
 				.send({
@@ -3392,18 +3262,16 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					const { user } = res.body;
-					expect(res.body).to.have.property('success', true);
-					expect(user.username).to.be.equal(editedUsername);
-					expect(user).to.not.have.property('e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			const { user } = res.body;
+			expect(res.body).to.have.property('success', true);
+			expect(user.username).to.be.equal(editedUsername);
+			expect(user).to.not.have.property('e2e');
 		});
 
-		it('should throw an error when user try change email without the password', (done) => {
-			void request
+		it('should throw an error when user try change email without the password', async () => {
+			await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)
 				.send({
@@ -3412,12 +3280,11 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.end(done);
+				.expect(400);
 		});
 
-		it('should throw an error when user try change password without the actual password', (done) => {
-			void request
+		it('should throw an error when user try change password without the actual password', async () => {
+			await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(credentials)
 				.send({
@@ -3426,12 +3293,11 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.end(done);
+				.expect(400);
 		});
 
-		it('should throw an error when the name is only whitespaces', (done) => {
-			void request
+		it('should throw an error when the name is only whitespaces', async () => {
+			const res = await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(credentials)
 				.send({
@@ -3440,15 +3306,13 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 
-		it("should set new email as 'unverified'", (done) => {
-			void request
+		it("should set new email as 'unverified'", async () => {
+			const res = await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)
 				.send({
@@ -3458,19 +3322,17 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					const { user } = res.body;
-					expect(res.body).to.have.property('success', true);
-					expect(user.emails[0].address).to.be.equal(editedEmail);
-					expect(user.emails[0].verified).to.be.false;
-					expect(user).to.not.have.property('e2e');
-				})
-				.end(done);
+				.expect(200);
+
+			const { user } = res.body;
+			expect(res.body).to.have.property('success', true);
+			expect(user.emails[0].address).to.be.equal(editedEmail);
+			expect(user.emails[0].verified).to.be.false;
+			expect(user).to.not.have.property('e2e');
 		});
 
-		it("should not include sensitive data on the 'services' object from the response", (done) => {
-			void request
+		it("should not include sensitive data on the 'services' object from the response", async () => {
+			const res = await request
 				.post(api('users.updateOwnBasicInfo'))
 				.set(userCredentials)
 				.send({
@@ -3479,20 +3341,18 @@ describe('[Users]', () => {
 					},
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					const { user } = res.body;
-					expect(res.body).to.have.property('success', true);
-					expect(user.services).to.not.have.property('passwordHistory');
-					expect(user.services).to.not.have.property('email');
-					expect(user.services.password).to.have.property('exists').that.is.a('boolean');
-				})
-				.end(done);
+				.expect(200);
+
+			const { user } = res.body;
+			expect(res.body).to.have.property('success', true);
+			expect(user.services).to.not.have.property('passwordHistory');
+			expect(user.services).to.not.have.property('email');
+			expect(user.services.password).to.have.property('exists').that.is.a('boolean');
 		});
 
 		function failUpdateUserOwnBasicInfo(name: string) {
-			it(`should not update an user's basic info if the new username is the reserved word ${name}`, (done) => {
-				void request
+			it(`should not update an user's basic info if the new username is the reserved word ${name}`, async () => {
+				const res = await request
 					.post(api('users.updateOwnBasicInfo'))
 					.set(credentials)
 					.send({
@@ -3501,12 +3361,10 @@ describe('[Users]', () => {
 						},
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'Could not save user identity [error-could-not-save-identity]');
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+				expect(res.body).to.have.property('error', 'Could not save user identity [error-could-not-save-identity]');
 			});
 		}
 
@@ -4063,65 +3921,53 @@ describe('[Users]', () => {
 	});
 
 	describe('[/users.forgotPassword]', () => {
-		it('should return an error when "Accounts_PasswordReset" is disabled', (done) => {
-			void updateSetting('Accounts_PasswordReset', false).then(() => {
-				void request
-					.post(api('users.forgotPassword'))
-					.send({
-						email: adminEmail,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'Password reset is not enabled');
-					})
-					.end(done);
-			});
+		it('should return an error when "Accounts_PasswordReset" is disabled', async () => {
+			await updateSetting('Accounts_PasswordReset', false);
+
+			const res = await request
+				.post(api('users.forgotPassword'))
+				.send({
+					email: adminEmail,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'Password reset is not enabled');
 		});
 
-		it('should send email to user (return success), when is a valid email', (done) => {
-			void updateSetting('Accounts_PasswordReset', true).then(() => {
-				void request
-					.post(api('users.forgotPassword'))
-					.send({
-						email: adminEmail,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-					})
-					.end(done);
-			});
+		it('should send email to user (return success), when is a valid email', async () => {
+			await updateSetting('Accounts_PasswordReset', true);
+
+			const res = await request
+				.post(api('users.forgotPassword'))
+				.send({
+					email: adminEmail,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should not send email to user(return error), when is a invalid email', (done) => {
-			void request
+		it('should not send email to user(return error), when is a invalid email', async () => {
+			const res = await request
 				.post(api('users.forgotPassword'))
 				.send({
 					email: 'invalidEmail',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
-		it('should return an error when email is missing', (done) => {
-			void request
-				.post(api('users.forgotPassword'))
-				.send({})
-				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('errorType', 'invalid-params');
-					expect(res.body).to.have.property('error', "must have required property 'email'");
-				})
-				.end(done);
+		it('should return an error when email is missing', async () => {
+			const res = await request.post(api('users.forgotPassword')).send({}).expect('Content-Type', 'application/json').expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('errorType', 'invalid-params');
+			expect(res.body).to.have.property('error', "must have required property 'email'");
 		});
 	});
 
@@ -4178,29 +4024,22 @@ describe('[Users]', () => {
 
 		after(() => deleteUser(targetUser));
 
-		it('should return an username suggestion', (done) => {
-			void request
+		it('should return an username suggestion', async () => {
+			const res = await request
 				.get(api('users.getUsernameSuggestion'))
 				.set(userCredentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.exist;
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.exist;
 		});
 
-		it('should return 401 when not authenticated', (done) => {
-			void request
-				.get(api('users.getUsernameSuggestion'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('status', 'error');
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should return 401 when not authenticated', async () => {
+			const res = await request.get(api('users.getUsernameSuggestion')).expect('Content-Type', 'application/json').expect(401);
+
+			expect(res.body).to.have.property('status', 'error');
+			expect(res.body).to.have.property('message');
 		});
 	});
 
@@ -4215,60 +4054,49 @@ describe('[Users]', () => {
 
 		after(() => deleteUser(targetUser));
 
-		it('should return 401 unauthorized when user is not logged in', (done) => {
-			void request
-				.get(api('users.checkUsernameAvailability'))
-				.expect('Content-Type', 'application/json')
-				.expect(401)
-				.expect((res) => {
-					expect(res.body).to.have.property('message');
-				})
-				.end(done);
+		it('should return 401 unauthorized when user is not logged in', async () => {
+			const res = await request.get(api('users.checkUsernameAvailability')).expect('Content-Type', 'application/json').expect(401);
+
+			expect(res.body).to.have.property('message');
 		});
 
-		it('should return true if the username is the same user username set', (done) => {
-			void request
+		it('should return true if the username is the same user username set', async () => {
+			const res = await request
 				.get(api('users.checkUsernameAvailability'))
 				.set(userCredentials)
 				.query({
 					username: targetUser.username,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.result).to.be.equal(true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.result).to.be.equal(true);
 		});
 
-		it('should return true if the username is available', (done) => {
-			void request
+		it('should return true if the username is available', async () => {
+			const res = await request
 				.get(api('users.checkUsernameAvailability'))
 				.set(userCredentials)
 				.query({
 					username: `${targetUser.username}-${+new Date()}`,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body.result).to.be.equal(true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.result).to.be.equal(true);
 		});
 
-		it('should return an error when the username is invalid', (done) => {
-			void request
+		it('should return an error when the username is invalid', async () => {
+			const res = await request
 				.get(api('users.checkUsernameAvailability'))
 				.set(userCredentials)
 				.query({})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
 		});
 	});
 
@@ -4296,19 +4124,17 @@ describe('[Users]', () => {
 				.end(wait(done, 200));
 		});
 
-		it('should delete user own account', (done) => {
-			void request
+		it('should delete user own account', async () => {
+			const res = await request
 				.post(api('users.deleteOwnAccount'))
 				.set(userCredentials)
 				.send({
 					password: crypto.createHash('sha256').update(password, 'utf8').digest('hex'),
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
 		});
 
 		it('should delete user own account when the SHA256 hash is in upper case', async () => {
@@ -4580,17 +4406,15 @@ describe('[Users]', () => {
 					.expect(200);
 			});
 			describe('[/users.getPersonalAccessTokens]', () => {
-				it('should return an array when the user does not have personal tokens configured', (done) => {
-					void request
+				it('should return an array when the user does not have personal tokens configured', async () => {
+					const res = await request
 						.get(api('users.getPersonalAccessTokens'))
 						.set(credentials)
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.property('tokens').and.to.be.an('array');
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('tokens').and.to.be.an('array');
 				});
 
 				it('should return 401 when not authenticated', async () => {
@@ -4605,34 +4429,30 @@ describe('[Users]', () => {
 			});
 
 			describe('[/users.generatePersonalAccessToken]', () => {
-				it('should return a personal access token to user', (done) => {
-					void request
+				it('should return a personal access token to user', async () => {
+					const res = await request
 						.post(api('users.generatePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.property('token');
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('token');
 				});
-				it('should throw an error when user tries generate a token with the same name', (done) => {
-					void request
+				it('should throw an error when user tries generate a token with the same name', async () => {
+					const res = await request
 						.post(api('users.generatePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
 				});
 
 				it('should return 401 when not authenticated', async () => {
@@ -4658,34 +4478,30 @@ describe('[Users]', () => {
 				});
 			});
 			describe('[/users.regeneratePersonalAccessToken]', () => {
-				it('should return a personal access token to user when user regenerates the token', (done) => {
-					void request
+				it('should return a personal access token to user when user regenerates the token', async () => {
+					const res = await request
 						.post(api('users.regeneratePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.property('token');
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('token');
 				});
-				it('should throw an error when user tries regenerate a token that does not exist', (done) => {
-					void request
+				it('should throw an error when user tries regenerate a token that does not exist', async () => {
+					const res = await request
 						.post(api('users.regeneratePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName: 'tokenthatdoesnotexist',
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
 				});
 
 				it('should return 401 when not authenticated', async () => {
@@ -4711,47 +4527,41 @@ describe('[Users]', () => {
 				});
 			});
 			describe('[/users.getPersonalAccessTokens]', () => {
-				it('should return my personal access tokens', (done) => {
-					void request
+				it('should return my personal access tokens', async () => {
+					const res = await request
 						.get(api('users.getPersonalAccessTokens'))
 						.set(credentials)
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-							expect(res.body).to.have.property('tokens').and.to.be.an('array');
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('tokens').and.to.be.an('array');
 				});
 			});
 			describe('[/users.removePersonalAccessToken]', () => {
-				it('should return success when user remove a personal access token', (done) => {
-					void request
+				it('should return success when user remove a personal access token', async () => {
+					const res = await request
 						.post(api('users.removePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(200)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', true);
-						})
-						.end(done);
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
 				});
-				it('should throw an error when user tries remove a token that does not exist', (done) => {
-					void request
+				it('should throw an error when user tries remove a token that does not exist', async () => {
+					const res = await request
 						.post(api('users.removePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName: 'tokenthatdoesnotexist',
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
 				});
 
 				it('should return 401 when not authenticated', async () => {
@@ -4782,77 +4592,67 @@ describe('[Users]', () => {
 			after(() => updatePermission('create-personal-access-tokens', ['admin']));
 
 			describe('should return an error when the user dont have the necessary permission "create-personal-access-tokens"', () => {
-				it('/users.generatePersonalAccessToken', (done) => {
-					void request
+				it('/users.generatePersonalAccessToken', async () => {
+					const res = await request
 						.post(api('users.generatePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body.errorType).to.be.equal('not-authorized');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.errorType).to.be.equal('not-authorized');
 				});
-				it('/users.regeneratePersonalAccessToken', (done) => {
-					void request
+				it('/users.regeneratePersonalAccessToken', async () => {
+					const res = await request
 						.post(api('users.regeneratePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body.errorType).to.be.equal('not-authorized');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.errorType).to.be.equal('not-authorized');
 				});
-				it('/users.getPersonalAccessTokens', (done) => {
-					void request
+				it('/users.getPersonalAccessTokens', async () => {
+					const res = await request
 						.get(api('users.getPersonalAccessTokens'))
 						.set(credentials)
 						.expect('Content-Type', 'application/json')
-						.expect(403)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body.error).to.be.equal('User does not have the permissions required for this action [error-unauthorized]');
-						})
-						.end(done);
+						.expect(403);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.error).to.be.equal('User does not have the permissions required for this action [error-unauthorized]');
 				});
-				it('/users.removePersonalAccessToken', (done) => {
-					void request
+				it('/users.removePersonalAccessToken', async () => {
+					const res = await request
 						.post(api('users.removePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName,
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body.errorType).to.be.equal('not-authorized');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.errorType).to.be.equal('not-authorized');
 				});
-				it('should throw an error when user tries remove a token that does not exist', (done) => {
-					void request
+				it('should throw an error when user tries remove a token that does not exist', async () => {
+					const res = await request
 						.post(api('users.removePersonalAccessToken'))
 						.set(credentials)
 						.send({
 							tokenName: 'tokenthatdoesnotexist',
 						})
 						.expect('Content-Type', 'application/json')
-						.expect(400)
-						.expect((res) => {
-							expect(res.body).to.have.property('success', false);
-							expect(res.body.errorType).to.be.equal('not-authorized');
-						})
-						.end(done);
+						.expect(400);
+
+					expect(res.body).to.have.property('success', false);
+					expect(res.body.errorType).to.be.equal('not-authorized');
 				});
 			});
 		});
@@ -4895,8 +4695,8 @@ describe('[Users]', () => {
 
 		after(() => Promise.all([removeAgent(agent.user._id), deleteUser(agent.user)]));
 
-		it('should set other user active status to false when the logged user has the necessary permission(edit-other-user-active-status)', (done) => {
-			void request
+		it('should set other user active status to false when the logged user has the necessary permission(edit-other-user-active-status)', async () => {
+			const res = await request
 				.post(api('users.setActiveStatus'))
 				.set(userCredentials)
 				.send({
@@ -4904,15 +4704,13 @@ describe('[Users]', () => {
 					userId: targetUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.active', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.active', false);
 		});
-		it('should set other user active status to true when the logged user has the necessary permission(edit-other-user-active-status)', (done) => {
-			void request
+		it('should set other user active status to true when the logged user has the necessary permission(edit-other-user-active-status)', async () => {
+			const res = await request
 				.post(api('users.setActiveStatus'))
 				.set(userCredentials)
 				.send({
@@ -4920,34 +4718,30 @@ describe('[Users]', () => {
 					userId: targetUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.nested.property('user.active', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.nested.property('user.active', true);
 		});
 
-		it('should return an error when trying to set other user active status and has not the necessary permission(edit-other-user-active-status)', (done) => {
-			void updatePermission('edit-other-user-active-status', []).then(() => {
-				void request
-					.post(api('users.setActiveStatus'))
-					.set(userCredentials)
-					.send({
-						activeStatus: false,
-						userId: targetUser._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
-			});
+		it('should return an error when trying to set other user active status and has not the necessary permission(edit-other-user-active-status)', async () => {
+			await updatePermission('edit-other-user-active-status', []);
+
+			const res = await request
+				.post(api('users.setActiveStatus'))
+				.set(userCredentials)
+				.send({
+					activeStatus: false,
+					userId: targetUser._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
-		it('should return an error when trying to set user own active status and has not the necessary permission(edit-other-user-active-status)', (done) => {
-			void request
+		it('should return an error when trying to set user own active status and has not the necessary permission(edit-other-user-active-status)', async () => {
+			const res = await request
 				.post(api('users.setActiveStatus'))
 				.set(userCredentials)
 				.send({
@@ -4955,30 +4749,26 @@ describe('[Users]', () => {
 					userId: user._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(403)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-				})
-				.end(done);
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
-		it('should set user own active status to false when the user has the necessary permission(edit-other-user-active-status)', (done) => {
-			void updatePermission('edit-other-user-active-status', ['admin']).then(() => {
-				void request
-					.post(api('users.setActiveStatus'))
-					.set(userCredentials)
-					.send({
-						activeStatus: false,
-						userId: user._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
-			});
+		it('should set user own active status to false when the user has the necessary permission(edit-other-user-active-status)', async () => {
+			await updatePermission('edit-other-user-active-status', ['admin']);
+
+			const res = await request
+				.post(api('users.setActiveStatus'))
+				.set(userCredentials)
+				.send({
+					activeStatus: false,
+					userId: user._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
 		it('users should retain their roles when they are deactivated', async () => {
 			const testUser = await createUser({ roles: ['user', 'livechat-agent'] });
@@ -5190,75 +4980,67 @@ describe('[Users]', () => {
 
 		after(() => Promise.all([deleteUser(testUser), updatePermission('edit-other-user-active-status', ['admin'])]));
 
-		it('should fail to deactivate if user doesnt have edit-other-user-active-status permission', (done) => {
-			void updatePermission('edit-other-user-active-status', []).then(() => {
-				void request
-					.post(api('users.deactivateIdle'))
-					.set(credentials)
-					.send({
-						daysIdle: 0,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
-					})
-					.end(done);
-			});
+		it('should fail to deactivate if user doesnt have edit-other-user-active-status permission', async () => {
+			await updatePermission('edit-other-user-active-status', []);
+
+			const res = await request
+				.post(api('users.deactivateIdle'))
+				.set(credentials)
+				.send({
+					daysIdle: 0,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error', 'User does not have the permissions required for this action [error-unauthorized]');
 		});
-		it('should deactivate no users when no users in time range', (done) => {
-			void updatePermission('edit-other-user-active-status', ['admin']).then(() => {
-				void request
-					.post(api('users.deactivateIdle'))
-					.set(credentials)
-					.send({
-						daysIdle: 999999,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('count', 0);
-					})
-					.end(done);
-			});
+		it('should deactivate no users when no users in time range', async () => {
+			await updatePermission('edit-other-user-active-status', ['admin']);
+
+			const res = await request
+				.post(api('users.deactivateIdle'))
+				.set(credentials)
+				.send({
+					daysIdle: 999999,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count', 0);
 		});
-		it('should deactivate the test user when given its role and daysIdle = 0', (done) => {
-			void updatePermission('edit-other-user-active-status', ['admin']).then(() => {
-				void request
-					.post(api('users.deactivateIdle'))
-					.set(credentials)
-					.send({
-						daysIdle: 0,
-						role: testRoleId,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('count', 1);
-					})
-					.end(done);
-			});
+		it('should deactivate the test user when given its role and daysIdle = 0', async () => {
+			await updatePermission('edit-other-user-active-status', ['admin']);
+
+			const res = await request
+				.post(api('users.deactivateIdle'))
+				.set(credentials)
+				.send({
+					daysIdle: 0,
+					role: testRoleId,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count', 1);
 		});
-		it('should not deactivate the test user again when given its role and daysIdle = 0', (done) => {
-			void updatePermission('edit-other-user-active-status', ['admin']).then(() => {
-				void request
-					.post(api('users.deactivateIdle'))
-					.set(credentials)
-					.send({
-						daysIdle: 0,
-						role: testRoleId,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('count', 0);
-					})
-					.end(done);
-			});
+		it('should not deactivate the test user again when given its role and daysIdle = 0', async () => {
+			await updatePermission('edit-other-user-active-status', ['admin']);
+
+			const res = await request
+				.post(api('users.deactivateIdle'))
+				.set(credentials)
+				.send({
+					daysIdle: 0,
+					role: testRoleId,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('count', 0);
 		});
 
 		it('should return 400 when body is empty', async () => {
@@ -5298,49 +5080,43 @@ describe('[Users]', () => {
 	});
 
 	describe('[/users.requestDataDownload]', () => {
-		it('should return the request data with fullExport false when no query parameter was send', (done) => {
-			void request
+		it('should return the request data with fullExport false when no query parameter was send', async () => {
+			const res = await request
 				.get(api('users.requestDataDownload'))
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('requested');
-					expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
-					expect(res.body.exportOperation).to.have.property('fullExport', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('requested');
+			expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
+			expect(res.body.exportOperation).to.have.property('fullExport', false);
 		});
-		it('should return the request data with fullExport false when the fullExport query parameter is false', (done) => {
-			void request
+		it('should return the request data with fullExport false when the fullExport query parameter is false', async () => {
+			const res = await request
 				.get(api('users.requestDataDownload'))
 				.query({ fullExport: 'false' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('requested');
-					expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
-					expect(res.body.exportOperation).to.have.property('fullExport', false);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('requested');
+			expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
+			expect(res.body.exportOperation).to.have.property('fullExport', false);
 		});
-		it('should return the request data with fullExport true when the fullExport query parameter is true', (done) => {
-			void request
+		it('should return the request data with fullExport true when the fullExport query parameter is true', async () => {
+			const res = await request
 				.get(api('users.requestDataDownload'))
 				.query({ fullExport: 'true' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('requested');
-					expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
-					expect(res.body.exportOperation).to.have.property('fullExport', true);
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('requested');
+			expect(res.body).to.have.property('exportOperation').and.to.be.an('object');
+			expect(res.body.exportOperation).to.have.property('fullExport', true);
 		});
 
 		it('should return 401 when not authenticated', async () => {
@@ -5511,18 +5287,16 @@ describe('[Users]', () => {
 				await Promise.all([deleteRoom({ type: 'c', roomId }), deleteUser(user), deleteUser(user2)]);
 			});
 
-			it('should return an empty list when the user does not have any subscription', (done) => {
-				void request
+			it('should return an empty list when the user does not have any subscription', async () => {
+				const res = await request
 					.get(api('users.autocomplete'))
 					.query({ selector: '{}' })
 					.set(userCredentials)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('items').and.to.be.an('array').that.has.lengthOf(0);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('items').and.to.be.an('array').that.has.lengthOf(0);
 			});
 
 			it('should return users that are subscribed to the same rooms as the requester', async () => {
@@ -5544,30 +5318,26 @@ describe('[Users]', () => {
 		describe('[with permission]', () => {
 			before(async () => updatePermission('view-outside-room', ['admin', 'user']));
 
-			it('should return an error when the required parameter "selector" is not provided', (done) => {
-				void request
+			it('should return an error when the required parameter "selector" is not provided', async () => {
+				const res = await request
 					.get(api('users.autocomplete'))
 					.query({})
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
-			it('should return the users to fill auto complete', (done) => {
-				void request
+			it('should return the users to fill auto complete', async () => {
+				const res = await request
 					.get(api('users.autocomplete'))
 					.query({ selector: '{}' })
 					.set(credentials)
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('items').and.to.be.an('array');
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('items').and.to.be.an('array');
 			});
 
 			(IS_EE ? it : it.skip)('should return users filtered by freeSwitchExtension and display it', async () => {
@@ -5587,8 +5357,8 @@ describe('[Users]', () => {
 				await deleteUser(user);
 			});
 
-			it('should filter results when using allowed operators', (done) => {
-				void request
+			it('should filter results when using allowed operators', async () => {
+				const res = await request
 					.get(api('users.autocomplete'))
 					.set(credentials)
 					.query({
@@ -5606,16 +5376,14 @@ describe('[Users]', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						expect(res.body).to.have.property('items').and.to.be.an('array').with.lengthOf(0);
-					})
-					.end(done);
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('items').and.to.be.an('array').with.lengthOf(0);
 			});
 
-			it('should return an error when using forbidden operators', (done) => {
-				void request
+			it('should return an error when using forbidden operators', async () => {
+				const res = await request
 					.get(api('users.autocomplete'))
 					.set(credentials)
 					.query({
@@ -5637,11 +5405,9 @@ describe('[Users]', () => {
 						}),
 					})
 					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-					})
-					.end(done);
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
 			});
 		});
 
@@ -5657,32 +5423,24 @@ describe('[Users]', () => {
 	});
 
 	describe('[/users.getStatus]', () => {
-		it('should return my own status', (done) => {
-			void request
-				.get(api('users.getStatus'))
-				.set(credentials)
-				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('_id', credentials['X-User-Id']);
-					expect(res.body).to.have.property('status');
-				})
-				.end(done);
+		it('should return my own status', async () => {
+			const res = await request.get(api('users.getStatus')).set(credentials).expect('Content-Type', 'application/json').expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('_id', credentials['X-User-Id']);
+			expect(res.body).to.have.property('status');
 		});
-		it('should return other user status', (done) => {
-			void request
+		it('should return other user status', async () => {
+			const res = await request
 				.get(api('users.getStatus'))
 				.query({ userId: 'rocket.cat' })
 				.set(credentials)
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('_id', 'rocket.cat');
-					expect(res.body).to.have.property('status');
-				})
-				.end(done);
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('_id', 'rocket.cat');
+			expect(res.body).to.have.property('status');
 		});
 
 		it('should return 401 when not authenticated', async () => {
@@ -5704,98 +5462,88 @@ describe('[Users]', () => {
 		});
 		after(() => Promise.all([deleteUser(user), updateSetting('Accounts_AllowUserStatusMessageChange', true)]));
 
-		it('should return an error when the setting "Accounts_AllowUserStatusMessageChange" is disabled', (done) => {
-			void updateSetting('Accounts_AllowUserStatusMessageChange', false).then(() => {
-				void request
-					.post(api('users.setStatus'))
-					.set(credentials)
-					.send({
-						status: 'busy',
-						message: 'test',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(400)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.errorType).to.be.equal('error-not-allowed');
-						expect(res.body.error).to.be.equal('Change status is not allowed [error-not-allowed]');
-					})
-					.end(done);
+		it('should return an error when the setting "Accounts_AllowUserStatusMessageChange" is disabled', async () => {
+			await updateSetting('Accounts_AllowUserStatusMessageChange', false);
+
+			const res = await request
+				.post(api('users.setStatus'))
+				.set(credentials)
+				.send({
+					status: 'busy',
+					message: 'test',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-not-allowed');
+			expect(res.body.error).to.be.equal('Change status is not allowed [error-not-allowed]');
+		});
+		it('should update my own status', async () => {
+			await updateSetting('Accounts_AllowUserStatusMessageChange', true);
+
+			const res = await request
+				.post(api('users.setStatus'))
+				.set(credentials)
+				.send({
+					status: 'busy',
+					message: 'test',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			void getUserStatus(credentials['X-User-Id']).then((status) => expect(status.status).to.be.equal('busy'));
+		});
+		it('should return an error when trying to update other user status without the required permission', async () => {
+			await updatePermission('edit-other-user-info', []);
+
+			const res = await request
+				.post(api('users.setStatus'))
+				.set(credentials)
+				.send({
+					status: 'busy',
+					message: 'test',
+					userId: user._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('unauthorized');
+		});
+		it('should update another user status succesfully', async () => {
+			await updatePermission('edit-other-user-info', ['admin']);
+
+			const res = await request
+				.post(api('users.setStatus'))
+				.set(credentials)
+				.send({
+					status: 'busy',
+					message: 'test',
+					userId: user._id,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			void getUserStatus(credentials['X-User-Id']).then((status) => {
+				expect(status.status).to.be.equal('busy');
 			});
 		});
-		it('should update my own status', (done) => {
-			void updateSetting('Accounts_AllowUserStatusMessageChange', true).then(() => {
-				void request
-					.post(api('users.setStatus'))
-					.set(credentials)
-					.send({
-						status: 'busy',
-						message: 'test',
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						void getUserStatus(credentials['X-User-Id']).then((status) => expect(status.status).to.be.equal('busy'));
-					})
-					.end(done);
-			});
-		});
-		it('should return an error when trying to update other user status without the required permission', (done) => {
-			void updatePermission('edit-other-user-info', []).then(() => {
-				void request
-					.post(api('users.setStatus'))
-					.set(credentials)
-					.send({
-						status: 'busy',
-						message: 'test',
-						userId: user._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', false);
-						expect(res.body.error).to.be.equal('unauthorized');
-					})
-					.end(done);
-			});
-		});
-		it('should update another user status succesfully', (done) => {
-			void updatePermission('edit-other-user-info', ['admin']).then(() => {
-				void request
-					.post(api('users.setStatus'))
-					.set(credentials)
-					.send({
-						status: 'busy',
-						message: 'test',
-						userId: user._id,
-					})
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.expect((res) => {
-						expect(res.body).to.have.property('success', true);
-						void getUserStatus(credentials['X-User-Id']).then((status) => {
-							expect(status.status).to.be.equal('busy');
-						});
-					})
-					.end(done);
-			});
-		});
-		it('should return an error when the user try to update user status with an invalid status', (done) => {
-			void request
+		it('should return an error when the user try to update user status with an invalid status', async () => {
+			const res = await request
 				.post(api('users.setStatus'))
 				.set(credentials)
 				.send({
 					status: 'invalid',
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.errorType).to.be.equal('invalid-params');
-					expect(res.body.error).to.include('must be equal to one of the allowed values');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('invalid-params');
+			expect(res.body.error).to.include('must be equal to one of the allowed values');
 		});
 		it('should return an error when user changes status to offline and "Accounts_AllowInvisibleStatusOption" is disabled', async () => {
 			await updateSetting('Accounts_AllowInvisibleStatusOption', false);
@@ -5833,18 +5581,16 @@ describe('[Users]', () => {
 
 			await updateSetting('Accounts_AllowInvisibleStatusOption', true);
 		});
-		it('should return an error when the payload is missing all supported fields', (done) => {
-			void request
+		it('should return an error when the payload is missing all supported fields', async () => {
+			const res = await request
 				.post(api('users.setStatus'))
 				.set(credentials)
 				.send({})
 				.expect('Content-Type', 'application/json')
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body.error).to.be.equal('Match error: Failed Match.OneOf, Match.Maybe or Match.Optional validation');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.error).to.be.equal('Match error: Failed Match.OneOf, Match.Maybe or Match.Optional validation');
 		});
 
 		it('should return 401 when not authenticated', async () => {
@@ -6071,25 +5817,23 @@ describe('[Users]', () => {
 
 		after(() => Promise.all([...[teamName1, teamName2].map((team) => deleteTeam(credentials, team)), deleteUser(testUser)]));
 
-		it('should list both channels', (done) => {
-			void request
+		it('should list both channels', async () => {
+			const res = await request
 				.get(api('users.listTeams'))
 				.set(credentials)
 				.query({
 					userId: testUser._id,
 				})
 				.expect('Content-Type', 'application/json')
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('teams');
+				.expect(200);
 
-					const { teams } = res.body;
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('teams');
 
-					expect(teams).to.have.length(2);
-					expect(teams[0].isOwner).to.not.be.eql(teams[1].isOwner);
-				})
-				.end(done);
+			const { teams } = res.body;
+
+			expect(teams).to.have.length(2);
+			expect(teams[0].isOwner).to.not.be.eql(teams[1].isOwner);
 		});
 
 		it('should return 401 when not authenticated', async () => {
@@ -6127,28 +5871,26 @@ describe('[Users]', () => {
 
 		after(() => Promise.all([deleteUser(user), deleteUser(otherUser), updatePermission('logout-other-user', ['admin'])]));
 
-		it('should throw unauthorized error to user w/o "logout-other-user" permission', (done) => {
-			void updatePermission('logout-other-user', []).then(() => {
-				void request
-					.post(api('users.logout'))
-					.set(credentials)
-					.send({ userId: otherUser._id })
-					.expect('Content-Type', 'application/json')
-					.expect(403)
-					.end(done);
-			});
+		it('should throw unauthorized error to user w/o "logout-other-user" permission', async () => {
+			await updatePermission('logout-other-user', []);
+
+			await request
+				.post(api('users.logout'))
+				.set(credentials)
+				.send({ userId: otherUser._id })
+				.expect('Content-Type', 'application/json')
+				.expect(403);
 		});
 
-		it('should logout other user', (done) => {
-			void updatePermission('logout-other-user', ['admin']).then(() => {
-				void request
-					.post(api('users.logout'))
-					.set(credentials)
-					.send({ userId: otherUser._id })
-					.expect('Content-Type', 'application/json')
-					.expect(200)
-					.end(done);
-			});
+		it('should logout other user', async () => {
+			await updatePermission('logout-other-user', ['admin']);
+
+			await request
+				.post(api('users.logout'))
+				.set(credentials)
+				.send({ userId: otherUser._id })
+				.expect('Content-Type', 'application/json')
+				.expect(200);
 		});
 
 		it('should logout the requester', (done) => {

--- a/apps/meteor/tests/end-to-end/api/webdav.ts
+++ b/apps/meteor/tests/end-to-end/api/webdav.ts
@@ -7,45 +7,33 @@ describe('[Webdav]', () => {
 	before((done) => getCredentials(done));
 
 	describe('/webdav.getMyAccounts', () => {
-		it('should return my webdav accounts', (done) => {
-			void request
-				.get(api('webdav.getMyAccounts'))
-				.set(credentials)
-				.expect(200)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('accounts').and.to.be.a('array');
-				})
-				.end(done);
+		it('should return my webdav accounts', async () => {
+			const res = await request.get(api('webdav.getMyAccounts')).set(credentials).expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('accounts').and.to.be.a('array');
 		});
 	});
 
 	describe('/webdav.removeWebdavAccount', () => {
-		it('should return an error when send an invalid request', (done) => {
-			void request
-				.post(api('webdav.removeWebdavAccount'))
-				.set(credentials)
-				.send({})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+		it('should return an error when send an invalid request', async () => {
+			const res = await request.post(api('webdav.removeWebdavAccount')).set(credentials).send({}).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
-		it('should return an error when using an invalid account id', (done) => {
-			void request
+
+		it('should return an error when using an invalid account id', async () => {
+			const res = await request
 				.post(api('webdav.removeWebdavAccount'))
 				.set(credentials)
 				.send({
 					accountId: {},
 				})
-				.expect(400)
-				.expect((res) => {
-					expect(res.body).to.have.property('success', false);
-					expect(res.body).to.have.property('error');
-				})
-				.end(done);
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body).to.have.property('error');
 		});
 	});
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
- [CORE-2502](https://rocketchat.atlassian.net/browse/CORE-2502)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modernized broad end-to-end API coverage with more consistent asynchronous request handling.
  * Strengthened validation of success responses, error messages, permissions, status codes, pagination, and response formats across messaging, rooms, users, teams, integrations, and other API areas.
  * Improved coverage for authentication, authorization, invalid input, and edge-case scenarios.
  * No end-user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2502]: https://rocketchat.atlassian.net/browse/CORE-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ