### PR TITLE
refactor(ui-voip): own the media session lifecycle from an effect

### DIFF
--- a/.changeset/media-session-instance-lifecycle.md
+++ b/.changeset/media-session-instance-lifecycle.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the media call session being ended and recreated on re-renders, which could drop an ongoing call, and makes ICE server and ICE gathering timeout changes apply to new calls without recreating the session

--- a/.changeset/media-session-instance-lifecycle.md
+++ b/.changeset/media-session-instance-lifecycle.md
@@ -1,6 +1,0 @@
----
-'@rocket.chat/ui-voip': patch
-'@rocket.chat/meteor': patch
----
-
-Fixes the media call session being ended and recreated on re-renders, which could drop an ongoing call, and makes ICE server and ICE gathering timeout changes apply to new calls without recreating the session

--- a/packages/ui-voip/src/providers/useMediaSessionInstance.ts
+++ b/packages/ui-voip/src/providers/useMediaSessionInstance.ts
@@ -291,7 +291,5 @@ export const useMediaSessionInstance = (userId?: string, enabled = true) => {
 		};
 	}, [userId, enabled, sendSignal, getWebRTCConfig, notifyUserStream]);
 
-
-
 	return instance;
 };

--- a/packages/ui-voip/src/providers/useMediaSessionInstance.ts
+++ b/packages/ui-voip/src/providers/useMediaSessionInstance.ts
@@ -1,9 +1,10 @@
 import { Emitter } from '@rocket.chat/emitter';
+import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { MediaSignalingSession, MediaCallWebRTCProcessor } from '@rocket.chat/media-signaling';
-import type { MediaSignalTransport, ClientMediaSignal, ServerMediaSignal, WebRTCProcessorConfig } from '@rocket.chat/media-signaling';
+import type { MediaSignalTransport, ClientMediaSignal, ServerMediaSignal } from '@rocket.chat/media-signaling';
 import type { TranslationKey } from '@rocket.chat/ui-contexts';
 import { useSetting, useStream, useToastMessageDispatch, useWriteStream } from '@rocket.chat/ui-contexts';
-import { useEffect, useSyncExternalStore, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { MediaCallLogger } from './MediaCallLogger';
@@ -25,7 +26,6 @@ const getSessionIdKey = (userId: string) => {
 };
 
 type MediaSessionStoreEventMap = {
-	change: void;
 	requestToast: { message: TranslationKey; args?: Record<string, string>; type: 'error' | 'success' | 'info' | 'warning' };
 };
 
@@ -70,35 +70,20 @@ class MediaSessionStore extends Emitter<MediaSessionStoreEventMap> {
 
 	private sendSignalFn: SignalTransport | null = null;
 
-	private _webrtcProcessorFactory: ((config: WebRTCProcessorConfig) => MediaCallWebRTCProcessor) | null = null;
-
 	private failedScreenShareAttempts = 0;
 
 	private logger = new MediaCallLogger();
 
 	private popoutWindow: Window | undefined;
 
+	private lastSessionId: string | undefined;
+
 	constructor() {
 		super();
 	}
 
-	private change() {
-		this.emit('change');
-	}
-
-	public onChange(callback: () => void) {
-		return this.on('change', callback);
-	}
-
 	private requestToast({ message, args, type }: MediaSessionStoreEventMap['requestToast']) {
 		this.emit('requestToast', { message, args, type });
-	}
-
-	private webrtcProcessorFactory(config: WebRTCProcessorConfig) {
-		if (!this._webrtcProcessorFactory) {
-			throw new Error('WebRTC processor factory not set');
-		}
-		return this._webrtcProcessorFactory(config);
 	}
 
 	private sendSignal(signal: ClientMediaSignal) {
@@ -124,6 +109,13 @@ class MediaSessionStore extends Emitter<MediaSessionStoreEventMap> {
 		}
 
 		window.sessionStorage.removeItem(key);
+
+		// never resume a session this tab created itself: the stored id is written on creation, so a re-created
+		// instance (StrictMode remount, userId change and back) would otherwise adopt the id of the one it replaced
+		if (oldSessionId === this.lastSessionId) {
+			return undefined;
+		}
+
 		return oldSessionId;
 	}
 
@@ -182,21 +174,38 @@ class MediaSessionStore extends Emitter<MediaSessionStoreEventMap> {
 		}
 	}
 
-	private cleanupInstance() {
-		if (this.sessionInstance !== null) {
-			this.sessionInstance.endSession();
-			this.sessionInstance = null;
+	public cleanupInstance() {
+		if (this.sessionInstance === null) {
+			return;
 		}
+		this.sessionInstance.endSession();
+		this.sessionInstance = null;
+		this.sendSignalFn = null;
 	}
 
-	private makeInstance(userId: string) {
+	public getInstance(
+		userId: string,
+		sendSignalFn: SignalTransport,
+		getWebRTCConfig: () => { iceServers: RTCIceServer[]; iceGatheringTimeout: number },
+	) {
+		// must be idempotent: it's called from render, which may run more than once per commit (StrictMode, discarded renders)
+		if (this.sessionInstance?.userId === userId) {
+			return this.sessionInstance;
+		}
+		return this.makeInstance(userId, sendSignalFn, getWebRTCConfig);
+	}
+
+	private makeInstance(
+		userId: string,
+		sendSignalFn: SignalTransport,
+		getWebRTCConfig: () => { iceServers: RTCIceServer[]; iceGatheringTimeout: number },
+	) {
 		this.cleanupInstance();
 
 		this.failedScreenShareAttempts = 0;
 
-		if (!this._webrtcProcessorFactory || !this.sendSignalFn) {
-			return null;
-		}
+		// must be set before the session is constructed: the constructor already sends the register signal
+		this.sendSignalFn = sendSignalFn;
 
 		this.sessionInstance = new MediaSignalingSession({
 			userId,
@@ -204,7 +213,11 @@ class MediaSessionStore extends Emitter<MediaSessionStoreEventMap> {
 				void this.sendSignal(signal);
 			},
 			processorFactories: {
-				webrtc: (config) => this.webrtcProcessorFactory(config),
+				// config read on every processor creation, so setting/ice changes apply without recreating the session
+				webrtc: (config) => {
+					const { iceServers, iceGatheringTimeout } = getWebRTCConfig();
+					return new MediaCallWebRTCProcessor({ ...config, rtc: { ...config.rtc, iceServers }, iceGatheringTimeout });
+				},
 			},
 			displayMediaFactory: (...args) => this.getDisplayMedia(...args),
 			mediaStreamFactory: (...args) => this.getUserMedia(...args),
@@ -215,51 +228,13 @@ class MediaSessionStore extends Emitter<MediaSessionStoreEventMap> {
 			autoSync: true,
 		});
 
+		this.lastSessionId = this.sessionInstance.sessionId;
+
 		if (window.sessionStorage) {
 			window.sessionStorage.setItem(getSessionIdKey(userId), this.sessionInstance.sessionId);
 		}
 
-		this.change();
-
 		return this.sessionInstance;
-	}
-
-	public getInstance(userId?: string, enabled = true) {
-		if (!enabled) {
-			this.cleanupInstance();
-			return null;
-		}
-
-		if (!userId) {
-			return null;
-		}
-
-		if (this.sessionInstance?.userId === userId) {
-			return this.sessionInstance;
-		}
-
-		return this.makeInstance(userId);
-	}
-
-	public setSendSignalFn(sendSignalFn: SignalTransport) {
-		this.sendSignalFn = sendSignalFn;
-		this.change();
-		return () => {
-			this.sendSignalFn = null;
-		};
-	}
-
-	public setWebRTCProcessorFactory(factory: (config: WebRTCProcessorConfig) => MediaCallWebRTCProcessor) {
-		this._webrtcProcessorFactory = factory;
-		this.change();
-	}
-
-	public processSignal(signal: ServerMediaSignal, userId?: string) {
-		if (!this.sessionInstance || this.sessionInstance.userId !== userId) {
-			return;
-		}
-
-		void this.sessionInstance.processSignal(signal);
 	}
 
 	public setPopoutWindow(popoutWindow?: Window) {
@@ -280,6 +255,7 @@ export const useSetPopoutWindow = (popoutWindow?: Window) => {
 };
 
 export const useMediaSessionInstance = (userId?: string, enabled = true) => {
+	const [instance, setInstance] = useState<MediaSignalingSession | undefined>(undefined);
 	const { t } = useTranslation();
 	const iceServers = useIceServers();
 	const iceGatheringTimeout = useSetting('VoIP_TeamCollab_Ice_Gathering_Timeout', 5000);
@@ -289,45 +265,33 @@ export const useMediaSessionInstance = (userId?: string, enabled = true) => {
 
 	const dispatchToastMessage = useToastMessageDispatch();
 
-	useEffect(() => {
-		mediaSession.setWebRTCProcessorFactory(
-			(config) => new MediaCallWebRTCProcessor({ ...config, rtc: { ...config.rtc, iceServers }, iceGatheringTimeout }),
-		);
-	}, [iceServers, iceGatheringTimeout]);
+	useEffect(
+		() => mediaSession.on('requestToast', ({ message, args, type }) => dispatchToastMessage({ message: t(message, args), type })),
+		[dispatchToastMessage, t],
+	);
+
+	const sendSignal = useStableCallback((signal: ClientMediaSignal) => writeStream(`${userId}/media-calls` as any, JSON.stringify(signal)));
+	const getWebRTCConfig = useStableCallback(() => ({ iceServers, iceGatheringTimeout }));
 
 	useEffect(() => {
-		// TODO: This stream is not typed.
-		return mediaSession.setSendSignalFn((signal: ClientMediaSignal) => writeStream(`${userId}/media-calls` as any, JSON.stringify(signal)));
-	}, [writeStream, userId]);
-
-	useEffect(() => {
-		if (!userId) {
+		if (!userId || !enabled) {
+			setInstance(undefined);
 			return;
 		}
 
-		const unsubNotification = notifyUserStream(`${userId}/media-signal`, (signal: ServerMediaSignal) =>
-			mediaSession.processSignal(signal, userId),
-		);
+		const instance = mediaSession.getInstance(userId, sendSignal, getWebRTCConfig);
+
+		setInstance(instance);
+
+		const subscription = notifyUserStream(`${userId}/media-signal`, (signal: ServerMediaSignal) => instance.processSignal(signal));
 
 		return () => {
-			unsubNotification();
+			subscription();
+			mediaSession.cleanupInstance();
 		};
-	}, [userId, notifyUserStream]);
+	}, [userId, enabled, sendSignal, getWebRTCConfig, notifyUserStream]);
 
-	useEffect(() => {
-		return mediaSession.on('requestToast', ({ message, args, type }) => {
-			dispatchToastMessage({ message: t(message, args), type });
-		});
-	}, [dispatchToastMessage, t]);
 
-	const instance = useSyncExternalStore(
-		useCallback((callback) => {
-			return mediaSession.onChange(callback);
-		}, []),
-		useCallback(() => {
-			return mediaSession.getInstance(userId, enabled);
-		}, [userId, enabled]),
-	);
 
-	return instance ?? undefined;
+	return instance;
 };


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`useMediaSessionInstance` exposed the session through `useSyncExternalStore`, so `MediaSessionStore` could only build an instance after three separate effects had fed it (`setSendSignalFn`, `setWebRTCProcessorFactory`, then instance creation on the next snapshot). Every change to `VoIP_TeamCollab_Ice_Gathering_Timeout` or to the ICE server list replaced the processor factory, and instance creation was driven by an impure `getSnapshot`.

The hook now creates the session in an effect and keeps it in state. Concretely:

- **ICE config is read lazily.** `makeInstance` takes a `getWebRTCConfig()` getter (a `useStableCallback`, stable identity + latest values) which the webrtc processor factory calls on every processor creation. New calls pick up new settings; the live session is left alone.
- **`getInstance` is idempotent per `userId`.** Creating the session is a side effect; without a guard, a re-render (StrictMode double render, a discarded render) called `endSession()` on the live session — which ignores every known call — and built a new one.
- **`getOldSessionId` ignores ids this tab created.** The session id is written to `sessionStorage` on creation, so a recreated instance read back the id of the instance it had just replaced and asked the server to resume it. Session recovery after a real page refresh still works, since `lastSessionId` is in-memory only.
- **Signal transport is set before construction.** The `MediaSignalingSession` constructor already sends the register signal, so `sendSignalFn` has to be in place first — that ordering is now explicit instead of depending on effect order.
- **Signal routing is per instance.** `notify-user/<uid>/media-signal` is subscribed with the instance in the dependency list and delivers to `instance.processSignal`, which removes the store-level `userId` comparison that existed only because the store was a singleton.
- **Dead code removed.** With the instance in React state nothing subscribed to the store's `change` event, so `change()` / `onChange()` / the `change` entry in the event map are gone, along with `setSendSignalFn` (its returned unsubscribe had no callers) and three unused imports.

No behavior change intended other than the session no longer being recreated.

## Issue(s)

## Steps to test or reproduce

1. Log in and confirm a single media session is registered (one register signal, one `sessionId` in `sessionStorage`).
2. Make a call, then change `VoIP_TeamCollab_Ice_Gathering_Timeout` in admin: the ongoing call is unaffected; the next call uses the new value.
3. Reload the page during a call: the session is resumed with the previous `sessionId`.
4. Log out and log in as another user: the previous session is ended and a new one is registered.

## Further comments

The remaining rough edge is that `MediaSignalingSession` does its side effects in the constructor (sends `register`, starts the state report interval). Splitting that into `start()`/`stop()` in `@rocket.chat/media-signaling` would make construction pure and let the effect own the lifecycle outright, removing the need for the idempotency guard here. Left out of this PR to keep it scoped to the hook.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

