### PR TITLE
feat: Add Matrix federation support for updating user profiles

### DIFF
--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -1043,6 +1043,44 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 		);
 	}
 
+	async setUserProfile(
+		userId: string,
+		profile: {
+			displayname?: string;
+			avatar_url?: string;
+		},
+	): Promise<void> {
+		const [username] = userId.slice(1).split(':');
+
+		const user = await Users.findOneByUsername(username);
+
+		if (!user) {
+			return;
+		}
+
+		const subs = await Subscriptions.findJoinedByUserId<Pick<ISubscription, 'rid'>>(user._id, { projection: { rid: 1 } }).toArray();
+
+		const rooms = await Rooms.findFederatedByIds<Pick<IRoomNativeFederated, '_id' | 'federation' | 'federated'>>(
+			subs.map(({ rid }) => rid),
+			{ projection: { _id: 1, federation: 1, federated: 1 } },
+		).toArray();
+
+		await Promise.all(
+			rooms.map(async ({ federation }) => {
+				try {
+					await federationSDK.updateRoomMembership({
+						roomId: roomIdSchema.parse(federation.mrid),
+						userId: userIdSchema.parse(userId),
+						membership: 'join',
+						content: profile,
+					});
+				} catch (err) {
+					this.logger.error({ msg: 'Failed to update user profile in Matrix for a room', roomId: federation.mrid, err });
+				}
+			}),
+		);
+	}
+
 	async joinAppServiceRoom(roomAlias: string, user: IUser): Promise<boolean> {
 		try {
 			if (isUserNativeFederated(user)) {

--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -1050,16 +1050,13 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 			avatar_url?: string;
 		},
 	): Promise<void> {
-		const [username] = userId.slice(1).split(':');
-
-		const user = await Users.findOneByUsername(username);
+		const user = await Users.findOneByUsername(userId);
 
 		if (!user) {
 			return;
 		}
-
+		
 		const subs = await Subscriptions.findJoinedByUserId<Pick<ISubscription, 'rid'>>(user._id, { projection: { rid: 1 } }).toArray();
-
 		const rooms = await Rooms.findFederatedByIds<Pick<IRoomNativeFederated, '_id' | 'federation' | 'federated'>>(
 			subs.map(({ rid }) => rid),
 			{ projection: { _id: 1, federation: 1, federated: 1 } },

--- a/ee/packages/federation-matrix/src/api/_matrix/client/profile.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/profile.ts
@@ -1,3 +1,4 @@
+import { FederationMatrix } from '@rocket.chat/core-services';
 import { federationSDK } from '@rocket.chat/federation-sdk';
 import { Users } from '@rocket.chat/models';
 import { ajv } from '@rocket.chat/rest-typings';
@@ -231,8 +232,16 @@ export const addProfileRoutes = (router: ClientRouter) => {
 					};
 				}
 
-				// TODO(federation-sdk): setUserProfile(userId, {displayname?, avatar_url?}) — global, propagates to rooms
-				return notImplemented('Global profile update not yet implemented', { userId });
+				const body = await c.req.json();
+
+				await FederationMatrix.setUserProfile(userId, {
+					avatar_url: body.avatar_url,
+				});
+
+				return {
+					statusCode: 200,
+					body: {},
+				};
 			},
 		);
 };

--- a/ee/packages/federation-matrix/src/api/_matrix/client/profile.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/profile.ts
@@ -221,6 +221,13 @@ export const addProfileRoutes = (router: ClientRouter) => {
 				const userId = c.req.param('userId');
 				const username = c.get('impersonatedUserId') as string;
 
+				if (userId !== (c.req.query('user_id') ?? username)) {
+					return {
+						statusCode: 403,
+						body: { errcode: 'M_FORBIDDEN', error: 'Cannot set the avatar of another user' },
+					};
+				}
+
 				const user = await Users.findOneByUsername(username);
 				if (!user) {
 					return {

--- a/packages/core-services/src/types/IFederationMatrixService.ts
+++ b/packages/core-services/src/types/IFederationMatrixService.ts
@@ -35,11 +35,11 @@ export interface IFederationMatrixService {
 	notifyRoomRead(params: { room: IRoomNativeFederated; userId: string; threadId?: string }): Promise<void>;
 	updateUserName(user: IUser): Promise<void>;
 	setUserProfile(
-		userId: string,
-		profile: {
-			displayname?: string;
-			avatar_url?: string;
-		},
+    	userId: string,
+    	profile: {
+        	displayname?: string;
+        	avatar_url?: string | null;
+    	},
 	): Promise<void>;
 	joinAppServiceRoom(roomAlias: string, user: IUser): Promise<boolean>;
 	saveFederationMessage(event: { event: PduForType<'m.room.message'>; event_id: EventID }): Promise<void>;

--- a/packages/core-services/src/types/IFederationMatrixService.ts
+++ b/packages/core-services/src/types/IFederationMatrixService.ts
@@ -34,6 +34,13 @@ export interface IFederationMatrixService {
 	canUserAccessFederation(user: IUser): Promise<boolean>;
 	notifyRoomRead(params: { room: IRoomNativeFederated; userId: string; threadId?: string }): Promise<void>;
 	updateUserName(user: IUser): Promise<void>;
+	setUserProfile(
+		userId: string,
+		profile: {
+			displayname?: string;
+			avatar_url?: string;
+		},
+	): Promise<void>;
 	joinAppServiceRoom(roomAlias: string, user: IUser): Promise<boolean>;
 	saveFederationMessage(event: { event: PduForType<'m.room.message'>; event_id: EventID }): Promise<void>;
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Implemented `setUserProfile` support for Matrix federation.

This adds the ability to update a user's profile information (currently avatar URL) through the Matrix profile API and propagate the update to federated rooms using `FederationMatrix.setUserProfile`.

Changes made:
- Added `setUserProfile` method to `IFederationMatrixService`.
- Implemented `setUserProfile` in `FederationMatrix` to update room membership events with profile data.
- Updated Matrix profile avatar update endpoint to use the new SDK/service method instead of returning `notImplemented`.

## Issue(s)

Closes #41446

## Steps to test or reproduce

1. Configure Matrix federation.
2. Update a federated user's profile avatar URL through the Matrix profile endpoint.
3. Verify that the profile update is propagated to the federated rooms.

## Further comments

This implementation follows the existing `updateUserName` flow by finding the user's joined federated rooms and sending membership updates through the federation SDK.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating federated Matrix user profiles with display names and avatar URLs.
  * Avatar profile updates now complete successfully instead of returning an unsupported-operation error.
  * Profile changes are applied across the user’s joined federated rooms.
  * Updates support optional display names and nullable avatar URLs, with successful requests returning an empty response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->