### PR TITLE
chore: deprecate LDAP and SAML on workspaces without a Premium plan

### DIFF
--- a/.changeset/deprecate-community-saml-ldap.md
+++ b/.changeset/deprecate-community-saml-ldap.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/i18n': minor
+'@rocket.chat/meteor': minor
+---
+
+Deprecates LDAP and SAML authentication on workspaces without a Premium plan. Both keep working as they are today, but the admin settings now warn that version 9.0.0 will require a license including the `ldap-enterprise` or `saml-enterprise` module, and a warning is logged when an unlicensed workspace authenticates a user through either of them.

--- a/apps/meteor/server/configuration/ldap.ts
+++ b/apps/meteor/server/configuration/ldap.ts
@@ -2,6 +2,7 @@ import { LDAP } from '@rocket.chat/core-services';
 import { Accounts } from 'meteor/accounts-base';
 
 import { callbacks } from '../lib/callbacks';
+import { warnUnlicensedAuthService } from '../lib/premiumAuthDeprecation';
 import type { ICachedSettings } from '../settings/CachedSettings';
 
 export async function configureLDAP(settings: ICachedSettings): Promise<void> {
@@ -10,6 +11,8 @@ export async function configureLDAP(settings: ICachedSettings): Promise<void> {
 		if (!loginRequest.ldap || !loginRequest.ldapOptions) {
 			return undefined;
 		}
+
+		warnUnlicensedAuthService('LDAP', 'ldap-enterprise');
 
 		return LDAP.loginRequest(loginRequest.username, loginRequest.ldapPass);
 	});

--- a/apps/meteor/server/lib/premiumAuthDeprecation.ts
+++ b/apps/meteor/server/lib/premiumAuthDeprecation.ts
@@ -1,0 +1,21 @@
+import type { LicenseModule } from '@rocket.chat/core-typings';
+import { License } from '@rocket.chat/license';
+
+import { SystemLogger } from './logger/system';
+
+const warned = new Set<LicenseModule>();
+
+// Checked on login instead of on startup so the license is already loaded and
+// workspaces that do have the module never see the warning.
+export function warnUnlicensedAuthService(service: 'LDAP' | 'SAML', module: LicenseModule): void {
+	if (warned.has(module) || License.hasModule(module)) {
+		return;
+	}
+
+	warned.add(module);
+
+	SystemLogger.warn({
+		msg: `${service} authentication will require a Premium plan starting on version 9.0.0. This workspace has no license covering it, so ${service} logins will stop working after the upgrade.`,
+		module,
+	});
+}

--- a/apps/meteor/server/lib/saml/lib/settings.ts
+++ b/apps/meteor/server/lib/saml/lib/settings.ts
@@ -180,6 +180,7 @@ export const addSettings = async function (name: string): Promise<void> {
 					type: 'boolean',
 					i18nLabel: 'Accounts_OAuth_Custom_Enable',
 					public: true,
+					alert: 'Premium_required_from_9_0_0_alert',
 				});
 				await this.add(`SAML_Custom_${name}_provider`, 'provider-name', {
 					type: 'string',

--- a/apps/meteor/server/lib/saml/loginHandler.ts
+++ b/apps/meteor/server/lib/saml/loginHandler.ts
@@ -6,6 +6,7 @@ import { i18n } from '../i18n';
 import { SAML } from './lib/SAML';
 import { SAMLUtils } from './lib/Utils';
 import { SystemLogger } from '../logger/system';
+import { warnUnlicensedAuthService } from '../premiumAuthDeprecation';
 
 const makeError = (message: string): Record<string, any> => ({
 	type: 'saml',
@@ -21,6 +22,8 @@ Accounts.registerLoginHandler('saml', async (loginRequest) => {
 	) {
 		return undefined;
 	}
+
+	warnUnlicensedAuthService('SAML', 'saml-enterprise');
 
 	const loginResult = await SAML.retrieveCredential(loginRequest.credentialToken);
 

--- a/apps/meteor/server/settings/ldap.ts
+++ b/apps/meteor/server/settings/ldap.ts
@@ -7,7 +7,7 @@ export const createLdapSettings = () =>
 		const ldapOnly = { _id: 'LDAP_Server_Type', value: '' };
 
 		await this.with({ tab: 'LDAP_Connection' }, async function () {
-			await this.add('LDAP_Enable', false, { type: 'boolean', public: true });
+			await this.add('LDAP_Enable', false, { type: 'boolean', public: true, alert: 'Premium_required_from_9_0_0_alert' });
 
 			await this.add('LDAP_Server_Type', 'ad', {
 				type: 'select',

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -4373,6 +4373,7 @@
   "Premium_capability": "Premium capability",
   "Premium_omnichannel_capabilities": "Premium omnichannel capabilities",
   "Premium_only": "Premium only",
+  "Premium_required_from_9_0_0_alert": "From version 9.0.0 on, this authentication method requires a Premium plan. Workspaces without a license covering it will not be able to authenticate users through it after the upgrade.",
   "Please_provide_a_name_for_your_token": "Please provide a name for your token",
   "Preparing_data_for_import_process": "Preparing data for import process",
   "Preparing_list_of_channels": "Preparing list of channels",


### PR DESCRIPTION
## Proposed changes

First of two PRs turning LDAP and SAML into Premium-only features. This one only announces it — nothing stops working on 8.x. The enforcement lives in #41643, targeting `release-9.0.0`.

Two channels, both aimed at workspaces that have no license covering the feature:

- **Admin settings**: `LDAP_Enable` and `SAML_Custom_<service>` now carry a deprecation callout stating that version 9.0.0 will require a Premium plan.
- **Server log**: the first LDAP or SAML login after a boot logs a warning naming the license module the workspace is missing (`ldap-enterprise` / `saml-enterprise`). Checked at login time, not at startup, so the license is already loaded and licensed workspaces never see it.

Warned once per module per process — enough for an ops alert to fire, quiet enough not to flood the log on a busy workspace.

## Issue(s)

Prerequisite for making LDAP and SAML Premium-only in 9.0.0.

## Steps to test or reproduce

1. Start a workspace with no license (or one without `ldap-enterprise`).
2. Open **Admin → Settings → LDAP** and confirm the callout on **Enable**. Same for **Admin → Settings → SAML**.
3. Log in with an LDAP user and confirm the warning in the server log; log in again and confirm it is not repeated.
4. Apply a license including `ldap-enterprise` and confirm no warning is logged on the next LDAP login.

## Further comments

The callout text is shared by both settings (`Premium_required_from_9_0_0_alert`) and is rendered regardless of license, since a workspace that already has the plan reads it as a statement of fact rather than a warning. Say the word if you'd rather gate the callout on the missing module — that needs client-side license awareness in the settings page, not a settings flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation Notice**
  - LDAP and SAML authentication remain available for now on unlicensed workspaces.
  - Admin settings now indicate that Premium licensing will be required starting with version 9.0.0.
  - Administrators are warned when unlicensed LDAP or SAML authentication is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->