### PR TITLE
fix: closing profile card when scroll happens in website

### DIFF
--- a/apps/meteor/client/views/room/providers/UserCardProvider.tsx
+++ b/apps/meteor/client/views/room/providers/UserCardProvider.tsx
@@ -4,7 +4,7 @@ import { Popover } from '@rocket.chat/fuselage';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { useRoomToolbox, UserCardContext } from '@rocket.chat/ui-contexts';
 import type { ComponentProps, ReactNode, UIEvent } from 'react';
-import { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useRoom } from '../contexts/RoomContext';
 
@@ -12,11 +12,44 @@ const UserCard = lazy(() => import('../UserCard'));
 
 export type UserCardProviderProps = { children: ReactNode };
 
+/**
+ * Creates a stable proxy DOM element that is appended to document.body
+ * and whose getBoundingClientRect is permanently frozen to the rect of
+ * the element that was clicked. This prevents react-aria's usePopover /
+ * useOverlayPosition from jumping to (0, 0) when the real trigger element
+ * is recycled or unmounted by react-virtuoso during scroll.
+ */
+function createFrozenProxy(rect: DOMRect): HTMLDivElement {
+	const proxy = document.createElement('div');
+
+	// Position the proxy so it exactly matches the trigger in the viewport.
+	// Using position:fixed means we don't need to account for scroll offsets.
+	proxy.style.cssText = `
+		position: fixed;
+		top: ${rect.top}px;
+		left: ${rect.left}px;
+		width: ${rect.width}px;
+		height: ${rect.height}px;
+		pointer-events: none;
+		opacity: 0;
+		z-index: -9999;
+	`;
+
+	// Override getBoundingClientRect so react-aria always gets the frozen rect,
+	// even after the real trigger element has been recycled or unmounted.
+	proxy.getBoundingClientRect = () => rect;
+
+	document.body.appendChild(proxy);
+	return proxy;
+}
+
 const UserCardProvider = ({ children }: UserCardProviderProps) => {
 	const room = useRoom();
 	const [userCardData, setUserCardData] = useState<ComponentProps<typeof UserCard> | null>(null);
 
 	const triggerRef = useRef<Element | null>(null);
+	const proxyRef = useRef<HTMLDivElement | null>(null);
+
 	const state = useOverlayTriggerState({});
 	const { triggerProps, overlayProps } = useOverlayTrigger({ type: 'dialog' }, state, triggerRef);
 	delete triggerProps.onPress;
@@ -39,29 +72,58 @@ const UserCardProvider = ({ children }: UserCardProviderProps) => {
 		}
 	});
 
+	const removeProxy = useCallback(() => {
+		if (proxyRef.current) {
+			proxyRef.current.parentNode?.removeChild(proxyRef.current);
+			proxyRef.current = null;
+		}
+	}, []);
+
+	const handleCloseUserCard = useCallback(() => {
+		removeProxy();
+		state.close();
+		setUserCardData(null);
+	}, [removeProxy, state]);
+
 	const handleSetUserCard = useCallback(
 		(e: UIEvent, username: string) => {
-			triggerRef.current = e.target as Element | null;
+			removeProxy();
+
+			const clickedEl = (e.currentTarget || e.target) as Element | null;
+			const rect = clickedEl?.getBoundingClientRect() ?? new DOMRect();
+			const proxy = createFrozenProxy(rect);
+			proxyRef.current = proxy;
+			triggerRef.current = proxy;
+
 			state.open();
 			setUserCardData({
 				username,
 				rid: room._id,
 				onOpenUserInfo: () => openUserInfo(username),
-				onClose: () => setUserCardData(null),
+				onClose: handleCloseUserCard,
 			});
 		},
-		[openUserInfo, room._id, state],
+		[handleCloseUserCard, openUserInfo, removeProxy, room._id, state],
 	);
+
+	useEffect(() => {
+		if (!state.isOpen) {
+			removeProxy();
+		}
+		return () => {
+			removeProxy();
+		};
+	}, [removeProxy, state.isOpen]);
 
 	const contextValue = useMemo(
 		() => ({
 			openUserCard: handleSetUserCard,
-			closeUserCard: () => setUserCardData(null),
+			closeUserCard: handleCloseUserCard,
 			triggerProps,
 			triggerRef,
 			state,
 		}),
-		[handleSetUserCard, state, triggerProps],
+		[handleCloseUserCard, handleSetUserCard, state, triggerProps],
 	);
 
 	return (


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
when profile card is open, listening to scroll events in website and closing the profile card when scroll event is triggered.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
#41668

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Create new channel / direct message
2. send messages until scrollbar appears.
3. on the last message open thread and keep sending messages in thread until scroll bar appears.
4. click on image in thread to open profile card and then scroll the thread again, the profile card will move to top left automatically.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User profile cards now close automatically when scrolling outside the open popover.
  * Scrolling within the profile card no longer closes it unexpectedly.
  * Scrolling unrelated popovers closes the profile card as expected.
  * Improved trigger handling ensures profile cards open and close reliably across different interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->