### PR TITLE
ci: name long release-versions setup steps for readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
         #   sparse-checkout-cone-mode: false
         #   ref: ${{ github.ref }}
 
-      - id: source
+      - name: Compute source hash
+        id: source
         run: |
           ls -la
 
@@ -89,7 +90,8 @@ jobs:
 
           echo "hash=${SOURCE_HASH}" >> "$GITHUB_OUTPUT"
 
-      - id: var
+      - name: Resolve Node and Deno versions
+        id: var
         run: |
           LOWERCASE_REPOSITORY=$(echo "${{ github.repository_owner }}" | tr "[:upper:]" "[:lower:]")
 
@@ -104,7 +106,8 @@ jobs:
           echo "DENO_VERSION: ${DENO_VERSION}"
           echo "deno-version=${DENO_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - id: ci-cache-keys
+      - name: Compute CI cache keys
+        id: ci-cache-keys
         run: |
           set -euo pipefail
           PACKAGES_HASH=$(cat yarn.lock .yarnrc.yml package.json turbo.json | sha256sum | awk '{print $1}')
@@ -112,7 +115,8 @@ jobs:
           METEOR_HASH=$(git archive HEAD apps/meteor | sha256sum | awk '{print $1}')
           echo "meteor-rc-cache-key=${METEOR_HASH}" >> "$GITHUB_OUTPUT"
 
-      - id: by-tag
+      - name: Determine release channel from tag
+        id: by-tag
         run: |
           if echo "$GITHUB_REF_NAME" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
             RELEASE="latest"
@@ -122,7 +126,8 @@ jobs:
           echo "RELEASE: ${RELEASE}"
           echo "release=${RELEASE}" >> "$GITHUB_OUTPUT"
 
-      - id: latest
+      - name: Resolve latest release tag
+        id: latest
         run: |
           LATEST_RELEASE="$(
             git -c 'versionsort.suffix=-' ls-remote -t --exit-code --refs --sort=-v:refname "https://github.com/$GITHUB_REPOSITORY" '*' |
@@ -131,7 +136,8 @@ jobs:
           echo "LATEST_RELEASE: ${LATEST_RELEASE}"
           echo "latest-release=${LATEST_RELEASE}" >> "$GITHUB_OUTPUT"
 
-      - id: docker
+      - name: Compute Docker tag
+        id: docker
         run: |
           if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
             DOCKER_TAG="pr-${{ github.event.number }}"
@@ -143,7 +149,8 @@ jobs:
           echo "DOCKER_TAG: ${DOCKER_TAG}"
           echo "gh-docker-tag=${DOCKER_TAG}" >> "$GITHUB_OUTPUT"
 
-      - id: diff
+      - name: Detect workflow file changes
+        id: diff
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PR_NUM: ${{ github.event.number }}


### PR DESCRIPTION
## Problem

In `.github/workflows/ci.yml`, the `release-versions` job has several helper `run` steps that are unnamed and longer than **300 characters**. In the GitHub Actions UI those steps collapse into generic labels, which hurts readability when source hashing, version resolution, cache-key computation, or Docker tag setup fails.

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same job output wiring (`steps.source`, `steps.var`, `steps.ci-cache-keys`, `steps.by-tag`, `steps.latest`, `steps.docker`, `steps.diff`).

- Add `name: Compute source hash` to `id: source`
- Add `name: Resolve Node and Deno versions` to `id: var`
- Add `name: Compute CI cache keys` to `id: ci-cache-keys`
- Add `name: Determine release channel from tag` to `id: by-tag`
- Add `name: Resolve latest release tag` to `id: latest`
- Add `name: Compute Docker tag` to `id: docker`
- Add `name: Detect workflow file changes` to `id: diff`

## Test plan
- [ ] Confirm job outputs still resolve via the same `steps.*.outputs.*` references
- [ ] Confirm Variables Setup job steps show the new names in the Actions UI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the clarity of release workflow steps with descriptive labels.
  * No changes to workflow behavior or release outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->