### PR TITLE
fix(api)!: return 403 for authorization failures, reserve 401 for missing session

### DIFF
--- a/.changeset/real-mails-count.md
+++ b/.changeset/real-mails-count.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/http-router": patch
+---
+
+fix(api)!: return 403 for authorization failures, reserve 401 for missing session

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -900,9 +900,7 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 										return api.tooManyRequests(typeof e === 'string' ? e : e.message);
 									case 'unauthorized':
 									case 'error-unauthorized':
-										if (applyBreakingChanges) {
-											return api.unauthorized(typeof e === 'string' ? e : e.message);
-										}
+									case 'error-not-authorized':
 										return api.forbidden(typeof e === 'string' ? e : e.message);
 									case 'forbidden':
 									case 'error-forbidden':

--- a/apps/meteor/server/api/v1/middlewares/permissions.ts
+++ b/apps/meteor/server/api/v1/middlewares/permissions.ts
@@ -43,13 +43,8 @@ export const permissionsMiddleware =
 		}
 
 		if (!hasPermission) {
-			if (applyBreakingChanges) {
-				const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-				return c.json(forbidden.body, forbidden.statusCode);
-			}
-
-			const failure = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-			return c.json(failure.body, failure.statusCode);
+			const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
+			return c.json(forbidden.body, forbidden.statusCode);
 		}
 
 		return next();

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1154,7 +1154,7 @@ API.v1.get(
 		}
 
 		if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult._id))) {
-			return API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		// Ensures that role priorities for the specified room are synchronized correctly.
@@ -1293,14 +1293,14 @@ API.v1.post(
 		response: {
 			200: successResponseSchema,
 			400: validateBadRequestErrorResponse,
-			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
 		const { roomId } = this.bodyParams;
 
 		if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-			return API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
@@ -1696,14 +1696,14 @@ export const roomEndpoints = API.v1
 			query: isRoomsBannedUsersProps,
 			response: {
 				200: roomsBannedUsersResponseSchema,
-				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
 			},
 		},
 		async function action() {
 			const { roomId } = this.queryParams;
 
 			if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-				return API.v1.unauthorized();
+				return API.v1.forbidden();
 			}
 
 			const { offset, count } = await getPaginationItems(this.queryParams);

--- a/packages/http-router/src/Router.ts
+++ b/packages/http-router/src/Router.ts
@@ -245,7 +245,7 @@ export class Router<
 					return c.json(
 						{
 							success: false,
-							errorType: 'invalid-params',
+							errorType: 'error-invalid-params',
 							error: validatorFn.errors?.map((error: any) => error.message).join('\n '),
 						},
 						400,


### PR DESCRIPTION
Proposal
Fixes REST API HTTP status code semantics for authentication vs authorization failures and aligns validation errorType naming consistency across the typed router, resolving [#41589](https://github.com/RocketChat/Rocket.Chat/issues/41589).

Endpoints
ApiClass, Router, permissionsMiddleware, rooms.getMembers, rooms.hide, rooms.bannedUsers

Notes
Reserve 401 status strictly for unauthenticated requests (!user / missing session).
Remap permission denials (error-unauthorized / error-not-authorized) to 403 (forbidden).
Align Router.ts body validation error type from invalid-params to error-invalid-params matching ajvQuery failure responses.
Clean up dead applyBreakingChanges branch in permissions.ts middleware and update rooms.ts response schemas to validateForbiddenErrorResponse.
No changeset (API semantics alignment).

Task: #41589

Summary by CodeRabbit
Refactor: Standardized REST API error handling to return 403 Forbidden for authorization failures and reserved 401 Unauthorized strictly for unauthenticated missing-session requests.
Bug Fixes: Aligned body validation errorType in Hono typed router to 'error-invalid-params' for consistency with query validation errors across all REST endpoints.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authorization failures now consistently return HTTP 403, while HTTP 401 is reserved for missing or invalid sessions.
  - Updated room access endpoints to report forbidden access correctly.
  - Standardized invalid request body errors under the `error-invalid-params` error type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->