### PR TITLE
fix: video conf stream reconnecting on every user update

### DIFF
--- a/.changeset/videoconf-user-update-reconnect.md
+++ b/.changeset/videoconf-user-update-reconnect.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the video conference notification stream being torn down and re-subscribed on every login or connection status update, even when the logged user had not changed

--- a/apps/meteor/client/lib/VideoConfManager.ts
+++ b/apps/meteor/client/lib/VideoConfManager.ts
@@ -301,7 +301,8 @@ export const VideoConfManager = new (class VideoConfManager extends Emitter<Vide
 	}
 
 	public updateUser(userId: string | null, isLoggingIn: boolean, isConnected: boolean): void {
-		if (userId === this.userId && !isLoggingIn && !isConnected) {
+		// nothing changed: same user, already connected and not mid-login - keep the current subscription
+		if (userId === this.userId && !isLoggingIn && isConnected) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`VideoConfManager.updateUser` had its no-op guard inverted:

```ts
if (userId === this.userId && !isLoggingIn && !isConnected) {
	return;
}
```

The early return only triggered while the client was *disconnected*, so in the normal case (connected, same user, not logging in) it always fell through to `disconnect()` + `connectUser()`, tearing down and re-subscribing the `notify-user/.../video-conference` stream.

`useUpdateVideoConfUser` calls `updateUser` from an effect with no cleanup, so under `StrictMode` the effect runs twice on mount and the browser console shows this on every page load:

```
[VideoConf] connecting user <uid>
[VideoConf] disconnecting user <uid>
[VideoConf] connecting user <uid>
```

Outside StrictMode the same churn happens on every `connected` / `isLoggingIn` flap. No calls were lost (`disconnect` is called with `clearCalls = false` when the user id is unchanged), only the subscription was recreated.

Fixed by comparing against `isConnected` instead of `!isConnected`.

## Issue(s)

## Steps to test or reproduce

1. Open the app with the browser console visible.
2. Before: `connecting` → `disconnecting` → `connecting` on every load.
3. After: a single `[VideoConf] connecting user <uid>`, and no reconnect when the websocket reconnects with the same logged user.

## Further comments

Alternative considered: adding a cleanup to `useUpdateVideoConfUser` so the effect is symmetric. That would hide the double-connect under StrictMode but the guard would still be wrong for connection flaps, so the fix belongs in `updateUser`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [ARCH-2422]

[ARCH-2422]: https://rocketchat.atlassian.net/browse/ARCH-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed video conference notifications being unnecessarily disconnected and reconnected during login or connection status updates.
  - Existing notification subscriptions now remain active when the connected user has not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->