### PR TITLE
fix(audit): forward visitor and agent fields in Omnichannel audit mutation

### DIFF
--- a/.changeset/omnichannel-audit-visitor-agent-filtering.md
+++ b/.changeset/omnichannel-audit-visitor-agent-filtering.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix Omnichannel audit filtering by forwarding selected visitor and agent IDs to `POST /v1/audit.omnichannelMessages` API endpoint.

--- a/apps/meteor/client/views/audit/hooks/useAuditMutation.ts
+++ b/apps/meteor/client/views/audit/hooks/useAuditMutation.ts
@@ -23,11 +23,8 @@ export const useAuditMutation = (type: IAuditLog['fields']['type']) => {
 					startDate,
 					endDate,
 					users,
-					// TODO: the Omnichannel audit form collects visitor/agent (required fields) but they are
-					// dropped here — carried over from the original DDP flow. Forwarding them would let the
-					// omnichannel audit filter by the selected visitor/agent. Left for investigation.
-					visitor: '',
-					agent: '',
+					visitor,
+					agent,
 				});
 				return messages.map((message) => mapMessageFromApi(message));
 			}


### PR DESCRIPTION
Proposal
Fixes Omnichannel audit filtering by forwarding visitor and agent parameters to the REST API endpoint, resolving #41583.

Endpoints
/v1/audit.omnichannelMessages

Notes
- Forward `visitor` and `agent` fields collected from the Omnichannel audit form in `useAuditMutation.ts` to `getOmnichannelAuditMessages`.
- Remove hardcoded empty strings and TODO comment in `useAuditMutation.ts`.
- Add changeset for patch release.

Task: #41583

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Omnichannel audit logs now correctly filter results by the selected visitor and agent.
  * Audit requests now retain the chosen filter values when retrieving messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->