### PR TITLE
fix(api): return 403 for authorization failures, reserve 401 for missing session

### DIFF
--- a/.changeset/real-mails-count.md
+++ b/.changeset/real-mails-count.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/meteor": patch
+"@rocket.chat/http-router": patch
+---
+
+fix(api): return 403 for authorization failures, reserve 401 for missing session

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -895,14 +895,13 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 							}
 						} catch (e: any) {
 							result = ((e: any) => {
-								switch (e.error) {
+								const errorKey = typeof e === 'string' ? e : e.error || e.message;
+								switch (errorKey) {
 									case 'error-too-many-requests':
 										return api.tooManyRequests(typeof e === 'string' ? e : e.message);
 									case 'unauthorized':
 									case 'error-unauthorized':
-										if (applyBreakingChanges) {
-											return api.unauthorized(typeof e === 'string' ? e : e.message);
-										}
+									case 'error-not-authorized':
 										return api.forbidden(typeof e === 'string' ? e : e.message);
 									case 'forbidden':
 									case 'error-forbidden':

--- a/apps/meteor/server/api/v1/middlewares/permissions.ts
+++ b/apps/meteor/server/api/v1/middlewares/permissions.ts
@@ -43,13 +43,8 @@ export const permissionsMiddleware =
 		}
 
 		if (!hasPermission) {
-			if (applyBreakingChanges) {
-				const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-				return c.json(forbidden.body, forbidden.statusCode);
-			}
-
-			const failure = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
-			return c.json(failure.body, failure.statusCode);
+			const forbidden = API.v1.forbidden('User does not have the permissions required for this action [error-unauthorized]');
+			return c.json(forbidden.body, forbidden.statusCode);
 		}
 
 		return next();

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -736,6 +736,7 @@ API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
@@ -775,6 +776,7 @@ API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
@@ -810,6 +812,7 @@ API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
@@ -1136,6 +1139,7 @@ API.v1.get(
 			}),
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 			404: validateNotFoundErrorResponse,
 		},
 	},
@@ -1154,7 +1158,7 @@ API.v1.get(
 		}
 
 		if (findResult.broadcast && !(await hasPermissionAsync(this.user, 'view-broadcast-member-list', findResult._id))) {
-			return API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		// Ensures that role priorities for the specified room are synchronized correctly.
@@ -1294,13 +1298,14 @@ API.v1.post(
 			200: successResponseSchema,
 			400: validateBadRequestErrorResponse,
 			401: validateUnauthorizedErrorResponse,
+			403: validateForbiddenErrorResponse,
 		},
 	},
 	async function action() {
 		const { roomId } = this.bodyParams;
 
 		if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-			return API.v1.unauthorized();
+			return API.v1.forbidden();
 		}
 
 		const user = await Users.findOneById(this.userId, { projection: { _id: 1 } });
@@ -1697,13 +1702,14 @@ export const roomEndpoints = API.v1
 			response: {
 				200: roomsBannedUsersResponseSchema,
 				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
 			},
 		},
 		async function action() {
 			const { roomId } = this.queryParams;
 
 			if (!(await canAccessRoomIdAsync(roomId, this.userId))) {
-				return API.v1.unauthorized();
+				return API.v1.forbidden();
 			}
 
 			const { offset, count } = await getPaginationItems(this.queryParams);

--- a/docs/api-endpoint-migration.md
+++ b/docs/api-endpoint-migration.md
@@ -597,7 +597,7 @@ expect(res.body).to.have.property('errorType', 'invalid-params');
 expect(res.body).to.have.property('errorType', 'error-invalid-params');
 ```
 
-This only affects **query** parameter validation (GET/DELETE). Body parameter validation (POST/PUT) keeps `'invalid-params'`.
+This affects both **query** parameter validation (GET/DELETE) and **body** parameter validation (POST/PUT).
 
 ### Error message format changes
 
@@ -615,7 +615,7 @@ expect(res.body).to.have.property('error', "must have required property 'platfor
 
 When migrating an endpoint, search for its tests and update:
 
-1. `errorType` from `'invalid-params'` to `'error-invalid-params'` (for query params only)
+1. `errorType` from `'invalid-params'` to `'error-invalid-params'` for query and body params
 2. Remove `' [invalid-params]'` suffix from `error` message assertions
 3. Verify that status codes remain the same (400 for validation errors)
 

--- a/packages/http-router/src/Router.spec.ts
+++ b/packages/http-router/src/Router.spec.ts
@@ -207,12 +207,12 @@ describe('Router', () => {
 			const invalidResponse = await request(app).post('/api/validate-body').send({ name: 'John' });
 
 			expect(invalidResponse.status).toBe(400);
-			expect(invalidResponse.body).toHaveProperty('errorType', 'invalid-params');
+			expect(invalidResponse.body).toHaveProperty('errorType', 'error-invalid-params');
 
 			const invalidTypeResponse = await request(app).post('/api/validate-body').send({ name: 'John', age: 'thirty' });
 
 			expect(invalidTypeResponse.status).toBe(400);
-			expect(invalidTypeResponse.body).toHaveProperty('errorType', 'invalid-params');
+			expect(invalidTypeResponse.body).toHaveProperty('errorType', 'error-invalid-params');
 		});
 
 		it('should validate response body in test mode', async () => {

--- a/packages/http-router/src/Router.ts
+++ b/packages/http-router/src/Router.ts
@@ -245,7 +245,7 @@ export class Router<
 					return c.json(
 						{
 							success: false,
-							errorType: 'invalid-params',
+							errorType: 'error-invalid-params',
 							error: validatorFn.errors?.map((error: any) => error.message).join('\n '),
 						},
 						400,


### PR DESCRIPTION
Proposal
Fixes REST API HTTP status code semantics for authentication vs authorization failures and aligns validation errorType naming consistency across the typed router, resolving [#41589](https://github.com/RocketChat/Rocket.Chat/issues/41589).

Endpoints
ApiClass, Router, permissionsMiddleware, rooms.getMembers, rooms.hide, rooms.bannedUsers

Notes
- Reserve 401 status strictly for unauthenticated requests (!user / missing session).
- Remap permission denials (error-unauthorized / error-not-authorized) to 403 (forbidden).
- Align Router.ts body validation error type from invalid-params to error-invalid-params matching ajvQuery failure responses.
- Clean up dead applyBreakingChanges branch in permissions.ts middleware and update rooms.ts response schemas to validateForbiddenErrorResponse.
- Add changeset for patch release.

Task: #41589

Summary by CodeRabbit
Refactor: Standardized REST API error handling to return 403 Forbidden for authorization failures and reserved 401 Unauthorized strictly for unauthenticated missing-session requests.
Bug Fixes: Aligned body validation errorType in Hono typed router to 'error-invalid-params' for consistency with query validation errors across all REST endpoints.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authorization failures now consistently return **403 Forbidden** for authenticated requests lacking access; **401 Unauthorized** is reserved for missing sessions.
  * Room access and administration endpoints now correctly report insufficient permissions with 403 responses.
  * API error handling now recognizes additional authorization error formats.
  * Invalid query and request-body parameters now consistently use `error-invalid-params`.

* **Documentation**
  * Updated API migration guidance to reflect standardized validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->