### PR TITLE
fix: composer popup staying open after programmatic text changes

### DIFF
--- a/.changeset/chatty-socks-hear.md
+++ b/.changeset/chatty-socks-hear.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the composer popups (mentions, slash commands and emojis) staying open after programmatic changes to the composer text, such as canceling the edition of a message that contains a mention.

--- a/apps/meteor/client/views/room/composer/hooks/useComposerBoxPopup.ts
+++ b/apps/meteor/client/views/room/composer/hooks/useComposerBoxPopup.ts
@@ -28,7 +28,6 @@ type ComposerBoxPopupResult<T extends { _id: string; sort?: number }> =
 			suspended: boolean;
 			filter: unknown;
 			clear: () => void;
-			update: () => void;
 	  }
 	| {
 			option: undefined;
@@ -40,7 +39,6 @@ type ComposerBoxPopupResult<T extends { _id: string; sort?: number }> =
 			suspended: undefined;
 			filter: unknown;
 			clear: () => void;
-			update: () => void;
 	  };
 
 const keys = {
@@ -81,7 +79,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 		setFocused((focused) => {
 			const sortedItems = items
 				.filter((item) => item.isSuccess)
-				.flatMap((item) => item.data as T[])
+				.flatMap((item) => item.data)
 				.sort((a, b) => (('sort' in a && a.sort) || 0) - (('sort' in b && b.sort) || 0));
 			return sortedItems.find((item) => item._id === focused?._id) ?? sortedItems[0];
 		});
@@ -157,21 +155,22 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 		setOptionByInput();
 	});
 
+	const handleInput = useStableCallback(() => {
+		setOptionByInput();
+	});
+
 	const handleKeyUp = useStableCallback((event: KeyboardEvent) => {
-		if (!setOptionByInput()) {
+		if (event.which === keys.ESC) {
+			if (option?.closeOnEsc === true) {
+				setOptionIndex(-1);
+				setFocused(undefined);
+				event.preventDefault();
+				event.stopImmediatePropagation();
+			}
 			return;
 		}
 
-		if (!option) {
-			return;
-		}
-
-		if (option.closeOnEsc === true && event.which === keys.ESC) {
-			setOptionIndex(-1);
-			setFocused(undefined);
-			event.preventDefault();
-			event.stopImmediatePropagation();
-		}
+		setOptionByInput();
 	});
 
 	const handleKeyDown = useStableCallback((event: KeyboardEvent) => {
@@ -194,7 +193,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 			setFocused((focused) => {
 				const list = items
 					.filter((item) => item.isSuccess)
-					.flatMap((item) => item.data as T[])
+					.flatMap((item) => item.data)
 					.sort((a, b) => (('sort' in a && a.sort) || 0) - (('sort' in b && b.sort) || 0));
 
 				if (!list) {
@@ -203,7 +202,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 
 				const focusedIndex = list.findIndex((item) => item === focused);
 
-				return (focusedIndex > 0 ? list[focusedIndex - 1] : list[list.length - 1]) as T;
+				return focusedIndex > 0 ? list[focusedIndex - 1] : list[list.length - 1];
 			});
 			event.preventDefault();
 			event.stopImmediatePropagation();
@@ -213,7 +212,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 			setFocused((focused) => {
 				const list = items
 					.filter((item) => item.isSuccess)
-					.flatMap((item) => item.data as T[])
+					.flatMap((item) => item.data)
 					.sort((a, b) => (('sort' in a && a.sort) || 0) - (('sort' in b && b.sort) || 0));
 
 				if (!list) {
@@ -222,7 +221,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 
 				const focusedIndex = list.findIndex((item) => item === focused);
 
-				return (focusedIndex < list.length - 1 ? list[focusedIndex + 1] : list[0]) as T;
+				return focusedIndex < list.length - 1 ? list[focusedIndex + 1] : list[0];
 			});
 			event.preventDefault();
 			event.stopImmediatePropagation();
@@ -231,10 +230,6 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 	});
 
 	const clear = useStableCallback(() => {
-		if (!option) {
-			return;
-		}
-
 		setOptionIndex(-1);
 		setFocused(undefined);
 		setFilter('');
@@ -244,6 +239,7 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 	const callbackRef = useCallback(
 		(node: HTMLElement | null) => {
 			if (ref.current) {
+				ref.current.removeEventListener('input', handleInput);
 				ref.current.removeEventListener('keyup', handleKeyUp);
 				ref.current.removeEventListener('keydown', handleKeyDown);
 				ref.current.removeEventListener('focus', handleFocus);
@@ -252,12 +248,13 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 
 			if (node) {
 				ref.current = node;
+				node.addEventListener('input', handleInput);
 				node.addEventListener('keyup', handleKeyUp);
 				node.addEventListener('keydown', handleKeyDown);
 				node.addEventListener('focus', handleFocus);
 			}
 		},
-		[handleKeyUp, handleKeyDown, handleFocus],
+		[handleInput, handleKeyUp, handleKeyDown, handleFocus],
 	);
 
 	if (!option) {
@@ -271,7 +268,6 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 			suspended: undefined,
 			filter: undefined,
 			clear,
-			update: setOptionByInput,
 		};
 	}
 
@@ -285,6 +281,5 @@ export const useComposerBoxPopup = <T extends { _id: string; sort?: number }>(
 		suspended,
 		filter,
 		clear,
-		update: setOptionByInput,
 	};
 };

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -51,7 +51,7 @@ import { useMessageBoxAutoFocus } from './hooks/useMessageBoxAutoFocus';
 import { useMessageBoxPlaceholder } from './hooks/useMessageBoxPlaceholder';
 
 const reducer = (_: unknown, event: ChangeEvent<HTMLInputElement>): boolean => {
-	const target = event.target as HTMLInputElement;
+	const { target } = event;
 
 	return Boolean(target.value.trim());
 };
@@ -195,23 +195,21 @@ const MessageBox = ({
 		});
 	});
 
-	const closeEditing = (event: KeyboardEvent | MouseEvent<HTMLElement>) => {
+	const closeEditing = async (event: KeyboardEvent | MouseEvent<HTMLElement>) => {
 		const mid = chat.currentEditingMessage.getMID();
 		if (mid) {
 			event.preventDefault();
 			event.stopPropagation();
 
-			chat.currentEditingMessage.reset().then((reset) => {
-				// NOTE: if the message was reset (i.e. content changed), we just update the popup (to re-apply/remove the preview)
-				if (reset) {
-					popup.update();
-					return;
-				}
+			// NOTE: if the message was reset (i.e. content changed), we keep the editing mode on
+			const reset = await chat.currentEditingMessage.reset();
 
-				chat.currentEditingMessage.cancel();
-				chat.currentEditingMessage.stop();
-				popup.clear();
-			});
+			if (!reset) {
+				await chat.currentEditingMessage.cancel();
+				await chat.currentEditingMessage.stop();
+			}
+
+			popup.clear();
 		}
 	};
 

--- a/apps/meteor/tests/e2e/e2e-encryption/e2ee-encrypted-channels.spec.ts
+++ b/apps/meteor/tests/e2e/e2e-encryption/e2ee-encrypted-channels.spec.ts
@@ -372,7 +372,7 @@ test.describe('E2EE Encrypted Channels', () => {
 		await poHomeChannel.content.btnOptionEditMessage.click();
 		await poHomeChannel.composer.inputMessage.fill(editedMessage);
 
-		await page.keyboard.press('Enter');
+		await poHomeChannel.composer.btnSend.click();
 
 		await expect(poHomeChannel.content.lastUserMessageBody).toHaveText(displayedMessage);
 		await expect(poHomeChannel.content.lastUserMessage.locator('.rcx-icon--name-key')).toBeVisible();

--- a/apps/meteor/tests/e2e/message-composer.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer.spec.ts
@@ -110,13 +110,13 @@ test.describe.serial('message-composer', () => {
 	});
 
 	test('should close mention popup when canceling a message edit via "Cancel" button', async ({ page }) => {
-		await poHomeChannel.content.sendMessage('hello composer');
+		await poHomeChannel.content.sendMessage('hello composer @rocket.cat');
 
 		await test.step('expect to edit last message', async () => {
 			await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
 			await poHomeChannel.content.openLastMessageMenu();
 			await poHomeChannel.content.btnOptionEditMessage.click();
-			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer');
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer @rocket.cat');
 		});
 
 		await test.step('expect to open popup on mention', async () => {
@@ -126,7 +126,7 @@ test.describe.serial('message-composer', () => {
 
 		await test.step('expect popup to close after the first edit is cancelled', async () => {
 			await poHomeChannel.composer.btnCancel.click();
-			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer');
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer @rocket.cat');
 			await expect(poHomeChannel.composer.boxPopup).not.toBeVisible();
 		});
 
@@ -137,13 +137,13 @@ test.describe.serial('message-composer', () => {
 	});
 
 	test('should close mention popup when canceling a message edit via keyboard', async ({ page }) => {
-		await poHomeChannel.content.sendMessage('hello composer');
+		await poHomeChannel.content.sendMessage('hello composer @rocket.cat');
 
 		await test.step('expect to edit last message', async () => {
 			await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
 			await poHomeChannel.content.openLastMessageMenu();
 			await poHomeChannel.content.btnOptionEditMessage.click();
-			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer');
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer @rocket.cat');
 		});
 
 		await test.step('expect to open popup on mention', async () => {
@@ -153,7 +153,7 @@ test.describe.serial('message-composer', () => {
 
 		await test.step('expect popup to close after the first edit is cancelled', async () => {
 			await page.keyboard.press('Escape');
-			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer');
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('hello composer @rocket.cat');
 			await expect(poHomeChannel.composer.boxPopup).not.toBeVisible();
 		});
 
@@ -161,6 +161,30 @@ test.describe.serial('message-composer', () => {
 			await page.keyboard.press('Escape');
 			await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
 		});
+	});
+
+	test('should close mention popup after sending a message ending with a mention', async ({ page }) => {
+		await poHomeChannel.composer.inputMessage.click();
+
+		await test.step('expect to open popup on mention', async () => {
+			await page.keyboard.type('hello composer @rocket.cat');
+			await expect(poHomeChannel.composer.boxPopup).toBeVisible();
+		});
+
+		await test.step('expect popup to close after sending the message', async () => {
+			await poHomeChannel.composer.btnSend.click();
+			await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
+			await expect(poHomeChannel.composer.boxPopup).not.toBeVisible();
+		});
+	});
+
+	test('should open mention popup on text inserted without keyboard events', async ({ page }) => {
+		await poHomeChannel.composer.inputMessage.click();
+
+		await page.keyboard.insertText('hello composer @rocket.cat');
+		await expect(poHomeChannel.composer.boxPopup).toBeVisible();
+
+		await poHomeChannel.composer.inputMessage.fill('');
 	});
 
 	test.describe('audio recorder', () => {

--- a/apps/meteor/tests/e2e/message-composer.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer.spec.ts
@@ -12,7 +12,7 @@ test.describe.serial('message-composer', () => {
 	let targetChannel: string;
 
 	test.beforeAll(async ({ api }) => {
-		targetChannel = await createTargetChannel(api);
+		targetChannel = await createTargetChannel(api, { members: ['rocket.cat'] });
 	});
 
 	test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

### Root cause

The composer popup (mentions, emojis, slash commands) only updates on keyboard events (`keyup`/`focus`), but programmatic text changes (`setText`, `clear`) emit `input`/`change` — so the popup gets out of sync with the composer. Canceling an edit restores the text via `setText`; the `popup.update()` workaround from #38635 then re-matches the restored text, reopening the popup when the message ends with a mention. The un-awaited `cancel()`/`stop()` also raced the dismissal.

### The fix

- `useComposerBoxPopup`: react to the `input` event, covering every text change (typed, pasted or programmatic) at the source. `keyup` keeps only what `input` can't cover: Escape and cursor-only movement. `clear()` no longer bails out when no option is rendered, so a dismissal can't be swallowed by a pending reopen.
- `MessageBox`: `closeEditing` awaits `reset`/`cancel`/`stop` and calls `popup.clear()` last in all cases. `popup.update()` was removed — its only caller was this workaround, now handled by the `input` listener.

## Issue(s)

- [CORE-2017](https://rocketchat.atlassian.net/browse/CORE-2017)

## Steps to test or reproduce

1. Send `hello @rocket.cat`, edit it (↑) and type ` @` — popup opens
2. Click Cancel (or Esc): before, the popup stayed open; now it closes

Also fixed: Send with text ending in a trigger, paste ending with a mention, and Escape reopening the popup on a second press.

## Further comments

- Listening to `input` is the intended integration point, not a workaround: `createComposerAPI` already dispatches an `input` event after every programmatic text change precisely so the UI can react to it. The popup was the only piece not listening.
- No debouncing was added, addressing the concern in the issue: `setOptionByInput` only runs a few regexes and sets state, and calling it twice with the same text is a no-op — while a debounce would add visible latency to the popup.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention, slash-command, and emoji popups remaining open after text changes.
  * Improved popup behavior when text is inserted programmatically.
  * Ensured popups close correctly after sending messages or pressing Escape.
  * Preserved message content when canceling edits through the cancel button or Escape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2017]: https://rocketchat.atlassian.net/browse/CORE-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ