### PR TITLE
fix(federation): error on first user interaction

### DIFF
--- a/apps/meteor/server/services/room/service.ts
+++ b/apps/meteor/server/services/room/service.ts
@@ -326,7 +326,8 @@ export class RoomService extends ServiceClassInternal implements IRoomService {
 			...(inviter && { inviter: { _id: inviter._id, username: inviter.username!, ...(inviter.name && { name: inviter.name }) } }),
 			...autoTranslateConfig,
 			...getDefaultSubscriptionPref(userToBeAdded),
-			...(room.t === 'd' && inviter && { fname: inviter.name, name: inviter.username }),
+			// `name` is optional for users, so fall back to the username like `getNameForDMs` does
+			...(room.t === 'd' && inviter && { fname: inviter.name || inviter.username, name: inviter.username }),
 		});
 
 		if (insertedId) {

--- a/ee/packages/federation-matrix/src/api/_matrix/client/account.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/account.ts
@@ -5,6 +5,7 @@ import type { ClientRouter } from './_shared';
 import { isMatrixErrorProps, license, tags } from './_shared';
 import { createOrUpdateFederatedUser } from '../../../helpers/createOrUpdateFederatedUser';
 import { decodeXmppUserId, isFullXmppUserId, parseXmppUserId } from '../../../helpers/parseXmppUserId';
+import { validateFederatedUsername } from '../../../helpers/validateFederatedUsername';
 import { logger } from '../../logger';
 import { isAppServiceAuthenticatedMiddleware } from '../../middlewares/isAppServiceAuthenticated';
 
@@ -93,7 +94,18 @@ export const addAccountRoutes = (router: ClientRouter) => {
 					// The spec defines `username` as the desired localpart; normalize either form to the
 					// fully-qualified MXID, which is what gets stored and what `user_id` must carry.
 					const withSigil = body.username.startsWith('@') ? body.username : `@${body.username}`;
-					const userId = withSigil.includes(':') ? withSigil : `${withSigil}:${serverName}`;
+					const userId: string = withSigil.includes(':') ? withSigil : `${withSigil}:${serverName}`;
+
+					if (!validateFederatedUsername(userId)) {
+						logger.warn({ msg: 'Malformed user id during AS registration', username: body.username });
+						return {
+							statusCode: 400,
+							body: {
+								errcode: 'M_INVALID_USERNAME',
+								error: 'Could not derive a username from the provided user id',
+							},
+						};
+					}
 
 					if (isReservedByAnotherAppService(userId)) {
 						return {
@@ -145,6 +157,17 @@ export const addAccountRoutes = (router: ClientRouter) => {
 				}
 
 				const username = `@${decodedUsername.resource}:${serverName}`;
+
+				if (!validateFederatedUsername(username)) {
+					logger.warn({ msg: 'Malformed user id derived from XMPP user id during AS registration', username: body.username });
+					return {
+						statusCode: 400,
+						body: {
+							errcode: 'M_INVALID_USERNAME',
+							error: 'Could not derive a username from the provided XMPP user id',
+						},
+					};
+				}
 
 				if (isReservedByAnotherAppService(username)) {
 					return {

--- a/ee/packages/federation-matrix/src/events/member.ts
+++ b/ee/packages/federation-matrix/src/events/member.ts
@@ -1,5 +1,5 @@
 import { Room, Upload } from '@rocket.chat/core-services';
-import { isBannedSubscription, isRegisterUser } from '@rocket.chat/core-typings';
+import { isBannedSubscription } from '@rocket.chat/core-typings';
 import type { IRoomNativeFederated, IRoom, IUser, RoomType } from '@rocket.chat/core-typings';
 import { federationSDK, type HomeserverEventSignatures, type PduForType } from '@rocket.chat/federation-sdk';
 import { Logger } from '@rocket.chat/logger';
@@ -7,9 +7,9 @@ import { Rooms, Subscriptions, Users } from '@rocket.chat/models';
 import debounce from 'lodash.debounce';
 import mem from 'mem';
 
-import { createOrUpdateFederatedUser } from '../helpers/createOrUpdateFederatedUser';
 import { extractDomainFromMatrixUserId } from '../helpers/extractDomainFromMatrixUserId';
 import { getFederatedRoomName } from '../helpers/getFederatedRoomName';
+import { getOrCreateFederatedUser } from '../helpers/getOrCreateFederatedUser';
 import { getUsernameServername } from '../helpers/getUsernameServername';
 import { MatrixMediaService } from '../services/MatrixMediaService';
 
@@ -71,40 +71,6 @@ async function downloadAndSetAvatar(user: IUser, avatarUrl: string | null): Prom
 		await Upload.setUserAvatar(user, buffer, contentType, 'rest');
 	} catch (error) {
 		logger.error({ err: error, user: user.username, msg: `Error downloading/setting avatar for user` });
-	}
-}
-
-async function getOrCreateFederatedUser(userId: string): Promise<IUser> {
-	try {
-		const serverName = federationSDK.getConfig('serverName');
-		const [username, userServerName, isLocal] = getUsernameServername(userId, serverName);
-
-		const user = await Users.findOneByUsername(username);
-		if (user) {
-			return user;
-		}
-
-		const as = federationSDK.getAppServiceForUser(userId);
-		if (as) {
-			const user = await Users.findOneByUsername(userId);
-			if (!user) {
-				throw new Error('AppService user not found for creating user');
-			}
-			return user;
-		}
-
-		if (isLocal) {
-			throw new Error(`Local user ${username} not found for Matrix ID: ${userId}`);
-		}
-
-		return createOrUpdateFederatedUser({
-			username: userId,
-			name: userId,
-			origin: userServerName,
-		});
-	} catch (err) {
-		logger.error({ msg: 'Error getting or creating federated user', err, userId });
-		throw new Error(`Error getting or creating federated user ${userId}`);
 	}
 }
 
@@ -200,18 +166,7 @@ async function handleInvite({
 	unsigned,
 }: HomeserverEventSignatures['homeserver.matrix.membership']['event']): Promise<void> {
 	const inviterUser = await getOrCreateFederatedUser(senderId);
-	if (!inviterUser) {
-		throw new Error(`Failed to get or create inviter user: ${senderId}`);
-	}
-
-	if (!isRegisterUser(inviterUser)) {
-		throw new Error('Inviter user is not registered');
-	}
-
 	const inviteeUser = await getOrCreateFederatedUser(userId);
-	if (!inviteeUser) {
-		throw new Error(`Failed to get or create invitee user: ${userId}`);
-	}
 
 	const strippedState = unsigned.invite_room_state;
 
@@ -298,9 +253,6 @@ async function handleJoin({
 	content,
 }: HomeserverEventSignatures['homeserver.matrix.membership']['event']): Promise<void> {
 	const joiningUser = await getOrCreateFederatedUser(userId);
-	if (!joiningUser?.username) {
-		throw new Error(`Failed to get or create joining user: ${userId}`);
-	}
 
 	const room = await Rooms.findOneFederatedByMrid(roomId);
 	if (!room) {
@@ -343,7 +295,7 @@ async function handleJoin({
 		await Room.updateDirectMessageRoomName(
 			room,
 			[subscription._id],
-			[{ _id: joiningUser._id, name: content.displayname || joiningUser.name || joiningUser.username, username: joiningUser.username }],
+			[{ _id: joiningUser._id, name: content.displayname || joiningUser.name, username: joiningUser.username }],
 		);
 	}
 

--- a/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.spec.ts
+++ b/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.spec.ts
@@ -113,6 +113,8 @@ describe('createOrUpdateFederatedUser', () => {
 		);
 	});
 
+	// callers subscribe the returned document to a room, so a projection here silently hands them a
+	// user missing every field but the two projected ones
 	it('should not project fields away, so the full user document is returned', async () => {
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
@@ -120,6 +122,16 @@ describe('createOrUpdateFederatedUser', () => {
 
 		const [, , options] = mockFindOneAndUpdate.mock.calls[0];
 		expect(options).not.toHaveProperty('projection');
+	});
+
+	// the pre-image of an upsert that inserted is null, which would fail every first contact
+	it('should ask for the document as it looks after the upsert', async () => {
+		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
+
+		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
+
+		const [, , options] = mockFindOneAndUpdate.mock.calls[0];
+		expect((options as any).returnDocument).toBe('after');
 	});
 
 	it('should return the user returned by findOneAndUpdate', async () => {

--- a/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.spec.ts
+++ b/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.spec.ts
@@ -11,13 +11,20 @@ jest.mock('@rocket.chat/models', () => ({
 
 const mockFindOneAndUpdate = Users.findOneAndUpdate as jest.MockedFunction<typeof Users.findOneAndUpdate>;
 
+const fakeUser = {
+	_id: 'user123',
+	username: '@alice:example.com',
+	name: '@alice:example.com',
+	federated: true,
+	federation: { version: 1, mui: '@alice:example.com', origin: 'example.com' },
+};
+
 describe('createOrUpdateFederatedUser', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
 
 	it('should assign the "federated" role to the new user', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -28,7 +35,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should not assign the "user" role to federated users', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -38,7 +44,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should set federated=true on the created/updated user', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -48,7 +53,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should use the provided name when supplied', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', name: 'Alice', origin: 'example.com' });
@@ -58,7 +62,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should default name to username when name is not provided', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -68,7 +71,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should set initial status to OFFLINE', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -78,7 +80,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should store the origin server in the federation object', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -88,7 +89,6 @@ describe('createOrUpdateFederatedUser', () => {
 	});
 
 	it('should use upsert so the user is created if not found', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
@@ -105,8 +105,24 @@ describe('createOrUpdateFederatedUser', () => {
 		);
 	});
 
+	it('should throw when the returned document is not a native federated user', async () => {
+		mockFindOneAndUpdate.mockResolvedValueOnce({ _id: 'user123', username: '@alice:example.com', name: 'Alice' } as any);
+
+		await expect(createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' })).rejects.toThrow(
+			'Failed to create or update federated user: @alice:example.com',
+		);
+	});
+
+	it('should not project fields away, so the full user document is returned', async () => {
+		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
+
+		await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });
+
+		const [, , options] = mockFindOneAndUpdate.mock.calls[0];
+		expect(options).not.toHaveProperty('projection');
+	});
+
 	it('should return the user returned by findOneAndUpdate', async () => {
-		const fakeUser = { _id: 'user123', username: '@alice:example.com' };
 		mockFindOneAndUpdate.mockResolvedValueOnce(fakeUser as any);
 
 		const result = await createOrUpdateFederatedUser({ username: '@alice:example.com', origin: 'example.com' });

--- a/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.ts
+++ b/ee/packages/federation-matrix/src/helpers/createOrUpdateFederatedUser.ts
@@ -1,4 +1,11 @@
-import { type IUser, UserStatus } from '@rocket.chat/core-typings';
+import {
+	type IRegisterUser,
+	type IUserNativeFederated,
+	isRegisterUser,
+	isUserNativeFederated,
+	UserStatus,
+} from '@rocket.chat/core-typings';
+import type { UserID } from '@rocket.chat/federation-sdk';
 import { Users } from '@rocket.chat/models';
 
 /**
@@ -9,11 +16,11 @@ import { Users } from '@rocket.chat/models';
  */
 
 export async function createOrUpdateFederatedUser(options: {
-	username: string;
+	username: UserID;
 	name?: string;
 	origin: string;
 	asId?: string;
-}): Promise<IUser> {
+}): Promise<IUserNativeFederated & IRegisterUser> {
 	const { username, name = username, origin, asId } = options;
 
 	// TODO: Have a specific method to handle this upsert
@@ -45,12 +52,12 @@ export async function createOrUpdateFederatedUser(options: {
 		},
 		{
 			upsert: true,
-			projection: { _id: 1, username: 1 },
 			returnDocument: 'after',
 		},
 	);
 
-	if (!user) {
+	// the upsert above writes every field these guards check, so they should never reject a returned document
+	if (!user || !isUserNativeFederated(user) || !isRegisterUser(user)) {
 		throw new Error(`Failed to create or update federated user: ${username}`);
 	}
 

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
@@ -101,7 +101,10 @@ describe('getOrCreateFederatedUser', () => {
 	});
 
 	describe('when the remote user is unknown locally (cold path)', () => {
-		it('should create the user and return what was created', async () => {
+		// the document itself is built by createOrUpdateFederatedUser, so its completeness is covered
+		// in createOrUpdateFederatedUser.spec.ts; all this path can show is that nothing is stripped
+		// off or rebuilt on the way out
+		it('should return the created document untouched', async () => {
 			mockFindOneByUsername.mockResolvedValueOnce(null);
 			mockCreateOrUpdateFederatedUser.mockResolvedValueOnce(createdUser as any);
 
@@ -120,24 +123,6 @@ describe('getOrCreateFederatedUser', () => {
 				username: '@alice:example.com',
 				name: '@alice:example.com',
 				origin: 'example.com',
-			});
-		});
-
-		// the cold path is the only one that returns a freshly built document, so it is the only
-		// one that can hand back a user missing the fields its consumers read
-		it('should return a user carrying the fields required to subscribe it to a room', async () => {
-			mockFindOneByUsername.mockResolvedValueOnce(null);
-			mockCreateOrUpdateFederatedUser.mockResolvedValueOnce(createdUser as any);
-
-			const result = await getOrCreateFederatedUser('@alice:example.com');
-
-			expect(result).toMatchObject({
-				_id: expect.any(String),
-				username: expect.any(String),
-				name: expect.any(String),
-				roles: expect.any(Array),
-				type: expect.any(String),
-				active: expect.any(Boolean),
 			});
 		});
 

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
@@ -82,8 +82,17 @@ describe('getOrCreateFederatedUser', () => {
 			expect(mockFindOneByUsername).toHaveBeenCalledWith('bob');
 		});
 
-		it('should throw when the existing user has no name', async () => {
-			mockFindOneByUsername.mockResolvedValueOnce({ _id: 'user123', username: '@alice:example.com' } as any);
+		// local users are allowed to exist without a display name, so requiring one here would
+		// drop every membership event they take part in
+		it('should return a local user that has no name', async () => {
+			const namelessUser = { _id: 'user123', username: 'bob' };
+			mockFindOneByUsername.mockResolvedValueOnce(namelessUser as any);
+
+			await expect(getOrCreateFederatedUser('@bob:local.com')).resolves.toBe(namelessUser);
+		});
+
+		it('should throw when the existing user has no username', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce({ _id: 'user123', name: 'Alice' } as any);
 
 			await expect(getOrCreateFederatedUser('@alice:example.com')).rejects.toThrow(
 				'Error getting or creating federated user @alice:example.com',

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.spec.ts
@@ -1,0 +1,185 @@
+import { federationSDK } from '@rocket.chat/federation-sdk';
+import { Users } from '@rocket.chat/models';
+
+import { createOrUpdateFederatedUser } from './createOrUpdateFederatedUser';
+import { getOrCreateFederatedUser } from './getOrCreateFederatedUser';
+
+jest.mock('@rocket.chat/models', () => ({
+	Users: {
+		findOneByUsername: jest.fn(),
+	},
+}));
+
+jest.mock('@rocket.chat/federation-sdk', () => ({
+	federationSDK: {
+		getConfig: jest.fn(),
+		getAppServiceForUser: jest.fn(),
+	},
+}));
+
+jest.mock('@rocket.chat/logger', () => ({
+	Logger: jest.fn().mockImplementation(() => ({
+		error: jest.fn(),
+		warn: jest.fn(),
+		info: jest.fn(),
+		debug: jest.fn(),
+	})),
+}));
+
+jest.mock('./createOrUpdateFederatedUser', () => ({
+	createOrUpdateFederatedUser: jest.fn(),
+}));
+
+const mockFindOneByUsername = Users.findOneByUsername as jest.MockedFunction<typeof Users.findOneByUsername>;
+const mockGetConfig = federationSDK.getConfig as jest.MockedFunction<typeof federationSDK.getConfig>;
+const mockGetAppServiceForUser = federationSDK.getAppServiceForUser as jest.MockedFunction<typeof federationSDK.getAppServiceForUser>;
+const mockCreateOrUpdateFederatedUser = createOrUpdateFederatedUser as jest.MockedFunction<typeof createOrUpdateFederatedUser>;
+
+// what createOrUpdateFederatedUser resolves to on first contact: a complete user document
+const createdUser = {
+	_id: 'user123',
+	username: '@alice:example.com',
+	name: '@alice:example.com',
+	createdAt: new Date(),
+	_updatedAt: new Date(),
+	type: 'user',
+	active: true,
+	roles: ['federated-external'],
+	federated: true,
+	federation: { version: 1, mui: '@alice:example.com', origin: 'example.com' },
+};
+
+describe('getOrCreateFederatedUser', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockGetConfig.mockReturnValue('local.com' as any);
+		mockGetAppServiceForUser.mockReturnValue(undefined);
+	});
+
+	describe('when the user already exists locally (warm path)', () => {
+		it('should return the existing user without creating anything', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(createdUser as any);
+
+			const result = await getOrCreateFederatedUser('@alice:example.com');
+
+			expect(result).toBe(createdUser);
+			expect(mockCreateOrUpdateFederatedUser).not.toHaveBeenCalled();
+		});
+
+		it('should look the remote user up by the full Matrix ID', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(createdUser as any);
+
+			await getOrCreateFederatedUser('@alice:example.com');
+
+			expect(mockFindOneByUsername).toHaveBeenCalledWith('@alice:example.com');
+		});
+
+		it('should look a local user up by the localpart only', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce({ ...createdUser, username: 'bob', name: 'Bob' } as any);
+
+			await getOrCreateFederatedUser('@bob:local.com');
+
+			expect(mockFindOneByUsername).toHaveBeenCalledWith('bob');
+		});
+
+		it('should throw when the existing user has no name', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce({ _id: 'user123', username: '@alice:example.com' } as any);
+
+			await expect(getOrCreateFederatedUser('@alice:example.com')).rejects.toThrow(
+				'Error getting or creating federated user @alice:example.com',
+			);
+		});
+	});
+
+	describe('when the remote user is unknown locally (cold path)', () => {
+		it('should create the user and return what was created', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+			mockCreateOrUpdateFederatedUser.mockResolvedValueOnce(createdUser as any);
+
+			const result = await getOrCreateFederatedUser('@alice:example.com');
+
+			expect(result).toBe(createdUser);
+		});
+
+		it('should create the user with the full Matrix ID and the origin server', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+			mockCreateOrUpdateFederatedUser.mockResolvedValueOnce(createdUser as any);
+
+			await getOrCreateFederatedUser('@alice:example.com');
+
+			expect(mockCreateOrUpdateFederatedUser).toHaveBeenCalledWith({
+				username: '@alice:example.com',
+				name: '@alice:example.com',
+				origin: 'example.com',
+			});
+		});
+
+		// the cold path is the only one that returns a freshly built document, so it is the only
+		// one that can hand back a user missing the fields its consumers read
+		it('should return a user carrying the fields required to subscribe it to a room', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+			mockCreateOrUpdateFederatedUser.mockResolvedValueOnce(createdUser as any);
+
+			const result = await getOrCreateFederatedUser('@alice:example.com');
+
+			expect(result).toMatchObject({
+				_id: expect.any(String),
+				username: expect.any(String),
+				name: expect.any(String),
+				roles: expect.any(Array),
+				type: expect.any(String),
+				active: expect.any(Boolean),
+			});
+		});
+
+		it('should not create anything for a malformed Matrix ID', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+
+			await expect(getOrCreateFederatedUser('@not a valid mxid:example.com')).rejects.toThrow(
+				'Error getting or creating federated user @not a valid mxid:example.com',
+			);
+			expect(mockCreateOrUpdateFederatedUser).not.toHaveBeenCalled();
+		});
+
+		it('should preserve the underlying failure as the error cause', async () => {
+			const cause = new Error('mongo is down');
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+			mockCreateOrUpdateFederatedUser.mockRejectedValueOnce(cause);
+
+			await expect(getOrCreateFederatedUser('@alice:example.com')).rejects.toThrow(expect.objectContaining({ cause }) as unknown as Error);
+		});
+	});
+
+	describe('when the user is local', () => {
+		it('should throw instead of creating a federated user for an unknown local user', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null);
+
+			await expect(getOrCreateFederatedUser('@bob:local.com')).rejects.toThrow('Error getting or creating federated user @bob:local.com');
+			expect(mockCreateOrUpdateFederatedUser).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('when the user belongs to an application service', () => {
+		it('should return the appservice user looked up by full Matrix ID', async () => {
+			const appServiceUser = { ...createdUser, username: '@irc_bob:local.com', name: 'irc_bob' };
+			mockFindOneByUsername.mockResolvedValueOnce(null).mockResolvedValueOnce(appServiceUser as any);
+			mockGetAppServiceForUser.mockReturnValue({ registration: { _id: 'as1' } } as any);
+
+			const result = await getOrCreateFederatedUser('@irc_bob:local.com');
+
+			expect(result).toBe(appServiceUser);
+			expect(mockFindOneByUsername).toHaveBeenLastCalledWith('@irc_bob:local.com');
+			expect(mockCreateOrUpdateFederatedUser).not.toHaveBeenCalled();
+		});
+
+		it('should throw when the appservice user does not exist', async () => {
+			mockFindOneByUsername.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+			mockGetAppServiceForUser.mockReturnValue({ registration: { _id: 'as1' } } as any);
+
+			await expect(getOrCreateFederatedUser('@irc_bob:local.com')).rejects.toThrow(
+				'Error getting or creating federated user @irc_bob:local.com',
+			);
+			expect(mockCreateOrUpdateFederatedUser).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
@@ -1,4 +1,4 @@
-import { type IRegisterUser, isRegisterUser } from '@rocket.chat/core-typings';
+import type { IUser, RequiredField } from '@rocket.chat/core-typings';
 import { federationSDK } from '@rocket.chat/federation-sdk';
 import { Logger } from '@rocket.chat/logger';
 import { Users } from '@rocket.chat/models';
@@ -10,21 +10,30 @@ import { validateFederatedUsername } from './validateFederatedUsername';
 const logger = new Logger('federation-matrix:user');
 
 /**
+ * `name` is deliberately not required: Rocket.Chat users are valid with a username and no
+ * display name (`Accounts_RequireNameForSignUp` off), and every consumer falls back to the
+ * username, so demanding it would drop membership events for nameless local users.
+ */
+type FederatedUser = RequiredField<IUser, 'username'>;
+
+const hasUsername = (user: IUser): user is FederatedUser => user.username !== undefined;
+
+/**
  * Resolves the local user for a Matrix user id, creating it on first contact.
  *
  * Only the last branch creates anything: once a user exists locally every later call
  * short-circuits on the lookup, which is why a broken creation path only ever surfaces
  * on the very first interaction with a given remote user.
  */
-export async function getOrCreateFederatedUser(userId: string): Promise<IRegisterUser> {
+export async function getOrCreateFederatedUser(userId: string): Promise<FederatedUser> {
 	try {
 		const serverName = federationSDK.getConfig('serverName');
 		const [username, userServerName, isLocal] = getUsernameServername(userId, serverName);
 
 		const user = await Users.findOneByUsername(username);
 		if (user) {
-			if (!isRegisterUser(user)) {
-				throw new Error(`User ${username} has no username or name for Matrix ID: ${userId}`);
+			if (!hasUsername(user)) {
+				throw new Error(`User ${username} has no username for Matrix ID: ${userId}`);
 			}
 			return user;
 		}
@@ -35,8 +44,8 @@ export async function getOrCreateFederatedUser(userId: string): Promise<IRegiste
 			if (!user) {
 				throw new Error('AppService user not found for creating user');
 			}
-			if (!isRegisterUser(user)) {
-				throw new Error(`AppService user ${userId} has no username or name`);
+			if (!hasUsername(user)) {
+				throw new Error(`AppService user ${userId} has no username`);
 			}
 			return user;
 		}

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
@@ -1,0 +1,62 @@
+import { type IRegisterUser, isRegisterUser } from '@rocket.chat/core-typings';
+import { federationSDK } from '@rocket.chat/federation-sdk';
+import { Logger } from '@rocket.chat/logger';
+import { Users } from '@rocket.chat/models';
+
+import { createOrUpdateFederatedUser } from './createOrUpdateFederatedUser';
+import { getUsernameServername } from './getUsernameServername';
+import { validateFederatedUsername } from './validateFederatedUsername';
+
+const logger = new Logger('federation-matrix:user');
+
+/**
+ * Resolves the local user for a Matrix user id, creating it on first contact.
+ *
+ * Only the last branch creates anything: once a user exists locally every later call
+ * short-circuits on the lookup, which is why a broken creation path only ever surfaces
+ * on the very first interaction with a given remote user.
+ */
+export async function getOrCreateFederatedUser(userId: string): Promise<IRegisterUser> {
+	try {
+		const serverName = federationSDK.getConfig('serverName');
+		const [username, userServerName, isLocal] = getUsernameServername(userId, serverName);
+
+		const user = await Users.findOneByUsername(username);
+		if (user) {
+			if (!isRegisterUser(user)) {
+				throw new Error(`User ${username} has no username or name for Matrix ID: ${userId}`);
+			}
+			return user;
+		}
+
+		const as = federationSDK.getAppServiceForUser(userId);
+		if (as) {
+			const user = await Users.findOneByUsername(userId);
+			if (!user) {
+				throw new Error('AppService user not found for creating user');
+			}
+			if (!isRegisterUser(user)) {
+				throw new Error(`AppService user ${userId} has no username or name`);
+			}
+			return user;
+		}
+
+		if (isLocal) {
+			throw new Error(`Local user ${username} not found for Matrix ID: ${userId}`);
+		}
+
+		if (!validateFederatedUsername(userId)) {
+			throw new Error(`Invalid federated Matrix ID: ${userId}`);
+		}
+
+		// awaited so a failure is logged with context and wrapped, instead of escaping the catch below
+		return await createOrUpdateFederatedUser({
+			username: userId,
+			name: userId,
+			origin: userServerName,
+		});
+	} catch (err) {
+		logger.error({ msg: 'Error getting or creating federated user', err, userId });
+		throw new Error(`Error getting or creating federated user ${userId}`, { cause: err });
+	}
+}

--- a/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
+++ b/ee/packages/federation-matrix/src/helpers/getOrCreateFederatedUser.ts
@@ -11,8 +11,8 @@ const logger = new Logger('federation-matrix:user');
 
 /**
  * `name` is deliberately not required: Rocket.Chat users are valid with a username and no
- * display name (`Accounts_RequireNameForSignUp` off), and every consumer falls back to the
- * username, so demanding it would drop membership events for nameless local users.
+ * display name (`Accounts_RequireNameForSignUp` off), so demanding it would drop membership
+ * events for nameless local users. Consumers must fall back to the username when displaying.
  */
 type FederatedUser = RequiredField<IUser, 'username'>;
 

--- a/ee/packages/federation-matrix/tests/end-to-end/first-contact.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/first-contact.spec.ts
@@ -114,9 +114,11 @@ const localUser = federationConfig.rc1.firstContactUser;
 			);
 		}, 30000);
 
-		// the invite handler is the only caller that reads the created user back, and it feeds it to
-		// the subscription and Apps layers, which need far more than an _id and a username
-		it('should create the remote user locally as a complete document', async () => {
+		// this covers the persisted document only. The shape of the object the invite handler reads back
+		// is not observable from here — it belongs to the createOrUpdateFederatedUser and
+		// getOrCreateFederatedUser unit tests, and when it regresses the room and subscription
+		// assertions below are what fail.
+		it('should persist the remote user locally as a complete document', async () => {
 			const response = await rc1AdminRequestConfig.request
 				.get(api('users.info'))
 				.set(rc1AdminRequestConfig.credentials)

--- a/ee/packages/federation-matrix/tests/end-to-end/first-contact.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/first-contact.spec.ts
@@ -1,0 +1,188 @@
+import type { IRoomNativeFederated, IUser } from '@rocket.chat/core-typings';
+import { Visibility } from 'matrix-js-sdk';
+
+import { api } from '../../../../../apps/meteor/tests/data/api-data';
+import { acceptRoomInvite } from '../../../../../apps/meteor/tests/data/rooms.helper';
+import {
+	type IRequestConfig,
+	createUser,
+	deleteUser,
+	getRequestConfig,
+	getUserByUsername,
+} from '../../../../../apps/meteor/tests/data/users.helper';
+import { IS_EE } from '../../../../../apps/meteor/tests/e2e/config/constants';
+import { retry } from '../../../../../apps/meteor/tests/end-to-end/api/helpers/retry';
+import { federationConfig } from '../helper/config';
+import { SynapseClient } from '../helper/synapse-client';
+
+const remoteUser = federationConfig.hs1.firstContactUser;
+const localUser = federationConfig.rc1.firstContactUser;
+
+/**
+ * Every other federation spec reuses Synapse users that earlier specs have already pulled into
+ * the local database, so the membership handlers always find a complete user document and the
+ * creation path is never observed. This spec reserves a Synapse user nobody else touches, removes
+ * the local document if a previous run left one behind, and only then lets that user reach in.
+ *
+ * The user is therefore created by the inbound invite itself, which is the one code path whose
+ * result is consumed rather than discarded.
+ */
+(IS_EE ? describe : describe.skip)('Federation first contact', () => {
+	let rc1AdminRequestConfig: IRequestConfig;
+	let rc1InviteeRequestConfig: IRequestConfig;
+	let hs1FirstContactApp: SynapseClient;
+
+	const forgetRemoteUserLocally = async () => {
+		const known = await getUserByUsername(remoteUser.matrixUserId, rc1AdminRequestConfig);
+		if (known?._id) {
+			await deleteUser({ _id: known._id }, { confirmRelinquish: true }, rc1AdminRequestConfig);
+		}
+	};
+
+	beforeAll(async () => {
+		rc1AdminRequestConfig = await getRequestConfig(
+			federationConfig.rc1.url,
+			federationConfig.rc1.adminUser,
+			federationConfig.rc1.adminPassword,
+		);
+
+		const existingLocalUser = await getUserByUsername(localUser.username, rc1AdminRequestConfig);
+		if (!existingLocalUser?._id) {
+			await createUser(
+				{
+					username: localUser.username,
+					password: localUser.password,
+					email: `${localUser.username}@rocket.chat`,
+					name: localUser.username,
+				},
+				rc1AdminRequestConfig,
+			);
+		}
+
+		rc1InviteeRequestConfig = await getRequestConfig(federationConfig.rc1.url, localUser.username, localUser.password);
+
+		// a previous run leaves the user behind, which would make this spec exercise the warm path instead
+		await forgetRemoteUserLocally();
+
+		hs1FirstContactApp = new SynapseClient(federationConfig.hs1.url, remoteUser.username, remoteUser.password);
+		await hs1FirstContactApp.initialize();
+	}, 60000);
+
+	afterAll(async () => {
+		// leave the environment cold so a rerun against persistent containers still tests first contact
+		await forgetRemoteUserLocally();
+		await hs1FirstContactApp?.close();
+	});
+
+	it('should not know the remote user before the first interaction', async () => {
+		const response = await rc1AdminRequestConfig.request
+			.get(api('users.info'))
+			.set(rc1AdminRequestConfig.credentials)
+			.query({ username: remoteUser.matrixUserId });
+
+		expect(response.status).toBe(400);
+		expect(response.body).toHaveProperty('success', false);
+	});
+
+	describe('when the first interaction is an invite from Synapse', () => {
+		let channelName: string;
+		let synapseRoomId: string;
+		let federatedRoomId: string;
+
+		beforeAll(async () => {
+			channelName = `fed-first-contact-${Date.now()}`;
+			synapseRoomId = await hs1FirstContactApp.createRoom(channelName, Visibility.Private);
+
+			await hs1FirstContactApp.inviteUserToRoom(synapseRoomId, localUser.matrixUserId);
+		}, 60000);
+
+		it('should create the room on the Rocket.Chat side', async () => {
+			await retry(
+				'waiting for the federated room to reach RC',
+				async () => {
+					// rooms.get is scoped to the caller's subscriptions, and only the invitee is in this room
+					const response = await rc1InviteeRequestConfig.request.get(api('rooms.get')).set(rc1InviteeRequestConfig.credentials).expect(200);
+
+					const rcRoom = response.body.update.find(
+						(room: IRoomNativeFederated) => room.federation?.mrid === synapseRoomId,
+					) as IRoomNativeFederated | null;
+
+					expect(rcRoom).toBeTruthy();
+					federatedRoomId = rcRoom!._id;
+				},
+				{ retries: 10, delayMs: 2000 },
+			);
+		}, 30000);
+
+		// the invite handler is the only caller that reads the created user back, and it feeds it to
+		// the subscription and Apps layers, which need far more than an _id and a username
+		it('should create the remote user locally as a complete document', async () => {
+			const response = await rc1AdminRequestConfig.request
+				.get(api('users.info'))
+				.set(rc1AdminRequestConfig.credentials)
+				.query({ username: remoteUser.matrixUserId })
+				.expect(200);
+
+			expect(response.body.user).toMatchObject({
+				username: remoteUser.matrixUserId,
+				name: remoteUser.matrixUserId,
+				type: 'user',
+				active: true,
+				federated: true,
+				roles: expect.arrayContaining(['federated-external']),
+			});
+			expect(response.body.user.createdAt).toBeTruthy();
+		});
+
+		it('should create the invited subscription for the local user', async () => {
+			const response = await rc1InviteeRequestConfig.request
+				.get(api('subscriptions.getOne'))
+				.set(rc1InviteeRequestConfig.credentials)
+				.query({ roomId: federatedRoomId })
+				.expect(200);
+
+			expect(response.body.subscription).toBeTruthy();
+			expect(response.body.subscription).toHaveProperty('status', 'INVITED');
+		});
+
+		it('should let the local user accept the invite', async () => {
+			const response = await acceptRoomInvite(federatedRoomId, rc1InviteeRequestConfig);
+
+			expect(response).toHaveProperty('success', true);
+		});
+
+		it('should reach the local user on the Synapse side', async () => {
+			await retry(
+				'waiting for the local user to appear as joined on Synapse',
+				async () => {
+					const member = await hs1FirstContactApp.findRoomMember(channelName, localUser.matrixUserId);
+
+					expect(member).not.toBeNull();
+					expect(member!.membership).toBe('join');
+				},
+				{ retries: 10, delayMs: 2000 },
+			);
+		}, 30000);
+
+		// a named, invite-only Synapse room becomes a private group on RC, so groups.members applies.
+		// it gates on canAccessRoomAsync without includeInvitations, meaning the accepted subscription
+		// has to have settled first — hence the retry and the ordering after the Synapse round-trip
+		it('should list the remote user among the room members', async () => {
+			await retry(
+				'waiting for the room members to include the remote user',
+				async () => {
+					const response = await rc1InviteeRequestConfig.request
+						.get(api('groups.members'))
+						.set(rc1InviteeRequestConfig.credentials)
+						.query({ roomId: federatedRoomId })
+						.expect(200);
+
+					expect(response.body.members).toEqual(
+						expect.arrayContaining([expect.objectContaining({ username: remoteUser.matrixUserId } as Partial<IUser>)]),
+					);
+				},
+				{ retries: 5, delayMs: 2000 },
+			);
+		}, 30000);
+	});
+});

--- a/ee/packages/federation-matrix/tests/helper/config.ts
+++ b/ee/packages/federation-matrix/tests/helper/config.ts
@@ -6,17 +6,25 @@
  * for end-to-end federation testing.
  */
 
+type FederationUserConfig = {
+	username: string;
+	password: string;
+	matrixUserId: string;
+};
+
 type FederationServerConfig = {
 	url: string;
 	domain: string;
 	adminUser: string;
 	adminPassword: string;
 	adminMatrixUserId: string;
-	additionalUser1: {
-		username: string;
-		password: string;
-		matrixUserId: string;
-	};
+	additionalUser1: FederationUserConfig;
+	/**
+	 * Reserved for tests that need a user the other side has never seen. Must not be used
+	 * anywhere else: the moment another spec touches it, the local user document exists and
+	 * first-contact behaviour can no longer be observed.
+	 */
+	firstContactUser: FederationUserConfig;
 };
 export interface IFederationConfig {
 	rc1: FederationServerConfig;
@@ -60,12 +68,17 @@ function getFederationConfig(): IFederationConfig {
 	const rcAdminPassword = validateEnvVar('FEDERATION_RC1_ADMIN_PASSWORD', 'admin');
 	const rcAdditionalUser1 = validateEnvVar('FEDERATION_RC1_ADDITIONAL_USER1', 'user2');
 	const rcAdditionalUser1Password = validateEnvVar('FEDERATION_RC1_ADDITIONAL_USER1_PASSWORD', 'user2pass');
+	const rcFirstContactUser = validateEnvVar('FEDERATION_RC1_FIRST_CONTACT_USER', 'user3');
+	const rcFirstContactUserPassword = validateEnvVar('FEDERATION_RC1_FIRST_CONTACT_USER_PASSWORD', 'user3pass');
 
 	const hs1Domain = validateEnvVar('FEDERATION_SYNAPSE_DOMAIN', 'hs1');
 	const hs1AdminUser = validateEnvVar('FEDERATION_SYNAPSE_ADMIN_USER', 'admin');
 	const hs1AdminPassword = validateEnvVar('FEDERATION_SYNAPSE_ADMIN_PASSWORD', 'admin');
 	const hs1AdditionalUser1 = validateEnvVar('FEDERATION_SYNAPSE_ADDITIONAL_USER1', 'alice');
 	const hs1AdditionalUser1Password = validateEnvVar('FEDERATION_SYNAPSE_ADDITIONAL_USER1_PASSWORD', 'alice');
+	// `cleiton` is registered by docker-compose.test.yml and deliberately used by no other spec
+	const hs1FirstContactUser = validateEnvVar('FEDERATION_SYNAPSE_FIRST_CONTACT_USER', 'cleiton');
+	const hs1FirstContactUserPassword = validateEnvVar('FEDERATION_SYNAPSE_FIRST_CONTACT_USER_PASSWORD', 'cleiton');
 
 	return {
 		rc1: {
@@ -79,6 +92,11 @@ function getFederationConfig(): IFederationConfig {
 				password: rcAdditionalUser1Password,
 				matrixUserId: `@${rcAdditionalUser1}:${rcDomain}`,
 			},
+			firstContactUser: {
+				username: rcFirstContactUser,
+				password: rcFirstContactUserPassword,
+				matrixUserId: `@${rcFirstContactUser}:${rcDomain}`,
+			},
 		},
 		hs1: {
 			url: `https://${hs1Domain}`,
@@ -90,6 +108,11 @@ function getFederationConfig(): IFederationConfig {
 				username: hs1AdditionalUser1,
 				password: hs1AdditionalUser1Password,
 				matrixUserId: `@${hs1AdditionalUser1}:${hs1Domain}`,
+			},
+			firstContactUser: {
+				username: hs1FirstContactUser,
+				password: hs1FirstContactUserPassword,
+				matrixUserId: `@${hs1FirstContactUser}:${hs1Domain}`,
 			},
 		},
 	};

--- a/packages/core-typings/src/IUser.ts
+++ b/packages/core-typings/src/IUser.ts
@@ -256,7 +256,7 @@ export const isRegisterUser = (user: IUser): user is IRegisterUser => user.usern
 
 export const isUserFederated = (user: Partial<IUser> | Partial<Serialized<IUser>>) => 'federated' in user && user.federated === true;
 
-interface IUserNativeFederated extends IUser {
+export interface IUserNativeFederated extends IUser {
 	federated: true;
 	username: `@${string}:${string}`;
 	federation: {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
First federation user interaction was failing due to `createOrUpdateFederatedUser` was returning a `projection` with less fields than needed. So now `createOrUpdateFederatedUser` correctly returns a full `IUser` and new tests were added to validate that.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2495]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2495]: https://rocketchat.atlassian.net/browse/CORE-2495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved federated user resolution and automatic creation during Matrix invitations, joins, and first-contact interactions.
  * Added validation for federated usernames, with clear errors for invalid IDs.
  * Improved direct-message room naming when display names are unavailable.

* **Bug Fixes**
  * Prevented local users and invalid federated results from being treated as remote users.
  * Improved error handling while preserving underlying causes.

* **Tests**
  * Added coverage for user resolution, registration validation, and first-contact federation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->