### PR TITLE
chore: fix formatting lint error in `SidebarFooterDefault`

### DIFF
--- a/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
+++ b/apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx
@@ -27,13 +27,7 @@ const SidebarFooterDefault = () => {
 	return (
 		<Footer>
 			<SidebarV2Divider />
-			<Box
-				paddingBlock={12}
-				height='x48'
-				width='auto'
-				className={sidebarFooterStyle}
-				dangerouslySetInnerHTML={dangerousLogo}
-			/>
+			<Box paddingBlock={12} height='x48' width='auto' className={sidebarFooterStyle} dangerouslySetInnerHTML={dangerousLogo} />
 			<SidebarFooterWatermark />
 		</Footer>
 	);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Formatting-only fix: the `<Box>` in `SidebarFooterDefault` was split across multiple lines and violated the Prettier `printWidth` config, failing lint. Collapsed it back to a single line. No behavior change.

## Issue(s)

None.

## Steps to test or reproduce

`yarn lint` passes on `apps/meteor/client/sidebar/footer/SidebarFooterDefault.tsx`.

## Further comments

No changeset — this doesn't affect end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code) 

 Task: [ARCH-2326]

[ARCH-2326]: https://rocketchat.atlassian.net/browse/ARCH-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted the footer logo markup for improved code readability without changing its appearance or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->