### PR TITLE
refactor: use ContextualbarV2 components everywhere

### DIFF
--- a/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesContextualBar.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesContextualBar.tsx
@@ -1,5 +1,4 @@
-import { ContextualbarTitle } from '@rocket.chat/fuselage';
-import { ContextualbarClose, ContextualbarHeader } from '@rocket.chat/ui-client';
+import { ContextualbarClose, ContextualbarHeader, ContextualbarTitle } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouteParameter, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormProvider, useForm } from 'react-hook-form';

--- a/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.stories.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.stories.tsx
@@ -1,5 +1,5 @@
-import { Contextualbar } from '@rocket.chat/fuselage';
 import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { Contextualbar } from '@rocket.chat/ui-client';
 import type { Meta, StoryObj } from '@storybook/react';
 import { FormProvider, useForm } from 'react-hook-form';
 

--- a/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/AttributesForm.tsx
@@ -1,17 +1,6 @@
-import {
-	Box,
-	Button,
-	ButtonGroup,
-	ContextualbarFooter,
-	Field,
-	FieldError,
-	FieldLabel,
-	FieldRow,
-	IconButton,
-	TextInput,
-} from '@rocket.chat/fuselage';
+import { Box, Button, ButtonGroup, Field, FieldError, FieldLabel, FieldRow, IconButton, TextInput } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
-import { ContextualbarScrollableContent } from '@rocket.chat/ui-client';
+import { ContextualbarFooter, ContextualbarScrollableContent } from '@rocket.chat/ui-client';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { useCallback, useId, useMemo, Fragment, useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';

--- a/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/__snapshots__/AttributesForm.spec.tsx.snap
+++ b/apps/meteor/client/views/admin/ABAC/ABACAttributesTab/__snapshots__/AttributesForm.spec.tsx.snap
@@ -133,7 +133,7 @@ exports[`AttributesForm renders NewAttribute without crashing 1`] = `
         </div>
       </div>
       <div
-        class="rcx-box rcx-box--full rcx-css-m843eh"
+        class="rcx-box rcx-box--full rcx-css-f51umh"
       >
         <div
           class="rcx-button-group rcx-button-group--stretch rcx-button-group--align-start"
@@ -353,7 +353,7 @@ exports[`AttributesForm renders WithLockedAttributes without crashing 1`] = `
         </div>
       </div>
       <div
-        class="rcx-box rcx-box--full rcx-css-m843eh"
+        class="rcx-box rcx-box--full rcx-css-f51umh"
       >
         <div
           class="rcx-button-group rcx-button-group--stretch rcx-button-group--align-start"

--- a/apps/meteor/client/views/admin/ABAC/ABACRoomsTab/RoomForm.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACRoomsTab/RoomForm.tsx
@@ -1,6 +1,6 @@
-import { Box, Callout, Field, FieldLabel, FieldRow, FieldError, ButtonGroup, Button, ContextualbarFooter } from '@rocket.chat/fuselage';
+import { Box, Callout, Field, FieldLabel, FieldRow, FieldError, ButtonGroup, Button } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
-import { GenericModal, ContextualbarScrollableContent } from '@rocket.chat/ui-client';
+import { GenericModal, ContextualbarFooter, ContextualbarScrollableContent } from '@rocket.chat/ui-client';
 import { useSetModal } from '@rocket.chat/ui-contexts';
 import type { Dispatch, SetStateAction } from 'react';
 import { useId } from 'react';

--- a/apps/meteor/client/views/admin/ABAC/ABACRoomsTab/RoomsContextualBar.tsx
+++ b/apps/meteor/client/views/admin/ABAC/ABACRoomsTab/RoomsContextualBar.tsx
@@ -1,5 +1,4 @@
-import { ContextualbarTitle } from '@rocket.chat/fuselage';
-import { ContextualbarClose, ContextualbarHeader } from '@rocket.chat/ui-client';
+import { ContextualbarClose, ContextualbarHeader, ContextualbarTitle } from '@rocket.chat/ui-client';
 import { useEndpoint, useRouteParameter, useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';

--- a/apps/meteor/client/views/admin/moderation/ModConsoleReportDetails.tsx
+++ b/apps/meteor/client/views/admin/moderation/ModConsoleReportDetails.tsx
@@ -1,7 +1,7 @@
 import type { IUser } from '@rocket.chat/core-typings';
-import { Tabs, TabsItem, ContextualbarHeader, ContextualbarTitle } from '@rocket.chat/fuselage';
+import { Tabs, TabsItem } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
-import { ContextualbarClose, ContextualbarDialog } from '@rocket.chat/ui-client';
+import { ContextualbarClose, ContextualbarDialog, ContextualbarHeader, ContextualbarTitle } from '@rocket.chat/ui-client';
 import { useTranslation, useRouter, useRouteParameter } from '@rocket.chat/ui-contexts';
 import { useState } from 'react';
 

--- a/apps/meteor/client/views/admin/users/AdminUsersPage.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUsersPage.tsx
@@ -1,10 +1,11 @@
 import type { LicenseInfo } from '@rocket.chat/core-typings';
-import { Callout, ContextualbarIcon, Skeleton, Tabs, TabsItem } from '@rocket.chat/fuselage';
+import { Callout, Skeleton, Tabs, TabsItem } from '@rocket.chat/fuselage';
 import { useDebouncedValue, useStableCallback } from '@rocket.chat/fuselage-hooks';
 import type { OptionProp } from '@rocket.chat/ui-client';
 import {
 	ExternalLink,
 	ContextualbarHeader,
+	ContextualbarIcon,
 	ContextualbarTitle,
 	ContextualbarClose,
 	ContextualbarDialog,

--- a/apps/meteor/client/views/omnichannel/cannedResponses/contextualBar/CannedResponse/CannedResponseList.tsx
+++ b/apps/meteor/client/views/omnichannel/cannedResponses/contextualBar/CannedResponse/CannedResponseList.tsx
@@ -1,5 +1,5 @@
 import type { ILivechatDepartment, IOmnichannelCannedResponse } from '@rocket.chat/core-typings';
-import { Box, Button, ButtonGroup, ContextualbarEmptyContent, Icon, Margins, Select, TextInput } from '@rocket.chat/fuselage';
+import { Box, Button, ButtonGroup, Icon, Margins, Select, TextInput } from '@rocket.chat/fuselage';
 import { useAutoFocus, useResizeObserver } from '@rocket.chat/fuselage-hooks';
 import {
 	VirtualizedScrollbars,
@@ -7,6 +7,7 @@ import {
 	ContextualbarTitle,
 	ContextualbarClose,
 	ContextualbarContent,
+	ContextualbarEmptyContent,
 	ContextualbarFooter,
 	ContextualbarDialog,
 } from '@rocket.chat/ui-client';

--- a/apps/meteor/client/views/omnichannel/priorities/PriorityEditForm.tsx
+++ b/apps/meteor/client/views/omnichannel/priorities/PriorityEditForm.tsx
@@ -1,6 +1,6 @@
 import type { ILivechatPriority, Serialized } from '@rocket.chat/core-typings';
-import { Field, FieldError, FieldLabel, FieldRow, TextInput, Button, ButtonGroup, ContextualbarFooter } from '@rocket.chat/fuselage';
-import { ContextualbarScrollableContent } from '@rocket.chat/ui-client';
+import { Field, FieldError, FieldLabel, FieldRow, TextInput, Button, ButtonGroup } from '@rocket.chat/fuselage';
+import { ContextualbarFooter, ContextualbarScrollableContent } from '@rocket.chat/ui-client';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useId } from 'react';
 import { Controller, useForm } from 'react-hook-form';

--- a/apps/meteor/client/views/omnichannel/slaPolicies/SlaEdit.tsx
+++ b/apps/meteor/client/views/omnichannel/slaPolicies/SlaEdit.tsx
@@ -1,16 +1,6 @@
 import type { IOmnichannelServiceLevelAgreements, Serialized } from '@rocket.chat/core-typings';
-import {
-	Field,
-	FieldLabel,
-	FieldRow,
-	FieldError,
-	TextInput,
-	Button,
-	NumberInput,
-	ButtonGroup,
-	ContextualbarFooter,
-} from '@rocket.chat/fuselage';
-import { ContextualbarScrollableContent } from '@rocket.chat/ui-client';
+import { Field, FieldLabel, FieldRow, FieldError, TextInput, Button, NumberInput, ButtonGroup } from '@rocket.chat/fuselage';
+import { ContextualbarFooter, ContextualbarScrollableContent } from '@rocket.chat/ui-client';
 import { useToastMessageDispatch, useRoute, useTranslation, useEndpoint } from '@rocket.chat/ui-contexts';
 import { useId } from 'react';
 import { useController, useForm } from 'react-hook-form';

--- a/apps/meteor/client/views/room/contextualBar/RoomFiles/RoomFiles.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomFiles/RoomFiles.tsx
@@ -1,6 +1,6 @@
 import type { IRoom, IUpload, IUploadWithUser } from '@rocket.chat/core-typings';
 import type { SelectOption } from '@rocket.chat/fuselage';
-import { Box, Icon, TextInput, Select, Throbber, ContextualbarSection } from '@rocket.chat/fuselage';
+import { Box, Icon, TextInput, Select, Throbber } from '@rocket.chat/fuselage';
 import {
 	VirtualizedScrollbars,
 	ContextualbarHeader,
@@ -9,6 +9,7 @@ import {
 	ContextualbarClose,
 	ContextualbarContent,
 	ContextualbarEmptyContent,
+	ContextualbarSection,
 	ContextualbarDialog,
 } from '@rocket.chat/ui-client';
 import type { ChangeEvent } from 'react';

--- a/apps/meteor/client/views/room/contextualBar/RoomFiles/__snapshots__/RoomFiles.spec.tsx.snap
+++ b/apps/meteor/client/views/room/contextualBar/RoomFiles/__snapshots__/RoomFiles.spec.tsx.snap
@@ -40,7 +40,7 @@ exports[`renders Default without crashing 1`] = `
             </div>
           </div>
           <div
-            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-137qgp8"
+            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-16mbly4"
           >
             <label
               class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-box--animated rcx-input-box__wrapper"
@@ -258,7 +258,7 @@ exports[`renders Empty without crashing 1`] = `
             </div>
           </div>
           <div
-            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-137qgp8"
+            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-16mbly4"
           >
             <label
               class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-box--animated rcx-input-box__wrapper"
@@ -473,7 +473,7 @@ exports[`renders Loading without crashing 1`] = `
             </div>
           </div>
           <div
-            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-137qgp8"
+            class="rcx-box rcx-box--full rcx-vertical-bar__section rcx-css-16mbly4"
           >
             <label
               class="rcx-box rcx-box--full rcx-label rcx-box rcx-box--full rcx-box--animated rcx-input-box__wrapper"

--- a/apps/uikit-playground/src/Components/Preview/Display/Surface/ContextualBarSurface.tsx
+++ b/apps/uikit-playground/src/Components/Preview/Display/Surface/ContextualBarSurface.tsx
@@ -3,11 +3,11 @@ import {
 	Box,
 	Button,
 	ButtonGroup,
-	Contextualbar,
-	ContextualbarAction,
-	ContextualbarFooter,
-	ContextualbarHeader,
-	ContextualbarTitle,
+	ContextualbarV2,
+	ContextualbarV2Action,
+	ContextualbarV2Footer,
+	ContextualbarV2Header,
+	ContextualbarV2Title,
 } from '@rocket.chat/fuselage';
 import { Scrollbars } from 'rc-scrollbars';
 import type { ReactNode } from 'react';
@@ -15,12 +15,12 @@ import type { ReactNode } from 'react';
 export type ContextualBarSurfaceProps = { children: ReactNode };
 
 const ContextualBarSurface = ({ children }: ContextualBarSurfaceProps) => (
-	<Contextualbar>
-		<ContextualbarHeader>
+	<ContextualbarV2>
+		<ContextualbarV2Header>
 			<Avatar url='data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==' />
-			<ContextualbarTitle>Contextual Bar</ContextualbarTitle>
-			<ContextualbarAction data-qa='ContextualbarActionClose' title='Close' name='cross' />
-		</ContextualbarHeader>
+			<ContextualbarV2Title>Contextual Bar</ContextualbarV2Title>
+			<ContextualbarV2Action data-qa='ContextualbarActionClose' title='Close' name='cross' />
+		</ContextualbarV2Header>
 
 		<Box height='100%' padding='12px'>
 			<Box height='100%' display='flex' flexShrink={1} flexDirection='column' flexGrow={1}>
@@ -50,13 +50,13 @@ const ContextualBarSurface = ({ children }: ContextualBarSurfaceProps) => (
 			</Box>
 		</Box>
 
-		<ContextualbarFooter>
+		<ContextualbarV2Footer>
 			<ButtonGroup stretch>
 				<Button>Cancel</Button>
 				<Button primary>Submit</Button>
 			</ButtonGroup>
-		</ContextualbarFooter>
-	</Contextualbar>
+		</ContextualbarV2Footer>
+	</ContextualbarV2>
 );
 
 export default ContextualBarSurface;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`@rocket.chat/fuselage` exports two generations of the contextual bar: the legacy `Contextualbar*` set and `ContextualbarV2*`. `@rocket.chat/ui-client` already wraps the V2 set exclusively and re-exports it under the legacy names, and that is what virtually every contextual bar in the client renders through.

A handful of files were still bypassing those wrappers and importing the legacy components straight from fuselage — several of them **mixing both generations inside a single tree**, e.g. a V2-backed `ContextualbarHeader` from `ui-client` wrapping a legacy `ContextualbarTitle` from fuselage:

```diff
-import { ContextualbarTitle } from '@rocket.chat/fuselage';
-import { ContextualbarClose, ContextualbarHeader } from '@rocket.chat/ui-client';
+import { ContextualbarClose, ContextualbarHeader, ContextualbarTitle } from '@rocket.chat/ui-client';
```

This routes all of them through the `ui-client` wrappers. Since the wrappers keep the legacy names, the JSX in those files is untouched — the diff is imports only. `apps/uikit-playground` has no `ui-client` dependency, so it imports the `ContextualbarV2*` exports from fuselage directly instead; it is now the only direct consumer outside the wrappers themselves.

**This is not a pure rename.** The root component is byte-identical between generations, but the sub-components are not:

| Component | Legacy → V2 |
| --- | --- |
| `Header` | height `x56` → `x44`, `paddingInline` `24` → `16`, `Margins x4` → `gap: 8px` |
| `Title` | `fontScale` `h4` → `h5`, now rendered as a real `<h5>` |
| `Footer` | `padding 24` → `paddingInline 16` / `paddingBlock 20` |
| `Section` | `paddingInline 24` / `paddingBlock 16` → `padding 16` |
| `Icon` | size `x24` → `x20` |
| `Action`, `EmptyContent`, root | no behavioral change |

In every affected file this *aligns* the piece with the V2 wrappers already rendered around it — e.g. the icon in the admin Users panel becomes `x20`, which is the size that matches the `x44` V2 header it already sat inside.

Going through the wrappers also picks up the `id='contextualbarTitle'` that `ContextualbarTitle` injects, which is exactly the id `ContextualbarDialog` points `aria-labelledby` at. The moderation report and ABAC attribute/room dialogs were previously missing that label and are now correctly labelled.

## Issue(s)

ARCH-2200

## Steps to test or reproduce

Padding/heading sizes are the only visible change; each panel should look consistent with the contextual bars around it.

- **Admin → Moderation →** open a report's details (header + title)
- **Admin → Users →** open *New user* / *Invite users* (header icon), and the info/edit panels
- **Admin → ABAC →** *Attributes* tab, create and edit an attribute; *Rooms* tab, add and edit a room (header, title, footer)
- **Admin → Omnichannel → Priorities** and **Service Level Agreements →** edit an entry (footer)
- **Room → kebab → Files** (search/filter section, empty state)
- **Room → kebab → Canned Responses** (empty state)
- Screen-reader check: the moderation and ABAC dialogs should announce their title.

## Further comments

Snapshot updates in this PR are five CSS class hashes across two suites (`AttributesForm`, `RoomFiles`) — no structural or accessibility-tree changes. I inspected each before regenerating.

Verified locally: `yarn build` (68/68), `yarn turbo run typecheck --force` (48/48, no cache), `yarn testunit` (42/42), and `eslint` on every changed file.

No changeset added — the visible delta is padding and heading levels in a few admin/omnichannel panels, so happy to add one if this should surface in the release notes. 

 Task: [ARCH-2320]

[ARCH-2320]: https://rocketchat.atlassian.net/browse/ARCH-2320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated contextual bar components across administration, moderation, omnichannel, and room views for consistent UI behavior and presentation.
  * Refreshed the UI playground’s contextual bar preview with the latest header, title, action, and footer components.
  * No functional changes to forms, pages, workflows, or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->