### PR TITLE
refactor(authorization): pass loaded user to audit can-audit check

### DIFF
--- a/apps/meteor/ee/server/lib/audit/functions.ts
+++ b/apps/meteor/ee/server/lib/audit/functions.ts
@@ -61,7 +61,7 @@ const requireAuditor = async (userId: string | null): Promise<IUser> => {
 	}
 
 	const user = await Users.findOneById(userId);
-	if (!user || !(await hasPermissionAsync(user._id, 'can-audit'))) {
+	if (!user || !(await hasPermissionAsync(user, 'can-audit'))) {
 		throw new Meteor.Error('Not allowed');
 	}
 	return user;


### PR DESCRIPTION
## Why

Final sweep of the `hasPermission` migration. Found by temporarily dropping `string` from the `IAuthorization` / wrapper signatures and letting the compiler flag every remaining string-arg call site (215), then classifying them.

Result: of the ~212 remaining string callers, ~192 hold only a bare user id (`this.userId`/`uid`/`userId` — no object, correctly left as strings) and 19 pass `X._id` from a **partial** user (`message.u`, `subscription.u`, `deletingUser`, roomAccessValidator's `Pick<IUser,'_id'>`, the integrations `findOneByUsername` projections, and `Room.join`'s partial-user contract — all intentionally kept on the id path).

Exactly **one** genuine miss: `ee/server/lib/audit/functions.ts`. `requireAuditor` loads the full user with `Users.findOneById(userId)` (no projection → roles present), but the `can-audit` check was still passing `user._id`.

## Change

Pass the loaded `user` object to `hasPermissionAsync` — skips the check's internal `Users.findOneById`, roles are already present at runtime.

The migration is otherwise complete: every other call site either has no user object in scope or holds a rolesless projection.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

