### PR TITLE
feat(Realtime Composer): Links

### DIFF
--- a/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
+++ b/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
@@ -46,6 +46,8 @@ describe('text exactness and caret round-trip on real rendered markup', () => {
 		['bare domain', 'see rocket.chat/docs now'],
 		['email', 'mail me@rocket.chat now'],
 		['link inside bold', 'a *see rocket.chat* b'],
+		['markdown link inside bold', 'a *[docs](https://rocket.chat)* b'],
+		['link with an unsafe scheme', 'see [x](javascript:alert(1))'],
 		['image', 'look ![alt](https://rocket.chat/a.png)'],
 		['timestamp', 'at <t:1700000000:t> ok'],
 		['horizontal rule', '---'],
@@ -79,6 +81,56 @@ describe('text exactness and caret round-trip on real rendered markup', () => {
 	});
 });
 
+describe('link styling', () => {
+	const anchorsOf = (text: string): HTMLAnchorElement[] => Array.from(mountMarkup(text).querySelectorAll('a'));
+
+	it.each([
+		['markdown link', 'see [the docs](https://rocket.chat/docs)', '[the docs](https://rocket.chat/docs)', 'https://rocket.chat/docs'],
+		['bare domain', 'see rocket.chat/docs now', 'rocket.chat/docs', '//rocket.chat/docs'],
+		['email', 'mail me@rocket.chat now', 'me@rocket.chat', 'mailto:me@rocket.chat'],
+	])('keeps the %s markup as the anchor text and only adds the href', (_label, text, expectedText, expectedHref) => {
+		const anchors = anchorsOf(text);
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0].textContent).toBe(expectedText);
+		expect(anchors[0].getAttribute('href')).toBe(expectedHref);
+	});
+
+	it('styles every link like the message list does', () => {
+		const [anchor] = anchorsOf('see [the docs](https://rocket.chat/docs)');
+
+		expect(anchor.getAttribute('style')).toBe('color:var(--rcx-color-font-info, #095ad2);text-decoration:underline');
+		expect(anchor.getAttribute('rel')).toBe('noopener noreferrer');
+	});
+
+	it('renders a link nested in other markup inside it', () => {
+		const [anchor] = anchorsOf('a *[docs](https://rocket.chat)* b');
+
+		expect(anchor.closest('strong')).not.toBeNull();
+		expect(anchor.textContent).toBe('[docs](https://rocket.chat)');
+	});
+
+	it.each([
+		['javascript', 'see [x](javascript:alert(1))'],
+		['data', 'see [x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)'],
+		['vbscript', 'see [x](vbscript:msgbox(1))'],
+	])('drops a %s href while keeping the typed text', (_label, text) => {
+		const input = mountMarkup(text);
+		const anchors = Array.from(input.querySelectorAll('a'));
+
+		expect(anchors).toHaveLength(1);
+		expect(anchors[0].getAttribute('href')).toBe('#');
+		expect(stripLineEnd(input.textContent ?? '')).toBe(stripLineEnd(text));
+	});
+
+	it('never renders an element the composer cannot emit', () => {
+		const input = mountMarkup('see [<img src=x onerror=alert(1)>](https://rocket.chat/<script>alert(2)</script>)');
+
+		expect(input.querySelector('img')).toBeNull();
+		expect(input.querySelector('script')).toBeNull();
+	});
+});
+
 describe('list styling', () => {
 	it.each([
 		['unordered', '- one\n- two', /^- $/],
@@ -108,6 +160,7 @@ const lossy: [string, string][] = [
 	['ordered list with a leading zero', '01. one'],
 	['ordered list with extra spacing', '1.  one'],
 	['slack-style link', '<https://rocket.chat|docs>'],
+	['phone link', 'call +15551234567 now'],
 	['padded horizontal rule', '  ---'],
 	['several big emoji', '😄 😄'],
 ];

--- a/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
+++ b/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
@@ -131,6 +131,72 @@ describe('link styling', () => {
 	});
 });
 
+describe('link scheme policy', () => {
+	const hrefOf = (text: string): string => {
+		const anchors = Array.from(mountMarkup(text).querySelectorAll('a'));
+
+		expect(anchors).toHaveLength(1);
+
+		return anchors[0].getAttribute('href') ?? '';
+	};
+
+	it.each([
+		['http', 'see [x](http://rocket.chat/docs)', 'http://rocket.chat/docs'],
+		['https', 'see [x](https://rocket.chat/docs)', 'https://rocket.chat/docs'],
+		['mailto', 'see [x](mailto:me@rocket.chat)', 'mailto:me@rocket.chat'],
+		['tel', 'see [x](tel:+15551234567)', 'tel:+15551234567'],
+	])('keeps the href of a %s link', (_label, text, expected) => {
+		expect(hrefOf(text)).toBe(expected);
+	});
+
+	it.each([
+		['javascript', 'see [x](javascript:alert(1))'],
+		['data', 'see [x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)'],
+		['vbscript', 'see [x](vbscript:msgbox(1))'],
+		['file', 'see [x](file:///etc/passwd)'],
+		['smb', 'see [x](smb://attacker.example/share)'],
+		['blob', 'see [x](blob:https://rocket.chat/2b1f)'],
+		['vscode', 'see [x](vscode://file/etc/passwd)'],
+		['ms-msdt', 'see [x](ms-msdt:/id)'],
+		['intent', 'see [x](intent://evil.example)'],
+		['jar', 'see [x](jar:http://evil.example/a.jar)'],
+	])('refuses the href of a %s link', (_label, text) => {
+		expect(hrefOf(text)).toBe('#');
+	});
+
+	it.each([
+		['javascript', 'see [x](javascript:alert(1))'],
+		['file', 'see [x](file:///etc/passwd)'],
+		['smb', 'see [x](smb://attacker.example/share)'],
+	])('keeps the typed text of a refused %s link', (_label, text) => {
+		expect(stripLineEnd(mountMarkup(text).textContent ?? '')).toBe(stripLineEnd(text));
+	});
+});
+
+describe('schemeless links', () => {
+	const hrefOf = (text: string): string => {
+		const anchors = Array.from(mountMarkup(text).querySelectorAll('a'));
+
+		expect(anchors).toHaveLength(1);
+
+		return anchors[0].getAttribute('href') ?? '';
+	};
+
+	it('resolves a bare domain to an explicit scheme instead of inheriting the page scheme', () => {
+		const href = hrefOf('see rocket.chat/docs now');
+
+		expect(() => new URL(href)).not.toThrow();
+		expect(new URL(href).protocol).toBe('https:');
+	});
+
+	it('normalizes a schemeless target so a backslash cannot disguise the real host', () => {
+		const href = hrefOf('see [x](evil.example\\@rocket.chat)');
+
+		expect(() => new URL(href)).not.toThrow();
+		expect(new URL(href).hostname).toBe('evil.example');
+	});
+});
+
 describe('list styling', () => {
 	it.each([
 		['unordered', '- one\n- two', /^- $/],

--- a/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
+++ b/apps/meteor/app/ui-message/client/messageBox/renderComposerMarkup.spec.tsx
@@ -86,7 +86,7 @@ describe('link styling', () => {
 
 	it.each([
 		['markdown link', 'see [the docs](https://rocket.chat/docs)', '[the docs](https://rocket.chat/docs)', 'https://rocket.chat/docs'],
-		['bare domain', 'see rocket.chat/docs now', 'rocket.chat/docs', '//rocket.chat/docs'],
+		['bare domain', 'see rocket.chat/docs now', 'rocket.chat/docs', 'https://rocket.chat/docs'],
 		['email', 'mail me@rocket.chat now', 'me@rocket.chat', 'mailto:me@rocket.chat'],
 	])('keeps the %s markup as the anchor text and only adds the href', (_label, text, expectedText, expectedHref) => {
 		const anchors = anchorsOf(text);
@@ -119,7 +119,7 @@ describe('link styling', () => {
 		const anchors = Array.from(input.querySelectorAll('a'));
 
 		expect(anchors).toHaveLength(1);
-		expect(anchors[0].getAttribute('href')).toBe('#');
+		expect(anchors[0].getAttribute('href')).toBeNull();
 		expect(stripLineEnd(input.textContent ?? '')).toBe(stripLineEnd(text));
 	});
 
@@ -132,12 +132,12 @@ describe('link styling', () => {
 });
 
 describe('link scheme policy', () => {
-	const hrefOf = (text: string): string => {
+	const hrefOf = (text: string): string | null => {
 		const anchors = Array.from(mountMarkup(text).querySelectorAll('a'));
 
 		expect(anchors).toHaveLength(1);
 
-		return anchors[0].getAttribute('href') ?? '';
+		return anchors[0].getAttribute('href');
 	};
 
 	it.each([
@@ -161,7 +161,7 @@ describe('link scheme policy', () => {
 		['intent', 'see [x](intent://evil.example)'],
 		['jar', 'see [x](jar:http://evil.example/a.jar)'],
 	])('refuses the href of a %s link', (_label, text) => {
-		expect(hrefOf(text)).toBe('#');
+		expect(hrefOf(text)).toBeNull();
 	});
 
 	it.each([

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -7,7 +7,7 @@ import { MessageComposerHint, RichTextComposerInputExpandable } from '@rocket.ch
 import { useTranslation, useUserPreference, useLayout, useSetting } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import type { ReactElement, FormEvent, MouseEvent, ClipboardEvent } from 'react';
-import { memo, useRef, useReducer, useCallback, useSyncExternalStore, useMemo } from 'react';
+import { memo, useRef, useReducer, useCallback, useState, useSyncExternalStore, useMemo } from 'react';
 
 import type { MessageBoxProps } from './MessageBox';
 import MessageBoxBase from './MessageBoxBase';
@@ -23,11 +23,13 @@ import {
 	handleFormattingShortcut,
 	extractImageFilesFromClipboard,
 	getModifierClickHref,
+	isCmdOrCtrlPressed,
 } from './messageBoxHelpers';
 import { handleRichTextSelectionWrapping } from './wrapSelection';
 import { createRichTextComposerAPI } from '../../../../../app/ui-message/client/messageBox/createRichTextComposerAPI';
 import { formattingButtons } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { getSelectionRange, setSelectionRange } from '../../../../../app/ui-message/client/messageBox/selectionRange';
+import { useExternalLink } from '../../../../hooks/useExternalLink';
 import { useFormatDateAndTime } from '../../../../hooks/useFormatDateAndTime';
 import { useIsFederationEnabled } from '../../../../hooks/useIsFederationEnabled';
 import { emoji } from '../../../../lib/emoji';
@@ -386,6 +388,8 @@ const RichTextMessageBox = ({
 		}
 	});
 
+	const openExternalLink = useExternalLink();
+
 	const handleClick = useStableCallback((event: MouseEvent<HTMLDivElement>) => {
 		const href = getModifierClickHref(event);
 
@@ -394,8 +398,14 @@ const RichTextMessageBox = ({
 		}
 
 		event.preventDefault();
-		window.open(href, '_blank', 'noopener,noreferrer');
+		openExternalLink(href);
 	});
+
+	const [linkModifier, setLinkModifier] = useState(false);
+
+	const handleMouseMove = useStableCallback((event: MouseEvent<HTMLDivElement>) => setLinkModifier(isCmdOrCtrlPressed(event)));
+
+	const handleMouseLeave = useStableCallback(() => setLinkModifier(false));
 
 	const popupOptions = useComposerPopupOptions();
 	const popup = useComposerBoxPopup(popupOptions);
@@ -430,7 +440,6 @@ const RichTextMessageBox = ({
 			[chat],
 		),
 	);
-
 	const composerHistoryRef = useComposerHistory(parseOptions);
 
 	const newMergedRefs = useMessageComposerMergedRefs(
@@ -490,6 +499,9 @@ const RichTextMessageBox = ({
 					hidetext={isRecordingAudio}
 					onPaste={handlePaste}
 					onClick={handleClick}
+					onMouseMove={handleMouseMove}
+					onMouseLeave={handleMouseLeave}
+					linkmodifier={linkModifier}
 					aria-activedescendant={popup.focused ? `popup-item-${popup.focused._id}` : undefined}
 					onBlur={setLastCursorPosition}
 					onFocus={getLastCursorPosition}

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -22,6 +22,7 @@ import {
 	getEmptyArray,
 	handleFormattingShortcut,
 	extractImageFilesFromClipboard,
+	getModifierClickHref,
 } from './messageBoxHelpers';
 import { handleRichTextSelectionWrapping } from './wrapSelection';
 import { createRichTextComposerAPI } from '../../../../../app/ui-message/client/messageBox/createRichTextComposerAPI';
@@ -385,6 +386,17 @@ const RichTextMessageBox = ({
 		}
 	});
 
+	const handleClick = useStableCallback((event: MouseEvent<HTMLDivElement>) => {
+		const href = getModifierClickHref(event);
+
+		if (!href) {
+			return;
+		}
+
+		event.preventDefault();
+		window.open(href, '_blank', 'noopener,noreferrer');
+	});
+
 	const popupOptions = useComposerPopupOptions();
 	const popup = useComposerBoxPopup(popupOptions);
 
@@ -477,6 +489,7 @@ const RichTextMessageBox = ({
 					hideplaceholder={hideplaceholder}
 					hidetext={isRecordingAudio}
 					onPaste={handlePaste}
+					onClick={handleClick}
 					aria-activedescendant={popup.focused ? `popup-item-${popup.focused._id}` : undefined}
 					onBlur={setLastCursorPosition}
 					onFocus={getLastCursorPosition}

--- a/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/RichTextMessageBox.tsx
@@ -22,6 +22,8 @@ import {
 	getEmptyArray,
 	handleFormattingShortcut,
 	extractImageFilesFromClipboard,
+	extractPastedPlainText,
+	getClickedLink,
 	getModifierClickHref,
 	isCmdOrCtrlPressed,
 } from './messageBoxHelpers';
@@ -385,20 +387,32 @@ const RichTextMessageBox = ({
 		if (files.length) {
 			event.preventDefault();
 			handleUploadFiles?.(files);
+			return;
+		}
+
+		const pastedText = extractPastedPlainText(event);
+
+		if (pastedText !== undefined) {
+			event.preventDefault();
+			chat.composer?.insertText(pastedText);
 		}
 	});
 
 	const openExternalLink = useExternalLink();
 
 	const handleClick = useStableCallback((event: MouseEvent<HTMLDivElement>) => {
-		const href = getModifierClickHref(event);
-
-		if (!href) {
+		if (!getClickedLink(event)) {
 			return;
 		}
 
+		// Claim the event before the router's document listener turns a composer link into a navigation.
 		event.preventDefault();
-		openExternalLink(href);
+
+		const href = getModifierClickHref(event);
+
+		if (href) {
+			openExternalLink(href);
+		}
 	});
 
 	const [linkModifier, setLinkModifier] = useState(false);

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
@@ -1,5 +1,6 @@
-import type { MouseEvent } from 'react';
+import type { ClipboardEvent, MouseEvent } from 'react';
 
+import * as messageBoxHelpers from './messageBoxHelpers';
 import { getModifierClickHref } from './messageBoxHelpers';
 
 const setPlatform = (platform: string): void => {
@@ -60,5 +61,63 @@ describe('getModifierClickHref', () => {
 		setPlatform('Linux x86_64');
 
 		expect(clickOn('<a href="#">[x](javascript:alert(1))</a>', { ctrlKey: true })).toBeUndefined();
+	});
+});
+
+describe('getModifierClickHref on anchors the renderer did not produce', () => {
+	beforeEach(() => {
+		setPlatform('Linux x86_64');
+	});
+
+	it.each([
+		['javascript', 'javascript:alert(1)'],
+		['data', 'data:text/html,<script>alert(1)</script>'],
+		['vbscript', 'vbscript:msgbox(1)'],
+		['file', 'file:///etc/passwd'],
+		['smb', 'smb://attacker.example/share'],
+		['ms-msdt', 'ms-msdt:/id'],
+	])('refuses a %s href that entered the composer outside the renderer', (_label, href) => {
+		expect(clickOn(`<a href="${href}">x</a>`, { ctrlKey: true })).toBeUndefined();
+	});
+
+	it.each([
+		['http', 'http://rocket.chat/docs'],
+		['https', 'https://rocket.chat/docs'],
+		['mailto', 'mailto:me@rocket.chat'],
+	])('still resolves a %s href', (_label, href) => {
+		expect(clickOn(`<a href="${href}">x</a>`, { ctrlKey: true })).toBe(href);
+	});
+});
+
+describe('pasting into the composer', () => {
+	// The paste guard has no home yet; this is the surface the fix has to expose.
+	const extractPastedPlainText = (messageBoxHelpers as Record<string, unknown>).extractPastedPlainText as
+		| ((event: ClipboardEvent<HTMLElement>) => string | undefined)
+		| undefined;
+
+	const clipboardEvent = (data: Record<string, string>): ClipboardEvent<HTMLElement> =>
+		({
+			clipboardData: {
+				types: Object.keys(data),
+				items: Object.keys(data).map((type) => ({ kind: 'string', type })),
+				files: [],
+				getData: (type: string) => data[type] ?? '',
+			},
+		}) as unknown as ClipboardEvent<HTMLElement>;
+
+	it('exposes a helper deciding what a paste is allowed to insert', () => {
+		expect(typeof extractPastedPlainText).toBe('function');
+	});
+
+	it.each([
+		['an anchor', '<a href="javascript:alert(1)">docs</a>', 'docs'],
+		['an image with an inline handler', '<img src=x onerror="alert(1)">', ''],
+		['a styled fragment', '<b style="color:red">bold</b>', 'bold'],
+	])('intercepts a paste carrying %s and yields only its plain text', (_label, html, plain) => {
+		expect(extractPastedPlainText?.(clipboardEvent({ 'text/html': html, 'text/plain': plain }))).toBe(plain);
+	});
+
+	it('lets a plain-text-only paste reach the browser default', () => {
+		expect(extractPastedPlainText?.(clipboardEvent({ 'text/plain': 'see rocket.chat/docs' }))).toBeUndefined();
 	});
 });

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
@@ -1,0 +1,64 @@
+import type { MouseEvent } from 'react';
+
+import { getModifierClickHref } from './messageBoxHelpers';
+
+const setPlatform = (platform: string): void => {
+	Object.defineProperty(window.navigator, 'platform', { value: platform, configurable: true });
+};
+
+const clickOn = (html: string, modifiers: { metaKey?: boolean; ctrlKey?: boolean } = {}): string | undefined => {
+	const container = document.createElement('div');
+	container.innerHTML = html;
+	document.body.appendChild(container);
+
+	const target = (container.querySelector('[data-target]') ?? container.firstElementChild ?? container) as HTMLElement;
+
+	return getModifierClickHref({ metaKey: false, ctrlKey: false, ...modifiers, target } as unknown as MouseEvent<HTMLElement>);
+};
+
+const originalPlatform = window.navigator.platform;
+
+afterEach(() => {
+	setPlatform(originalPlatform);
+	document.body.innerHTML = '';
+});
+
+describe('getModifierClickHref', () => {
+	it('ignores a click without the platform modifier so it only moves the caret', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<a href="https://rocket.chat">rocket.chat</a>')).toBeUndefined();
+	});
+
+	it('resolves the href on ctrl+click outside macOS', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<a href="https://rocket.chat">rocket.chat</a>', { ctrlKey: true })).toBe('https://rocket.chat');
+		expect(clickOn('<a href="https://rocket.chat">rocket.chat</a>', { metaKey: true })).toBeUndefined();
+	});
+
+	it('resolves the href on cmd+click on macOS', () => {
+		setPlatform('MacIntel');
+
+		expect(clickOn('<a href="https://rocket.chat">rocket.chat</a>', { metaKey: true })).toBe('https://rocket.chat');
+		expect(clickOn('<a href="https://rocket.chat">rocket.chat</a>', { ctrlKey: true })).toBeUndefined();
+	});
+
+	it('finds the link when the click lands on markup nested in it', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<a href="//rocket.chat/docs"><strong data-target>docs</strong></a>', { ctrlKey: true })).toBe('//rocket.chat/docs');
+	});
+
+	it('ignores a click outside a link', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<span data-target>plain text</span>', { ctrlKey: true })).toBeUndefined();
+	});
+
+	it('ignores a link whose href the renderer refused to trust', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<a href="#">[x](javascript:alert(1))</a>', { ctrlKey: true })).toBeUndefined();
+	});
+});

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.spec.ts
@@ -1,7 +1,7 @@
 import type { ClipboardEvent, MouseEvent } from 'react';
 
 import * as messageBoxHelpers from './messageBoxHelpers';
-import { getModifierClickHref } from './messageBoxHelpers';
+import { getClickedLink, getModifierClickHref } from './messageBoxHelpers';
 
 const setPlatform = (platform: string): void => {
 	Object.defineProperty(window.navigator, 'platform', { value: platform, configurable: true });
@@ -62,6 +62,12 @@ describe('getModifierClickHref', () => {
 
 		expect(clickOn('<a href="#">[x](javascript:alert(1))</a>', { ctrlKey: true })).toBeUndefined();
 	});
+
+	it('ignores a link the renderer left without an href', () => {
+		setPlatform('Linux x86_64');
+
+		expect(clickOn('<a>[x](javascript:alert(1))</a>', { ctrlKey: true })).toBeUndefined();
+	});
 });
 
 describe('getModifierClickHref on anchors the renderer did not produce', () => {
@@ -86,6 +92,34 @@ describe('getModifierClickHref on anchors the renderer did not produce', () => {
 		['mailto', 'mailto:me@rocket.chat'],
 	])('still resolves a %s href', (_label, href) => {
 		expect(clickOn(`<a href="${href}">x</a>`, { ctrlKey: true })).toBe(href);
+	});
+});
+
+describe('getClickedLink', () => {
+	const linkOn = (html: string): HTMLAnchorElement | null => {
+		const container = document.createElement('div');
+		container.innerHTML = html;
+		document.body.appendChild(container);
+
+		const target = (container.querySelector('[data-target]') ?? container.firstElementChild ?? container) as HTMLElement;
+
+		return getClickedLink({ metaKey: false, ctrlKey: false, target } as unknown as MouseEvent<HTMLElement>);
+	};
+
+	it('reports the link of an unmodified click so the router cannot navigate away', () => {
+		expect(linkOn('<a href="#">[x](javascript:alert(1))</a>')?.getAttribute('href')).toBe('#');
+	});
+
+	it('reports a link pointing at the server itself', () => {
+		expect(linkOn('<a href="https://rocket.chat/admin/rooms">x</a>')?.getAttribute('href')).toBe('https://rocket.chat/admin/rooms');
+	});
+
+	it('reports the link when the click lands on markup nested in it', () => {
+		expect(linkOn('<a href="//rocket.chat/docs"><strong data-target>docs</strong></a>')?.getAttribute('href')).toBe('//rocket.chat/docs');
+	});
+
+	it('reports nothing for a click outside a link', () => {
+		expect(linkOn('<span data-target>plain text</span>')).toBeNull();
 	});
 });
 

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
@@ -1,3 +1,4 @@
+import { sanitizeUrl } from '@rocket.chat/gazzodown-alt';
 import type { ClipboardEvent, MouseEvent } from 'react';
 
 import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
@@ -15,16 +16,21 @@ export const isCmdOrCtrlPressed = (event: { metaKey: boolean; ctrlKey: boolean }
 	return (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
 };
 
+export const getClickedLink = (event: MouseEvent<HTMLElement>): HTMLAnchorElement | null => (event.target as HTMLElement).closest('a');
+
 // A contenteditable swallows link navigation, so Cmd/Ctrl+click has to be resolved by hand.
 export const getModifierClickHref = (event: MouseEvent<HTMLElement>): string | undefined => {
 	if (!isCmdOrCtrlPressed(event)) {
 		return undefined;
 	}
 
-	const href = (event.target as HTMLElement).closest('a')?.getAttribute('href');
+	const href = getClickedLink(event)?.getAttribute('href');
 
-	// Links the renderer could not trust are rendered with a '#' href.
-	return href && href !== '#' ? href : undefined;
+	if (!href || !sanitizeUrl(href)) {
+		return undefined;
+	}
+
+	return href;
 };
 
 export const handleFormattingShortcut = (
@@ -51,6 +57,18 @@ export const handleFormattingShortcut = (
 
 	composer.wrapSelection(formatter.pattern);
 	return true;
+};
+
+// The composer renders its own markup from plain text, so a paste carrying HTML must never reach the
+// contenteditable: the browser would insert that markup verbatim.
+export const extractPastedPlainText = (event: ClipboardEvent<HTMLElement>): string | undefined => {
+	const { clipboardData } = event;
+
+	if (!clipboardData || !Array.from(clipboardData.types).includes('text/html')) {
+		return undefined;
+	}
+
+	return clipboardData.getData('text/plain');
 };
 
 export const extractImageFilesFromClipboard = (event: ClipboardEvent<HTMLElement>, format: (date: Date) => string): File[] => {

--- a/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/messageBoxHelpers.ts
@@ -1,4 +1,4 @@
-import type { ClipboardEvent } from 'react';
+import type { ClipboardEvent, MouseEvent } from 'react';
 
 import type { FormattingButton } from '../../../../../app/ui-message/client/messageBox/messageBoxFormatting';
 import { getImageExtensionFromMime } from '../../../../../lib/getImageExtensionFromMime';
@@ -15,16 +15,25 @@ export const isCmdOrCtrlPressed = (event: { metaKey: boolean; ctrlKey: boolean }
 	return (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
 };
 
+// A contenteditable swallows link navigation, so Cmd/Ctrl+click has to be resolved by hand.
+export const getModifierClickHref = (event: MouseEvent<HTMLElement>): string | undefined => {
+	if (!isCmdOrCtrlPressed(event)) {
+		return undefined;
+	}
+
+	const href = (event.target as HTMLElement).closest('a')?.getAttribute('href');
+
+	// Links the renderer could not trust are rendered with a '#' href.
+	return href && href !== '#' ? href : undefined;
+};
+
 export const handleFormattingShortcut = (
 	event: KeyboardEvent,
 	formattingButtons: FormattingButton[],
 	composer: ComposerAPI,
 	preventDefault = false,
 ) => {
-	const isMacOS = navigator.platform.indexOf('Mac') !== -1;
-	const isCmdOrCtrlPressed = (isMacOS && event.metaKey) || (!isMacOS && event.ctrlKey);
-
-	if (!isCmdOrCtrlPressed) {
+	if (!isCmdOrCtrlPressed(event)) {
 		return false;
 	}
 

--- a/packages/gazzodown-alt/src/ComposerInlineElements.tsx
+++ b/packages/gazzodown-alt/src/ComposerInlineElements.tsx
@@ -5,6 +5,7 @@ import { useContext } from 'react';
 import ComposerBoldSpan from './ComposerBoldSpan';
 import ComposerCodeElement from './ComposerCodeElement';
 import ComposerItalicSpan from './ComposerItalicSpan';
+import ComposerLinkSpan from './ComposerLinkSpan';
 import { ComposerMarkupContext } from './ComposerMarkupContext';
 import ComposerMentionChannel from './ComposerMentionChannel';
 import ComposerMentionUser from './ComposerMentionUser';
@@ -47,6 +48,9 @@ const ComposerInlineElements = ({ children }: ComposerInlineElementsProps): Reac
 
 					case 'INLINE_CODE':
 						return <ComposerCodeElement key={index} code={child.value.value} />;
+
+					case 'LINK':
+						return <ComposerLinkSpan key={index} href={child.value.src.value} text={sourceOf(child, source)} />;
 
 					default: {
 						if (child.type === undefined) {

--- a/packages/gazzodown-alt/src/ComposerLinkSpan.tsx
+++ b/packages/gazzodown-alt/src/ComposerLinkSpan.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+
+import { sanitizeUrl } from './sanitizeUrl';
+
+type ComposerLinkSpanProps = {
+	href: string;
+	text: string;
+};
+
+const linkStyle = {
+	color: 'var(--rcx-color-font-info, #095ad2)',
+	textDecoration: 'underline',
+} as const;
+
+const ComposerLinkSpan = ({ href, text }: ComposerLinkSpanProps): ReactElement => (
+	<a href={sanitizeUrl(href)} rel='noopener noreferrer' style={linkStyle}>
+		{text}
+	</a>
+);
+
+export default ComposerLinkSpan;

--- a/packages/gazzodown-alt/src/index.ts
+++ b/packages/gazzodown-alt/src/index.ts
@@ -1,3 +1,4 @@
 export { default as ComposerMarkup } from './ComposerMarkup';
 export { ComposerMarkupContext } from './ComposerMarkupContext';
 export type { ComposerMarkupContextValue } from './ComposerMarkupContext';
+export { sanitizeUrl } from './sanitizeUrl';

--- a/packages/gazzodown-alt/src/sanitizeUrl.ts
+++ b/packages/gazzodown-alt/src/sanitizeUrl.ts
@@ -1,21 +1,16 @@
-const dangerousProtocols = ['javascript:', 'data:', 'vbscript:'];
+const allowedProtocols = ['http:', 'https:', 'mailto:', 'tel:'];
 
-export const sanitizeUrl = (href: string): string => {
+export const sanitizeUrl = (href: string): string | undefined => {
 	if (!href) {
-		return '#';
+		return undefined;
 	}
 
 	try {
 		const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(href);
+		const url = hasProtocol ? new URL(href) : new URL(`https://${href.replace(/^\/+/, '')}`);
 
-		if (hasProtocol) {
-			const url = new URL(href);
-
-			return dangerousProtocols.includes(url.protocol.toLowerCase()) ? '#' : url.href;
-		}
-
-		return href.startsWith('//') ? href : `//${href}`;
+		return allowedProtocols.includes(url.protocol.toLowerCase()) ? url.href : undefined;
 	} catch {
-		return '#';
+		return undefined;
 	}
 };

--- a/packages/gazzodown-alt/src/sanitizeUrl.ts
+++ b/packages/gazzodown-alt/src/sanitizeUrl.ts
@@ -1,0 +1,21 @@
+const dangerousProtocols = ['javascript:', 'data:', 'vbscript:'];
+
+export const sanitizeUrl = (href: string): string => {
+	if (!href) {
+		return '#';
+	}
+
+	try {
+		const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(href);
+
+		if (hasProtocol) {
+			const url = new URL(href);
+
+			return dangerousProtocols.includes(url.protocol.toLowerCase()) ? '#' : url.href;
+		}
+
+		return href.startsWith('//') ? href : `//${href}`;
+	} catch {
+		return '#';
+	}
+};

--- a/packages/ui-composer/src/MessageComposer/RichTextComposerInput.tsx
+++ b/packages/ui-composer/src/MessageComposer/RichTextComposerInput.tsx
@@ -12,7 +12,7 @@ const RichTextComposerInputStyle = css`
 
 // Links only open on Cmd/Ctrl+click, so the pointer is offered while that modifier is held.
 const RichTextComposerLinkModifierStyle = css`
-	a:not([href='#']) {
+	a[href] {
 		cursor: pointer;
 	}
 `;

--- a/packages/ui-composer/src/MessageComposer/RichTextComposerInput.tsx
+++ b/packages/ui-composer/src/MessageComposer/RichTextComposerInput.tsx
@@ -10,16 +10,24 @@ const RichTextComposerInputStyle = css`
 	}
 `;
 
+// Links only open on Cmd/Ctrl+click, so the pointer is offered while that modifier is held.
+const RichTextComposerLinkModifierStyle = css`
+	a:not([href='#']) {
+		cursor: pointer;
+	}
+`;
+
 type RichTextComposerInputProps = ComponentProps<typeof Box> & {
 	placeholder?: string;
 	hideplaceholder?: boolean;
 	hidetext?: boolean;
+	linkmodifier?: boolean;
 };
 
 const RichTextComposerInput = forwardRef<HTMLDivElement, RichTextComposerInputProps>(function RichTextComposerInput(props, ref) {
 	// Supress warnings related to hideplaceholder/hidetext being invalid DOM props.
 	// `disabled` is inert on a contenteditable, so it drives contentEditable instead of reaching the DOM.
-	const { placeholder, hideplaceholder, hidetext, disabled, ...rest } = props;
+	const { placeholder, hideplaceholder, hidetext, linkmodifier, disabled, ...rest } = props;
 
 	return (
 		<Box is='div' width='full' style={hidetext ? { visibility: 'hidden' } : undefined}>
@@ -43,7 +51,11 @@ const RichTextComposerInput = forwardRef<HTMLDivElement, RichTextComposerInputPr
 				{placeholder}
 			</Box>
 			<Box
-				className={[RichTextComposerInputStyle, 'rc-message-box__divcontenteditable js-input-message']}
+				className={[
+					RichTextComposerInputStyle,
+					...(linkmodifier ? [RichTextComposerLinkModifierStyle] : []),
+					'rc-message-box__divcontenteditable js-input-message',
+				]}
 				color='default'
 				width='full'
 				minHeight={20}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clickable links to the rich-text message composer.
  - Cmd/Ctrl-clicking a link opens it externally, with visual feedback when the modifier key is pressed.
  - Pasting formatted content now converts it to plain text while preserving normal plain-text paste behavior.

- **Bug Fixes**
  - Improved handling for nested, schemeless, numbered-list, and phone links.
  - Blocked unsafe URL schemes and sanitized links before displaying or opening them.
  - Improved link styling and rendering for composer content.
  - Prevented unsent message text from being lost during asynchronous sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->