### PR TITLE
chore: fix returning types for projections

### DIFF
--- a/apps/meteor/app/apps/server/bridges/livechat.ts
+++ b/apps/meteor/app/apps/server/bridges/livechat.ts
@@ -334,7 +334,7 @@ export class AppLivechatBridge extends LivechatBridge {
 		return this.orch
 			.getConverters()
 			?.get('visitors')
-			.convertVisitor(await LivechatVisitors.getVisitorByToken(token, {}));
+			.convertVisitor(await LivechatVisitors.getVisitorByToken<ILivechatVisitor>(token, {}));
 	}
 
 	protected async findVisitorByPhoneNumber(phoneNumber: string, appId: string): Promise<IVisitor | undefined> {
@@ -380,7 +380,7 @@ export class AppLivechatBridge extends LivechatBridge {
 		return this.orch
 			.getConverters()
 			?.get('departments')
-			.convertDepartment(await LivechatDepartment.findOneByIdOrName(value, {}));
+			.convertDepartment(await LivechatDepartment.findOneByIdOrName<ILivechatDepartment>(value, {}));
 	}
 
 	protected async findDepartmentsEnabledWithAgents(appId: string): Promise<Array<IDepartment>> {

--- a/apps/meteor/ee/server/api/abac/schemas.ts
+++ b/apps/meteor/ee/server/api/abac/schemas.ts
@@ -108,7 +108,7 @@ const GetAbacAttributesResponse = {
 };
 
 export const GETAbacAttributesResponseSchema = ajv.compile<{
-	attributes: IAbacAttribute[];
+	attributes: Pick<IAbacAttribute, '_id' | 'key' | 'values'>[];
 	offset: number;
 	count: number;
 	total: number;

--- a/apps/meteor/ee/server/apps/marketplace/appRequestNotifyUsers.ts
+++ b/apps/meteor/ee/server/apps/marketplace/appRequestNotifyUsers.ts
@@ -22,7 +22,7 @@ const notifyBatchOfUsers = async (appName: string, learnMoreUrl: string, appRequ
 		return acc;
 	}, []);
 
-	const msgFn = (user: IUser): string => {
+	const msgFn = (user: Pick<IUser, 'language'>): string => {
 		const defaultLang = user.language || 'en';
 		const msg = `${i18n.t('App_request_enduser_message', { appName, learnmore: learnMoreUrl, lng: defaultLang })}`;
 

--- a/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
+++ b/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
@@ -74,7 +74,12 @@ export class AppRealStorage extends AppMetadataStorage {
 			updateQuery.$unset = { permissionsGranted: 1 };
 		}
 
-		return this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' });
+		const updated = await this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' });
+		if (!updated) {
+			throw new Error(`App storage item not found for _id: ${_id}`);
+		}
+
+		return updated;
 	}
 
 	public async updateStatus(_id: string, status: AppStatus): Promise<boolean> {

--- a/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
+++ b/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
@@ -74,12 +74,9 @@ export class AppRealStorage extends AppMetadataStorage {
 			updateQuery.$unset = { permissionsGranted: 1 };
 		}
 
-		const updated = await this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' });
-		if (!updated) {
-			throw new Error(`App storage item not found for _id: ${_id}`);
-		}
-
-		return updated;
+		// TODO need to change method return type to IAppStorageItem | null, because findOneAndUpdate can return null if the document is not found.
+		// But for now, we are asserting that it will always return a document.
+		return this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' }) as Promise<IAppStorageItem>;
 	}
 
 	public async updateStatus(_id: string, status: AppStatus): Promise<boolean> {

--- a/apps/meteor/ee/server/lib/audit/functions.ts
+++ b/apps/meteor/ee/server/lib/audit/functions.ts
@@ -42,7 +42,7 @@ const getRoomInfoByAuditParams = async ({
 
 	if (type === 'l') {
 		const extraQuery = await callbacks.run('livechat.applyRoomRestrictions', {}, { userId });
-		const rooms: IRoom[] = await LivechatRooms.findByVisitorIdAndAgentId(
+		const rooms = await LivechatRooms.findByVisitorIdAndAgentId(
 			visitor,
 			agent,
 			{
@@ -176,7 +176,7 @@ export const auditGetOmnichannelMessagesMethod = async (
 	// No livechat.applyRoomRestrictions here (unlike the type 'l' path in getRoomInfoByAuditParams): this
 	// mirrors the original DDP auditGetOmnichannelMessages. Access is gated by the can-audit permission and
 	// audit is intended to span all omnichannel rooms, so unit/visibility restrictions are not applied.
-	const rooms: IRoom[] = await LivechatRooms.findByVisitorIdAndAgentId(visitor, agent, {
+	const rooms = await LivechatRooms.findByVisitorIdAndAgentId(visitor, agent, {
 		projection: { _id: 1 },
 	}).toArray();
 	// keep rids an array — `$in: undefined` throws "$in needs an array" when no rooms match

--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -8,8 +8,8 @@ import { settings } from '../../../../server/settings';
 
 // debounced function by roomId, so multiple calls within 2 seconds to same roomId runs only once
 const list: Record<string, NodeJS.Timeout> = {};
-const debounceByRoomId = function (fn: (room: IRoom) => Promise<void>) {
-	return function (this: unknown, room: IRoom) {
+const debounceByRoomId = function <T extends Pick<IRoom, '_id'>>(fn: (room: T) => Promise<void>) {
+	return function (this: unknown, room: T) {
 		clearTimeout(list[room._id]);
 		list[room._id] = setTimeout(() => {
 			void fn.call(this, room);
@@ -18,7 +18,7 @@ const debounceByRoomId = function (fn: (room: IRoom) => Promise<void>) {
 	};
 };
 
-const updateMessages = debounceByRoomId(async ({ _id, lm }: IRoom) => {
+const updateMessages = debounceByRoomId(async ({ _id, lm }: Pick<IRoom, '_id' | 'lm'>) => {
 	// @TODO maybe store firstSubscription in room object so we don't need to call the above update method
 	const firstSubscription = await Subscriptions.getMinimumLastSeenByRoomId(_id);
 	if (!firstSubscription?.ls) {

--- a/apps/meteor/ee/server/lib/omnichannel/business-hour/lib/business-hour.ts
+++ b/apps/meteor/ee/server/lib/omnichannel/business-hour/lib/business-hour.ts
@@ -30,7 +30,7 @@ export async function findBusinessHours(userId: string, { offset, count, sort }:
 	const businessHoursWithDepartments = await Promise.all(
 		businessHours.map(async (businessHour) => {
 			const currentDepartments = await LivechatDepartment.findByBusinessHourId(businessHour._id, {
-				projection: { _id: 1 },
+				projection: { _id: 1, name: 1 },
 			}).toArray();
 
 			if (currentDepartments.length) {

--- a/apps/meteor/ee/server/models/LivechatUnit.ts
+++ b/apps/meteor/ee/server/models/LivechatUnit.ts
@@ -3,5 +3,4 @@ import { registerModel } from '@rocket.chat/models';
 import { LivechatUnitRaw } from './raw/LivechatUnit';
 import { db } from '../../../server/database/utils';
 
-// @ts-expect-error - Overriding base types :)
 registerModel('ILivechatUnitModel', new LivechatUnitRaw(db));

--- a/apps/meteor/ee/server/models/raw/CannedResponse.ts
+++ b/apps/meteor/ee/server/models/raw/CannedResponse.ts
@@ -1,7 +1,7 @@
 import type { IOmnichannelCannedResponse } from '@rocket.chat/core-typings';
 import type { ICannedResponseModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { BaseRaw } from '@rocket.chat/models';
-import type { Db, DeleteResult, FindCursor, FindOptions, IndexDescription, UpdateFilter, Document } from 'mongodb';
+import type { Db, DeleteResult, FindCursor, IndexDescription, UpdateFilter, Document } from 'mongodb';
 
 // TODO need to define type for CannedResponse object
 export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> implements ICannedResponseModel {
@@ -64,13 +64,19 @@ export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> imple
 		return Object.assign(record, { _id });
 	}
 
-	override findOneById(_id: string, options?: FindOptions<IOmnichannelCannedResponse>): Promise<IOmnichannelCannedResponse | null> {
+	override findOneById<
+		P extends Document = IOmnichannelCannedResponse,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(_id: string, options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		const query = { _id };
 
-		return this.findOne(query, options);
+		return this.findOne<P, O>(query, options);
 	}
 
-	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(shortcut: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		shortcut: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			shortcut,
 		};
@@ -78,7 +84,10 @@ export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> imple
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByDepartmentId<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByDepartmentId<
+		T extends Document = IOmnichannelCannedResponse,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope: 'department',
 			departmentId,

--- a/apps/meteor/ee/server/models/raw/CannedResponse.ts
+++ b/apps/meteor/ee/server/models/raw/CannedResponse.ts
@@ -1,7 +1,7 @@
 import type { IOmnichannelCannedResponse } from '@rocket.chat/core-typings';
-import type { ICannedResponseModel } from '@rocket.chat/model-typings';
+import type { ICannedResponseModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { BaseRaw } from '@rocket.chat/models';
-import type { Db, DeleteResult, FindCursor, FindOptions, IndexDescription, UpdateFilter } from 'mongodb';
+import type { Db, DeleteResult, FindCursor, FindOptions, IndexDescription, UpdateFilter, Document } from 'mongodb';
 
 // TODO need to define type for CannedResponse object
 export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> implements ICannedResponseModel {
@@ -70,21 +70,21 @@ export class CannedResponseRaw extends BaseRaw<IOmnichannelCannedResponse> imple
 		return this.findOne(query, options);
 	}
 
-	findOneByShortcut(shortcut: string, options?: FindOptions<IOmnichannelCannedResponse>): Promise<IOmnichannelCannedResponse | null> {
+	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(shortcut: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			shortcut,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByDepartmentId(departmentId: string, options?: FindOptions<IOmnichannelCannedResponse>): FindCursor<IOmnichannelCannedResponse> {
+	findByDepartmentId<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope: 'department',
 			departmentId,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	// REMOVE

--- a/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
@@ -33,7 +33,10 @@ export class LivechatDepartmentEE extends LivechatDepartmentRaw implements ILive
 		return this.updateMany({ parentId: id }, { $unset: { parentId: 1 }, $pull: { ancestors: id } });
 	}
 
-	override findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	override findActiveByUnitIds<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			enabled: true,
 			numAgents: { $gt: 0 },

--- a/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatDepartment.ts
@@ -1,5 +1,5 @@
 import type { ILivechatDepartment, RocketChatRecordDeleted, LivechatDepartmentDTO } from '@rocket.chat/core-typings';
-import type { ILivechatDepartmentModel } from '@rocket.chat/model-typings';
+import type { ILivechatDepartmentModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { LivechatDepartmentRaw } from '@rocket.chat/models';
 import type { Collection, Document, FindCursor, FindOptions, UpdateResult, Db, AggregationCursor } from 'mongodb';
 
@@ -33,7 +33,7 @@ export class LivechatDepartmentEE extends LivechatDepartmentRaw implements ILive
 		return this.updateMany({ parentId: id }, { $unset: { parentId: 1 }, $pull: { ancestors: id } });
 	}
 
-	override findActiveByUnitIds<T extends Document = ILivechatDepartment>(unitIds: string[], options: FindOptions<T> = {}): FindCursor<T> {
+	override findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			enabled: true,
 			numAgents: { $gt: 0 },
@@ -43,7 +43,7 @@ export class LivechatDepartmentEE extends LivechatDepartmentRaw implements ILive
 			},
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	override findEnabledWithAgentsAndBusinessUnit<T extends Document = ILivechatDepartment>(

--- a/apps/meteor/ee/server/models/raw/LivechatUnit.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatUnit.ts
@@ -39,10 +39,7 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 		P extends Document = IOmnichannelBusinessUnit,
 		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
 	>(_id: IOmnichannelBusinessUnit['_id'], options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
-		if (options) {
-			return this.findOne<P, O>({ _id }, options, extra);
-		}
-		return this.findOne<P, O>({ _id }, {}, extra);
+		return this.findOne<P, O>({ _id }, options, extra);
 	}
 
 	async createOrUpdateUnit(

--- a/apps/meteor/ee/server/models/raw/LivechatUnit.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatUnit.ts
@@ -21,7 +21,10 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 		super(db, 'livechat_department');
 	}
 
-	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IOmnichannelBusinessUnit>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<IOmnichannelBusinessUnit>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		return super.findPaginated<T, O>({ ...query, type: 'u' }, options);
 	}
 
@@ -155,7 +158,10 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 		return result;
 	}
 
-	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{

--- a/apps/meteor/ee/server/models/raw/LivechatUnit.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatUnit.ts
@@ -1,7 +1,7 @@
 import type { IOmnichannelBusinessUnit, ILivechatDepartment } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatUnitModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, ILivechatUnitModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { LivechatUnitMonitors, LivechatDepartment, LivechatRooms, BaseRaw } from '@rocket.chat/models';
-import type { FindOptions, Filter, FindCursor, Db, FilterOperators, UpdateResult, DeleteResult, Document, UpdateFilter } from 'mongodb';
+import type { Filter, FindCursor, Db, FilterOperators, UpdateResult, DeleteResult, Document, UpdateFilter } from 'mongodb';
 
 const addQueryRestrictions = async (originalQuery: Filter<IOmnichannelBusinessUnit> = {}, unitsFromUser?: string[]) => {
 	const query: FilterOperators<IOmnichannelBusinessUnit> = { ...originalQuery, type: 'u' };
@@ -21,32 +21,21 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 		super(db, 'livechat_department');
 	}
 
-	findPaginatedUnits(
-		query: Filter<IOmnichannelBusinessUnit>,
-		options?: FindOptions<IOmnichannelBusinessUnit>,
-	): FindPaginated<FindCursor<IOmnichannelBusinessUnit>> {
-		return super.findPaginated({ ...query, type: 'u' }, options);
+	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IOmnichannelBusinessUnit>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+		return super.findPaginated<T, O>({ ...query, type: 'u' }, options);
 	}
 
 	// @ts-expect-error - Overriding base types :)
-	async findOne<P extends Document = IOmnichannelBusinessUnit>(
-		originalQuery: Filter<IOmnichannelBusinessUnit>,
-		options: FindOptions<IOmnichannelBusinessUnit>,
-		extra?: Record<string, any>,
-	): Promise<P | null> {
+	async findOne<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(originalQuery: Filter<IOmnichannelBusinessUnit>, options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
 		const query = await addQueryRestrictions(originalQuery, extra?.unitsFromUser);
 		return this.col.findOne<P>(query, options);
 	}
 
-	override async findOneById<P extends Document = IOmnichannelBusinessUnit>(
-		_id: IOmnichannelBusinessUnit['_id'],
-		options: FindOptions<IOmnichannelBusinessUnit>,
-		extra?: Record<string, any>,
-	): Promise<P | null> {
+	override async findOneById<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: IOmnichannelBusinessUnit['_id'], options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
 		if (options) {
-			return this.findOne<P>({ _id }, options, extra);
+			return this.findOne<P, O>({ _id }, options, extra);
 		}
-		return this.findOne<P>({ _id }, {}, extra);
+		return this.findOne<P, O>({ _id }, {}, extra);
 	}
 
 	async createOrUpdateUnit(
@@ -162,7 +151,7 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 		return result;
 	}
 
-	findOneByIdOrName(_idOrName: string, options: FindOptions<IOmnichannelBusinessUnit>): Promise<IOmnichannelBusinessUnit | null> {
+	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -174,7 +163,7 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	async findByMonitorId(monitorId: string): Promise<string[]> {

--- a/apps/meteor/ee/server/models/raw/LivechatUnit.ts
+++ b/apps/meteor/ee/server/models/raw/LivechatUnit.ts
@@ -26,12 +26,19 @@ export class LivechatUnitRaw extends BaseRaw<IOmnichannelBusinessUnit> implement
 	}
 
 	// @ts-expect-error - Overriding base types :)
-	async findOne<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(originalQuery: Filter<IOmnichannelBusinessUnit>, options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
+	async findOne<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		originalQuery: Filter<IOmnichannelBusinessUnit>,
+		options?: O,
+		extra?: Record<string, any>,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		const query = await addQueryRestrictions(originalQuery, extra?.unitsFromUser);
-		return this.col.findOne<P>(query, options);
+		return super.findOne<P, O>(query, options);
 	}
 
-	override async findOneById<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: IOmnichannelBusinessUnit['_id'], options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
+	override async findOneById<
+		P extends Document = IOmnichannelBusinessUnit,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(_id: IOmnichannelBusinessUnit['_id'], options?: O, extra?: Record<string, any>): Promise<DocumentWithProjection<P, O> | null> {
 		if (options) {
 			return this.findOne<P, O>({ _id }, options, extra);
 		}

--- a/apps/meteor/ee/server/models/raw/ServiceLevelAgreements.ts
+++ b/apps/meteor/ee/server/models/raw/ServiceLevelAgreements.ts
@@ -1,5 +1,5 @@
 import type { IOmnichannelServiceLevelAgreements } from '@rocket.chat/core-typings';
-import type { IOmnichannelServiceLevelAgreementsModel } from '@rocket.chat/model-typings/src';
+import type { IOmnichannelServiceLevelAgreementsModel } from '@rocket.chat/model-typings';
 import { BaseRaw } from '@rocket.chat/models';
 import type { Db, IndexDescription } from 'mongodb';
 

--- a/apps/meteor/ee/server/settings/settings.ts
+++ b/apps/meteor/ee/server/settings/settings.ts
@@ -7,7 +7,7 @@ import { Meteor } from 'meteor/meteor';
 import { settings, SettingsEvents } from '../../../server/settings';
 import { use } from '../../../server/settings/Middleware';
 
-export function changeSettingValue(record: ISetting): SettingValue {
+export function changeSettingValue(record: Pick<ISetting, 'value' | 'enterprise' | 'invalidValue' | 'modules'>): SettingValue {
 	if (!record.enterprise) {
 		return record.value;
 	}
@@ -40,7 +40,7 @@ settings.set = use(settings.set, (context, next) => {
 	return next({ ...record, value });
 });
 
-SettingsEvents.on('fetch-settings', (settings: Array<ISetting>): void => {
+SettingsEvents.on('fetch-settings', (settings): void => {
 	for (const setting of settings) {
 		const changedValue = changeSettingValue(setting);
 		if (changedValue === undefined) {

--- a/apps/meteor/ee/tests/unit/server/hooks/messages/BeforeSaveCannedResponse.tests.ts
+++ b/apps/meteor/ee/tests/unit/server/hooks/messages/BeforeSaveCannedResponse.tests.ts
@@ -39,7 +39,7 @@ class LivechatVisitorsModel extends BaseRaw<any> {
 }
 
 class UsersModel extends BaseRaw<any> {
-	override async findOneById() {
+	override async findOneById(): Promise<any> {
 		return {
 			name: 'John Doe Agent',
 		};

--- a/apps/meteor/server/api/lib/webdav.ts
+++ b/apps/meteor/server/api/lib/webdav.ts
@@ -1,7 +1,7 @@
-import type { IWebdavAccount } from '@rocket.chat/core-typings';
+import type { IWebdavAccountIntegration } from '@rocket.chat/core-typings';
 import { WebdavAccounts } from '@rocket.chat/models';
 
-export async function findWebdavAccountsByUserId({ uid }: { uid: string }): Promise<IWebdavAccount[]> {
+export async function findWebdavAccountsByUserId({ uid }: { uid: string }): Promise<IWebdavAccountIntegration[]> {
 	return WebdavAccounts.findWithUserId(uid, {
 		projection: {
 			_id: 1,

--- a/apps/meteor/server/api/v1/middlewares/authentication.ts
+++ b/apps/meteor/server/api/v1/middlewares/authentication.ts
@@ -25,7 +25,8 @@ export function authenticationMiddleware(
 		const { 'x-user-id': userId, 'x-auth-token': authToken } = req.headers;
 
 		if (userId && authToken) {
-			req.user = (await Users.findOneByIdAndLoginToken(userId as string, hashLoginToken(authToken as string))) || undefined;
+			const user = await Users.findOneByIdAndLoginToken(userId as string, hashLoginToken(authToken as string));
+			req.user = user || undefined;
 		} else {
 			const { authorization } = req.headers;
 			const accessToken = typeof req.query.access_token === 'string' ? req.query.access_token : undefined;

--- a/apps/meteor/server/api/v1/omnichannel/lib/departments.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/departments.ts
@@ -141,7 +141,7 @@ export async function findDepartmentsToAutocomplete({
 	selector,
 	onlyMyDepartments = false,
 	showArchived = false,
-}: FindDepartmentToAutocompleteParams): Promise<{ items: ILivechatDepartment[] }> {
+}: FindDepartmentToAutocompleteParams): Promise<{ items: Pick<ILivechatDepartment, '_id' | 'name'>[] }> {
 	const { exceptions = [] } = selector;
 	let { conditions = {} } = selector;
 

--- a/apps/meteor/server/api/v1/omnichannel/lib/livechat.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/livechat.ts
@@ -52,7 +52,9 @@ export function findGuest(token: string): Promise<ILivechatVisitor | null> {
 	return LivechatVisitors.getVisitorByToken(token);
 }
 
-export function findGuestWithoutActivity(token: string): Promise<ILivechatVisitor | null> {
+export function findGuestWithoutActivity(
+	token: string,
+): Promise<Pick<ILivechatVisitor, '_id' | 'name' | 'username' | 'token' | 'visitorEmails' | 'department'> | null> {
 	return LivechatVisitors.getVisitorByToken(token, { projection: { name: 1, username: 1, token: 1, visitorEmails: 1, department: 1 } });
 }
 

--- a/apps/meteor/server/api/v1/omnichannel/lib/rooms.ts
+++ b/apps/meteor/server/api/v1/omnichannel/lib/rooms.ts
@@ -73,7 +73,7 @@ export async function findRooms({
 			projection: { name: 1 },
 		}).toArray();
 
-		rooms.forEach((room: IOmnichannelRoom & { department?: ILivechatDepartment }) => {
+		rooms.forEach((room: IOmnichannelRoom & { department?: Pick<ILivechatDepartment, '_id' | 'name'> }) => {
 			if (!room.departmentId) {
 				return;
 			}

--- a/apps/meteor/server/api/v1/omnichannel/statistics.ts
+++ b/apps/meteor/server/api/v1/omnichannel/statistics.ts
@@ -49,7 +49,7 @@ API.v1.addRoute(
 				throw new Error('invalid-chart-name');
 			}
 
-			const user = await Users.findOneById(this.userId, { projection: { _id: 1, utcOffset: 1 } });
+			const user = await Users.findOneById(this.userId, { projection: { _id: 1, utcOffset: 1, language: 1 } });
 			const language = user?.language || settings.get('Language') || 'en';
 
 			return API.v1.success(

--- a/apps/meteor/server/api/v1/settings.ts
+++ b/apps/meteor/server/api/v1/settings.ts
@@ -32,6 +32,7 @@ import { disableCustomScripts } from '../../lib/shared/disableCustomScripts';
 import { addOAuthServiceMethod } from '../../meteor-methods/auth/addOAuthService';
 import { removeCustomOAuthSettings } from '../../meteor-methods/auth/removeOAuthService';
 import { SettingsEvents, settings } from '../../settings';
+import type { FetchedSetting } from '../../settings/SettingsRegistry';
 import { checkSettingValueBounds } from '../../settings/checkSettingValueBonds';
 import { updateAuditedByUser } from '../../settings/lib/auditedSettingUpdates';
 import { saveSettingsBulk } from '../../settings/lib/saveSettingsBulk';
@@ -45,7 +46,7 @@ async function fetchSettings(
 	offset: FindOptions<ISetting>['skip'],
 	count: FindOptions<ISetting>['limit'],
 	fields: FindOptions<ISetting>['projection'],
-): Promise<{ settings: ISetting[]; totalCount: number }> {
+): Promise<{ settings: FetchedSetting[]; totalCount: number }> {
 	const { cursor, totalCount } = Settings.findPaginated(query || {}, {
 		sort: sort || { _id: 1 },
 		skip: offset,
@@ -59,7 +60,7 @@ async function fetchSettings(
 	return { settings: settingsList, totalCount: total };
 }
 
-const settingsPublicResponseSchema = ajv.compile<{ settings: ISetting[]; count: number; offset: number; total: number }>({
+const settingsPublicResponseSchema = ajv.compile<{ settings: FetchedSetting[]; count: number; offset: number; total: number }>({
 	type: 'object',
 	properties: {
 		settings: { type: 'array', items: { type: 'object' } },
@@ -89,7 +90,7 @@ const addCustomOAuthBodySchema = ajv.compile<{ name: string }>({
 	additionalProperties: false,
 });
 
-const settingsListResponseSchema = ajv.compile<{ settings: ISetting[]; count: number; offset: number; total: number }>({
+const settingsListResponseSchema = ajv.compile<{ settings: FetchedSetting[]; count: number; offset: number; total: number }>({
 	type: 'object',
 	properties: {
 		settings: { type: 'array', items: { type: 'object' } },

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -12,7 +12,10 @@ import { deleteRoom } from '../../lib/rooms/deleteRoom';
  * have to be applied on top of the stored room, otherwise the discussion metadata would always
  * be left one message behind.
  */
-const withPendingRoomChanges = (room: IRoom, roomUpdater?: Updater<IRoom>): IRoom => {
+const withPendingRoomChanges = (
+	room: Pick<IRoom, '_id' | 'msgs' | 'lm'>,
+	roomUpdater?: Updater<IRoom>,
+): Pick<IRoom, '_id' | 'msgs' | 'lm'> => {
 	const { $inc, $set } = roomUpdater?.getRawUpdateFilter() ?? {};
 	const pendingMsgs = typeof $inc?.msgs === 'number' ? $inc.msgs : 0;
 	const pendingLm = $set?.lm instanceof Date ? $set.lm : undefined;

--- a/apps/meteor/server/lib/2fa/code/EmailCheck.ts
+++ b/apps/meteor/server/lib/2fa/code/EmailCheck.ts
@@ -1,10 +1,10 @@
-import { isOAuthUser, type IUser } from '@rocket.chat/core-typings';
+import { isOAuthUser } from '@rocket.chat/core-typings';
 import { Users } from '@rocket.chat/models';
 import { Random } from '@rocket.chat/random';
 import bcrypt from 'bcrypt';
 import { Accounts } from 'meteor/accounts-base';
 
-import type { ICodeCheck, IProcessInvalidCodeResult } from './ICodeCheck';
+import type { ICodeCheck, IProcessInvalidCodeResult, TwoFactorUser } from './ICodeCheck';
 import { settings } from '../../../settings';
 import { i18n } from '../../i18n';
 import * as Mailer from '../../notifications/email/api';
@@ -12,14 +12,14 @@ import * as Mailer from '../../notifications/email/api';
 export class EmailCheck implements ICodeCheck {
 	public readonly name: string = 'email';
 
-	private getUserVerifiedEmails(user: IUser): string[] {
+	private getUserVerifiedEmails(user: TwoFactorUser): string[] {
 		if (!Array.isArray(user.emails)) {
 			return [];
 		}
 		return user.emails.filter(({ verified }) => verified).map((e) => e.address);
 	}
 
-	public isEnabled(user: IUser): boolean {
+	public isEnabled(user: TwoFactorUser): boolean {
 		if (!settings.get('Accounts_TwoFactorAuthentication_By_Email_Enabled')) {
 			return false;
 		}
@@ -35,7 +35,7 @@ export class EmailCheck implements ICodeCheck {
 		return this.getUserVerifiedEmails(user).length > 0;
 	}
 
-	private async send2FAEmail(address: string, random: string, user: IUser): Promise<void> {
+	private async send2FAEmail(address: string, random: string, user: TwoFactorUser): Promise<void> {
 		const language = user.language || settings.get('Language') || 'en';
 
 		const t = i18n.getFixedT(language);
@@ -68,7 +68,7 @@ ${t('If_you_didnt_try_to_login_in_your_account_please_ignore_this_email')}
 		});
 	}
 
-	public async verify(user: IUser, codeFromEmail: string): Promise<boolean> {
+	public async verify(user: TwoFactorUser, codeFromEmail: string): Promise<boolean> {
 		if (!this.isEnabled(user)) {
 			return false;
 		}
@@ -96,7 +96,7 @@ ${t('If_you_didnt_try_to_login_in_your_account_please_ignore_this_email')}
 		return false;
 	}
 
-	public async sendEmailCode(user: IUser): Promise<void> {
+	public async sendEmailCode(user: TwoFactorUser): Promise<void> {
 		const emails = this.getUserVerifiedEmails(user);
 		const random = Random._randomString(6, '0123456789');
 		const encryptedRandom = await bcrypt.hash(random, Accounts._bcryptRounds());
@@ -112,7 +112,7 @@ ${t('If_you_didnt_try_to_login_in_your_account_please_ignore_this_email')}
 		}
 	}
 
-	public async processInvalidCode(user: IUser): Promise<IProcessInvalidCodeResult> {
+	public async processInvalidCode(user: TwoFactorUser): Promise<IProcessInvalidCodeResult> {
 		await Users.removeExpiredEmailCodeOfUserId(user._id);
 
 		// Generate new code if the there isn't any code with more than 5 minutes to expire
@@ -143,7 +143,7 @@ ${t('If_you_didnt_try_to_login_in_your_account_please_ignore_this_email')}
 		};
 	}
 
-	public async maxFaildedAttemtpsReached(user: IUser) {
+	public async maxFaildedAttemtpsReached(user: TwoFactorUser) {
 		const maxAttempts = settings.get<number>('Accounts_TwoFactorAuthentication_Max_Invalid_Email_Code_Attempts');
 		return Users.maxInvalidEmailCodeAttemptsReached(user._id, maxAttempts);
 	}

--- a/apps/meteor/server/lib/2fa/code/EmailCheckForOAuth.ts
+++ b/apps/meteor/server/lib/2fa/code/EmailCheckForOAuth.ts
@@ -1,21 +1,21 @@
-import type { IUser } from '@rocket.chat/core-typings';
 import { TwoFactorChallenges } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 
 import { EmailCheck } from './EmailCheck';
+import type { TwoFactorUser } from './ICodeCheck';
 
 export class EmailCheckForOAuth extends EmailCheck {
 	public override readonly name = 'email-oauth';
 
 	public readonly method = 'email';
 
-	public async sendTwoFactorChallenge(user: IUser): Promise<string> {
+	public async sendTwoFactorChallenge(user: TwoFactorUser): Promise<string> {
 		const challengeId = await TwoFactorChallenges.createTwoFactorChallenge(user._id, 'email');
 		await this.sendEmailCode(user);
 		return challengeId;
 	}
 
-	public async verifyEmailTwoFactorChallenge(user: IUser, challengeId: string, code: string): Promise<boolean> {
+	public async verifyEmailTwoFactorChallenge(user: TwoFactorUser, challengeId: string, code: string): Promise<boolean> {
 		const challenge = await TwoFactorChallenges.findOneByPendingChallengeId(challengeId);
 		if (!challenge) {
 			return false;

--- a/apps/meteor/server/lib/2fa/code/ICodeCheck.ts
+++ b/apps/meteor/server/lib/2fa/code/ICodeCheck.ts
@@ -1,5 +1,8 @@
 import type { IUser } from '@rocket.chat/core-typings';
 
+/** The user fields the 2FA checks read; `getUserForCheck` projects exactly these. */
+export type TwoFactorUser = Pick<IUser, '_id' | 'username' | 'emails' | 'language' | 'createdAt' | 'services'>;
+
 export interface IProcessInvalidCodeResult {
 	codeGenerated: boolean;
 	codeExpires?: Date;
@@ -9,11 +12,11 @@ export interface IProcessInvalidCodeResult {
 export interface ICodeCheck {
 	readonly name: string;
 
-	isEnabled(user: IUser, force?: boolean): boolean;
+	isEnabled(user: TwoFactorUser, force?: boolean): boolean;
 
-	verify(user: IUser, code: string, force?: boolean): Promise<boolean>;
+	verify(user: TwoFactorUser, code: string, force?: boolean): Promise<boolean>;
 
-	processInvalidCode(user: IUser): Promise<IProcessInvalidCodeResult>;
+	processInvalidCode(user: TwoFactorUser): Promise<IProcessInvalidCodeResult>;
 
-	maxFaildedAttemtpsReached(user: IUser): Promise<boolean>;
+	maxFaildedAttemtpsReached(user: TwoFactorUser): Promise<boolean>;
 }

--- a/apps/meteor/server/lib/2fa/code/PasswordCheckFallback.ts
+++ b/apps/meteor/server/lib/2fa/code/PasswordCheckFallback.ts
@@ -1,14 +1,13 @@
-import type { IUser } from '@rocket.chat/core-typings';
 import { Accounts } from 'meteor/accounts-base';
 import type { Meteor } from 'meteor/meteor';
 
-import type { ICodeCheck, IProcessInvalidCodeResult } from './ICodeCheck';
+import type { ICodeCheck, IProcessInvalidCodeResult, TwoFactorUser } from './ICodeCheck';
 import { settings } from '../../../settings';
 
 export class PasswordCheckFallback implements ICodeCheck {
 	public readonly name = 'password';
 
-	public isEnabled(user: IUser, force: boolean): boolean {
+	public isEnabled(user: TwoFactorUser, force: boolean): boolean {
 		if (force) {
 			return true;
 		}
@@ -20,7 +19,7 @@ export class PasswordCheckFallback implements ICodeCheck {
 		return false;
 	}
 
-	public async verify(user: IUser, code: string, force: boolean): Promise<boolean> {
+	public async verify(user: TwoFactorUser, code: string, force: boolean): Promise<boolean> {
 		if (!this.isEnabled(user, force)) {
 			return false;
 		}
@@ -43,7 +42,7 @@ export class PasswordCheckFallback implements ICodeCheck {
 		};
 	}
 
-	public async maxFaildedAttemtpsReached(_user: IUser): Promise<boolean> {
+	public async maxFaildedAttemtpsReached(_user: TwoFactorUser): Promise<boolean> {
 		return false;
 	}
 }

--- a/apps/meteor/server/lib/2fa/code/TOTPCheck.ts
+++ b/apps/meteor/server/lib/2fa/code/TOTPCheck.ts
@@ -1,13 +1,11 @@
-import type { IUser } from '@rocket.chat/core-typings';
-
-import type { ICodeCheck, IProcessInvalidCodeResult } from './ICodeCheck';
+import type { ICodeCheck, IProcessInvalidCodeResult, TwoFactorUser } from './ICodeCheck';
 import { settings } from '../../../settings';
 import { TOTP } from '../lib/totp';
 
 export class TOTPCheck implements ICodeCheck {
 	public readonly name: string = 'totp';
 
-	public isEnabled(user: IUser): boolean {
+	public isEnabled(user: TwoFactorUser): boolean {
 		if (!settings.get('Accounts_TwoFactorAuthentication_By_TOTP_Enabled')) {
 			return false;
 		}
@@ -15,7 +13,7 @@ export class TOTPCheck implements ICodeCheck {
 		return user.services?.totp?.enabled === true;
 	}
 
-	public async verify(user: IUser, code: string): Promise<boolean> {
+	public async verify(user: TwoFactorUser, code: string): Promise<boolean> {
 		if (!this.isEnabled(user)) {
 			return false;
 		}
@@ -39,7 +37,7 @@ export class TOTPCheck implements ICodeCheck {
 		};
 	}
 
-	public async maxFaildedAttemtpsReached(_user: IUser): Promise<boolean> {
+	public async maxFaildedAttemtpsReached(_user: TwoFactorUser): Promise<boolean> {
 		return false;
 	}
 }

--- a/apps/meteor/server/lib/2fa/code/TOTPCheckForOAuth.ts
+++ b/apps/meteor/server/lib/2fa/code/TOTPCheckForOAuth.ts
@@ -1,7 +1,7 @@
-import type { IUser } from '@rocket.chat/core-typings';
 import { TwoFactorChallenges } from '@rocket.chat/models';
 import { Meteor } from 'meteor/meteor';
 
+import type { TwoFactorUser } from './ICodeCheck';
 import { TOTPCheck } from './TOTPCheck';
 
 export class TOTPCheckForOAuth extends TOTPCheck {
@@ -9,11 +9,11 @@ export class TOTPCheckForOAuth extends TOTPCheck {
 
 	public readonly method = 'totp';
 
-	public async sendTwoFactorChallenge(user: IUser): Promise<string> {
+	public async sendTwoFactorChallenge(user: TwoFactorUser): Promise<string> {
 		return TwoFactorChallenges.createTwoFactorChallenge(user._id, 'totp');
 	}
 
-	public async verifyEmailTwoFactorChallenge(user: IUser, challengeId: string, code: string): Promise<boolean> {
+	public async verifyEmailTwoFactorChallenge(user: TwoFactorUser, challengeId: string, code: string): Promise<boolean> {
 		const challenge = await TwoFactorChallenges.findOneByPendingChallengeId(challengeId);
 		if (!challenge) {
 			return false;

--- a/apps/meteor/server/lib/2fa/code/index.ts
+++ b/apps/meteor/server/lib/2fa/code/index.ts
@@ -6,7 +6,7 @@ import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 
 import { EmailCheck } from './EmailCheck';
-import type { ICodeCheck } from './ICodeCheck';
+import type { ICodeCheck, TwoFactorUser } from './ICodeCheck';
 import { PasswordCheckFallback } from './PasswordCheckFallback';
 import { TOTPCheck } from './TOTPCheck';
 import { settings } from '../../../settings';
@@ -27,7 +27,7 @@ const checkMethods = new Map<string, ICodeCheck>();
 checkMethods.set(totpCheck.name, totpCheck);
 checkMethods.set(emailCheck.name, emailCheck);
 
-function getMethodByNameOrFirstActiveForUser(user: IUser, name?: string): ICodeCheck | undefined {
+function getMethodByNameOrFirstActiveForUser(user: TwoFactorUser, name?: string): ICodeCheck | undefined {
 	if (name && checkMethods.has(name)) {
 		return checkMethods.get(name);
 	}
@@ -35,7 +35,7 @@ function getMethodByNameOrFirstActiveForUser(user: IUser, name?: string): ICodeC
 	return Array.from(checkMethods.values()).find((method) => method.isEnabled(user));
 }
 
-function getAvailableMethodNames(user: IUser): string[] {
+function getAvailableMethodNames(user: TwoFactorUser): string[] {
 	return (
 		Array.from(checkMethods)
 			.filter(([, method]) => method.isEnabled(user))
@@ -43,9 +43,10 @@ function getAvailableMethodNames(user: IUser): string[] {
 	);
 }
 
-export async function getUserForCheck(userId: string): Promise<IUser | null> {
+export async function getUserForCheck(userId: string): Promise<TwoFactorUser | null> {
 	return Users.findOneById(userId, {
 		projection: {
+			username: 1,
 			emails: 1,
 			language: 1,
 			createdAt: 1,
@@ -76,7 +77,7 @@ export function getRememberDate(from: Date = new Date()): Date | undefined {
 	return expires;
 }
 
-function isAuthorizedForToken(connection: IMethodConnection, user: IUser, options: ITwoFactorOptions): boolean {
+function isAuthorizedForToken(connection: IMethodConnection, user: TwoFactorUser, options: ITwoFactorOptions): boolean {
 	// Resolve the current login token from both transports:
 	// - DDP: the login flow registers it in `Accounts._accountData`, read via `_getLoginToken`.
 	// - REST: it is not registered in account data, so it is carried on `connection.token`.
@@ -140,7 +141,7 @@ export async function rememberAuthorizationByToken(token: string, userId: IUser[
 	await Users.setTwoFactorAuthorizationHashAndUntilForUserIdAndToken(user._id, token, getFingerprintFromConnection(connection), expires);
 }
 
-async function rememberAuthorization(connection: IMethodConnection, user: IUser): Promise<void> {
+async function rememberAuthorization(connection: IMethodConnection, user: TwoFactorUser): Promise<void> {
 	// Same dual-transport resolution as `isAuthorizedForToken`: DDP reads from `Accounts._accountData`
 	// via `_getLoginToken`, REST falls back to the token carried on `connection.token`.
 	const currentToken = Accounts._getLoginToken(connection.id) || connection.token;
@@ -163,14 +164,18 @@ async function rememberAuthorization(connection: IMethodConnection, user: IUser)
 }
 
 interface ICheckCodeForUser {
-	user: IUser | string;
+	user: TwoFactorUser | string;
 	code?: string;
 	method?: string;
 	options?: ITwoFactorOptions;
 	connection?: IMethodConnection;
 }
 
-export const getSecondFactorMethod = (user: IUser, method: string | undefined, options: ITwoFactorOptions): ICodeCheck | undefined => {
+export const getSecondFactorMethod = (
+	user: TwoFactorUser,
+	method: string | undefined,
+	options: ITwoFactorOptions,
+): ICodeCheck | undefined => {
 	// try first getting one of the available methods or the one that was already provided
 	const selectedMethod = getMethodByNameOrFirstActiveForUser(user, method);
 	if (selectedMethod) {
@@ -197,7 +202,7 @@ export async function checkCodeForUser({ user, code, method, options = {}, conne
 		return true;
 	}
 
-	let existingUser: IUser | null;
+	let existingUser: TwoFactorUser | null;
 	if (typeof user === 'string') {
 		existingUser = await getUserForCheck(user);
 	} else {

--- a/apps/meteor/server/lib/messaging/getHiddenSystemMessages.ts
+++ b/apps/meteor/server/lib/messaging/getHiddenSystemMessages.ts
@@ -1,6 +1,6 @@
 import type { MessageTypesValues, IRoom } from '@rocket.chat/core-typings';
 
-export const getHiddenSystemMessages = (room: IRoom, hiddenSystemMessages: MessageTypesValues[]): MessageTypesValues[] => {
+export const getHiddenSystemMessages = (room: Pick<IRoom, 'sysMes'>, hiddenSystemMessages: MessageTypesValues[]): MessageTypesValues[] => {
 	const hiddenTypes = hiddenSystemMessages.reduce((array, value): MessageTypesValues[] => {
 		const newValue: MessageTypesValues[] = value === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [value];
 		return [...array, ...newValue];

--- a/apps/meteor/server/lib/omnichannel/QueueManager.ts
+++ b/apps/meteor/server/lib/omnichannel/QueueManager.ts
@@ -58,7 +58,8 @@ export const saveQueueInquiry = async (inquiry: ILivechatInquiryRecord) => {
  *  @deprecated
  */
 export const queueInquiry = async (inquiry: ILivechatInquiryRecord, defaultAgent?: SelectedAgent) => {
-	const room = await LivechatRooms.findOneById(inquiry.rid, { projection: { v: 1 } });
+	// No projection: requeueInquiry forwards the room into the routing pipeline, which expects a full room.
+	const room = await LivechatRooms.findOneById(inquiry.rid);
 
 	if (!room) {
 		await saveQueueInquiry(inquiry);

--- a/apps/meteor/server/lib/omnichannel/analytics/dashboards.ts
+++ b/apps/meteor/server/lib/omnichannel/analytics/dashboards.ts
@@ -36,7 +36,7 @@ const getProductivityMetricsAsync = async ({
 	start: string;
 	end: string;
 	departmentId?: string;
-	user: IUser;
+	user: Pick<IUser, '_id' | 'utcOffset' | 'language'>;
 }) => {
 	if (!start || !end) {
 		throw new Error('"start" and "end" must be provided');
@@ -83,7 +83,7 @@ const getAgentsProductivityMetricsAsync = async ({
 	start: string;
 	end: string;
 	departmentId?: string;
-	user: IUser;
+	user: Pick<IUser, '_id' | 'utcOffset' | 'language'>;
 }) => {
 	if (!start || !end) {
 		throw new Error('"start" and "end" must be provided');
@@ -230,7 +230,7 @@ const getConversationsMetricsAsync = async ({
 	start: string;
 	end: string;
 	departmentId?: string;
-	user: IUser;
+	user: Pick<IUser, '_id' | 'utcOffset' | 'language'>;
 }) => {
 	if (!start || !end) {
 		throw new Error('"start" and "end" must be provided');

--- a/apps/meteor/server/lib/omnichannel/business-hour/Helper.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/Helper.ts
@@ -11,7 +11,7 @@ import { businessHourLogger } from '../logger';
 export { filterBusinessHoursThatMustBeOpened };
 
 export const filterBusinessHoursThatMustBeOpenedByDay = async (
-	businessHours: ILivechatBusinessHour[],
+	businessHours: Pick<ILivechatBusinessHour, '_id' | 'type' | 'active' | 'workHours'>[],
 	day: string, // Format: moment.format('dddd')
 ): Promise<Pick<ILivechatBusinessHour, '_id' | 'type'>[]> => {
 	return filterBusinessHoursThatMustBeOpened(

--- a/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
@@ -514,10 +514,8 @@ describe('finish time boundary', () => {
 		const bh = await filterBusinessHoursThatMustBeOpened([
 			{
 				_id: '68516f256ebb4bdceda2757f',
-				name: '',
 				active: true,
 				type: LivechatBusinessHourTypes.DEFAULT,
-				ts: new Date(),
 				workHours: [
 					{
 						day: 'Monday',
@@ -535,10 +533,6 @@ describe('finish time boundary', () => {
 						code: '',
 					},
 				],
-				timezone: {
-					name: 'UTC',
-					utc: '+00:00',
-				},
 			},
 		]);
 

--- a/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
@@ -9,7 +9,6 @@ describe('different timezones between server and business hours saturday ', () =
 		const bh = await filterBusinessHoursThatMustBeOpened([
 			{
 				_id: '65c40fa9052d6750ae25df83',
-				name: '',
 				active: true,
 				type: LivechatBusinessHourTypes.DEFAULT,
 				workHours: [
@@ -41,11 +40,6 @@ describe('different timezones between server and business hours saturday ', () =
 						code: '',
 					},
 				],
-				timezone: {
-					name: 'Asia/Kolkata',
-					utc: '+05:30',
-				},
-				ts: new Date(),
 			},
 		]);
 
@@ -62,8 +56,6 @@ describe('different timezones between server and business hours sunday ', () => 
 				_id: '68516f256ebb4bdceda2757e',
 				active: true,
 				type: LivechatBusinessHourTypes.DEFAULT,
-				ts: new Date(),
-				name: '',
 				workHours: [
 					{
 						day: 'Sunday',
@@ -255,10 +247,6 @@ describe('different timezones between server and business hours sunday ', () => 
 						code: '',
 					},
 				],
-				timezone: {
-					name: 'Asia/Kolkata',
-					utc: '+05:30',
-				},
 			},
 		]);
 
@@ -275,8 +263,6 @@ describe('regular business hours', () => {
 				_id: '68516f256ebb4bdceda2757e',
 				active: true,
 				type: LivechatBusinessHourTypes.DEFAULT,
-				ts: new Date(),
-				name: '',
 				workHours: [
 					{
 						day: 'Sunday',
@@ -468,10 +454,6 @@ describe('regular business hours', () => {
 						code: '',
 					},
 				],
-				timezone: {
-					name: 'America/Sao_Paulo',
-					utc: '-3',
-				},
 			},
 		]);
 

--- a/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.ts
@@ -2,7 +2,7 @@ import type { ILivechatBusinessHour } from '@rocket.chat/core-typings';
 import moment from 'moment';
 
 export const filterBusinessHoursThatMustBeOpened = async (
-	businessHours: Omit<ILivechatBusinessHour, '_updatedAt'>[],
+	businessHours: Pick<ILivechatBusinessHour, '_id' | 'type' | 'active' | 'workHours'>[],
 ): Promise<Pick<ILivechatBusinessHour, '_id' | 'type'>[]> => {
 	const currentTime = moment(moment().format('dddd:HH:mm:ss'), 'dddd:HH:mm:ss');
 

--- a/apps/meteor/server/lib/omnichannel/custom-fields.ts
+++ b/apps/meteor/server/lib/omnichannel/custom-fields.ts
@@ -4,7 +4,10 @@ import { LivechatContacts, LivechatCustomField, LivechatRooms, LivechatVisitors 
 import { livechatLogger } from './logger';
 import { i18n } from '../../../app/utils/lib/i18n';
 
-export const validateRequiredCustomFields = (customFields: string[], livechatCustomFields: ILivechatCustomField[]) => {
+export const validateRequiredCustomFields = (
+	customFields: string[],
+	livechatCustomFields: Pick<ILivechatCustomField, '_id' | 'required'>[],
+) => {
 	const errors: string[] = [];
 	const requiredCustomFields = livechatCustomFields.filter((field) => field.required);
 
@@ -103,14 +106,14 @@ export async function setMultipleVisitorCustomFields(
 		value: string;
 		overwrite: boolean;
 	}[],
-	livechatCustomFields?: ILivechatCustomField[],
+	livechatCustomFields?: Pick<ILivechatCustomField, '_id' | 'required'>[],
 ) {
 	const keys = customFields.map((field) => field.key);
 
 	livechatCustomFields ??= await LivechatCustomField.findByScope('visitor', { projection: { _id: 1, required: 1 } }, false).toArray();
 	validateRequiredCustomFields(keys, livechatCustomFields);
 
-	const matchingCustomFields = livechatCustomFields.filter((field: ILivechatCustomField) => keys.includes(field._id));
+	const matchingCustomFields = livechatCustomFields.filter((field) => keys.includes(field._id));
 	const validCustomFields = customFields.filter((cf) => matchingCustomFields.find((mcf) => cf.key === mcf._id));
 	if (!validCustomFields.length) {
 		return false;

--- a/apps/meteor/server/lib/omnichannel/guests.ts
+++ b/apps/meteor/server/lib/omnichannel/guests.ts
@@ -123,7 +123,7 @@ async function cleanGuestHistory(_id: string) {
 
 	await LivechatRooms.removeByVisitorId(_id);
 
-	const livechatInquiries = await LivechatInquiry.findIdsByVisitorId(_id).toArray();
+	const livechatInquiries = await LivechatInquiry.findByVisitorIds([_id]).toArray();
 	await LivechatInquiry.removeByIds(livechatInquiries.map(({ _id }) => _id));
 	void notifyOnLivechatInquiryChanged(livechatInquiries, 'removed');
 }

--- a/apps/meteor/server/lib/omnichannel/hooks.ts
+++ b/apps/meteor/server/lib/omnichannel/hooks.ts
@@ -27,7 +27,7 @@ export async function afterAgentUserActivated(user: IUser) {
 	callbacks.runAsync('livechat.onNewAgentCreated', user._id);
 }
 
-export async function afterAgentAdded(user: AtLeast<IUser, '_id' | 'status'>) {
+export async function afterAgentAdded<T extends AtLeast<IUser, '_id'>>(user: T): Promise<T> {
 	await setUserStatusLivechat(user._id, user.status !== 'offline' ? ILivechatAgentStatus.AVAILABLE : ILivechatAgentStatus.NOT_AVAILABLE);
 	callbacks.runAsync('livechat.onNewAgentCreated', user._id);
 

--- a/apps/meteor/server/lib/omnichannel/hooks.ts
+++ b/apps/meteor/server/lib/omnichannel/hooks.ts
@@ -27,7 +27,7 @@ export async function afterAgentUserActivated(user: IUser) {
 	callbacks.runAsync('livechat.onNewAgentCreated', user._id);
 }
 
-export async function afterAgentAdded(user: IUser) {
+export async function afterAgentAdded(user: AtLeast<IUser, '_id' | 'status'>) {
 	await setUserStatusLivechat(user._id, user.status !== 'offline' ? ILivechatAgentStatus.AVAILABLE : ILivechatAgentStatus.NOT_AVAILABLE);
 	callbacks.runAsync('livechat.onNewAgentCreated', user._id);
 

--- a/apps/meteor/server/lib/omnichannel/omni-users.ts
+++ b/apps/meteor/server/lib/omnichannel/omni-users.ts
@@ -43,7 +43,9 @@ export async function addManager(username: string) {
 }
 
 export async function addAgent(username: string) {
-	const user = await Users.findOneByUsername(username, { projection: { _id: 1, username: 1, status: 1 } });
+	// `status` is deliberately not projected: this endpoint has always turned the new agent available
+	// regardless of the user's presence, and `afterAgentAdded` relies on the field being absent to do so.
+	const user = await Users.findOneByUsername(username, { projection: { _id: 1, username: 1 } });
 
 	if (!user) {
 		throw new Error('error-invalid-user');

--- a/apps/meteor/server/lib/omnichannel/omni-users.ts
+++ b/apps/meteor/server/lib/omnichannel/omni-users.ts
@@ -43,7 +43,7 @@ export async function addManager(username: string) {
 }
 
 export async function addAgent(username: string) {
-	const user = await Users.findOneByUsername(username, { projection: { _id: 1, username: 1 } });
+	const user = await Users.findOneByUsername(username, { projection: { _id: 1, username: 1, status: 1 } });
 
 	if (!user) {
 		throw new Error('error-invalid-user');

--- a/apps/meteor/server/lib/omnichannel/parseTranscriptRequest.ts
+++ b/apps/meteor/server/lib/omnichannel/parseTranscriptRequest.ts
@@ -35,7 +35,9 @@ export const parseTranscriptRequest = async (
 		return options;
 	}
 
-	const defOptions = { projection: { _id: 1, username: 1, name: 1 } };
+	// `as const` keeps the projection statically readable so the return type narrows; `utcOffset` is
+	// part of the `requestedBy` contract and was silently missing from the fetched fields.
+	const defOptions = { projection: { _id: 1, username: 1, name: 1, utcOffset: 1 } } as const;
 	const requestedBy =
 		user ||
 		(room.servedBy && (await Users.findOneById(room.servedBy._id, defOptions))) ||

--- a/apps/meteor/server/lib/omnichannel/parseTranscriptRequest.ts
+++ b/apps/meteor/server/lib/omnichannel/parseTranscriptRequest.ts
@@ -35,8 +35,8 @@ export const parseTranscriptRequest = async (
 		return options;
 	}
 
-	// `as const` keeps the projection statically readable so the return type narrows; `utcOffset` is
-	// part of the `requestedBy` contract and was silently missing from the fetched fields.
+	// `as const` keeps the projection statically readable so the return type narrows;
+	// `utcOffset` is part of the `requestedBy` contract.
 	const defOptions = { projection: { _id: 1, username: 1, name: 1, utcOffset: 1 } } as const;
 	const requestedBy =
 		user ||

--- a/apps/meteor/server/lib/omnichannel/sendTranscript.ts
+++ b/apps/meteor/server/lib/omnichannel/sendTranscript.ts
@@ -229,7 +229,8 @@ export async function requestTranscript({
 	subject: string;
 	user: AtLeast<IUser, '_id' | 'username' | 'utcOffset' | 'name'>;
 }) {
-	const room = await LivechatRooms.findOneById(rid, { projection: { _id: 1, open: 1, transcriptRequest: 1 } });
+	// `v` is required by the MAC-limit check below
+	const room = await LivechatRooms.findOneById(rid, { projection: { _id: 1, open: 1, transcriptRequest: 1, v: 1 } });
 
 	if (!room?.open) {
 		throw new Meteor.Error('error-invalid-room', 'Invalid room');

--- a/apps/meteor/server/lib/rooms/createDirectRoom.ts
+++ b/apps/meteor/server/lib/rooms/createDirectRoom.ts
@@ -78,7 +78,8 @@ export async function createDirectRoom(
 	const uids = roomMembers.map(({ _id }) => _id).sort();
 
 	// Deprecated: using users' _id to compose the room _id is deprecated
-	const room: IRoom | null = options?.forceNew ? null : await Rooms.findOneDirectRoomContainingAllUserIDs(uids, { projection: { _id: 1 } });
+	// No projection: the full room is spread into the ICreatedRoom returned below.
+	const room: IRoom | null = options?.forceNew ? null : await Rooms.findOneDirectRoomContainingAllUserIDs(uids);
 
 	const isNewRoom = !room;
 

--- a/apps/meteor/server/lib/rooms/updateGroupDMsName.ts
+++ b/apps/meteor/server/lib/rooms/updateGroupDMsName.ts
@@ -5,17 +5,19 @@ import type { ClientSession } from 'mongodb';
 
 import { notifyOnSubscriptionChangedByRoomId } from '../notifyListener';
 
-const getFname = (members: IUser[]): string => members.map(({ name, username }) => name || username).join(', ');
-const getName = (members: IUser[]): string => members.map(({ username }) => username).join(',');
+type GroupDMMember = Pick<IUser, '_id' | 'username' | 'name'>;
 
-async function getUsersWhoAreInTheSameGroupDMsAs(user: IUser) {
+const getFname = (members: GroupDMMember[]): string => members.map(({ name, username }) => name || username).join(', ');
+const getName = (members: GroupDMMember[]): string => members.map(({ username }) => username).join(',');
+
+async function getUsersWhoAreInTheSameGroupDMsAs(user: GroupDMMember) {
 	// add all users to single array so we can fetch details from them all at once
 	if ((await Rooms.countGroupDMsByUids([user._id])) === 0) {
 		return;
 	}
 
 	const userIds = new Set<string>();
-	const users = new Map<string, IUser>();
+	const users = new Map<string, GroupDMMember>();
 
 	const rooms = Rooms.findGroupDMsByUids([user._id], { projection: { uids: 1 } });
 	await rooms.forEach((room) => {
@@ -31,13 +33,13 @@ async function getUsersWhoAreInTheSameGroupDMsAs(user: IUser) {
 	return users;
 }
 
-function sortUsersAlphabetically(u1: IUser, u2: IUser): number {
+function sortUsersAlphabetically(u1: GroupDMMember, u2: GroupDMMember): number {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	return (u1.name! || u1.username!).localeCompare(u2.name! || u2.username!);
 }
 
 export const updateGroupDMsName = async (
-	userThatChangedName: IUser,
+	userThatChangedName: GroupDMMember,
 	options?: {
 		session?: ClientSession;
 	},

--- a/apps/meteor/server/lib/sendDirectMessageToUsers.ts
+++ b/apps/meteor/server/lib/sendDirectMessageToUsers.ts
@@ -8,7 +8,7 @@ import { executeSendMessage } from '../meteor-methods/messages/sendMessage';
 export async function sendDirectMessageToUsers(
 	fromId = 'rocket.cat',
 	toIds: string[],
-	messageFn: (user: IUser) => string,
+	messageFn: (user: Pick<IUser, '_id' | 'username' | 'language'>) => string,
 ): Promise<string[]> {
 	const fromUser = await Users.findOneById(fromId, { projection: { _id: 1, username: 1 } });
 	if (!fromUser) {

--- a/apps/meteor/server/lib/statistics/lib/statistics.ts
+++ b/apps/meteor/server/lib/statistics/lib/statistics.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 
 import { Analytics, Team, VideoConf, Presence } from '@rocket.chat/core-services';
-import type { IRoom, IStats, ISetting } from '@rocket.chat/core-typings';
+import type { IStats, ISetting } from '@rocket.chat/core-typings';
 import { UserStatus } from '@rocket.chat/core-typings';
 import { License } from '@rocket.chat/license';
 import {
@@ -278,36 +278,33 @@ export const statistics = {
 
 		// Message statistics
 		const channels = await Rooms.findByType('c', { projection: { msgs: 1, prid: 1 } }).toArray();
-		const totalChannelDiscussionsMessages = channels.reduce(function _countChannelDiscussionsMessages(num: number, room: IRoom) {
+		const totalChannelDiscussionsMessages = channels.reduce(function _countChannelDiscussionsMessages(num: number, room) {
 			return num + (room.prid ? room.msgs : 0);
 		}, 0);
 		statistics.totalChannelMessages =
-			channels.reduce(function _countChannelMessages(num: number, room: IRoom) {
+			channels.reduce(function _countChannelMessages(num: number, room) {
 				return num + room.msgs;
 			}, 0) - totalChannelDiscussionsMessages;
 
 		const privateGroups = await Rooms.findByType('p', { projection: { msgs: 1, prid: 1 } }).toArray();
-		const totalPrivateGroupsDiscussionsMessages = privateGroups.reduce(function _countPrivateGroupsDiscussionsMessages(
-			num: number,
-			room: IRoom,
-		) {
+		const totalPrivateGroupsDiscussionsMessages = privateGroups.reduce(function _countPrivateGroupsDiscussionsMessages(num: number, room) {
 			return num + (room.prid ? room.msgs : 0);
 		}, 0);
 		statistics.totalPrivateGroupMessages =
-			privateGroups.reduce(function _countPrivateGroupMessages(num: number, room: IRoom) {
+			privateGroups.reduce(function _countPrivateGroupMessages(num: number, room) {
 				return num + room.msgs;
 			}, 0) - totalPrivateGroupsDiscussionsMessages;
 
 		statistics.totalDiscussionsMessages = totalPrivateGroupsDiscussionsMessages + totalChannelDiscussionsMessages;
 
 		statistics.totalDirectMessages = (await Rooms.findByType('d', { projection: { msgs: 1 } }).toArray()).reduce(
-			function _countDirectMessages(num: number, room: IRoom) {
+			function _countDirectMessages(num: number, room) {
 				return num + room.msgs;
 			},
 			0,
 		);
 		statistics.totalLivechatMessages = (await Rooms.findByType('l', { projection: { msgs: 1 } }).toArray()).reduce(
-			function _countLivechatMessages(num: number, room: IRoom) {
+			function _countLivechatMessages(num: number, room) {
 				return num + room.msgs;
 			},
 			0,

--- a/apps/meteor/server/lib/users/getUserSingleOwnedRooms.ts
+++ b/apps/meteor/server/lib/users/getUserSingleOwnedRooms.ts
@@ -1,4 +1,3 @@
-import type { IRoom } from '@rocket.chat/core-typings';
 import { Rooms } from '@rocket.chat/models';
 
 import type { SubscribedRoomsForUserWithDetails } from '../rooms/getRoomsWithSingleOwner';
@@ -17,7 +16,7 @@ export const getUserSingleOwnedRooms = async function (subscribedRooms: Subscrib
 		shouldChangeOwner: [] as string[],
 	};
 
-	await rooms.forEach((room: IRoom) => {
+	await rooms.forEach((room) => {
 		const name = room.fname || room.name;
 		if (roomsThatWillBeRemoved.includes(room._id)) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/apps/meteor/server/lib/users/setRealName.ts
+++ b/apps/meteor/server/lib/users/setRealName.ts
@@ -20,7 +20,7 @@ export const setRealName = async function (
 		return;
 	}
 
-	const user = fullUser || (await Users.findOneById(userId, { session }));
+	const user = fullUser || (await Users.findOneById<IUser>(userId, { session }));
 
 	if (!user) {
 		return;

--- a/apps/meteor/server/lib/users/setUserActiveStatus.ts
+++ b/apps/meteor/server/lib/users/setUserActiveStatus.ts
@@ -1,4 +1,4 @@
-import type { IUser, IUserEmail } from '@rocket.chat/core-typings';
+import type { IUserEmail } from '@rocket.chat/core-typings';
 import { isUserFederated, isDirectMessageRoom } from '@rocket.chat/core-typings';
 import { Rooms, Users, Subscriptions, OAuthAccessTokens, OAuthRefreshTokens, OAuthAuthCodes } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
@@ -34,7 +34,7 @@ async function reactivateDirectConversations(userId: string) {
 	}, []);
 	const uniqueUserIds = [...new Set(userIds)];
 	const activeUsers = await Users.findActiveByUserIds(uniqueUserIds, { projection: { _id: 1 } }).toArray();
-	const activeUserIds = activeUsers.map((u: IUser) => u._id);
+	const activeUserIds = activeUsers.map((u) => u._id);
 	const roomsToReactivate = directConversations.reduce((acc: string[], room) => {
 		const otherUserId = isDirectMessageRoom(room) ? room.uids.find((u: string) => u !== userId) : undefined;
 		if (otherUserId && activeUserIds.includes(otherUserId)) {

--- a/apps/meteor/server/lib/users/setUserAvatar.ts
+++ b/apps/meteor/server/lib/users/setUserAvatar.ts
@@ -40,7 +40,7 @@ export const setAvatarFromServiceWithValidation = async (
 		});
 	}
 
-	let user: IUser | null;
+	let user: Pick<IUser, '_id' | 'username'> | null;
 
 	if (targetUserId && targetUserId !== userId) {
 		if (!(await hasPermissionAsync(userId, 'edit-other-user-avatar'))) {

--- a/apps/meteor/server/lib/utils/lib/normalizeMessagesForUser.ts
+++ b/apps/meteor/server/lib/utils/lib/normalizeMessagesForUser.ts
@@ -3,7 +3,9 @@ import { Users } from '@rocket.chat/models';
 
 import { settings } from '../../../settings';
 
-const filterStarred = <T extends IMessage = IMessage>(message: T, uid?: string): T => {
+type NormalizableMessage = Pick<IMessage, 'u' | 'starred' | 'mentions' | 'reactions'>;
+
+const filterStarred = <T extends Pick<IMessage, 'starred'>>(message: T, uid?: string): T => {
 	// if Allow_anonymous_read is enabled, uid will be undefined
 	if (!uid) return message;
 
@@ -20,7 +22,7 @@ function getNameOfUsername(users: Map<string, string>, username: string): string
 	return users.get(username) || username;
 }
 
-export const normalizeMessagesForUser = async <T extends IMessage = IMessage>(messages: T[], uid?: string): Promise<T[]> => {
+export const normalizeMessagesForUser = async <T extends NormalizableMessage = IMessage>(messages: T[], uid?: string): Promise<T[]> => {
 	// if not using real names, there is nothing else to do
 	if (!settings.get('UI_Use_Real_Name')) {
 		return messages.map((message) => filterStarred(message, uid));
@@ -58,7 +60,7 @@ export const normalizeMessagesForUser = async <T extends IMessage = IMessage>(me
 		names.set(user.username, user.name);
 	});
 
-	messages.forEach((message: IMessage) => {
+	messages.forEach((message) => {
 		if (!message.u) {
 			return;
 		}

--- a/apps/meteor/server/meteor-methods/messages/createDirectMessage.ts
+++ b/apps/meteor/server/meteor-methods/messages/createDirectMessage.ts
@@ -55,7 +55,8 @@ export async function createDirectMessage(
 		if ((await hasPermissionAsync(userId, 'view-d-room')) && !Object.keys(roomUsers).some((user) => typeof user === 'string')) {
 			// Check if the direct room already exists, then return it
 			const uids = (roomUsers as IUser[]).map(({ _id }) => _id).sort();
-			const room = await Rooms.findOneDirectRoomContainingAllUserIDs(uids, { projection: { _id: 1 } });
+			// No projection: the full room is spread into the ICreatedRoom-shaped return below.
+			const room = await Rooms.findOneDirectRoomContainingAllUserIDs(uids);
 			if (room) {
 				return {
 					...room,

--- a/apps/meteor/server/meteor-methods/messages/createDiscussion.ts
+++ b/apps/meteor/server/meteor-methods/messages/createDiscussion.ts
@@ -124,15 +124,11 @@ const create = async ({
 	}
 
 	if (pmid) {
-		const discussionAlreadyExists = await Rooms.findOne(
-			{
-				prid,
-				pmid,
-			},
-			{
-				projection: { _id: 1 },
-			},
-		);
+		// No projection: the full room is spread into the returned discussion below.
+		const discussionAlreadyExists = await Rooms.findOne({
+			prid,
+			pmid,
+		});
 		if (discussionAlreadyExists) {
 			// do not allow multiple discussions to the same message'\
 			await addUserToRoom(discussionAlreadyExists._id, user);

--- a/apps/meteor/server/meteor-methods/omnichannel/sendMessageLivechat.ts
+++ b/apps/meteor/server/meteor-methods/omnichannel/sendMessageLivechat.ts
@@ -43,14 +43,8 @@ export const sendMessageLivechat = async ({
 		}),
 	);
 
-	const guest = await LivechatVisitors.getVisitorByToken(token, {
-		projection: {
-			name: 1,
-			username: 1,
-			department: 1,
-			token: 1,
-		},
-	});
+	// No projection: the guest is forwarded into the message-sending pipeline, which expects a full visitor.
+	const guest = await LivechatVisitors.getVisitorByToken(token);
 
 	if (!guest) {
 		throw new Meteor.Error('invalid-token');

--- a/apps/meteor/server/services/ai-search/service.ts
+++ b/apps/meteor/server/services/ai-search/service.ts
@@ -229,7 +229,7 @@ export class AISearchService extends ServiceClass implements IAISearchService {
 			}
 		}
 		const msgIds = [...msgIdSet];
-		let messageMap = new Map<string, IMessage>();
+		let messageMap = new Map<string, Pick<IMessage, '_id' | 'rid' | 'msg' | 'ts' | 'u'>>();
 
 		if (msgIds.length > 0) {
 			messageMap = new Map(

--- a/apps/meteor/server/services/calendar/service.ts
+++ b/apps/meteor/server/services/calendar/service.ts
@@ -234,7 +234,6 @@ export class CalendarService extends ServiceClassInternal implements ICalendarSe
 		const processTime = new Date();
 
 		try {
-			// the query already excludes `busy: false` events
 			const eventsStartingNow = await CalendarEvent.findEventsStartingNow({ now: processTime, offset: 5000 }).toArray();
 			for await (const event of eventsStartingNow) {
 				await this.processEventStart(event);

--- a/apps/meteor/server/services/calendar/service.ts
+++ b/apps/meteor/server/services/calendar/service.ts
@@ -234,11 +234,9 @@ export class CalendarService extends ServiceClassInternal implements ICalendarSe
 		const processTime = new Date();
 
 		try {
+			// the query already excludes `busy: false` events
 			const eventsStartingNow = await CalendarEvent.findEventsStartingNow({ now: processTime, offset: 5000 }).toArray();
 			for await (const event of eventsStartingNow) {
-				if (event.busy === false) {
-					continue;
-				}
 				await this.processEventStart(event);
 			}
 		} catch (err) {
@@ -248,7 +246,7 @@ export class CalendarService extends ServiceClassInternal implements ICalendarSe
 		await this.doSetupNextStatusChange();
 	}
 
-	private async processEventStart(event: ICalendarEvent): Promise<void> {
+	private async processEventStart(event: Pick<ICalendarEvent, '_id' | 'uid' | 'endTime'>): Promise<void> {
 		// no endTime → no expiry to set, so the claim could never auto-clear
 		if (!event.endTime) {
 			return;

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -575,7 +575,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 			throw new Error('user-not-on-private-team');
 		}
 
-		const teamRooms: (IRoom & {
+		const teamRooms: (Pick<IRoom, '_id' | 't'> & {
 			userCanDelete?: boolean;
 		})[] = await Rooms.findByTeamId(teamId, {
 			projection: { _id: 1, t: 1 },

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -783,9 +783,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		const membersIds = members.map((m) => m.userId);
-		const usersToRemove = await Users.findByIds(membersIds, {
-			projection: { _id: 1, username: 1 },
-		}).toArray();
+		const usersToRemove = await Users.findByIds(membersIds).toArray();
 		const byUser = await Users.findOneById(uid);
 
 		for await (const member of members) {

--- a/apps/meteor/server/services/upload/service.ts
+++ b/apps/meteor/server/services/upload/service.ts
@@ -57,7 +57,11 @@ export class UploadService extends ServiceClassInternal implements IUploadServic
 		return parseFileIntoMessageAttachments(file, roomId, user);
 	}
 
-	async canDeleteFile(user: IUser, file: IUpload, msg: IMessage | null): Promise<boolean> {
+	async canDeleteFile(
+		user: Pick<IUser, '_id' | 'username'>,
+		file: Pick<IUpload, '_id' | 'userId' | 'rid' | 'expiresAt' | 'uploadedAt'>,
+		msg: IMessage | null,
+	): Promise<boolean> {
 		if (msg) {
 			return canDeleteMessageAsync(user, msg);
 		}

--- a/apps/meteor/server/settings/SettingsRegistry.ts
+++ b/apps/meteor/server/settings/SettingsRegistry.ts
@@ -34,9 +34,12 @@ const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
  * @deprecated
  * please do not use event emitter to mutate values
  */
+/** The fields the enterprise value-masking listener needs; `fetchSettings` projects exactly these. */
+export type FetchedSetting = Pick<ISetting, '_id' | 'value' | 'enterprise' | 'invalidValue' | 'modules'>;
+
 export const SettingsEvents = new Emitter<{
 	'store-setting-value': [ISetting, { value: SettingValue }];
-	'fetch-settings': ISetting[];
+	'fetch-settings': FetchedSetting[];
 	'remove-setting-value': ISetting;
 }>();
 

--- a/ee/packages/abac/src/index.ts
+++ b/ee/packages/abac/src/index.ts
@@ -350,7 +350,7 @@ export class AbacService extends ServiceClass implements IAbacService {
 		filters?: { key?: string; values?: string; offset?: number; count?: number },
 		actor?: AbacActor,
 	): Promise<{
-		attributes: Pick<IAbacAttribute, 'key' | 'values'>[];
+		attributes: Pick<IAbacAttribute, '_id' | 'key' | 'values'>[];
 		offset: number;
 		count: number;
 		total: number;

--- a/ee/packages/abac/src/index.ts
+++ b/ee/packages/abac/src/index.ts
@@ -350,7 +350,7 @@ export class AbacService extends ServiceClass implements IAbacService {
 		filters?: { key?: string; values?: string; offset?: number; count?: number },
 		actor?: AbacActor,
 	): Promise<{
-		attributes: IAbacAttribute[];
+		attributes: Pick<IAbacAttribute, 'key' | 'values'>[];
 		offset: number;
 		count: number;
 		total: number;

--- a/ee/packages/abac/src/pdp/LocalPDP.ts
+++ b/ee/packages/abac/src/pdp/LocalPDP.ts
@@ -51,7 +51,7 @@ export class LocalPDP implements IPolicyDecisionPoint {
 		return Users.find(query, { projection: { __rooms: 0 } }).toArray();
 	}
 
-	async onSubjectAttributesChanged(user: IUser, _next: IAbacAttributeDefinition[]): Promise<IRoom[]> {
+	async onSubjectAttributesChanged(user: IUser, _next: IAbacAttributeDefinition[]): Promise<Pick<IRoom, '_id'>[]> {
 		const roomIds = user.__rooms;
 
 		// No attributes: no rooms :(

--- a/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.spec.ts
@@ -387,7 +387,7 @@ describe('VirtruPDP.onSubjectAttributesChanged', () => {
 		const apiCall = jest.fn();
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['r1'], emails: [] }) as any, []);
-		expect(result).toEqual(rooms);
+		expect(result).toEqual([{ _id: 'r1' }]);
 		expect(apiCall).not.toHaveBeenCalled();
 	});
 
@@ -405,7 +405,7 @@ describe('VirtruPDP.onSubjectAttributesChanged', () => {
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['rP', 'rD'] }) as any, []);
-		expect(result).toEqual([rooms[1]]);
+		expect(result).toEqual([{ _id: 'rD' }]);
 	});
 
 	it('still treats DECISION_UNSPECIFIED as non-compliant (LDAP-driven path cannot yield inconclusive decisions)', async () => {
@@ -416,7 +416,7 @@ describe('VirtruPDP.onSubjectAttributesChanged', () => {
 		});
 		const pdp = new VirtruPDP(mkClient({ apiCall }));
 		const result = await pdp.onSubjectAttributesChanged(user({ __rooms: ['r1'] }) as any, []);
-		expect(result).toEqual(rooms);
+		expect(result).toEqual([{ _id: 'r1' }]);
 	});
 
 	it('splits >200 rooms into multiple decision batches', async () => {

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -266,9 +266,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			return [];
 		}
 
-		const users = Users.findActiveByRoomIds([room._id], {
-			projection: { __rooms: 0 },
-		});
+		const users = Users.findActiveByRoomIds([room._id]);
 
 		const config = this.client.getConfig();
 		const nonCompliantUsers: IUser[] = [];
@@ -410,7 +408,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 				msg: 'User has no entity key for Virtru PDP evaluation, treating as non-compliant for all ABAC rooms',
 				userId: user._id,
 			});
-			return abacRooms;
+			return abacRooms.map(({ _id }) => ({ _id }));
 		}
 
 		const decisionRequests = abacRooms.map((room) => ({
@@ -435,7 +433,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 		responses.forEach((resp, index) => {
 			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');
 			if (!permitted && abacRooms[index]) {
-				nonCompliantRooms.push(abacRooms[index]);
+				nonCompliantRooms.push({ _id: abacRooms[index]._id });
 			}
 		});
 

--- a/ee/packages/abac/src/pdp/VirtruPDP.ts
+++ b/ee/packages/abac/src/pdp/VirtruPDP.ts
@@ -4,8 +4,6 @@ import { serverFetch } from '@rocket.chat/server-fetch';
 import { isTruthy } from '@rocket.chat/tools';
 import pLimit from 'p-limit';
 
-import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
-import { logger } from '../logger';
 import type {
 	IPolicyDecisionPoint,
 	IGetDecisionBulkRequest,
@@ -17,6 +15,8 @@ import type {
 import { HEALTH_CHECK_TIMEOUT } from '../clients/virtru/VirtruClient';
 import type { VirtruClient } from '../clients/virtru/VirtruClient';
 import { buildEntityIdentifier, buildAttributeFqns, getUserEntityKey } from '../clients/virtru/identity';
+import { OnlyCompliantCanBeAddedToRoomError, PdpHealthCheckError } from '../errors';
+import { logger } from '../logger';
 
 const pdpLogger = logger.section('VirtruPDP');
 
@@ -267,7 +267,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 		}
 
 		const users = Users.findActiveByRoomIds([room._id], {
-			projection: { _id: 1, emails: 1, username: 1 },
+			projection: { __rooms: 0 },
 		});
 
 		const config = this.client.getConfig();
@@ -374,7 +374,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 			projection: { _id: 1, abacAttributes: 1 },
 		});
 
-		const abacRoomById = new Map<string, IRoom>();
+		const abacRoomById = new Map<string, Pick<IRoom, '_id' | 'abacAttributes'>>();
 		for await (const room of abacRoomCursor) {
 			abacRoomById.set(room._id, room);
 		}
@@ -389,7 +389,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 		return this.evaluateUserRooms(entries);
 	}
 
-	async onSubjectAttributesChanged(user: IUser, _next: IAbacAttributeDefinition[]): Promise<IRoom[]> {
+	async onSubjectAttributesChanged(user: IUser, _next: IAbacAttributeDefinition[]): Promise<Pick<IRoom, '_id'>[]> {
 		const roomIds = user.__rooms;
 		if (!roomIds?.length) {
 			return [];
@@ -430,7 +430,7 @@ export class VirtruPDP implements IPolicyDecisionPoint {
 
 		const responses = await this.getDecisionBulk(decisionRequests);
 
-		const nonCompliantRooms: IRoom[] = [];
+		const nonCompliantRooms: Pick<IRoom, '_id'>[] = [];
 
 		responses.forEach((resp, index) => {
 			const permitted = resp?.resourceDecisions?.length && resp.resourceDecisions.every((rd) => rd.decision === 'DECISION_PERMIT');

--- a/ee/packages/abac/src/pdp/types.ts
+++ b/ee/packages/abac/src/pdp/types.ts
@@ -52,7 +52,7 @@ export interface IPolicyDecisionPoint {
 		newAttributes: IAbacAttributeDefinition[],
 	): Promise<IUser[]>;
 
-	onSubjectAttributesChanged(user: IUser, next: IAbacAttributeDefinition[]): Promise<IRoom[]>;
+	onSubjectAttributesChanged(user: IUser, next: IAbacAttributeDefinition[]): Promise<Pick<IRoom, '_id'>[]>;
 
 	evaluateUserRooms(
 		entries: Array<{

--- a/ee/packages/abac/src/store/VirtruAttributeStore.ts
+++ b/ee/packages/abac/src/store/VirtruAttributeStore.ts
@@ -1,5 +1,5 @@
 import type { AbacActor } from '@rocket.chat/core-services';
-import type { IAbacAttribute, IAbacAttributeDefinition, IRoom, IRoomAbacRedaction } from '@rocket.chat/core-typings';
+import type { IAbacAttributeDefinition, IRoom, IRoomAbacRedaction } from '@rocket.chat/core-typings';
 import { Users } from '@rocket.chat/models';
 import mem from 'mem';
 
@@ -96,7 +96,7 @@ export class VirtruAttributeStore implements IAttributeStore {
 		const count = opts?.count ?? total;
 		const slice = attributes.slice(offset, offset + count);
 		return {
-			attributes: slice.map((a) => ({ _id: a.key, ...a })) as IAbacAttribute[],
+			attributes: slice.map((a) => ({ _id: a.key, ...a })),
 			offset,
 			count: slice.length,
 			total,

--- a/ee/packages/abac/src/store/types.ts
+++ b/ee/packages/abac/src/store/types.ts
@@ -5,7 +5,7 @@ export type AttributeEntitlements = Map<string, Set<string>>;
 
 export type ListAttributesOptions = { key?: string; values?: string; offset?: number; count?: number };
 
-export type ListAttributesResult = { attributes: IAbacAttribute[]; offset: number; count: number; total: number };
+export type ListAttributesResult = { attributes: Pick<IAbacAttribute, 'key' | 'values'>[]; offset: number; count: number; total: number };
 
 export interface IAttributeStore {
 	list(actor: AbacActor | undefined, opts?: ListAttributesOptions): Promise<ListAttributesResult>;

--- a/ee/packages/abac/src/store/types.ts
+++ b/ee/packages/abac/src/store/types.ts
@@ -5,7 +5,12 @@ export type AttributeEntitlements = Map<string, Set<string>>;
 
 export type ListAttributesOptions = { key?: string; values?: string; offset?: number; count?: number };
 
-export type ListAttributesResult = { attributes: Pick<IAbacAttribute, 'key' | 'values'>[]; offset: number; count: number; total: number };
+export type ListAttributesResult = {
+	attributes: Pick<IAbacAttribute, '_id' | 'key' | 'values'>[];
+	offset: number;
+	count: number;
+	total: number;
+};
 
 export interface IAttributeStore {
 	list(actor: AbacActor | undefined, opts?: ListAttributesOptions): Promise<ListAttributesResult>;

--- a/packages/core-services/src/types/IAbacService.ts
+++ b/packages/core-services/src/types/IAbacService.ts
@@ -22,7 +22,7 @@ export interface IAbacService {
 			count?: number;
 		},
 		actor?: AbacActor,
-	): Promise<{ attributes: IAbacAttribute[]; offset: number; count: number; total: number }>;
+	): Promise<{ attributes: Pick<IAbacAttribute, 'key' | 'values'>[]; offset: number; count: number; total: number }>;
 	listAbacRooms(
 		filters?: {
 			offset?: number;

--- a/packages/core-services/src/types/IAbacService.ts
+++ b/packages/core-services/src/types/IAbacService.ts
@@ -22,7 +22,7 @@ export interface IAbacService {
 			count?: number;
 		},
 		actor?: AbacActor,
-	): Promise<{ attributes: Pick<IAbacAttribute, 'key' | 'values'>[]; offset: number; count: number; total: number }>;
+	): Promise<{ attributes: Pick<IAbacAttribute, '_id' | 'key' | 'values'>[]; offset: number; count: number; total: number }>;
 	listAbacRooms(
 		filters?: {
 			offset?: number;

--- a/packages/core-services/src/types/IUploadService.ts
+++ b/packages/core-services/src/types/IUploadService.ts
@@ -30,7 +30,11 @@ export interface IUploadService {
 	getFileBuffer({ file }: { file: IUpload }): Promise<Buffer>;
 	extractMetadata(file: IUpload): Promise<{ height?: number; width?: number; format?: string }>;
 	parseFileIntoMessageAttachments(file: Partial<IUpload>, roomId: string, user: IUser): Promise<FilesAndAttachments>;
-	canDeleteFile(user: IUser, file: IUpload, msg: IMessage | null): Promise<boolean>;
+	canDeleteFile(
+		user: Pick<IUser, '_id' | 'username'>,
+		file: Pick<IUpload, '_id' | 'userId' | 'rid' | 'expiresAt' | 'uploadedAt'>,
+		msg: IMessage | null,
+	): Promise<boolean>;
 	deleteFile(user: IUser, fileId: IUpload['_id'], msg: IMessage | null): Promise<{ deletedFiles: IUpload['_id'][] }>;
 	streamUploadedFile({
 		file,

--- a/packages/core-typings/src/ILivechatBusinessHour.ts
+++ b/packages/core-typings/src/ILivechatBusinessHour.ts
@@ -37,5 +37,6 @@ export interface ILivechatBusinessHour extends IRocketChatRecord {
 	timezone: IBusinessHourTimezone;
 	ts: Date;
 	workHours: IBusinessHourWorkHour[];
-	departments?: ILivechatDepartment[];
+	/** Populated on the fly by the business-hours endpoints; never persisted with the record. */
+	departments?: Pick<ILivechatDepartment, '_id' | 'name'>[];
 }

--- a/packages/core-typings/src/ISetting.ts
+++ b/packages/core-typings/src/ISetting.ts
@@ -167,7 +167,11 @@ export const isSetting = (setting: any): setting is ISetting =>
 
 export const isSettingEnterprise = (setting: ISettingBase): setting is ISettingEnterprise => setting.enterprise === true;
 
-export const isSettingColor = (setting: ISettingBase): setting is ISettingColor => setting.type === 'color';
+export function isSettingColor(setting: ISettingBase): setting is ISettingColor;
+export function isSettingColor<T extends Pick<ISettingBase, 'type'>>(setting: T): setting is T & { type: 'color' };
+export function isSettingColor(setting: Pick<ISettingBase, 'type'>): boolean {
+	return setting.type === 'color';
+}
 
 export const isSettingCode = (setting: ISettingBase): setting is ISettingCode => setting.type === 'code';
 

--- a/packages/core-typings/src/ISubscription.ts
+++ b/packages/core-typings/src/ISubscription.ts
@@ -96,6 +96,8 @@ export interface IBannedSubscription extends ISubscription {
 	status: 'BANNED';
 }
 
-export const isBannedSubscription = (subscription: ISubscription): subscription is IBannedSubscription => {
+export const isBannedSubscription = <T extends Pick<ISubscription, 'status'>>(
+	subscription: T,
+): subscription is T & { status: 'BANNED' } => {
 	return subscription?.status === 'BANNED';
 };

--- a/packages/core-typings/src/IUser.ts
+++ b/packages/core-typings/src/IUser.ts
@@ -140,12 +140,13 @@ const userServiceKeys: IUserService[] = ['emailCode', 'email2fa', 'totp', 'resum
 const isUserServiceKey = (key: string): key is IUserService =>
 	userServiceKeys.includes(key as IUserService) || defaultOAuthKeys.includes(key as IOAuthService);
 
-const isDefaultOAuthUser = (user: IUser): boolean =>
+const isDefaultOAuthUser = (user: Pick<IUser, 'services'>): boolean =>
 	!!user.services && Object.keys(user.services).some((key) => defaultOAuthKeys.includes(key as IOAuthService));
 
-const isCustomOAuthUser = (user: IUser): boolean => !!user.services && Object.keys(user.services).some((key) => !isUserServiceKey(key));
+const isCustomOAuthUser = (user: Pick<IUser, 'services'>): boolean =>
+	!!user.services && Object.keys(user.services).some((key) => !isUserServiceKey(key));
 
-export const isOAuthUser = (user: IUser): boolean => isDefaultOAuthUser(user) || isCustomOAuthUser(user);
+export const isOAuthUser = (user: Pick<IUser, 'services'>): boolean => isDefaultOAuthUser(user) || isCustomOAuthUser(user);
 
 export interface IUserEmail {
 	address: string;

--- a/packages/core-typings/src/IUser.ts
+++ b/packages/core-typings/src/IUser.ts
@@ -252,7 +252,9 @@ export interface IRegisterUser extends IUser {
 	name: string;
 }
 
-export const isRegisterUser = (user: IUser): user is IRegisterUser => user.username !== undefined && user.name !== undefined;
+export const isRegisterUser = <T extends Pick<IUser, 'username' | 'name'>>(
+	user: T,
+): user is T & Required<Pick<IUser, 'username' | 'name'>> => user.username !== undefined && user.name !== undefined;
 
 export const isUserFederated = (user: Partial<IUser> | Partial<Serialized<IUser>>) => 'federated' in user && user.federated === true;
 

--- a/packages/model-typings/package.json
+++ b/packages/model-typings/package.json
@@ -8,8 +8,8 @@
 		"/dist"
 	],
 	"scripts": {
-		"build": "rm -rf dist && tsc -p tsconfig.json",
-		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
+		"build": "rm -rf dist && tsc -p tsconfig.build.json",
+		"typecheck": "tsc --noEmit -p tsconfig.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},

--- a/packages/model-typings/package.json
+++ b/packages/model-typings/package.json
@@ -9,6 +9,7 @@
 	],
 	"scripts": {
 		"build": "rm -rf dist && tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix ."
 	},

--- a/packages/model-typings/src/index.ts
+++ b/packages/model-typings/src/index.ts
@@ -76,6 +76,7 @@ export type * from './models/IMigrationsModel';
 export type * from './models/IModerationReportsModel';
 export type * from './models/IMediaCallsModel';
 export type * from './models/IMediaCallNegotiationsModel';
+export type * from './types/DocumentWithProjection';
 export type * from './updater';
 export type * from './models/IWorkspaceCredentialsModel';
 export type * from './models/ICallHistoryModel';

--- a/packages/model-typings/src/models/IAbacAttributesModel.ts
+++ b/packages/model-typings/src/models/IAbacAttributesModel.ts
@@ -5,6 +5,9 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IAbacAttributesModel extends IBaseModel<IAbacAttribute> {
-	findOneByKey<T extends Document = IAbacAttribute, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(key: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByKey<T extends Document = IAbacAttribute, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		key: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	countTotalValues(): Promise<number>;
 }

--- a/packages/model-typings/src/models/IAbacAttributesModel.ts
+++ b/packages/model-typings/src/models/IAbacAttributesModel.ts
@@ -1,9 +1,10 @@
 import type { IAbacAttribute } from '@rocket.chat/core-typings';
-import type { FindOptions } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IAbacAttributesModel extends IBaseModel<IAbacAttribute> {
-	findOneByKey(key: string, options?: FindOptions<IAbacAttribute>): Promise<IAbacAttribute | null>;
+	findOneByKey<T extends Document = IAbacAttribute, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(key: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	countTotalValues(): Promise<number>;
 }

--- a/packages/model-typings/src/models/IBannersDismissModel.ts
+++ b/packages/model-typings/src/models/IBannersDismissModel.ts
@@ -1,9 +1,22 @@
 import type { IBannerDismiss } from '@rocket.chat/core-typings';
-import type { Document, FindCursor } from 'mongodb';
+import type { Document, FindCursor, FindOptions } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
-import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IBannersDismissModel extends IBaseModel<IBannerDismiss> {
-	findByUserIdAndBannerId<P extends Document = IBannerDismiss, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, bannerIds: string[], options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByUserIdAndBannerId(userId: string, bannerIds: string[]): FindCursor<IBannerDismiss>;
+
+	findByUserIdAndBannerId(userId: string, bannerIds: string[], options: FindOptions<IBannerDismiss>): FindCursor<IBannerDismiss>;
+
+	findByUserIdAndBannerId<P extends Document>(
+		userId: string,
+		bannerIds: string[],
+		options: FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
+	): FindCursor<P>;
+
+	findByUserIdAndBannerId<P extends Document>(
+		userId: string,
+		bannerIds: string[],
+		options?: FindOptions<IBannerDismiss> | FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
+	): FindCursor<P> | FindCursor<IBannerDismiss>;
 }

--- a/packages/model-typings/src/models/IBannersDismissModel.ts
+++ b/packages/model-typings/src/models/IBannersDismissModel.ts
@@ -1,22 +1,9 @@
 import type { IBannerDismiss } from '@rocket.chat/core-typings';
-import type { Document, FindCursor, FindOptions } from 'mongodb';
+import type { Document, FindCursor } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IBannersDismissModel extends IBaseModel<IBannerDismiss> {
-	findByUserIdAndBannerId(userId: string, bannerIds: string[]): FindCursor<IBannerDismiss>;
-
-	findByUserIdAndBannerId(userId: string, bannerIds: string[], options: FindOptions<IBannerDismiss>): FindCursor<IBannerDismiss>;
-
-	findByUserIdAndBannerId<P extends Document>(
-		userId: string,
-		bannerIds: string[],
-		options: FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
-	): FindCursor<P>;
-
-	findByUserIdAndBannerId<P extends Document>(
-		userId: string,
-		bannerIds: string[],
-		options?: undefined | FindOptions<IBannerDismiss> | FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
-	): FindCursor<P> | FindCursor<IBannerDismiss>;
+	findByUserIdAndBannerId<P extends Document = IBannerDismiss, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, bannerIds: string[], options?: O): FindCursor<DocumentWithProjection<P, O>>;
 }

--- a/packages/model-typings/src/models/IBannersModel.ts
+++ b/packages/model-typings/src/models/IBannersModel.ts
@@ -1,12 +1,13 @@
 import type { BannerPlatform, IBanner, Optional } from '@rocket.chat/core-typings';
-import type { Document, FindCursor, FindOptions, UpdateResult, InsertOneResult } from 'mongodb';
+import type { Document, FindCursor, UpdateResult, InsertOneResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IBannersModel extends IBaseModel<IBanner> {
 	create(doc: Optional<IBanner, '_updatedAt'>): Promise<InsertOneResult<IBanner>>;
 
-	findActiveByRoleOrId(roles: string[], platform: BannerPlatform, bannerId?: string, options?: FindOptions<IBanner>): FindCursor<IBanner>;
+	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], platform: BannerPlatform, bannerId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	disable(bannerId: string): Promise<UpdateResult | Document>;
 

--- a/packages/model-typings/src/models/IBannersModel.ts
+++ b/packages/model-typings/src/models/IBannersModel.ts
@@ -7,7 +7,12 @@ import type { DocumentWithProjection, FindOptionsWithProjection } from '../types
 export interface IBannersModel extends IBaseModel<IBanner> {
 	create(doc: Optional<IBanner, '_updatedAt'>): Promise<InsertOneResult<IBanner>>;
 
-	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], platform: BannerPlatform, bannerId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: string[],
+		platform: BannerPlatform,
+		bannerId?: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	disable(bannerId: string): Promise<UpdateResult | Document>;
 

--- a/packages/model-typings/src/models/IBaseModel.ts
+++ b/packages/model-typings/src/models/IBaseModel.ts
@@ -24,14 +24,15 @@ import type {
 	WithId,
 } from 'mongodb';
 
+import type { ApplyProjection, DocumentWithProjection, FindOptionsWithProjection, ProjectionSpec } from '../types/DocumentWithProjection';
 import type { Updater } from '../updater';
 
 export type DefaultFields<Base> = Partial<Record<keyof Base, 1>> | Partial<Record<keyof Base, 0>> | void;
-export type ResultFields<Base, Defaults> = Defaults extends void
+export type ResultFields<Base, Defaults> = Defaults extends void | undefined
 	? Base
-	: Defaults[keyof Defaults] extends 1
-		? Pick<Defaults, keyof Defaults>
-		: Omit<Defaults, keyof Defaults>;
+	: Defaults extends ProjectionSpec
+		? ApplyProjection<Base, Defaults>
+		: Base;
 
 export type InsertionModel<T> = EnhancedOmit<OptionalId<T>, '_updatedAt'> & {
 	_updatedAt?: Date;
@@ -59,20 +60,29 @@ export interface IBaseModel<
 	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<null | WithId<T>>;
 	findOneAndUpdate(query: Filter<T>, update: UpdateFilter<T> | T, options?: FindOneAndUpdateOptions): Promise<null | WithId<T>>;
 
-	findOneById(_id: T['_id'], options?: FindOptions<T> | undefined): Promise<T | null>;
-	findOneById<P extends Document = T>(_id: T['_id'], options?: FindOptions<P>): Promise<P | null>;
+	findOneById(_id: T['_id'], options?: undefined): Promise<ResultFields<T, C> | null>;
+	findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: T['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 
-	findOne(query?: Filter<T> | T['_id'], options?: undefined): Promise<T | null>;
-	findOne<P extends Document = T>(query: Filter<T> | T['_id'], options?: FindOptions<P extends T ? T : P>): Promise<P | null>;
+	findOne(query?: Filter<T> | T['_id'], options?: undefined): Promise<ResultFields<T, C> | null>;
+	findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> | T['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 
 	find(query?: Filter<T>): FindCursor<ResultFields<T, C>>;
-	find<P extends Document = T>(query: Filter<T>, options: FindOptions<P extends T ? T : P>): FindCursor<P>;
-	find<P extends Document>(
+	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		query: Filter<T> | undefined,
-		options?: FindOptions<P extends T ? T : P>,
-	): FindCursor<WithId<P>> | FindCursor<WithId<T>>;
+		options?: O,
+	): FindCursor<DocumentWithProjection<P, O>>;
 
-	findPaginated<P extends Document = T>(query: Filter<T>, options?: FindOptions<P extends T ? T : P>): FindPaginated<FindCursor<WithId<P>>>;
+	findPaginated(query?: Filter<T>): FindPaginated<FindCursor<ResultFields<T, C>>>;
+	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> | undefined,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>>;
 
 	update(
 		filter: Filter<T>,

--- a/packages/model-typings/src/models/IBaseModel.ts
+++ b/packages/model-typings/src/models/IBaseModel.ts
@@ -11,8 +11,6 @@ import type {
 	EnhancedOmit,
 	Filter,
 	FindCursor,
-	FindOneAndDeleteOptions,
-	FindOneAndUpdateOptions,
 	FindOptions,
 	InsertManyResult,
 	InsertOneOptions,
@@ -24,7 +22,15 @@ import type {
 	WithId,
 } from 'mongodb';
 
-import type { ApplyProjection, DocumentWithProjection, FindOptionsWithProjection, ProjectionSpec } from '../types/DocumentWithProjection';
+import type {
+	ApplyProjection,
+	DocumentWithDriverProjection,
+	DocumentWithProjection,
+	FindOneAndDeleteOptionsWithProjection,
+	FindOneAndUpdateOptionsWithProjection,
+	FindOptionsWithProjection,
+	ProjectionSpec,
+} from '../types/DocumentWithProjection';
 import type { Updater } from '../updater';
 
 export type DefaultFields<Base> = Partial<Record<keyof Base, 1>> | Partial<Record<keyof Base, 0>> | void;
@@ -56,9 +62,19 @@ export interface IBaseModel<
 	getUpdater(): Updater<T>;
 	updateFromUpdater(query: Filter<T>, updater: Updater<T>, options?: UpdateOptions): Promise<UpdateResult>;
 
-	findOneAndDelete(filter: Filter<T>, options?: FindOneAndDeleteOptions): Promise<null | WithId<T>>;
-	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<null | WithId<T>>;
-	findOneAndUpdate(query: Filter<T>, update: UpdateFilter<T> | T, options?: FindOneAndUpdateOptions): Promise<null | WithId<T>>;
+	findOneAndDelete<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
+		filter: Filter<T>,
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null>;
+	findOneAndDeleteById<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
+		_id: T['_id'],
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null>;
+	findOneAndUpdate<P extends Document = T, O extends FindOneAndUpdateOptionsWithProjection = FindOneAndUpdateOptionsWithProjection>(
+		query: Filter<T>,
+		update: UpdateFilter<T> | T,
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null>;
 
 	findOneById(_id: T['_id'], options?: undefined): Promise<ResultFields<T, C> | null>;
 	findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(

--- a/packages/model-typings/src/models/IBaseModel.ts
+++ b/packages/model-typings/src/models/IBaseModel.ts
@@ -11,6 +11,7 @@ import type {
 	EnhancedOmit,
 	Filter,
 	FindCursor,
+	FindOneAndDeleteOptions,
 	FindOptions,
 	InsertManyResult,
 	InsertOneOptions,
@@ -26,7 +27,6 @@ import type {
 	ApplyProjection,
 	DocumentWithDriverProjection,
 	DocumentWithProjection,
-	FindOneAndDeleteOptionsWithProjection,
 	FindOneAndUpdateOptionsWithProjection,
 	FindOptionsWithProjection,
 	ProjectionSpec,
@@ -62,14 +62,14 @@ export interface IBaseModel<
 	getUpdater(): Updater<T>;
 	updateFromUpdater(query: Filter<T>, updater: Updater<T>, options?: UpdateOptions): Promise<UpdateResult>;
 
-	findOneAndDelete<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
-		filter: Filter<T>,
-		options?: O,
-	): Promise<DocumentWithDriverProjection<P, O> | null>;
-	findOneAndDeleteById<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
-		_id: T['_id'],
-		options?: O,
-	): Promise<DocumentWithDriverProjection<P, O> | null>;
+	/**
+	 * No projection narrowing: whether the model archives to a trash collection is a runtime detail
+	 * (a constructor argument), and the trash path has to read the whole document to archive it, so
+	 * it returns every field regardless of the projection. Narrowing here would claim a filtering
+	 * that only happens for models without a trash collection.
+	 */
+	findOneAndDelete(filter: Filter<T>, options?: FindOneAndDeleteOptions): Promise<WithId<T> | null>;
+	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<WithId<T> | null>;
 	findOneAndUpdate<P extends Document = T, O extends FindOneAndUpdateOptionsWithProjection = FindOneAndUpdateOptionsWithProjection>(
 		query: Filter<T>,
 		update: UpdateFilter<T> | T,

--- a/packages/model-typings/src/models/IBaseUploadsModel.ts
+++ b/packages/model-typings/src/models/IBaseUploadsModel.ts
@@ -1,7 +1,8 @@
 import type { EncryptedContent, IUpload } from '@rocket.chat/core-typings';
-import type { DeleteResult, UpdateResult, ClientSession, Document, InsertOneResult, WithId, FindCursor, FindOptions } from 'mongodb';
+import type { DeleteResult, UpdateResult, ClientSession, Document, InsertOneResult, WithId, FindCursor } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IBaseUploadsModel<T extends IUpload> extends IBaseModel<T> {
 	insertFileInit(userId: string, store: string, file: { name: string }, extra: object): Promise<InsertOneResult<WithId<IUpload>>>;
@@ -10,19 +11,19 @@ export interface IBaseUploadsModel<T extends IUpload> extends IBaseModel<T> {
 
 	confirmTemporaryFile(fileId: string, userId: string): Promise<Document | UpdateResult> | undefined;
 
-	findByIds(_ids: string[], options?: FindOptions<T>): FindCursor<T>;
+	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(_ids: string[], options?: O): FindCursor<DocumentWithProjection<T_, O>>;
 
 	findOneByName(name: string, options?: { session?: ClientSession }): Promise<T | null>;
 
 	findOneByRoomId(rid: string): Promise<T | null>;
 
-	findExpiredTemporaryFiles(options?: FindOptions<T>): FindCursor<T>;
+	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(options?: O): FindCursor<DocumentWithProjection<T_, O>>;
 
 	updateFileNameById(fileId: string, name: string): Promise<Document | UpdateResult>;
 
 	deleteFile(fileId: string, options?: { session?: ClientSession }): Promise<DeleteResult>;
 
-	findOneByIdAndUserIdAndRoomId(fileId: string, userId: string, rid: string, options?: FindOptions<T>): Promise<T | null>;
+	findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(fileId: string, userId: string, rid: string, options?: O): Promise<DocumentWithProjection<T_, O> | null>;
 
 	updateFileMetadata(
 		fileId: string,

--- a/packages/model-typings/src/models/IBaseUploadsModel.ts
+++ b/packages/model-typings/src/models/IBaseUploadsModel.ts
@@ -11,19 +11,29 @@ export interface IBaseUploadsModel<T extends IUpload> extends IBaseModel<T> {
 
 	confirmTemporaryFile(fileId: string, userId: string): Promise<Document | UpdateResult> | undefined;
 
-	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(_ids: string[], options?: O): FindCursor<DocumentWithProjection<T_, O>>;
+	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		_ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T_, O>>;
 
 	findOneByName(name: string, options?: { session?: ClientSession }): Promise<T | null>;
 
 	findOneByRoomId(rid: string): Promise<T | null>;
 
-	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(options?: O): FindCursor<DocumentWithProjection<T_, O>>;
+	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T_, O>>;
 
 	updateFileNameById(fileId: string, name: string): Promise<Document | UpdateResult>;
 
 	deleteFile(fileId: string, options?: { session?: ClientSession }): Promise<DeleteResult>;
 
-	findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(fileId: string, userId: string, rid: string, options?: O): Promise<DocumentWithProjection<T_, O> | null>;
+	findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		fileId: string,
+		userId: string,
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T_, O> | null>;
 
 	updateFileMetadata(
 		fileId: string,

--- a/packages/model-typings/src/models/ICalendarEventModel.ts
+++ b/packages/model-typings/src/models/ICalendarEventModel.ts
@@ -14,6 +14,12 @@ export interface ICalendarEventModel extends IBaseModel<ICalendarEvent> {
 		uid: ICalendarEvent['uid'],
 	): Promise<ICalendarEvent | null>;
 	findOverlappingEvents(eventId: ICalendarEvent['_id'], uid: IUser['_id'], startTime: Date, endTime: Date): FindCursor<ICalendarEvent>;
-	findNextFutureEvent(startTime: Date): Promise<ICalendarEvent | null>;
-	findEventsStartingNow({ now, offset }: { now: Date; offset?: number }): FindCursor<ICalendarEvent>;
+	findNextFutureEvent(startTime: Date): Promise<Pick<ICalendarEvent, '_id' | 'startTime'> | null>;
+	findEventsStartingNow({
+		now,
+		offset,
+	}: {
+		now: Date;
+		offset?: number;
+	}): FindCursor<Pick<ICalendarEvent, '_id' | 'uid' | 'startTime' | 'endTime'>>;
 }

--- a/packages/model-typings/src/models/ICallHistoryModel.ts
+++ b/packages/model-typings/src/models/ICallHistoryModel.ts
@@ -1,31 +1,20 @@
 import type { CallHistoryItem, IRegisterUser, IUser } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions } from 'mongodb';
+import type { FindCursor, Document } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICallHistoryModel extends IBaseModel<CallHistoryItem> {
-	findOneByIdAndUid(
-		_id: CallHistoryItem['_id'],
-		uid: CallHistoryItem['uid'],
-		options?: FindOptions<CallHistoryItem>,
-	): Promise<CallHistoryItem | null>;
+	findOneByIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: CallHistoryItem['_id'], uid: CallHistoryItem['uid'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByCallIdAndUid(
-		callId: CallHistoryItem['callId'],
-		uid: CallHistoryItem['uid'],
-		options?: FindOptions<CallHistoryItem>,
-	): Promise<CallHistoryItem | null>;
+	findOneByCallIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: CallHistoryItem['callId'], uid: CallHistoryItem['uid'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findAllByUserIdAndSearchFilters(
-		uid: IUser['_id'],
-		filters: {
+	findAllByUserIdAndSearchFilters<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], filters: {
 			type?: CallHistoryItem['type'];
 			searchTerm?: string;
 			direction?: CallHistoryItem['direction'];
 			inStates?: CallHistoryItem['state'][];
-		},
-		options: FindOptions<CallHistoryItem>,
-	): FindPaginated<FindCursor<CallHistoryItem>>;
+		}, options: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	updateUserReferences(userId: IRegisterUser['_id'], username: IRegisterUser['username'], name?: IRegisterUser['name']): Promise<void>;
 }

--- a/packages/model-typings/src/models/ICallHistoryModel.ts
+++ b/packages/model-typings/src/models/ICallHistoryModel.ts
@@ -5,16 +5,31 @@ import type { FindPaginated, IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICallHistoryModel extends IBaseModel<CallHistoryItem> {
-	findOneByIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: CallHistoryItem['_id'], uid: CallHistoryItem['uid'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: CallHistoryItem['_id'],
+		uid: CallHistoryItem['uid'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByCallIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: CallHistoryItem['callId'], uid: CallHistoryItem['uid'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByCallIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		callId: CallHistoryItem['callId'],
+		uid: CallHistoryItem['uid'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findAllByUserIdAndSearchFilters<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], filters: {
+	findAllByUserIdAndSearchFilters<
+		T extends Document = CallHistoryItem,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		uid: IUser['_id'],
+		filters: {
 			type?: CallHistoryItem['type'];
 			searchTerm?: string;
 			direction?: CallHistoryItem['direction'];
 			inStates?: CallHistoryItem['state'][];
-		}, options: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+		},
+		options: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	updateUserReferences(userId: IRegisterUser['_id'], username: IRegisterUser['username'], name?: IRegisterUser['name']): Promise<void>;
 }

--- a/packages/model-typings/src/models/ICannedResponseModel.ts
+++ b/packages/model-typings/src/models/ICannedResponseModel.ts
@@ -1,12 +1,12 @@
 import type { IOmnichannelCannedResponse } from '@rocket.chat/core-typings';
-import type { FindOptions, FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
+import type { FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICannedResponseModel extends IBaseModel<IOmnichannelCannedResponse> {
-	findOneById(_id: string, options?: FindOptions<IOmnichannelCannedResponse>): Promise<IOmnichannelCannedResponse | null>;
-	findOneByShortcut(shortcut: string, options?: FindOptions<IOmnichannelCannedResponse>): Promise<IOmnichannelCannedResponse | null>;
-	findByDepartmentId(departmentId: string, options?: FindOptions<IOmnichannelCannedResponse>): FindCursor<IOmnichannelCannedResponse>;
+	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(shortcut: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByDepartmentId<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	removeById(_id: string): Promise<DeleteResult>;
 	createCannedResponse({
 		shortcut,

--- a/packages/model-typings/src/models/ICannedResponseModel.ts
+++ b/packages/model-typings/src/models/ICannedResponseModel.ts
@@ -5,8 +5,17 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICannedResponseModel extends IBaseModel<IOmnichannelCannedResponse> {
-	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(shortcut: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByDepartmentId<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByShortcut<T extends Document = IOmnichannelCannedResponse, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		shortcut: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByDepartmentId<
+		T extends Document = IOmnichannelCannedResponse,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		departmentId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	removeById(_id: string): Promise<DeleteResult>;
 	createCannedResponse({
 		shortcut,

--- a/packages/model-typings/src/models/ICustomSoundsModel.ts
+++ b/packages/model-typings/src/models/ICustomSoundsModel.ts
@@ -1,11 +1,12 @@
 import type { ICustomSound } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { FindCursor, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICustomSoundsModel extends IBaseModel<ICustomSound> {
-	findByName(name: string, exceptId?: string, options?: FindOptions<ICustomSound>): FindCursor<ICustomSound>;
-	findOneByName(name: string, exceptId?: string, options?: FindOptions<ICustomSound>): Promise<ICustomSound | null>;
+	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	create(data: Omit<ICustomSound, '_id' | '_updatedAt'>): Promise<InsertOneResult<WithId<ICustomSound>>>;
 	updateById(_id: string, data: Partial<Omit<ICustomSound, '_id'>>): Promise<UpdateResult>;
 }

--- a/packages/model-typings/src/models/ICustomSoundsModel.ts
+++ b/packages/model-typings/src/models/ICustomSoundsModel.ts
@@ -5,8 +5,16 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICustomSoundsModel extends IBaseModel<ICustomSound> {
-	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		exceptId?: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		exceptId?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	create(data: Omit<ICustomSound, '_id' | '_updatedAt'>): Promise<InsertOneResult<WithId<ICustomSound>>>;
 	updateById(_id: string, data: Partial<Omit<ICustomSound, '_id'>>): Promise<UpdateResult>;
 }

--- a/packages/model-typings/src/models/ICustomUserStatusModel.ts
+++ b/packages/model-typings/src/models/ICustomUserStatusModel.ts
@@ -1,14 +1,14 @@
 import type { ICustomUserStatus } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { FindCursor, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import type { IBaseModel, InsertionModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICustomUserStatusModel extends IBaseModel<ICustomUserStatus> {
-	findOneByName(name: string, options?: undefined): Promise<ICustomUserStatus | null>;
-	findOneByName(name: string, options?: FindOptions<ICustomUserStatus>): Promise<ICustomUserStatus | null>;
-	findOneByNameExceptId(name: string, except: string, options?: FindOptions<ICustomUserStatus>): Promise<ICustomUserStatus | null>;
-	findByName(name: string, options?: FindOptions<ICustomUserStatus>): FindCursor<ICustomUserStatus>;
-	findByNameExceptId(name: string, except: string, options?: FindOptions<ICustomUserStatus>): FindCursor<ICustomUserStatus>;
+	findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	setName(_id: string, name: string): Promise<UpdateResult>;
 	setStatusType(_id: string, statusType: string): Promise<UpdateResult>;
 	create(data: InsertionModel<ICustomUserStatus>): Promise<InsertOneResult<WithId<ICustomUserStatus>>>;

--- a/packages/model-typings/src/models/ICustomUserStatusModel.ts
+++ b/packages/model-typings/src/models/ICustomUserStatusModel.ts
@@ -5,10 +5,24 @@ import type { IBaseModel, InsertionModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ICustomUserStatusModel extends IBaseModel<ICustomUserStatus> {
-	findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	setName(_id: string, name: string): Promise<UpdateResult>;
 	setStatusType(_id: string, statusType: string): Promise<UpdateResult>;
 	create(data: InsertionModel<ICustomUserStatus>): Promise<InsertOneResult<WithId<ICustomUserStatus>>>;

--- a/packages/model-typings/src/models/IEmojiCustomModel.ts
+++ b/packages/model-typings/src/models/IEmojiCustomModel.ts
@@ -5,14 +5,28 @@ import type { IBaseModel, InsertionModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IEmojiCustomModel extends IBaseModel<IEmojiCustom> {
-	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emojiName: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(names: string[], exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emojiName: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		names: string[],
+		exceptId?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	setName(_id: string, name: string): Promise<UpdateResult>;
 	setAliases(_id: string, aliases: string[]): Promise<UpdateResult>;
 	setExtension(_id: string, extension: string): Promise<UpdateResult>;
 	setETagByName(name: string, etag: string): Promise<UpdateResult>;
 	create(data: InsertionModel<IEmojiCustom>): Promise<InsertOneResult<WithId<IEmojiCustom>>>;
 	countByNameOrAlias(name: string): Promise<number>;
-	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IEmojiCustomModel.ts
+++ b/packages/model-typings/src/models/IEmojiCustomModel.ts
@@ -1,17 +1,18 @@
 import type { IEmojiCustom } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { FindCursor, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import type { IBaseModel, InsertionModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IEmojiCustomModel extends IBaseModel<IEmojiCustom> {
-	findByNameOrAlias(emojiName: string, options?: FindOptions<IEmojiCustom>): FindCursor<IEmojiCustom>;
-	findOneByNamesOrAliases(names: string[], exceptId?: string, options?: FindOptions<IEmojiCustom>): Promise<IEmojiCustom | null>;
-	findByNameOrAliasExceptID(name: string, except: string, options?: FindOptions<IEmojiCustom>): FindCursor<IEmojiCustom>;
+	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emojiName: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(names: string[], exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	setName(_id: string, name: string): Promise<UpdateResult>;
 	setAliases(_id: string, aliases: string[]): Promise<UpdateResult>;
 	setExtension(_id: string, extension: string): Promise<UpdateResult>;
 	setETagByName(name: string, etag: string): Promise<UpdateResult>;
 	create(data: InsertionModel<IEmojiCustom>): Promise<InsertOneResult<WithId<IEmojiCustom>>>;
 	countByNameOrAlias(name: string): Promise<number>;
-	findOneByName(name: string, options?: FindOptions<IEmojiCustom>): Promise<IEmojiCustom | null>;
+	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IIntegrationsModel.ts
+++ b/packages/model-typings/src/models/IIntegrationsModel.ts
@@ -21,6 +21,10 @@ export interface IIntegrationsModel extends IBaseModel<IIntegration> {
 	removeByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
 	findOneByUrl(url: string): Promise<IIntegration | null>;
 	updateRoomName(oldRoomName: string, newRoomName: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;
-	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(id: IIntegration['_id'], token: string, options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		id: IIntegration['_id'],
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 	getStatistics(options?: AggregateOptions): Promise<IntegrationsStatistics>;
 }

--- a/packages/model-typings/src/models/IIntegrationsModel.ts
+++ b/packages/model-typings/src/models/IIntegrationsModel.ts
@@ -1,7 +1,8 @@
 import type { IIntegration, IUser } from '@rocket.chat/core-typings';
-import type { AggregateOptions, FindCursor, FindOptions } from 'mongodb';
+import type { AggregateOptions, FindCursor, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export type IntegrationsStatistics = {
 	totalIntegrations: number;
@@ -20,10 +21,6 @@ export interface IIntegrationsModel extends IBaseModel<IIntegration> {
 	removeByIdAndCreatedByIfExists(params: { _id: IIntegration['_id']; createdBy?: IUser['_id'] }): Promise<IIntegration | null>;
 	findOneByUrl(url: string): Promise<IIntegration | null>;
 	updateRoomName(oldRoomName: string, newRoomName: string): ReturnType<IBaseModel<IIntegration>['updateMany']>;
-	findOneByIdAndToken<P extends IIntegration = IIntegration>(
-		id: IIntegration['_id'],
-		token: string,
-		options?: FindOptions<P>,
-	): Promise<P | null>;
+	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(id: IIntegration['_id'], token: string, options?: O): Promise<DocumentWithProjection<P, O> | null>;
 	getStatistics(options?: AggregateOptions): Promise<IntegrationsStatistics>;
 }

--- a/packages/model-typings/src/models/ILivechatBusinessHoursModel.ts
+++ b/packages/model-typings/src/models/ILivechatBusinessHoursModel.ts
@@ -1,7 +1,8 @@
 import type { ILivechatBusinessHour, LivechatBusinessHourTypes } from '@rocket.chat/core-typings';
-import type { Document, FindOptions } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IWorkHoursCronJobsItem {
 	day: string;
@@ -14,14 +15,9 @@ export interface IWorkHoursCronJobsWrapper {
 }
 
 export interface ILivechatBusinessHoursModel extends IBaseModel<ILivechatBusinessHour> {
-	findActiveBusinessHours(options?: FindOptions<ILivechatBusinessHour>): Promise<ILivechatBusinessHour[]>;
-	findOneDefaultBusinessHour(options?: undefined): Promise<ILivechatBusinessHour | null>;
-	findOneDefaultBusinessHour(options: FindOptions<ILivechatBusinessHour>): Promise<ILivechatBusinessHour | null>;
-	findOneDefaultBusinessHour<P extends Document>(
-		options: FindOptions<P extends ILivechatBusinessHour ? ILivechatBusinessHour : P>,
-	): Promise<P | null>;
-	findOneDefaultBusinessHour<P>(options?: any): Promise<ILivechatBusinessHour | P | null>;
-	findActiveAndOpenBusinessHoursByDay(day: string, options?: FindOptions<ILivechatBusinessHour>): Promise<ILivechatBusinessHour[]>;
+	findActiveBusinessHours<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O>[]>;
+	findOneDefaultBusinessHour<P extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findActiveAndOpenBusinessHoursByDay<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(day: string, options?: O): Promise<DocumentWithProjection<T, O>[]>;
 	findDefaultActiveAndOpenBusinessHoursByDay(day: string, options?: any): Promise<ILivechatBusinessHour[]>;
 	insertOne(data: Omit<ILivechatBusinessHour, '_id' | '_updatedAt'>): Promise<any>;
 	findHoursToScheduleJobs(): Promise<IWorkHoursCronJobsWrapper[]>;

--- a/packages/model-typings/src/models/ILivechatBusinessHoursModel.ts
+++ b/packages/model-typings/src/models/ILivechatBusinessHoursModel.ts
@@ -15,9 +15,25 @@ export interface IWorkHoursCronJobsWrapper {
 }
 
 export interface ILivechatBusinessHoursModel extends IBaseModel<ILivechatBusinessHour> {
-	findActiveBusinessHours<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O>[]>;
-	findOneDefaultBusinessHour<P extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(options?: O): Promise<DocumentWithProjection<P, O> | null>;
-	findActiveAndOpenBusinessHoursByDay<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(day: string, options?: O): Promise<DocumentWithProjection<T, O>[]>;
+	findActiveBusinessHours<
+		T extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		options?: O,
+	): Promise<DocumentWithProjection<T, O>[]>;
+	findOneDefaultBusinessHour<
+		P extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
+	findActiveAndOpenBusinessHoursByDay<
+		T extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		day: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O>[]>;
 	findDefaultActiveAndOpenBusinessHoursByDay(day: string, options?: any): Promise<ILivechatBusinessHour[]>;
 	insertOne(data: Omit<ILivechatBusinessHour, '_id' | '_updatedAt'>): Promise<any>;
 	findHoursToScheduleJobs(): Promise<IWorkHoursCronJobsWrapper[]>;

--- a/packages/model-typings/src/models/ILivechatContactsModel.ts
+++ b/packages/model-typings/src/models/ILivechatContactsModel.ts
@@ -1,6 +1,11 @@
-import type { AtLeast, ILivechatContact, ILivechatContactChannel, ILivechatContactVisitorAssociation, ILivechatVisitor, } from '@rocket.chat/core-typings';
 import type {
-	AggregationCursor, Document, FindCursor, FindOneAndUpdateOptions, UpdateFilter, UpdateOptions, UpdateResult } from 'mongodb';
+	AtLeast,
+	ILivechatContact,
+	ILivechatContactChannel,
+	ILivechatContactVisitorAssociation,
+	ILivechatVisitor,
+} from '@rocket.chat/core-typings';
+import type { AggregationCursor, Document, FindCursor, FindOneAndUpdateOptions, UpdateFilter, UpdateOptions, UpdateResult } from 'mongodb';
 
 import type { Updater } from '../updater';
 import type { FindPaginated, IBaseModel, InsertionModel } from './IBaseModel';
@@ -20,7 +25,10 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	): Promise<ILivechatContact | null>;
 	updateById(contactId: string, update: UpdateFilter<ILivechatContact>, options?: UpdateOptions): Promise<Document | UpdateResult>;
 	addChannel(contactId: string, channel: ILivechatContactChannel): Promise<void>;
-	findPaginatedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(search: { searchText?: string; unknown?: boolean }, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		search: { searchText?: string; unknown?: boolean },
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 	updateLastChatById(
 		contactId: string,
 		visitor: ILivechatContactVisitorAssociation,
@@ -28,14 +36,21 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	): Promise<UpdateResult>;
 	findContactMatchingVisitor(visitor: AtLeast<ILivechatVisitor, 'visitorEmails' | 'phone'>): Promise<ILivechatContact | null>;
 	findContactByEmailAndContactManager(email: string): Promise<Pick<ILivechatContact, 'contactManager'> | null>;
-	findOneByVisitor<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitor: ILivechatContactVisitorAssociation, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByVisitor<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitor: ILivechatContactVisitorAssociation,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	isChannelBlocked(visitor: ILivechatContactVisitorAssociation): Promise<boolean>;
 	updateFromUpdaterByAssociation(
 		visitor: ILivechatContactVisitorAssociation,
 		contactUpdater: Updater<ILivechatContact>,
 		options?: UpdateOptions,
 	): Promise<UpdateResult>;
-	findSimilarVerifiedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(channel: Pick<ILivechatContactChannel, 'field' | 'value'>, originalContactId: string, options?: O): Promise<DocumentWithProjection<T, O>[]>;
+	findSimilarVerifiedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		channel: Pick<ILivechatContactChannel, 'field' | 'value'>,
+		originalContactId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O>[]>;
 	findAllByVisitorId(visitorId: string): FindCursor<ILivechatContact>;
 	addEmail(contactId: string, email: string): Promise<ILivechatContact | null>;
 	isContactActiveOnPeriod(visitor: ILivechatContactVisitorAssociation, period: string): Promise<number>;
@@ -54,5 +69,8 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	getStatistics(): AggregationCursor<{ totalConflicts: number; avgChannelsPerContact: number }>;
 	disableByVisitorId(visitorId: string): Promise<UpdateResult | Document>;
 	disableByContactId(contactId: string): Promise<UpdateResult>;
-	findOneEnabledById<P extends Document = ILivechatContact, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: ILivechatContact['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findOneEnabledById<P extends Document = ILivechatContact, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: ILivechatContact['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 }

--- a/packages/model-typings/src/models/ILivechatContactsModel.ts
+++ b/packages/model-typings/src/models/ILivechatContactsModel.ts
@@ -1,23 +1,10 @@
+import type { AtLeast, ILivechatContact, ILivechatContactChannel, ILivechatContactVisitorAssociation, ILivechatVisitor, } from '@rocket.chat/core-typings';
 import type {
-	AtLeast,
-	ILivechatContact,
-	ILivechatContactChannel,
-	ILivechatContactVisitorAssociation,
-	ILivechatVisitor,
-} from '@rocket.chat/core-typings';
-import type {
-	AggregationCursor,
-	Document,
-	FindCursor,
-	FindOneAndUpdateOptions,
-	FindOptions,
-	UpdateFilter,
-	UpdateOptions,
-	UpdateResult,
-} from 'mongodb';
+	AggregationCursor, Document, FindCursor, FindOneAndUpdateOptions, UpdateFilter, UpdateOptions, UpdateResult } from 'mongodb';
 
 import type { Updater } from '../updater';
 import type { FindPaginated, IBaseModel, InsertionModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	insertContact(
@@ -33,10 +20,7 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	): Promise<ILivechatContact | null>;
 	updateById(contactId: string, update: UpdateFilter<ILivechatContact>, options?: UpdateOptions): Promise<Document | UpdateResult>;
 	addChannel(contactId: string, channel: ILivechatContactChannel): Promise<void>;
-	findPaginatedContacts(
-		search: { searchText?: string; unknown?: boolean },
-		options?: FindOptions<ILivechatContact>,
-	): FindPaginated<FindCursor<ILivechatContact>>;
+	findPaginatedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(search: { searchText?: string; unknown?: boolean }, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 	updateLastChatById(
 		contactId: string,
 		visitor: ILivechatContactVisitorAssociation,
@@ -44,21 +28,14 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	): Promise<UpdateResult>;
 	findContactMatchingVisitor(visitor: AtLeast<ILivechatVisitor, 'visitorEmails' | 'phone'>): Promise<ILivechatContact | null>;
 	findContactByEmailAndContactManager(email: string): Promise<Pick<ILivechatContact, 'contactManager'> | null>;
-	findOneByVisitor<T extends Document = ILivechatContact>(
-		visitor: ILivechatContactVisitorAssociation,
-		options?: FindOptions<ILivechatContact>,
-	): Promise<T | null>;
+	findOneByVisitor<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitor: ILivechatContactVisitorAssociation, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	isChannelBlocked(visitor: ILivechatContactVisitorAssociation): Promise<boolean>;
 	updateFromUpdaterByAssociation(
 		visitor: ILivechatContactVisitorAssociation,
 		contactUpdater: Updater<ILivechatContact>,
 		options?: UpdateOptions,
 	): Promise<UpdateResult>;
-	findSimilarVerifiedContacts(
-		channel: Pick<ILivechatContactChannel, 'field' | 'value'>,
-		originalContactId: string,
-		options?: FindOptions<ILivechatContact>,
-	): Promise<ILivechatContact[]>;
+	findSimilarVerifiedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(channel: Pick<ILivechatContactChannel, 'field' | 'value'>, originalContactId: string, options?: O): Promise<DocumentWithProjection<T, O>[]>;
 	findAllByVisitorId(visitorId: string): FindCursor<ILivechatContact>;
 	addEmail(contactId: string, email: string): Promise<ILivechatContact | null>;
 	isContactActiveOnPeriod(visitor: ILivechatContactVisitorAssociation, period: string): Promise<number>;
@@ -77,7 +54,5 @@ export interface ILivechatContactsModel extends IBaseModel<ILivechatContact> {
 	getStatistics(): AggregationCursor<{ totalConflicts: number; avgChannelsPerContact: number }>;
 	disableByVisitorId(visitorId: string): Promise<UpdateResult | Document>;
 	disableByContactId(contactId: string): Promise<UpdateResult>;
-	findOneEnabledById(_id: ILivechatContact['_id'], options?: FindOptions<ILivechatContact>): Promise<ILivechatContact | null>;
-	findOneEnabledById<P extends Document = ILivechatContact>(_id: P['_id'], options?: FindOptions<P>): Promise<P | null>;
-	findOneEnabledById(_id: ILivechatContact['_id'], options?: any): Promise<ILivechatContact | null>;
+	findOneEnabledById<P extends Document = ILivechatContact, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: ILivechatContact['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
 }

--- a/packages/model-typings/src/models/ILivechatCustomFieldModel.ts
+++ b/packages/model-typings/src/models/ILivechatCustomFieldModel.ts
@@ -5,9 +5,28 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatCustomFieldModel extends IBaseModel<ILivechatCustomField> {
-	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], options?: O, includeHidden?: boolean): FindCursor<DocumentWithProjection<T, O>>;
-	findMatchingCustomFields<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], searchable: boolean, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findMatchingCustomFieldsByIds<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: ILivechatCustomField['_id'][], scope: ILivechatCustomField['scope'], searchable: boolean, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		scope: ILivechatCustomField['scope'],
+		options?: O,
+		includeHidden?: boolean,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findMatchingCustomFields<
+		T extends Document = ILivechatCustomField,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		scope: ILivechatCustomField['scope'],
+		searchable: boolean,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findMatchingCustomFieldsByIds<
+		T extends Document = ILivechatCustomField,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		ids: ILivechatCustomField['_id'][],
+		scope: ILivechatCustomField['scope'],
+		searchable: boolean,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	createOrUpdateCustomField(
 		_id: string | null,
 		field: string,

--- a/packages/model-typings/src/models/ILivechatCustomFieldModel.ts
+++ b/packages/model-typings/src/models/ILivechatCustomFieldModel.ts
@@ -1,30 +1,13 @@
 import type { ILivechatCustomField } from '@rocket.chat/core-typings';
-import type { FindOptions, FindCursor, Document } from 'mongodb';
+import type { FindCursor, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatCustomFieldModel extends IBaseModel<ILivechatCustomField> {
-	findByScope<T extends Document = ILivechatCustomField>(
-		scope: ILivechatCustomField['scope'],
-		options?: FindOptions<T>,
-		includeHidden?: boolean,
-	): FindCursor<T>;
-	findByScope(
-		scope: ILivechatCustomField['scope'],
-		options?: FindOptions<ILivechatCustomField>,
-		includeHidden?: boolean,
-	): FindCursor<ILivechatCustomField>;
-	findMatchingCustomFields(
-		scope: ILivechatCustomField['scope'],
-		searchable: boolean,
-		options?: FindOptions<ILivechatCustomField>,
-	): FindCursor<ILivechatCustomField>;
-	findMatchingCustomFieldsByIds(
-		ids: ILivechatCustomField['_id'][],
-		scope: ILivechatCustomField['scope'],
-		searchable: boolean,
-		options?: FindOptions<ILivechatCustomField>,
-	): FindCursor<ILivechatCustomField>;
+	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], options?: O, includeHidden?: boolean): FindCursor<DocumentWithProjection<T, O>>;
+	findMatchingCustomFields<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], searchable: boolean, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findMatchingCustomFieldsByIds<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: ILivechatCustomField['_id'][], scope: ILivechatCustomField['scope'], searchable: boolean, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	createOrUpdateCustomField(
 		_id: string | null,
 		field: string,

--- a/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
+++ b/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
@@ -1,38 +1,19 @@
 import type { AvailableAgentsAggregation, ILivechatDepartmentAgents } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindCursor, FindOptions, Document, UpdateResult, Filter, AggregationCursor } from 'mongodb';
+import type { DeleteResult, FindCursor, Document, UpdateResult, Filter, AggregationCursor } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatDepartmentAgentsModel extends IBaseModel<ILivechatDepartmentAgents> {
-	findByAgentId(agentId: string, options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents>;
+	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findAgentsByDepartmentId(departmentId: string): FindPaginated<FindCursor<ILivechatDepartmentAgents>>;
-
-	findAgentsByDepartmentId(
-		departmentId: string,
-		options: FindOptions<ILivechatDepartmentAgents>,
-	): FindPaginated<FindCursor<ILivechatDepartmentAgents>>;
-
-	findAgentsByDepartmentId<P extends Document>(
-		departmentId: string,
-		options: FindOptions<P extends ILivechatDepartmentAgents ? ILivechatDepartmentAgents : P>,
-	): FindPaginated<FindCursor<P>>;
-
-	findAgentsByDepartmentId(
-		departmentId: string,
-		options?: undefined | FindOptions<ILivechatDepartmentAgents>,
-	): FindPaginated<FindCursor<ILivechatDepartmentAgents>>;
+	findAgentsByDepartmentId<P extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(departmentId: string, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>>;
 
 	findByDepartmentIds(departmentIds: string[], options?: Record<string, any>): FindCursor<ILivechatDepartmentAgents>;
 	setDepartmentEnabledByDepartmentId(departmentId: string, departmentEnabled: boolean): Promise<Document | UpdateResult>;
 	removeByDepartmentId(departmentId: string): Promise<DeleteResult>;
-	findByDepartmentId(departmentId: string, options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents>;
-	findOneByAgentIdAndDepartmentId(
-		agentId: string,
-		departmentId: string,
-		options?: FindOptions<ILivechatDepartmentAgents>,
-	): Promise<ILivechatDepartmentAgents | null>;
-	findOneByAgentIdAndDepartmentId(agentId: string, departmentId: string): Promise<ILivechatDepartmentAgents | null>;
+	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByAgentIdAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	saveAgent(agent: Omit<ILivechatDepartmentAgents, '_id' | '_updatedAt'>): Promise<UpdateResult>;
 	removeByAgentId(agentId: string): Promise<DeleteResult>;
 	getNextAgentForDepartment(
@@ -52,11 +33,7 @@ export interface ILivechatDepartmentAgentsModel extends IBaseModel<ILivechatDepa
 	disableAgentsByDepartmentId(departmentId: string): Promise<UpdateResult | Document>;
 	enableAgentsByDepartmentId(departmentId: string): Promise<UpdateResult | Document>;
 	findAllAgentsConnectedToListOfDepartments(departmentIds: string[]): Promise<string[]>;
-	findByAgentIds(agentIds: string[], options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents>;
-	findByAgentsAndDepartmentId(
-		agentsIds: ILivechatDepartmentAgents['agentId'][],
-		departmentId: ILivechatDepartmentAgents['departmentId'],
-		options?: FindOptions<ILivechatDepartmentAgents>,
-	): FindCursor<ILivechatDepartmentAgents>;
+	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByAgentsAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentsIds: ILivechatDepartmentAgents['agentId'][], departmentId: ILivechatDepartmentAgents['departmentId'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	findDepartmentsOfAgent(agentId: string, enabled?: boolean): AggregationCursor<ILivechatDepartmentAgents & { departmentName: string }>;
 }

--- a/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
+++ b/packages/model-typings/src/models/ILivechatDepartmentAgentsModel.ts
@@ -5,15 +5,34 @@ import type { FindPaginated, IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatDepartmentAgentsModel extends IBaseModel<ILivechatDepartmentAgents> {
-	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		agentId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findAgentsByDepartmentId<P extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(departmentId: string, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>>;
+	findAgentsByDepartmentId<
+		P extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(
+		departmentId: string,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>>;
 
 	findByDepartmentIds(departmentIds: string[], options?: Record<string, any>): FindCursor<ILivechatDepartmentAgents>;
 	setDepartmentEnabledByDepartmentId(departmentId: string, departmentEnabled: boolean): Promise<Document | UpdateResult>;
 	removeByDepartmentId(departmentId: string): Promise<DeleteResult>;
-	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findOneByAgentIdAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByAgentIdAndDepartmentId<
+		T extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		agentId: string,
+		departmentId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	saveAgent(agent: Omit<ILivechatDepartmentAgents, '_id' | '_updatedAt'>): Promise<UpdateResult>;
 	removeByAgentId(agentId: string): Promise<DeleteResult>;
 	getNextAgentForDepartment(
@@ -33,7 +52,17 @@ export interface ILivechatDepartmentAgentsModel extends IBaseModel<ILivechatDepa
 	disableAgentsByDepartmentId(departmentId: string): Promise<UpdateResult | Document>;
 	enableAgentsByDepartmentId(departmentId: string): Promise<UpdateResult | Document>;
 	findAllAgentsConnectedToListOfDepartments(departmentIds: string[]): Promise<string[]>;
-	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByAgentsAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentsIds: ILivechatDepartmentAgents['agentId'][], departmentId: ILivechatDepartmentAgents['departmentId'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		agentIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByAgentsAndDepartmentId<
+		T extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		agentsIds: ILivechatDepartmentAgents['agentId'][],
+		departmentId: ILivechatDepartmentAgents['departmentId'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	findDepartmentsOfAgent(agentId: string, enabled?: boolean): AggregationCursor<ILivechatDepartmentAgents & { departmentName: string }>;
 }

--- a/packages/model-typings/src/models/ILivechatDepartmentModel.ts
+++ b/packages/model-typings/src/models/ILivechatDepartmentModel.ts
@@ -6,15 +6,40 @@ import type { DocumentWithProjection, FindOptionsWithProjection } from '../types
 
 export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment> {
 	countTotal(): Promise<number>;
-	findInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentsIds: string[], options: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByNameRegexWithExceptionsAndConditions<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], conditions: Filter<ILivechatDepartment>, options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentsIds: string[],
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameRegexWithExceptionsAndConditions<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: string,
+		exceptions: string[],
+		conditions: Filter<ILivechatDepartment>,
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(businessHourId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		businessHourId: string,
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countByBusinessHourIdExcludingDepartmentId(businessHourId: string, departmentId: string): Promise<number>;
 
-	findEnabledByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(businessHourId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findEnabledByBusinessHourId<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		businessHourId: string,
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveDepartmentsWithoutBusinessHour<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveDepartmentsWithoutBusinessHour<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	addBusinessHourToDepartmentsByIds(ids: string[], businessHourId: string): Promise<Document | UpdateResult>;
 
@@ -35,11 +60,22 @@ export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment
 		_: any,
 		projection: FindOptions<T>['projection'],
 	): FindCursor<T>;
-	findOneByIdOrName<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByIdOrName<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		unitIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countDepartmentsInUnit(unitId: string): Promise<number>;
-	findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findNotArchived<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		unitIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findNotArchived<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	getBusinessHoursWithDepartmentStatuses(): Promise<
 		{
 			_id: string;
@@ -49,7 +85,10 @@ export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment
 	>;
 	checkIfMonitorIsMonitoringDepartmentById(monitorId: string, departmentId: string): Promise<boolean>;
 	countArchived(): Promise<number>;
-	findEnabledInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentsIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findEnabledInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentsIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	archiveDepartment(_id: string): Promise<UpdateResult>;
 	unarchiveDepartment(_id: string): Promise<UpdateResult>;
 	addDepartmentToUnit(_id: string, unitId: string, ancestors: string[]): Promise<Document | UpdateResult>;

--- a/packages/model-typings/src/models/ILivechatDepartmentModel.ts
+++ b/packages/model-typings/src/models/ILivechatDepartmentModel.ts
@@ -2,23 +2,19 @@ import type { ILivechatDepartment, LivechatDepartmentDTO } from '@rocket.chat/co
 import type { FindOptions, FindCursor, Filter, UpdateResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment> {
 	countTotal(): Promise<number>;
-	findInIds(departmentsIds: string[], options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
-	findByNameRegexWithExceptionsAndConditions(
-		searchTerm: string,
-		exceptions: string[],
-		conditions: Filter<ILivechatDepartment>,
-		options: FindOptions<ILivechatDepartment>,
-	): FindCursor<ILivechatDepartment>;
+	findInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentsIds: string[], options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameRegexWithExceptionsAndConditions<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], conditions: Filter<ILivechatDepartment>, options: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByBusinessHourId(businessHourId: string, options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(businessHourId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
 	countByBusinessHourIdExcludingDepartmentId(businessHourId: string, departmentId: string): Promise<number>;
 
-	findEnabledByBusinessHourId(businessHourId: string, options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findEnabledByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(businessHourId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveDepartmentsWithoutBusinessHour(options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findActiveDepartmentsWithoutBusinessHour<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	addBusinessHourToDepartmentsByIds(ids: string[], businessHourId: string): Promise<Document | UpdateResult>;
 
@@ -39,11 +35,11 @@ export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment
 		_: any,
 		projection: FindOptions<T>['projection'],
 	): FindCursor<T>;
-	findOneByIdOrName(_idOrName: string, options?: FindOptions<ILivechatDepartment>): Promise<ILivechatDepartment | null>;
-	findByUnitIds(unitIds: string[], options?: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findOneByIdOrName<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	countDepartmentsInUnit(unitId: string): Promise<number>;
-	findActiveByUnitIds(unitIds: string[], options?: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
-	findNotArchived(options?: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(unitIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findNotArchived<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	getBusinessHoursWithDepartmentStatuses(): Promise<
 		{
 			_id: string;
@@ -53,7 +49,7 @@ export interface ILivechatDepartmentModel extends IBaseModel<ILivechatDepartment
 	>;
 	checkIfMonitorIsMonitoringDepartmentById(monitorId: string, departmentId: string): Promise<boolean>;
 	countArchived(): Promise<number>;
-	findEnabledInIds(departmentsIds: string[], options?: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment>;
+	findEnabledInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentsIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	archiveDepartment(_id: string): Promise<UpdateResult>;
 	unarchiveDepartment(_id: string): Promise<UpdateResult>;
 	addDepartmentToUnit(_id: string, unitId: string, ancestors: string[]): Promise<Document | UpdateResult>;

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -5,7 +5,10 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord> {
-	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]>;
 	setDepartmentByInquiryId(inquiryId: string, department: string): Promise<ILivechatInquiryRecord | null>;
 	setLastMessageByRoomId(rid: ILivechatInquiryRecord['rid'], message: IMessage): Promise<ILivechatInquiryRecord | null>;
@@ -23,7 +26,9 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 		queueSortBy: FindOptions<ILivechatInquiryRecord>['sort'];
 	}): Promise<(Pick<ILivechatInquiryRecord, '_id' | 'rid' | 'name' | 'ts' | 'status' | 'department'> & { position: number })[]>;
 	removeByRoomId(rid: string, options?: DeleteOptions): Promise<DeleteResult>;
-	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	takeInquiry(inquiryId: string, lockedAt?: Date): Promise<UpdateResult>;
 	queueInquiry(inquiryId: string, lastMessage?: IMessage, defaultAgent?: SelectedAgent | null): Promise<ILivechatInquiryRecord | null>;
 	queueInquiryAndRemoveDefaultAgent(inquiryId: string): Promise<UpdateResult>;
@@ -38,5 +43,8 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	markInquiryActiveForPeriod(rid: ILivechatInquiryRecord['rid'], period: string): Promise<ILivechatInquiryRecord | null>;
 	setStatusById(inquiryId: string, status: LivechatInquiryStatus): Promise<ILivechatInquiryRecord>;
 	updateNameByVisitorIds(visitorIds: string[], name: string): Promise<UpdateResult | Document>;
-	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -19,7 +19,6 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	): Promise<ILivechatInquiryRecord | null>;
 	unlock(inquiryId: string): Promise<UpdateResult>;
 	unlockAll(): Promise<UpdateResult | Document>;
-	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<Pick<ILivechatInquiryRecord, '_id'>>;
 	getCurrentSortedQueueAsync(props: {
 		inquiryId?: string;
 		department?: string;

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -19,7 +19,7 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	): Promise<ILivechatInquiryRecord | null>;
 	unlock(inquiryId: string): Promise<UpdateResult>;
 	unlockAll(): Promise<UpdateResult | Document>;
-	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<ILivechatInquiryRecord>;
+	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<Pick<ILivechatInquiryRecord, '_id'>>;
 	getCurrentSortedQueueAsync(props: {
 		inquiryId?: string;
 		department?: string;

--- a/packages/model-typings/src/models/ILivechatInquiryModel.ts
+++ b/packages/model-typings/src/models/ILivechatInquiryModel.ts
@@ -2,12 +2,10 @@ import type { IMessage, ILivechatInquiryRecord, LivechatInquiryStatus, SelectedA
 import type { FindOptions, Document, UpdateResult, DeleteResult, FindCursor, DeleteOptions, AggregateOptions } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord> {
-	findOneByRoomId<T extends Document = ILivechatInquiryRecord>(
-		rid: string,
-		options?: FindOptions<T extends ILivechatInquiryRecord ? ILivechatInquiryRecord : T>,
-	): Promise<T | null>;
+	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]>;
 	setDepartmentByInquiryId(inquiryId: string, department: string): Promise<ILivechatInquiryRecord | null>;
 	setLastMessageByRoomId(rid: ILivechatInquiryRecord['rid'], message: IMessage): Promise<ILivechatInquiryRecord | null>;
@@ -25,7 +23,7 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 		queueSortBy: FindOptions<ILivechatInquiryRecord>['sort'];
 	}): Promise<(Pick<ILivechatInquiryRecord, '_id' | 'rid' | 'name' | 'ts' | 'status' | 'department'> & { position: number })[]>;
 	removeByRoomId(rid: string, options?: DeleteOptions): Promise<DeleteResult>;
-	getQueuedInquiries(options?: FindOptions<ILivechatInquiryRecord>): FindCursor<ILivechatInquiryRecord>;
+	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	takeInquiry(inquiryId: string, lockedAt?: Date): Promise<UpdateResult>;
 	queueInquiry(inquiryId: string, lastMessage?: IMessage, defaultAgent?: SelectedAgent | null): Promise<ILivechatInquiryRecord | null>;
 	queueInquiryAndRemoveDefaultAgent(inquiryId: string): Promise<UpdateResult>;
@@ -40,5 +38,5 @@ export interface ILivechatInquiryModel extends IBaseModel<ILivechatInquiryRecord
 	markInquiryActiveForPeriod(rid: ILivechatInquiryRecord['rid'], period: string): Promise<ILivechatInquiryRecord | null>;
 	setStatusById(inquiryId: string, status: LivechatInquiryStatus): Promise<ILivechatInquiryRecord>;
 	updateNameByVisitorIds(visitorIds: string[], name: string): Promise<UpdateResult | Document>;
-	findByVisitorIds(visitorIds: string[], options?: FindOptions<ILivechatInquiryRecord>): FindCursor<ILivechatInquiryRecord>;
+	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -308,5 +308,5 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		contactId: ILivechatContact['_id'],
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
-	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null>;
+	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<Pick<IOmnichannelRoom, '_id'> | null>;
 }

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -13,6 +13,7 @@ import type { FindCursor, UpdateResult, AggregationCursor, Document, FindOptions
 import type { FindPaginated } from '..';
 import type { Updater } from '../updater';
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 type Period = {
 	start: any;
@@ -139,7 +140,7 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 	closeRoomById(roomId: string, closeInfo: IOmnichannelRoomClosingInfo, options?: UpdateOptions): Promise<UpdateResult>;
 
 	bulkRemoveDepartmentAndUnitsFromRooms(departmentId: string): Promise<Document | UpdateResult>;
-	findOneByIdOrName(_idOrName: string, options?: FindOptions<IOmnichannelRoom>): Promise<IOmnichannelRoom | null>;
+	findOneByIdOrName<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	updateSurveyFeedbackById(_id: string, surveyFeedback: unknown): Promise<UpdateResult>;
 	updateDataByToken(token: string, key: string, value: string, overwrite?: boolean): Promise<UpdateResult | Document | boolean>;
 	saveRoomById(
@@ -155,57 +156,18 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		visitorToken: string,
 		fields?: FindOptions<IOmnichannelRoom>['projection'],
 	): Promise<IOmnichannelRoom | null>;
-	findOneByVisitorTokenAndEmailThreadAndDepartment(
-		visitorToken: string,
-		emailThread: string[],
-		departmentId?: string,
-		options?: FindOptions<IOmnichannelRoom>,
-	): Promise<IOmnichannelRoom | null>;
+	findOneByVisitorTokenAndEmailThreadAndDepartment<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, emailThread: string[], departmentId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	updateEmailThreadByRoomId(roomId: string, threadIds: string[] | string): Promise<UpdateResult>;
-	findOneLastServedAndClosedByVisitorToken(visitorToken: string, options?: FindOptions<IOmnichannelRoom>): Promise<IOmnichannelRoom | null>;
+	findOneLastServedAndClosedByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	findOneByVisitorToken(visitorToken: string, fields?: FindOptions<IOmnichannelRoom>['projection']): Promise<IOmnichannelRoom | null>;
-	findOpenByVisitorToken(
-		visitorToken: string,
-		options?: FindOptions<IOmnichannelRoom>,
-		extraQuery?: Filter<IOmnichannelRoom>,
-	): FindCursor<IOmnichannelRoom>;
-	findOneOpenByContactChannelVisitor(
-		association: ILivechatContactVisitorAssociation,
-		options?: FindOptions<IOmnichannelRoom>,
-	): Promise<IOmnichannelRoom | null>;
-	findOneOpenByVisitorToken(
-		visitorToken: string,
-		options?: FindOptions<IOmnichannelRoom>,
-		extraQuery?: Filter<IOmnichannelRoom>,
-	): Promise<IOmnichannelRoom | null>;
-	findOneOpenByVisitorTokenAndDepartmentIdAndSource(
-		visitorToken: string,
-		departmentId?: string,
-		source?: string,
-		options?: FindOptions<IOmnichannelRoom>,
-	): Promise<IOmnichannelRoom | null>;
-	findOpenByVisitorTokenAndDepartmentId(
-		visitorToken: string,
-		departmentId: string,
-		options?: FindOptions<IOmnichannelRoom>,
-		extraQuery?: Filter<IOmnichannelRoom>,
-	): FindCursor<IOmnichannelRoom>;
-	findByVisitorIdAndAgentId(
-		visitorId?: string,
-		agentId?: string,
-		options?: FindOptions<IOmnichannelRoom>,
-		extraQuery?: Filter<IOmnichannelRoom>,
-	): FindCursor<IOmnichannelRoom>;
-	findOneOpenByRoomIdAndVisitorToken(
-		roomId: string,
-		visitorToken: string,
-		options?: FindOptions<IOmnichannelRoom>,
-	): Promise<IOmnichannelRoom | null>;
-	findClosedRooms(
-		departmentIds?: string[],
-		options?: FindOptions<IOmnichannelRoom>,
-		extraQuery?: Filter<IOmnichannelRoom>,
-	): FindCursor<IOmnichannelRoom>;
+	findOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
+	findOneOpenByContactChannelVisitor<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(association: ILivechatContactVisitorAssociation, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): Promise<DocumentWithProjection<T, O> | null>;
+	findOneOpenByVisitorTokenAndDepartmentIdAndSource<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, departmentId?: string, source?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOpenByVisitorTokenAndDepartmentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, departmentId: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
+	findByVisitorIdAndAgentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorId?: string, agentId?: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
+	findOneOpenByRoomIdAndVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findClosedRooms<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentIds?: string[], options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
 	getResponseByRoomIdUpdateQuery(
 		responseBy: IOmnichannelRoom['responseBy'],
 		updater?: Updater<IOmnichannelRoom>,
@@ -241,11 +203,7 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		date: { gte: Date; lte: Date },
 		data?: { departmentId: string },
 	): AggregationCursor<Pick<IOmnichannelRoom, 'ts' | 'departmentId' | 'open' | 'servedBy' | 'metrics' | 'msgs' | 'onHold'>>;
-	findOpenByAgent(
-		userId: string,
-		extraQuery?: Filter<IOmnichannelRoom>,
-		options?: FindOptions<IOmnichannelRoom>,
-	): FindCursor<IOmnichannelRoom>;
+	findOpenByAgent<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, extraQuery?: Filter<IOmnichannelRoom>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	countOpenByAgent(userId: string, extraQuery?: Filter<IOmnichannelRoom>): Promise<number>;
 	changeAgentByRoomId(roomId: string, newAgent: { agentId: string; username: string }): Promise<UpdateResult>;
 	changeDepartmentIdByRoomId(roomId: string, departmentId: string): Promise<UpdateResult>;
@@ -279,6 +237,6 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		oldContactId: ILivechatContact['_id'],
 		contact: Partial<Pick<ILivechatContact, '_id' | 'name'>>,
 	): Promise<UpdateResult | Document>;
-	findOpenByContactId(contactId: ILivechatContact['_id'], options?: FindOptions<IOmnichannelRoom>): FindCursor<IOmnichannelRoom>;
+	findOpenByContactId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(contactId: ILivechatContact['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null>;
 }

--- a/packages/model-typings/src/models/ILivechatRoomsModel.ts
+++ b/packages/model-typings/src/models/ILivechatRoomsModel.ts
@@ -140,7 +140,10 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 	closeRoomById(roomId: string, closeInfo: IOmnichannelRoomClosingInfo, options?: UpdateOptions): Promise<UpdateResult>;
 
 	bulkRemoveDepartmentAndUnitsFromRooms(departmentId: string): Promise<Document | UpdateResult>;
-	findOneByIdOrName<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdOrName<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	updateSurveyFeedbackById(_id: string, surveyFeedback: unknown): Promise<UpdateResult>;
 	updateDataByToken(token: string, key: string, value: string, overwrite?: boolean): Promise<UpdateResult | Document | boolean>;
 	saveRoomById(
@@ -156,18 +159,78 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		visitorToken: string,
 		fields?: FindOptions<IOmnichannelRoom>['projection'],
 	): Promise<IOmnichannelRoom | null>;
-	findOneByVisitorTokenAndEmailThreadAndDepartment<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, emailThread: string[], departmentId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByVisitorTokenAndEmailThreadAndDepartment<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		visitorToken: string,
+		emailThread: string[],
+		departmentId?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	updateEmailThreadByRoomId(roomId: string, threadIds: string[] | string): Promise<UpdateResult>;
-	findOneLastServedAndClosedByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneLastServedAndClosedByVisitorToken<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		visitorToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	findOneByVisitorToken(visitorToken: string, fields?: FindOptions<IOmnichannelRoom>['projection']): Promise<IOmnichannelRoom | null>;
-	findOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
-	findOneOpenByContactChannelVisitor<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(association: ILivechatContactVisitorAssociation, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): Promise<DocumentWithProjection<T, O> | null>;
-	findOneOpenByVisitorTokenAndDepartmentIdAndSource<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, departmentId?: string, source?: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOpenByVisitorTokenAndDepartmentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorToken: string, departmentId: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
-	findByVisitorIdAndAgentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorId?: string, agentId?: string, options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
-	findOneOpenByRoomIdAndVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findClosedRooms<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentIds?: string[], options?: O, extraQuery?: Filter<IOmnichannelRoom>): FindCursor<DocumentWithProjection<T, O>>;
+	findOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorToken: string,
+		options?: O,
+		extraQuery?: Filter<IOmnichannelRoom>,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneOpenByContactChannelVisitor<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		association: ILivechatContactVisitorAssociation,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorToken: string,
+		options?: O,
+		extraQuery?: Filter<IOmnichannelRoom>,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneOpenByVisitorTokenAndDepartmentIdAndSource<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		visitorToken: string,
+		departmentId?: string,
+		source?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOpenByVisitorTokenAndDepartmentId<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		visitorToken: string,
+		departmentId: string,
+		options?: O,
+		extraQuery?: Filter<IOmnichannelRoom>,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByVisitorIdAndAgentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorId?: string,
+		agentId?: string,
+		options?: O,
+		extraQuery?: Filter<IOmnichannelRoom>,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneOpenByRoomIdAndVisitorToken<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		roomId: string,
+		visitorToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findClosedRooms<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentIds?: string[],
+		options?: O,
+		extraQuery?: Filter<IOmnichannelRoom>,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	getResponseByRoomIdUpdateQuery(
 		responseBy: IOmnichannelRoom['responseBy'],
 		updater?: Updater<IOmnichannelRoom>,
@@ -203,7 +266,11 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		date: { gte: Date; lte: Date },
 		data?: { departmentId: string },
 	): AggregationCursor<Pick<IOmnichannelRoom, 'ts' | 'departmentId' | 'open' | 'servedBy' | 'metrics' | 'msgs' | 'onHold'>>;
-	findOpenByAgent<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, extraQuery?: Filter<IOmnichannelRoom>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOpenByAgent<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		extraQuery?: Filter<IOmnichannelRoom>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countOpenByAgent(userId: string, extraQuery?: Filter<IOmnichannelRoom>): Promise<number>;
 	changeAgentByRoomId(roomId: string, newAgent: { agentId: string; username: string }): Promise<UpdateResult>;
 	changeDepartmentIdByRoomId(roomId: string, departmentId: string): Promise<UpdateResult>;
@@ -237,6 +304,9 @@ export interface ILivechatRoomsModel extends IBaseModel<IOmnichannelRoom> {
 		oldContactId: ILivechatContact['_id'],
 		contact: Partial<Pick<ILivechatContact, '_id' | 'name'>>,
 	): Promise<UpdateResult | Document>;
-	findOpenByContactId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(contactId: ILivechatContact['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOpenByContactId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		contactId: ILivechatContact['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null>;
 }

--- a/packages/model-typings/src/models/ILivechatUnitModel.ts
+++ b/packages/model-typings/src/models/ILivechatUnitModel.ts
@@ -1,5 +1,5 @@
 import type { ILivechatDepartment, IOmnichannelBusinessUnit } from '@rocket.chat/core-typings';
-import type { Filter, FindCursor, FindOptions, DeleteResult, UpdateResult, Document } from 'mongodb';
+import type { Filter, FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
@@ -10,18 +10,18 @@ export interface ILivechatUnitModel extends IBaseModel<IOmnichannelBusinessUnit>
 		query: Filter<IOmnichannelBusinessUnit>,
 		options?: O,
 	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
-	// goes straight to the driver to apply unit restrictions, so it bypasses BaseRaw's projection
-	// rewrite and cannot use projection inference — callers narrow with an explicit `P`
-	findOne<P extends Document = IOmnichannelBusinessUnit>(
+	// `extra` carries the unit restrictions applied to the query before it reaches `BaseRaw.findOne`,
+	// so the projection is rewritten as usual and inference behaves like every other model
+	findOne<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		originalQuery: Filter<IOmnichannelBusinessUnit>,
-		options?: FindOptions<IOmnichannelBusinessUnit>,
+		options?: O,
 		extra?: Record<string, any>,
-	): Promise<P | null>;
-	findOneById<P extends Document = IOmnichannelBusinessUnit>(
+	): Promise<DocumentWithProjection<P, O> | null>;
+	findOneById<P extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		_id: IOmnichannelBusinessUnit['_id'],
-		options?: FindOptions<IOmnichannelBusinessUnit>,
+		options?: O,
 		extra?: Record<string, any>,
-	): Promise<P | null>;
+	): Promise<DocumentWithProjection<P, O> | null>;
 	createOrUpdateUnit(
 		_id: string | null,
 		{ name, visibility }: { name: string; visibility: IOmnichannelBusinessUnit['visibility'] },

--- a/packages/model-typings/src/models/ILivechatUnitModel.ts
+++ b/packages/model-typings/src/models/ILivechatUnitModel.ts
@@ -1,28 +1,27 @@
 import type { ILivechatDepartment, IOmnichannelBusinessUnit } from '@rocket.chat/core-typings';
-import type { Filter, FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
+import type { Filter, FindCursor, FindOptions, DeleteResult, UpdateResult, Document } from 'mongodb';
 
-import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatUnitModel extends IBaseModel<IOmnichannelBusinessUnit> {
 	//
-	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IOmnichannelBusinessUnit>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
-	findOne<
-		P extends Document = IOmnichannelBusinessUnit,
-		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
-	>(
+	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<IOmnichannelBusinessUnit>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	// goes straight to the driver to apply unit restrictions, so it bypasses BaseRaw's projection
+	// rewrite and cannot use projection inference — callers narrow with an explicit `P`
+	findOne<P extends Document = IOmnichannelBusinessUnit>(
 		originalQuery: Filter<IOmnichannelBusinessUnit>,
-		options?: O,
+		options?: FindOptions<IOmnichannelBusinessUnit>,
 		extra?: Record<string, any>,
-	): Promise<DocumentWithProjection<P, O> | null>;
-	findOneById<
-		P extends Document = IOmnichannelBusinessUnit,
-		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
-	>(
+	): Promise<P | null>;
+	findOneById<P extends Document = IOmnichannelBusinessUnit>(
 		_id: IOmnichannelBusinessUnit['_id'],
-		options?: O,
+		options?: FindOptions<IOmnichannelBusinessUnit>,
 		extra?: Record<string, any>,
-	): Promise<DocumentWithProjection<P, O> | null>;
+	): Promise<P | null>;
 	createOrUpdateUnit(
 		_id: string | null,
 		{ name, visibility }: { name: string; visibility: IOmnichannelBusinessUnit['visibility'] },
@@ -35,7 +34,10 @@ export interface ILivechatUnitModel extends IBaseModel<IOmnichannelBusinessUnit>
 	decrementDepartmentsCount(_id: string): Promise<UpdateResult | Document>;
 	removeById(_id: string): Promise<DeleteResult>;
 	removeByIdAndUnit(_id: string, unitsFromUser?: string[]): Promise<DeleteResult>;
-	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	findByMonitorId(monitorId: string): Promise<string[]>;
 	findMonitoredDepartmentsByMonitorId(monitorId: string, includeDisabled: boolean): Promise<ILivechatDepartment[]>;
 	countUnits(): Promise<number>;

--- a/packages/model-typings/src/models/ILivechatUnitModel.ts
+++ b/packages/model-typings/src/models/ILivechatUnitModel.ts
@@ -1,25 +1,28 @@
 import type { ILivechatDepartment, IOmnichannelBusinessUnit } from '@rocket.chat/core-typings';
-import type { FindOptions, Filter, FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
+import type { Filter, FindCursor, DeleteResult, UpdateResult, Document } from 'mongodb';
 
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 import type { FindPaginated, IBaseModel } from './IBaseModel';
 
-// @ts-expect-error - Overriding base types :)
 export interface ILivechatUnitModel extends IBaseModel<IOmnichannelBusinessUnit> {
 	//
-	findPaginatedUnits(
-		query: Filter<IOmnichannelBusinessUnit>,
-		options?: FindOptions<IOmnichannelBusinessUnit>,
-	): FindPaginated<FindCursor<IOmnichannelBusinessUnit>>;
-	findOne(
+	findPaginatedUnits<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IOmnichannelBusinessUnit>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findOne<
+		P extends Document = IOmnichannelBusinessUnit,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(
 		originalQuery: Filter<IOmnichannelBusinessUnit>,
-		options: FindOptions<IOmnichannelBusinessUnit>,
+		options?: O,
 		extra?: Record<string, any>,
-	): Promise<IOmnichannelBusinessUnit | null>;
-	findOneById<P extends Document = IOmnichannelBusinessUnit>(
+	): Promise<DocumentWithProjection<P, O> | null>;
+	findOneById<
+		P extends Document = IOmnichannelBusinessUnit,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(
 		_id: IOmnichannelBusinessUnit['_id'],
-		options: FindOptions<IOmnichannelBusinessUnit>,
+		options?: O,
 		extra?: Record<string, any>,
-	): Promise<P | null>;
+	): Promise<DocumentWithProjection<P, O> | null>;
 	createOrUpdateUnit(
 		_id: string | null,
 		{ name, visibility }: { name: string; visibility: IOmnichannelBusinessUnit['visibility'] },
@@ -32,7 +35,7 @@ export interface ILivechatUnitModel extends IBaseModel<IOmnichannelBusinessUnit>
 	decrementDepartmentsCount(_id: string): Promise<UpdateResult | Document>;
 	removeById(_id: string): Promise<DeleteResult>;
 	removeByIdAndUnit(_id: string, unitsFromUser?: string[]): Promise<DeleteResult>;
-	findOneByIdOrName(_idOrName: string, options: FindOptions<IOmnichannelBusinessUnit>): Promise<IOmnichannelBusinessUnit | null>;
+	findOneByIdOrName<T extends Document = IOmnichannelBusinessUnit, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
 	findByMonitorId(monitorId: string): Promise<string[]>;
 	findMonitoredDepartmentsByMonitorId(monitorId: string, includeDisabled: boolean): Promise<ILivechatDepartment[]>;
 	countUnits(): Promise<number>;

--- a/packages/model-typings/src/models/ILivechatVisitorsModel.ts
+++ b/packages/model-typings/src/models/ILivechatVisitorsModel.ts
@@ -15,9 +15,18 @@ import type { FindPaginated, IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
-	findById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByIds<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	getVisitorByToken<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByIds<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	getVisitorByToken<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	findByNameRegexWithExceptionsAndConditions<P extends Document = ILivechatVisitor>(
 		searchTerm: string,
 		exceptions: string[],
@@ -29,7 +38,15 @@ export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
 		}
 	>;
 
-	findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailOrPhone?: string, nameOrUsername?: RegExp, allowedCustomFields?: string[], options?: O): Promise<FindPaginated<FindCursor<DocumentWithProjection<T, O>>>>;
+	findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField<
+		T extends Document = ILivechatVisitor,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		emailOrPhone?: string,
+		nameOrUsername?: RegExp,
+		allowedCustomFields?: string[],
+		options?: O,
+	): Promise<FindPaginated<FindCursor<DocumentWithProjection<T, O>>>>;
 
 	findOneByEmailAndPhoneAndCustomField(
 		email: string | null | undefined,
@@ -69,11 +86,17 @@ export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
 
 	saveGuestEmailPhoneById(_id: string, emails: string[], phones: string[]): Promise<UpdateResult | Document | void>;
 
-	findOneEnabledById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneEnabledById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	disableById(_id: string): Promise<UpdateResult>;
 
-	findEnabled<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<ILivechatVisitor>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findEnabled<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<ILivechatVisitor>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	saveGuestById(
 		_id: string,

--- a/packages/model-typings/src/models/ILivechatVisitorsModel.ts
+++ b/packages/model-typings/src/models/ILivechatVisitorsModel.ts
@@ -12,11 +12,12 @@ import type {
 } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
-	findById(_id: string, options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor>;
-	findByIds(ids: string[], options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor>;
-	getVisitorByToken(token: string, options?: FindOptions<ILivechatVisitor>): Promise<ILivechatVisitor | null>;
+	findById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByIds<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	getVisitorByToken<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	findByNameRegexWithExceptionsAndConditions<P extends Document = ILivechatVisitor>(
 		searchTerm: string,
 		exceptions: string[],
@@ -28,12 +29,7 @@ export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
 		}
 	>;
 
-	findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField(
-		emailOrPhone?: string,
-		nameOrUsername?: RegExp,
-		allowedCustomFields?: string[],
-		options?: FindOptions<ILivechatVisitor>,
-	): Promise<FindPaginated<FindCursor<ILivechatVisitor>>>;
+	findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailOrPhone?: string, nameOrUsername?: RegExp, allowedCustomFields?: string[], options?: O): Promise<FindPaginated<FindCursor<DocumentWithProjection<T, O>>>>;
 
 	findOneByEmailAndPhoneAndCustomField(
 		email: string | null | undefined,
@@ -73,11 +69,11 @@ export interface ILivechatVisitorsModel extends IBaseModel<ILivechatVisitor> {
 
 	saveGuestEmailPhoneById(_id: string, emails: string[], phones: string[]): Promise<UpdateResult | Document | void>;
 
-	findOneEnabledById<T extends Document = ILivechatVisitor>(_id: string, options?: FindOptions<ILivechatVisitor>): Promise<T | null>;
+	findOneEnabledById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	disableById(_id: string): Promise<UpdateResult>;
 
-	findEnabled(query: Filter<ILivechatVisitor>, options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor>;
+	findEnabled<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<ILivechatVisitor>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	saveGuestById(
 		_id: string,

--- a/packages/model-typings/src/models/ILoginServiceConfigurationModel.ts
+++ b/packages/model-typings/src/models/ILoginServiceConfigurationModel.ts
@@ -1,7 +1,8 @@
 import type { LoginServiceConfiguration } from '@rocket.chat/core-typings';
-import type { Document, FindOptions } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ILoginServiceConfigurationModel extends IBaseModel<LoginServiceConfiguration> {
 	createOrUpdateService(
@@ -9,8 +10,5 @@ export interface ILoginServiceConfigurationModel extends IBaseModel<LoginService
 		serviceData: Partial<LoginServiceConfiguration>,
 	): Promise<LoginServiceConfiguration['_id']>;
 	removeByService(serviceName: LoginServiceConfiguration['service']): Promise<Pick<LoginServiceConfiguration, '_id'> | null>;
-	findOneByService<P extends Document = LoginServiceConfiguration>(
-		serviceName: LoginServiceConfiguration['service'],
-		options?: FindOptions<P>,
-	): Promise<P | null>;
+	findOneByService<P extends Document = LoginServiceConfiguration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(serviceName: LoginServiceConfiguration['service'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
 }

--- a/packages/model-typings/src/models/ILoginServiceConfigurationModel.ts
+++ b/packages/model-typings/src/models/ILoginServiceConfigurationModel.ts
@@ -10,5 +10,8 @@ export interface ILoginServiceConfigurationModel extends IBaseModel<LoginService
 		serviceData: Partial<LoginServiceConfiguration>,
 	): Promise<LoginServiceConfiguration['_id']>;
 	removeByService(serviceName: LoginServiceConfiguration['service']): Promise<Pick<LoginServiceConfiguration, '_id'> | null>;
-	findOneByService<P extends Document = LoginServiceConfiguration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(serviceName: LoginServiceConfiguration['service'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findOneByService<P extends Document = LoginServiceConfiguration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		serviceName: LoginServiceConfiguration['service'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 }

--- a/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
+++ b/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
@@ -1,13 +1,11 @@
 import type { IMediaCallNegotiation, MediaCallNegotiationStream, RTCSessionDescriptionInit } from '@rocket.chat/core-typings';
-import type { Document, FindOptions, UpdateResult } from 'mongodb';
+import type { Document, UpdateResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IMediaCallNegotiationsModel extends IBaseModel<IMediaCallNegotiation> {
-	findLatestByCallId<T extends Document = IMediaCallNegotiation>(
-		callId: IMediaCallNegotiation['callId'],
-		options?: FindOptions<T>,
-	): Promise<T | null>;
+	findLatestByCallId<T extends Document = IMediaCallNegotiation, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: IMediaCallNegotiation['callId'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	setOfferById(id: string, offer: RTCSessionDescriptionInit, offerStreams?: MediaCallNegotiationStream[]): Promise<UpdateResult>;
 	setAnswerById(id: string, answer: RTCSessionDescriptionInit, answerStreams?: MediaCallNegotiationStream[]): Promise<UpdateResult>;
 	setStableById(id: string): Promise<UpdateResult>;

--- a/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
+++ b/packages/model-typings/src/models/IMediaCallNegotiationsModel.ts
@@ -5,7 +5,10 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IMediaCallNegotiationsModel extends IBaseModel<IMediaCallNegotiation> {
-	findLatestByCallId<T extends Document = IMediaCallNegotiation, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: IMediaCallNegotiation['callId'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findLatestByCallId<T extends Document = IMediaCallNegotiation, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		callId: IMediaCallNegotiation['callId'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	setOfferById(id: string, offer: RTCSessionDescriptionInit, offerStreams?: MediaCallNegotiationStream[]): Promise<UpdateResult>;
 	setAnswerById(id: string, answer: RTCSessionDescriptionInit, answerStreams?: MediaCallNegotiationStream[]): Promise<UpdateResult>;
 	setStableById(id: string): Promise<UpdateResult>;

--- a/packages/model-typings/src/models/IMediaCallsModel.ts
+++ b/packages/model-typings/src/models/IMediaCallsModel.ts
@@ -1,20 +1,40 @@
-import type { IMediaCall, IUser, MediaCallActor, MediaCallActorType, MediaCallContact, MediaCallSignedContact, } from '@rocket.chat/core-typings';
+import type {
+	IMediaCall,
+	IUser,
+	MediaCallActor,
+	MediaCallActorType,
+	MediaCallContact,
+	MediaCallSignedContact,
+} from '@rocket.chat/core-typings';
 import type { Document, FindCursor, UpdateResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IMediaCallsModel extends IBaseModel<IMediaCall> {
-	findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: IMediaCall['_id'], callee: MediaCallActor, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByCallerRequestedId<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: Required<IMediaCall>['callerRequestedId'], caller: { type: MediaCallActorType; id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		id: IMediaCall['_id'],
+		callee: MediaCallActor,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByCallerRequestedId<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		id: Required<IMediaCall>['callerRequestedId'],
+		caller: { type: MediaCallActorType; id: string },
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	startRingingById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	acceptCallById(callId: string, data: { calleeContractId: string; supportedFeatures: string[] }, expiresAt: Date): Promise<UpdateResult>;
 	activateCallById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	setExpiresAtById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	hangupCallById(callId: string, params: { endedBy?: IMediaCall['endedBy']; reason?: string } | undefined): Promise<UpdateResult>;
 	transferCallById(callId: string, params: { by: MediaCallSignedContact; to: MediaCallContact }): Promise<UpdateResult>;
-	findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IUser['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	hasUnfinishedCalls(): Promise<boolean>;
 	hasUnfinishedCallsByUid(uid: IUser['_id'], exceptCallId?: string): Promise<boolean>;
 }

--- a/packages/model-typings/src/models/IMediaCallsModel.ts
+++ b/packages/model-typings/src/models/IMediaCallsModel.ts
@@ -1,34 +1,20 @@
-import type {
-	IMediaCall,
-	IUser,
-	MediaCallActor,
-	MediaCallActorType,
-	MediaCallContact,
-	MediaCallSignedContact,
-} from '@rocket.chat/core-typings';
-import type { Document, FindCursor, FindOptions, UpdateResult } from 'mongodb';
+import type { IMediaCall, IUser, MediaCallActor, MediaCallActorType, MediaCallContact, MediaCallSignedContact, } from '@rocket.chat/core-typings';
+import type { Document, FindCursor, UpdateResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IMediaCallsModel extends IBaseModel<IMediaCall> {
-	findOneByIdAndCallee<T extends Document = IMediaCall>(
-		id: IMediaCall['_id'],
-		callee: MediaCallActor,
-		options?: FindOptions<IMediaCall>,
-	): Promise<T | null>;
-	findOneByCallerRequestedId<T extends Document = IMediaCall>(
-		id: Required<IMediaCall>['callerRequestedId'],
-		caller: { type: MediaCallActorType; id: string },
-		options?: FindOptions<T>,
-	): Promise<T | null>;
+	findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: IMediaCall['_id'], callee: MediaCallActor, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByCallerRequestedId<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: Required<IMediaCall>['callerRequestedId'], caller: { type: MediaCallActorType; id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	startRingingById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	acceptCallById(callId: string, data: { calleeContractId: string; supportedFeatures: string[] }, expiresAt: Date): Promise<UpdateResult>;
 	activateCallById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	setExpiresAtById(callId: string, expiresAt: Date): Promise<UpdateResult>;
 	hangupCallById(callId: string, params: { endedBy?: IMediaCall['endedBy']; reason?: string } | undefined): Promise<UpdateResult>;
 	transferCallById(callId: string, params: { by: MediaCallSignedContact; to: MediaCallContact }): Promise<UpdateResult>;
-	findAllExpiredCalls<T extends Document = IMediaCall>(options: FindOptions<T> | undefined): FindCursor<T>;
-	findAllNotOverByUid<T extends Document = IMediaCall>(uid: IUser['_id'], options?: FindOptions<T>): FindCursor<T>;
+	findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	hasUnfinishedCalls(): Promise<boolean>;
 	hasUnfinishedCallsByUid(uid: IUser['_id'], exceptCallId?: string): Promise<boolean>;
 }

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -22,6 +22,7 @@ import type {
 } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 type PaginatedRequest<S extends string = string> = {
 	count?: number;
@@ -31,23 +32,38 @@ type PaginatedRequest<S extends string = string> = {
 	query?: string;
 };
 export interface IMessagesModel extends IBaseModel<IMessage> {
-	findPaginatedVisibleByMentionAndRoomId(
+	findPaginatedVisibleByMentionAndRoomId<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		username: IUser['username'],
 		rid: IRoom['_id'],
-		options?: FindOptions<IMessage>,
-	): FindPaginated<FindCursor<IMessage>>;
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id'], options?: FindOptions<IMessage>): FindCursor<IMessage>;
+	findVisibleByMentionAndRoomId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: IUser['username'],
+		rid: IRoom['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findStarredByUserAtRoom(userId: IUser['_id'], roomId: IRoom['_id'], options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
+	findStarredByUserAtRoom<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		roomId: IRoom['_id'],
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByRoomIdAndType(
+	findPaginatedByRoomIdAndType<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: IRoom['_id'],
 		type: IMessage['t'],
-		options?: FindOptions<IMessage>,
-	): FindPaginated<FindCursor<IMessage>>;
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findDiscussionsByRoomAndText(rid: IRoom['_id'], text: string, options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
+	findDiscussionsByRoomAndText<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		text: string,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	findAllNumberOfTransferredRooms(p: {
 		start: Date;
@@ -67,13 +83,17 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 
 	getTotalOfMessagesSentByDate(params: { start: Date; end: Date; options?: any }): Promise<any[]>;
 
-	findLivechatClosedMessages(rid: IRoom['_id'], searchTerm?: string, options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
-	findLivechatMessagesWithoutTypes(
+	findLivechatClosedMessages<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		searchTerm?: string,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findLivechatMessagesWithoutTypes<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		rid: IRoom['_id'],
 		ignoredTypes: IMessage['t'][],
 		showSystemMessages: boolean,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countRoomsWithStarredMessages(options: AggregateOptions): Promise<number>;
 
 	countRoomsWithPinnedMessages(options: AggregateOptions): Promise<number>;
@@ -84,7 +104,10 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 
 	countByType(type: IMessage['t'], options: CountDocumentsOptions): Promise<number>;
 
-	findPaginatedPinnedByRoom(roomId: IMessage['rid'], options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>>;
+	findPaginatedPinnedByRoom<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IMessage['rid'],
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	setFederationReactionEventId(username: string, _id: string, reaction: string, federationEventId: string): Promise<void>;
 
@@ -98,16 +121,22 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 
 	removeByRoomId(roomId: IRoom['_id']): Promise<DeleteResult>;
 
-	findVisibleByRoomIdNotContainingTypesBeforeTs(
+	findVisibleByRoomIdNotContainingTypesBeforeTs<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: IRoom['_id'],
 		types: IMessage['t'][],
 		ts: Date,
 		showSystemMessages: boolean,
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages?: boolean,
-	): FindCursor<IMessage>;
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findLivechatClosingMessage(rid: IRoom['_id'], options?: FindOptions<IMessage>): Promise<IMessage | null>;
+	findLivechatClosingMessage<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	setReactions(messageId: string, reactions: IMessage['reactions']): Promise<UpdateResult>;
 	setRoomIdByToken(token: string, rid: string): Promise<UpdateResult | Document>;
@@ -129,59 +158,86 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	): Promise<UpdateResult | Document>;
 	countVisibleByRoomIdBetweenTimestampsInclusive(roomId: string, afterTimestamp: Date, beforeTimestamp: Date): Promise<number>;
 
-	findByMention(username: string, options?: FindOptions<IMessage>): FindCursor<IMessage>;
-	findVisibleThreadByThreadId(tmid: string, options?: FindOptions<IMessage>): FindCursor<IMessage>;
+	findByMention<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findVisibleThreadByThreadId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		tmid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	findFilesByUserId(userId: string, options?: FindOptions<IMessage>): FindCursor<Pick<IMessage, 'file' | 'files'>>;
-	findVisibleByIds(ids: string[], options?: FindOptions<IMessage>): FindCursor<IMessage>;
-	findVisibleByRoomIdNotContainingTypes(
+	findVisibleByIds<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findVisibleByRoomIdNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: string,
 		types: MessageTypesValues[],
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages?: boolean,
-	): FindCursor<IMessage>;
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countVisibleByRoomIdContainingTypes(roomId: string, types: MessageTypesValues[]): Promise<number>;
-	findFilesByRoomIdPinnedTimestampAndUsers(
+	findFilesByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		rid: string,
 		excludePinned: boolean,
 		ignoreDiscussion: boolean,
 		ts: Filter<IMessage>['ts'],
 		users: string[],
 		ignoreThreads: boolean,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
-	findVisibleByRoomId<T extends IMessage = IMessage>(rid: string, options?: FindOptions<T>): FindCursor<T>;
-	findDiscussionByRoomIdPinnedTimestampAndUsers(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findVisibleByRoomId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findDiscussionByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		rid: string,
 		excludePinned: boolean,
 		ts: Filter<IMessage>['ts'],
 		users: string[],
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
-	findVisibleByRoomIdAfterTimestamp(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findVisibleByRoomIdAfterTimestamp<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: string,
 		timestamp: Date,
 		showThreadMessages?: boolean,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
-	findVisibleByRoomIdBeforeTimestampNotContainingTypes(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findVisibleByRoomIdBeforeTimestampNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: string,
 		timestamp: Date,
 		types: MessageTypesValues[],
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages?: boolean,
 		inclusive?: boolean,
-	): FindCursor<IMessage>;
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+	findVisibleByRoomIdBetweenTimestampsNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: string,
 		afterTimestamp: Date,
 		beforeTimestamp: Date,
 		types: MessageTypesValues[],
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages?: boolean,
 		inclusive?: boolean,
-	): FindCursor<IMessage>;
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countVisibleByRoomIdBetweenTimestampsNotContainingTypes(
 		roomId: string,
 		afterTimestamp: Date,
@@ -190,20 +246,24 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 		showThreadMessages?: boolean,
 		inclusive?: boolean,
 	): Promise<number>;
-	findVisibleByRoomIdBeforeTimestamp(
+	findVisibleByRoomIdBeforeTimestamp<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: string,
 		timestamp: Date,
 		showThreadMessages?: boolean,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	getLastTimestamp(options?: FindOptions<IMessage>): Promise<Date | undefined>;
 	findOneBySlackBotIdAndSlackTs(slackBotId: string, slackTs: Date): Promise<IMessage | null>;
-	findByRoomIdAndMessageIds(rid: string, messageIds: string[], options?: FindOptions<IMessage>): FindCursor<IMessage>;
-	findForUpdates(
+	findByRoomIdAndMessageIds<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findForUpdates<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: IMessage['rid'],
 		{ updatedAt, minTs }: { updatedAt: { $lt: Date } | { $gt: Date }; minTs?: Date },
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	updateUsernameOfEditByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 	updateAllUsernamesByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 
@@ -225,7 +285,11 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 		pinned?: boolean,
 		pinnedAt?: Date,
 	): Promise<UpdateResult>;
-	findOneByRoomIdAndMessageId(rid: string, messageId: string, options?: FindOptions<IMessage>): Promise<IMessage | null>;
+	findOneByRoomIdAndMessageId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	updateUserStarById(_id: string, userId: string, starred?: boolean): Promise<UpdateResult>;
 	updateUsernameAndMessageOfMentionByIdAndOldUsername(
@@ -241,10 +305,13 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 
 	removeByRoomIds(rids: string[]): Promise<DeleteResult>;
 
-	findThreadsByRoomIdPinnedTimestampAndUsers(
+	findThreadsByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		data: { rid: string; pinned: boolean; ignoreDiscussion?: boolean; ts: Filter<IMessage>['ts']; users: string[] },
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage>;
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	removeByIdPinnedTimestampLimitAndUsers(
 		rid: string,

--- a/packages/model-typings/src/models/INpsVoteModel.ts
+++ b/packages/model-typings/src/models/INpsVoteModel.ts
@@ -5,9 +5,19 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface INpsVoteModel extends IBaseModel<INpsVote> {
-	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, status: INpsVoteStatus, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		status: INpsVoteStatus,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	save(vote: Omit<INpsVote, '_id' | '_updatedAt'>): Promise<UpdateResult>;
 	updateVotesToSent(voteIds: string[]): Promise<UpdateResult | Document>;
 	updateOldSendingToNewByNpsId(npsId: string): Promise<UpdateResult | Document>;

--- a/packages/model-typings/src/models/INpsVoteModel.ts
+++ b/packages/model-typings/src/models/INpsVoteModel.ts
@@ -5,9 +5,11 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface INpsVoteModel extends IBaseModel<INpsVote> {
+	// `sort` and `limit` are branded away because the implementation overwrites both on the cursor;
+	// a caller passing them would have them silently dropped
 	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		npsId: string,
-		options?: O,
+		options?: O & { sort?: never; limit?: never },
 	): FindCursor<DocumentWithProjection<T, O>>;
 	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		npsId: string,

--- a/packages/model-typings/src/models/INpsVoteModel.ts
+++ b/packages/model-typings/src/models/INpsVoteModel.ts
@@ -1,12 +1,13 @@
 import type { INpsVote, INpsVoteStatus } from '@rocket.chat/core-typings';
-import type { Document, FindCursor, FindOptions, UpdateResult } from 'mongodb';
+import type { Document, FindCursor, UpdateResult } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface INpsVoteModel extends IBaseModel<INpsVote> {
-	findNotSentByNpsId(npsId: string, options?: FindOptions<INpsVote>): FindCursor<INpsVote>;
-	findByNpsIdAndStatus(npsId: string, status: INpsVoteStatus, options?: FindOptions<INpsVote>): FindCursor<INpsVote>;
-	findByNpsId(npsId: string, options?: FindOptions<INpsVote>): FindCursor<INpsVote>;
+	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, status: INpsVoteStatus, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	save(vote: Omit<INpsVote, '_id' | '_updatedAt'>): Promise<UpdateResult>;
 	updateVotesToSent(voteIds: string[]): Promise<UpdateResult | Document>;
 	updateOldSendingToNewByNpsId(npsId: string): Promise<UpdateResult | Document>;

--- a/packages/model-typings/src/models/IOAuthAccessTokensModel.ts
+++ b/packages/model-typings/src/models/IOAuthAccessTokensModel.ts
@@ -5,8 +5,14 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAccessTokensModel extends IBaseModel<IOAuthAccessToken> {
-	findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(accessToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByRefreshToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		accessToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRefreshToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		refreshToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IOAuthAccessTokensModel.ts
+++ b/packages/model-typings/src/models/IOAuthAccessTokensModel.ts
@@ -1,11 +1,12 @@
 import type { IOAuthAccessToken } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindOptions } from 'mongodb';
+import type { DeleteResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAccessTokensModel extends IBaseModel<IOAuthAccessToken> {
-	findOneByAccessToken(accessToken: string, options?: FindOptions<IOAuthAccessToken>): Promise<IOAuthAccessToken | null>;
-	findOneByRefreshToken(refreshToken: string, options?: FindOptions<IOAuthAccessToken>): Promise<IOAuthAccessToken | null>;
+	findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(accessToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRefreshToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IOAuthAppsModel.ts
+++ b/packages/model-typings/src/models/IOAuthAppsModel.ts
@@ -5,19 +5,32 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAppsModel extends IBaseModel<IOAuthApps> {
-	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(props:
+	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		props:
 			| { clientId: string }
 			| { appId: string }
 			| {
 					_id: string;
-			  }, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+			  },
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		clientId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	updateById(
 		_id: IOAuthApps['_id'],
 		data: Partial<Pick<IOAuthApps, 'name' | 'active' | 'redirectUri' | '_updatedBy'>>,
 	): Promise<IOAuthApps | null>;
 
-	findOneActiveByClientIdAndClientSecret<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, clientSecret: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneActiveByClientIdAndClientSecret<
+		T extends Document = IOAuthApps,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		clientId: string,
+		clientSecret: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IOAuthAppsModel.ts
+++ b/packages/model-typings/src/models/IOAuthAppsModel.ts
@@ -1,29 +1,23 @@
 import type { IOAuthApps } from '@rocket.chat/core-typings';
-import type { FindOptions } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAppsModel extends IBaseModel<IOAuthApps> {
-	findOneAuthAppByIdOrClientId(
-		props:
+	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(props:
 			| { clientId: string }
 			| { appId: string }
 			| {
 					_id: string;
-			  },
-		options?: FindOptions<IOAuthApps>,
-	): Promise<IOAuthApps | null>;
+			  }, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneActiveByClientId(clientId: string, options?: FindOptions<IOAuthApps>): Promise<IOAuthApps | null>;
+	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	updateById(
 		_id: IOAuthApps['_id'],
 		data: Partial<Pick<IOAuthApps, 'name' | 'active' | 'redirectUri' | '_updatedBy'>>,
 	): Promise<IOAuthApps | null>;
 
-	findOneActiveByClientIdAndClientSecret(
-		clientId: string,
-		clientSecret: string,
-		options?: FindOptions<IOAuthApps>,
-	): Promise<IOAuthApps | null>;
+	findOneActiveByClientIdAndClientSecret<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, clientSecret: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IOAuthAuthCodesModel.ts
+++ b/packages/model-typings/src/models/IOAuthAuthCodesModel.ts
@@ -1,10 +1,11 @@
 import type { IOAuthAuthCode } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindOptions } from 'mongodb';
+import type { DeleteResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAuthCodesModel extends IBaseModel<IOAuthAuthCode> {
-	findOneByAuthCode(authCode: string, options?: FindOptions<IOAuthAuthCode>): Promise<IOAuthAuthCode | null>;
+	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(authCode: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IOAuthAuthCodesModel.ts
+++ b/packages/model-typings/src/models/IOAuthAuthCodesModel.ts
@@ -5,7 +5,10 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthAuthCodesModel extends IBaseModel<IOAuthAuthCode> {
-	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(authCode: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		authCode: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IOAuthRefreshTokensModel.ts
+++ b/packages/model-typings/src/models/IOAuthRefreshTokensModel.ts
@@ -5,7 +5,10 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthRefreshTokensModel extends IBaseModel<IOAuthRefreshToken> {
-	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		refreshToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IOAuthRefreshTokensModel.ts
+++ b/packages/model-typings/src/models/IOAuthRefreshTokensModel.ts
@@ -1,10 +1,11 @@
 import type { IOAuthRefreshToken } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindOptions } from 'mongodb';
+import type { DeleteResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IOAuthRefreshTokensModel extends IBaseModel<IOAuthRefreshToken> {
-	findOneByRefreshToken(refreshToken: string, options?: FindOptions<IOAuthRefreshToken>): Promise<IOAuthRefreshToken | null>;
+	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	deleteByUserId(userId: string): Promise<DeleteResult>;
 	deleteByUserIds(userIds: string[]): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IPushTokenModel.ts
+++ b/packages/model-typings/src/models/IPushTokenModel.ts
@@ -1,20 +1,17 @@
 import type { AtLeast, IPushToken, IUser } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindOptions, InsertOneResult, UpdateResult, FindCursor } from 'mongodb';
+import type { DeleteResult, InsertOneResult, UpdateResult, FindCursor, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IPushTokenModel extends IBaseModel<IPushToken> {
 	countTokensByUserId(userId: IUser['_id']): Promise<number>;
 	countGcmTokens(): Promise<number>;
 	countApnTokens(): Promise<number>;
 	findOneByTokenAndAppName(token: IPushToken['token'], appName: IPushToken['appName']): Promise<IPushToken | null>;
-	findFirstByUserId<T extends IPushToken>(userId: IUser['_id'], options?: FindOptions<IPushToken>): Promise<T | null>;
-	findAllTokensByUserId<T extends IPushToken>(userId: IUser['_id'], options?: FindOptions<IPushToken>): FindCursor<T>;
-	findTokensByUserIdExceptId<T extends IPushToken>(
-		userId: IUser['_id'],
-		idToIgnore: IPushToken['_id'],
-		options?: FindOptions<IPushToken>,
-	): FindCursor<T>;
+	findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], idToIgnore: IPushToken['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	insertToken(data: AtLeast<IPushToken, 'token' | 'authToken' | 'appName' | 'userId'>): Promise<InsertOneResult<IPushToken>>;
 	refreshTokenById(

--- a/packages/model-typings/src/models/IPushTokenModel.ts
+++ b/packages/model-typings/src/models/IPushTokenModel.ts
@@ -9,9 +9,19 @@ export interface IPushTokenModel extends IBaseModel<IPushToken> {
 	countGcmTokens(): Promise<number>;
 	countApnTokens(): Promise<number>;
 	findOneByTokenAndAppName(token: IPushToken['token'], appName: IPushToken['appName']): Promise<IPushToken | null>;
-	findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], idToIgnore: IPushToken['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		idToIgnore: IPushToken['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	insertToken(data: AtLeast<IPushToken, 'token' | 'authToken' | 'appName' | 'userId'>): Promise<InsertOneResult<IPushToken>>;
 	refreshTokenById(

--- a/packages/model-typings/src/models/IRolesModel.ts
+++ b/packages/model-typings/src/models/IRolesModel.ts
@@ -5,16 +5,25 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IRolesModel extends IBaseModel<IRole> {
-	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(updatedAfterDate: Date, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		updatedAfterDate: Date,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	isUserInRoles(userId: IUser['_id'], roles: IRole['_id'][], scope?: IRoom['_id']): Promise<boolean>;
-	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_idOrName: IRole['_id'] | IRole['name'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_idOrName: IRole['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null>;
 	findOneByName<P = IRole>(name: IRole['name'], options?: any): Promise<IRole | P | null>;
 	findInIds<P>(ids: IRole['_id'][], options?: FindOptions<IRole>): P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
 	findInIdsOrNames<P>(
-		_idsOrNames: IRole['_id'][] | IRole['name'][],
+		_idsOrNames: IRole['_id'][],
 		options?: FindOptions<IRole>,
 	): P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
-	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: IRole['scope'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		scope: IRole['scope'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	updateById(
 		_id: IRole['_id'],
 		name: IRole['name'],
@@ -33,13 +42,11 @@ export interface IRolesModel extends IBaseModel<IRole> {
 	): Promise<FindCursor<P extends IUser ? IUser : P>>;
 
 	/** @deprecated function getUsersInRole should be used instead */
-	findUsersInRole<P>(
-		roleId: IRole['_id'],
-		scope: IRoom['_id'] | undefined,
-		options?: any | undefined,
-	): Promise<FindCursor<IUser> | FindCursor<P>>;
+	findUsersInRole<P>(roleId: IRole['_id'], scope: IRoom['_id'] | undefined, options?: any): Promise<FindCursor<IUser> | FindCursor<P>>;
 
-	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	createWithRandomId(
 		name: IRole['name'],

--- a/packages/model-typings/src/models/IRolesModel.ts
+++ b/packages/model-typings/src/models/IRolesModel.ts
@@ -1,28 +1,20 @@
 import type { IRole, IUser, IRoom } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions, CountDocumentsOptions } from 'mongodb';
+import type { FindCursor, FindOptions, CountDocumentsOptions, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IRolesModel extends IBaseModel<IRole> {
-	findByUpdatedDate(updatedAfterDate: Date, options?: FindOptions<IRole>): FindCursor<IRole>;
+	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(updatedAfterDate: Date, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	isUserInRoles(userId: IUser['_id'], roles: IRole['_id'][], scope?: IRoom['_id']): Promise<boolean>;
-	findOneByIdOrName(_idOrName: IRole['_id'] | IRole['name'], options?: undefined): Promise<IRole | null>;
-
-	findOneByIdOrName(_idOrName: IRole['_id'] | IRole['name'], options: FindOptions<IRole>): Promise<IRole | null>;
-
-	findOneByIdOrName<P extends Document>(
-		_idOrName: IRole['_id'] | IRole['name'],
-		options: FindOptions<P extends IRole ? IRole : P>,
-	): Promise<P | null>;
-
-	findOneByIdOrName<P>(_idOrName: IRole['_id'] | IRole['name'], options?: any): Promise<IRole | P | null>;
+	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_idOrName: IRole['_id'] | IRole['name'], options?: O): Promise<DocumentWithProjection<P, O> | null>;
 	findOneByName<P = IRole>(name: IRole['name'], options?: any): Promise<IRole | P | null>;
 	findInIds<P>(ids: IRole['_id'][], options?: FindOptions<IRole>): P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
 	findInIdsOrNames<P>(
 		_idsOrNames: IRole['_id'][] | IRole['name'][],
 		options?: FindOptions<IRole>,
 	): P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
-	findByScope(scope: IRole['scope'], options?: FindOptions<IRole>): FindCursor<IRole>;
+	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: IRole['scope'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	updateById(
 		_id: IRole['_id'],
 		name: IRole['name'],
@@ -47,7 +39,7 @@ export interface IRolesModel extends IBaseModel<IRole> {
 		options?: any | undefined,
 	): Promise<FindCursor<IUser> | FindCursor<P>>;
 
-	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole>;
+	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	createWithRandomId(
 		name: IRole['name'],

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -447,7 +447,11 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	unsetAbacAttributesById(rid: IRoom['_id']): Promise<UpdateResult>;
 	unsetAllAbacAttributes(): Promise<Document | UpdateResult>;
 	updateSingleAbacAttributeValuesById(rid: IRoom['_id'], key: string, values: string[]): Promise<UpdateResult>;
-	insertAbacAttributeIfNotExistsById(rid: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null>;
+	insertAbacAttributeIfNotExistsById(
+		rid: IRoom['_id'],
+		key: string,
+		values: string[],
+	): Promise<Pick<IRoom, '_id' | 'abacAttributes'> | null>;
 	updateAbacAttributeValuesArrayFilteredById(rid: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null>;
 	removeAbacAttributeByRoomIdAndKey(rid: IRoom['_id'], key: string): Promise<UpdateResult>;
 	removeUserReferenceFromDMsById(roomId: string, username: string, userId: string): Promise<UpdateResult>;

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -23,6 +23,7 @@ import type {
 
 import type { Updater } from '../updater';
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IChannelsWithNumberOfMessagesBetweenDate {
 	room: {
@@ -39,22 +40,19 @@ export interface IChannelsWithNumberOfMessagesBetweenDate {
 }
 
 export interface IRoomsModel extends IBaseModel<IRoom> {
-	findAllByTypesAndDiscussionAndTeam(
-		filters?: {
+	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filters?: {
 			types?: Array<IRoom['t']>;
 			discussions?: boolean;
 			teams?: boolean;
-		},
-		findOptions?: FindOptions<IRoom>,
-	): FindCursor<IRoom>;
+		}, findOptions?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	isAbacAttributeInUse(key: string, values: string[]): Promise<boolean>;
 
-	findOneByRoomIdAndUserId(rid: IRoom['_id'], uid: IUser['_id'], options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findManyByRoomIds(roomIds: Array<IRoom['_id']>, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findManyArchivedByRoomIds(roomIds: Array<IRoom['_id']>, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	findPaginatedByIds(
 		roomIds: Array<IRoom['_id']>,
@@ -63,49 +61,25 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	getMostRecentAverageChatDurationTime(numberMostRecentChats: number, department?: string): Promise<Document>;
 
-	findByNameOrFnameContainingAndTypes(
-		name: NonNullable<IRoom['name']>,
-		types: Array<IRoom['t']>,
-		discussion?: boolean,
-		teams?: boolean,
-		options?: FindOptions<IRoom>,
-	): FindPaginated<FindCursor<IRoom>>;
+	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, types: Array<IRoom['t']>, discussion?: boolean, teams?: boolean, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPrivateRoomsAndTeamsPaginated(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): FindPaginated<FindCursor<IRoom>>;
+	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findByTeamId(teamId: ITeam['_id'], options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByTeamId(teamId: ITeam['_id']): Promise<number>;
 
-	findPaginatedByTeamIdContainingNameAndDefault(
-		teamId: ITeam['_id'],
-		name: IRoom['name'],
-		teamDefault: boolean,
-		ids: Array<IRoom['_id']> | undefined,
-		options?: FindOptions<IRoom>,
-	): FindPaginated<FindCursor<IRoom>>;
+	findPaginatedByTeamIdContainingNameAndDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], name: IRoom['name'], teamDefault: boolean, ids: Array<IRoom['_id']> | undefined, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findByTeamIdAndRoomsId(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findRoomsByNameOrFnameStarting(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findRoomsWithoutDiscussionsByRoomIds(
-		name: NonNullable<IRoom['name']>,
-		roomIds: Array<IRoom['_id']>,
-		options?: FindOptions<IRoom>,
-	): FindCursor<IRoom>;
+	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findPaginatedRoomsWithoutDiscussionsByRoomIds(
-		name: NonNullable<IRoom['name']>,
-		roomIds: Array<IRoom['_id']>,
-		options?: FindOptions<IRoom>,
-	): FindPaginated<FindCursor<IRoom>>;
+	findPaginatedRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findChannelAndGroupListWithoutTeamsByNameStartingByOwner(
-		name: IRoom['name'],
-		groupsToAccept: Array<IRoom['_id']>,
-		options?: FindOptions<IRoom>,
-	): FindCursor<IRoom>;
+	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'], groupsToAccept: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	unsetTeamId(teamId: ITeam['_id'], options?: UpdateOptions): Promise<Document | UpdateResult>;
 
@@ -117,17 +91,17 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	setTeamDefaultById(rid: IRoom['_id'], teamDefault: NonNullable<IRoom['teamDefault']>, options?: UpdateOptions): Promise<UpdateResult>;
 
-	findOneByName(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	findDefaultRoomsForTeam(teamId: any): FindCursor<IRoom>;
 
 	incUsersCountByIds(ids: Array<IRoom['_id']>, inc: number, options?: UpdateOptions): Promise<Document | UpdateResult>;
 
-	findOneByNameOrFname(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByJoinCodeAndId(joinCode: string, rid: IRoom['_id'], options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(joinCode: string, rid: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByNonValidatedName(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByNonValidatedName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	allRoomSourcesCount(): AggregationCursor<{ _id: Required<IOmnichannelGenericRoom['source']>; count: number }>;
 
@@ -137,30 +111,21 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	setFnameById(_id: IRoom['_id'], fname: IRoom['fname']): Promise<UpdateResult>;
 
-	findE2ERoomById(roomId: IRoom['_id'], options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	countRoomsInsideTeams(autoJoin?: boolean): Promise<number>;
 
-	findOneDirectRoomContainingAllUserIDs(uid: IDirectMessageRoom['uids'], options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IDirectMessageRoom['uids'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	countByType(t: IRoom['t']): Promise<number>;
 
-	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms(
-		searchTerm: RegExp | null,
-		teamIds: Array<ITeam['_id']>,
-		roomIds: Array<IRoom['_id']>,
-		options?: FindOptions<IRoom>,
-	): FindPaginated<FindCursor<IRoom>>;
+	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, teamIds: Array<ITeam['_id']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedContainingNameOrFNameInIdsAsTeamMain(
-		searchTerm: RegExp | null,
-		rids: Array<IRoom['_id']>,
-		options?: FindOptions<IRoom>,
-	): FindPaginated<FindCursor<IRoom>>;
+	findPaginatedContainingNameOrFNameInIdsAsTeamMain<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, rids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByTypeAndIds(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: FindOptions<IRoom>): FindPaginated<FindCursor<IRoom>>;
+	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findOneFederatedByMrid(mrid: string, options?: FindOptions<IRoomFederated>): Promise<IRoomFederated | null>;
+	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(mrid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	findBiggestFederatedRoomInNumberOfUsers(options?: FindOptions<IRoom>): Promise<IRoom | undefined>;
 
@@ -175,7 +140,7 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	): Promise<IRoom | null>;
 	getIncMsgCountUpdateQuery(inc: number, roomUpdater: Updater<IRoom>): Updater<IRoom>;
 	decreaseMessageCountById(rid: string, dec: number): Promise<UpdateResult>;
-	findOneByIdOrName(_idOrName: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	setReactionsInLastMessage(roomId: string, reactions: NonNullable<IRoom['lastMessage']>['reactions']): Promise<UpdateResult>;
 	unsetReactionsInLastMessage(roomId: string): Promise<UpdateResult>;
 	unsetAllImportIds(): Promise<Document | UpdateResult>;
@@ -191,7 +156,7 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		readOnly: NonNullable<IRoom['ro']>,
 		reactWhenReadOnly: NonNullable<IRoom['reactWhenReadOnly']>,
 	): Promise<UpdateResult | Document>;
-	getDirectConversationsByUserId(userId: string, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	setAllowReactingWhenReadOnlyById(
 		roomId: string,
 		allowReactingWhenReadOnly: NonNullable<IRoom['reactWhenReadOnly']>,
@@ -204,44 +169,28 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		e2eKeyId: string,
 		options?: Omit<FindOneAndUpdateOptions, 'returnDocument' | 'includeResultMetadata' | 'upsert'>,
 	): Promise<IRoom | null>;
-	findOneByImportId(importId: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
+	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(importId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	findOneByNameAndNotId(name: string, rid: string): Promise<IRoom | null>;
-	findOneByIdAndType<T extends Document = IRoom>(roomId: IRoom['_id'], type: IRoom['t'], options?: FindOptions<T>): Promise<T | null>;
-	findOneByDisplayName(displayName: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
-	findOneByNameAndType(
-		name: string,
-		type: IRoom['t'],
-		options?: FindOptions<IRoom>,
-		includeFederatedRooms?: boolean,
-	): Promise<IRoom | null>;
-	findById(rid: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
-	findByIds(rids: string[], options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findByType(type: IRoom['t'], options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findByTypeInIds(type: IRoom['t'], ids: string[], options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findPrivateRoomsByIdsWithAbacAttributes(ids: string[], options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findAllPrivateRoomsWithAbacAttributes(options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findBySubscriptionUserId(userId: string, options?: FindOptions<IRoom>): Promise<FindCursor<IRoom>>;
-	findBySubscriptionUserIdUpdatedAfter(userId: string, updatedAfter: Date, options?: FindOptions<IRoom>): Promise<FindCursor<IRoom>>;
-	findByNameAndTypeNotDefault(
-		name: IRoom['name'] | RegExp,
-		type: IRoom['t'],
-		options?: FindOptions<IRoom>,
-		includeFederatedRooms?: boolean,
-	): FindCursor<IRoom>;
-	findByNameOrFNameAndTypesNotInIds(
-		name: IRoom['name'] | RegExp,
-		types: IRoom['t'][],
-		ids: string[],
-		options?: FindOptions<IRoom>,
-		includeFederatedRooms?: boolean,
-	): FindCursor<IRoom>;
-	findByDefaultAndTypes(defaultValue: boolean, types: IRoom['t'][], options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findDirectRoomContainingAllUsernames(usernames: string[], options?: FindOptions<IRoom>): Promise<IRoom | null>;
-	findByTypeAndNameOrId(type: IRoom['t'], name: string, options?: FindOptions<IRoom>): Promise<IRoom | null>;
-	findByTypeAndNameContaining(type: IRoom['t'], name: string, options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findByTypeInIdsAndNameContaining(type: IRoom['t'], ids: string[], name: string, options?: FindOptions<IRoom>): FindCursor<IRoom>;
-	findGroupDMsByUids(uids: string[], options?: FindOptions<IDirectMessageRoom>): FindCursor<IDirectMessageRoom>;
-	find1On1ByUserId(userId: string, options?: FindOptions<IRoom>): FindCursor<IRoom>;
+	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], type: IRoom['t'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(displayName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, type: IRoom['t'], options?: O, includeFederatedRooms?: boolean): Promise<DocumentWithProjection<T, O> | null>;
+	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findPrivateRoomsByIdsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findBySubscriptionUserIdUpdatedAfter<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, updatedAfter: Date, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, type: IRoom['t'], options?: O, includeFederatedRooms?: boolean): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, types: IRoom['t'][], ids: string[], options?: O, includeFederatedRooms?: boolean): FindCursor<DocumentWithProjection<T, O>>;
+	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(defaultValue: boolean, types: IRoom['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: string[], name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	findByUsernamesOrUids(uids: IRoom['u']['_id'][], usernames: IRoom['u']['username'][]): FindCursor<IRoom>;
 	findDMsByUids(uids: IRoom['u']['_id'][]): FindCursor<IRoom>;
 	addImportIds(rid: string, importIds: string[]): Promise<UpdateResult>;
@@ -322,5 +271,5 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	updateAbacAttributeValuesArrayFilteredById(rid: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null>;
 	removeAbacAttributeByRoomIdAndKey(rid: IRoom['_id'], key: string): Promise<UpdateResult>;
 	removeUserReferenceFromDMsById(roomId: string, username: string, userId: string): Promise<UpdateResult>;
-	findFederatedByIds<T extends Document = IRoomNativeFederated>(ids: Array<IRoom['_id']>, options?: FindOptions<T>): FindCursor<T>;
+	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -40,19 +40,32 @@ export interface IChannelsWithNumberOfMessagesBetweenDate {
 }
 
 export interface IRoomsModel extends IBaseModel<IRoom> {
-	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filters?: {
+	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		filters?: {
 			types?: Array<IRoom['t']>;
 			discussions?: boolean;
 			teams?: boolean;
-		}, findOptions?: O): FindCursor<DocumentWithProjection<T, O>>;
+		},
+		findOptions?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	isAbacAttributeInUse(key: string, values: string[]): Promise<boolean>;
 
-	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		uid: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	findPaginatedByIds(
 		roomIds: Array<IRoom['_id']>,
@@ -61,25 +74,71 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	getMostRecentAverageChatDurationTime(numberMostRecentChats: number, department?: string): Promise<Document>;
 
-	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, types: Array<IRoom['t']>, discussion?: boolean, teams?: boolean, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		types: Array<IRoom['t']>,
+		discussion?: boolean,
+		teams?: boolean,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		teamId: ITeam['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByTeamId(teamId: ITeam['_id']): Promise<number>;
 
-	findPaginatedByTeamIdContainingNameAndDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], name: IRoom['name'], teamDefault: boolean, ids: Array<IRoom['_id']> | undefined, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedByTeamIdContainingNameAndDefault<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		teamId: ITeam['_id'],
+		name: IRoom['name'],
+		teamDefault: boolean,
+		ids: Array<IRoom['_id']> | undefined,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		teamId: ITeam['_id'],
+		rids: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findPaginatedRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedRoomsWithoutDiscussionsByRoomIds<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		name: NonNullable<IRoom['name']>,
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'], groupsToAccept: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		name: IRoom['name'],
+		groupsToAccept: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	unsetTeamId(teamId: ITeam['_id'], options?: UpdateOptions): Promise<Document | UpdateResult>;
 
@@ -91,17 +150,24 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	setTeamDefaultById(rid: IRoom['_id'], teamDefault: NonNullable<IRoom['teamDefault']>, options?: UpdateOptions): Promise<UpdateResult>;
 
-	findOneByName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByName(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 
 	findDefaultRoomsForTeam(teamId: any): FindCursor<IRoom>;
 
 	incUsersCountByIds(ids: Array<IRoom['_id']>, inc: number, options?: UpdateOptions): Promise<Document | UpdateResult>;
 
-	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(joinCode: string, rid: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		joinCode: string,
+		rid: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneByNonValidatedName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNonValidatedName(name: NonNullable<IRoom['name']>, options?: FindOptions<IRoom>): Promise<IRoom | null>;
 
 	allRoomSourcesCount(): AggregationCursor<{ _id: Required<IOmnichannelGenericRoom['source']>; count: number }>;
 
@@ -111,21 +177,49 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 
 	setFnameById(_id: IRoom['_id'], fname: IRoom['fname']): Promise<UpdateResult>;
 
-	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	countRoomsInsideTeams(autoJoin?: boolean): Promise<number>;
 
-	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IDirectMessageRoom['uids'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IDirectMessageRoom['uids'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	countByType(t: IRoom['t']): Promise<number>;
 
-	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, teamIds: Array<ITeam['_id']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: RegExp | null,
+		teamIds: Array<ITeam['_id']>,
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedContainingNameOrFNameInIdsAsTeamMain<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, rids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedContainingNameOrFNameInIdsAsTeamMain<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: RegExp | null,
+		rids: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(mrid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		mrid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	findBiggestFederatedRoomInNumberOfUsers(options?: FindOptions<IRoom>): Promise<IRoom | undefined>;
 
@@ -140,7 +234,10 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	): Promise<IRoom | null>;
 	getIncMsgCountUpdateQuery(inc: number, roomUpdater: Updater<IRoom>): Updater<IRoom>;
 	decreaseMessageCountById(rid: string, dec: number): Promise<UpdateResult>;
-	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	setReactionsInLastMessage(roomId: string, reactions: NonNullable<IRoom['lastMessage']>['reactions']): Promise<UpdateResult>;
 	unsetReactionsInLastMessage(roomId: string): Promise<UpdateResult>;
 	unsetAllImportIds(): Promise<Document | UpdateResult>;
@@ -156,7 +253,10 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		readOnly: NonNullable<IRoom['ro']>,
 		reactWhenReadOnly: NonNullable<IRoom['reactWhenReadOnly']>,
 	): Promise<UpdateResult | Document>;
-	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	setAllowReactingWhenReadOnlyById(
 		roomId: string,
 		allowReactingWhenReadOnly: NonNullable<IRoom['reactWhenReadOnly']>,
@@ -169,28 +269,108 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		e2eKeyId: string,
 		options?: Omit<FindOneAndUpdateOptions, 'returnDocument' | 'includeResultMetadata' | 'upsert'>,
 	): Promise<IRoom | null>;
-	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(importId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		importId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	findOneByNameAndNotId(name: string, rid: string): Promise<IRoom | null>;
-	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], type: IRoom['t'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(displayName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, type: IRoom['t'], options?: O, includeFederatedRooms?: boolean): Promise<DocumentWithProjection<T, O> | null>;
-	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findPrivateRoomsByIdsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
-	findBySubscriptionUserIdUpdatedAfter<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, updatedAfter: Date, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
-	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, type: IRoom['t'], options?: O, includeFederatedRooms?: boolean): FindCursor<DocumentWithProjection<T, O>>;
-	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, types: IRoom['t'][], ids: string[], options?: O, includeFederatedRooms?: boolean): FindCursor<DocumentWithProjection<T, O>>;
-	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(defaultValue: boolean, types: IRoom['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: string[], name: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uids: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IRoom['_id'],
+		type: IRoom['t'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		displayName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		type: IRoom['t'],
+		options?: O,
+		includeFederatedRooms?: boolean,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findPrivateRoomsByIdsWithAbacAttributes<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findBySubscriptionUserIdUpdatedAfter<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		updatedAfter: Date,
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: IRoom['name'] | RegExp,
+		type: IRoom['t'],
+		options?: O,
+		includeFederatedRooms?: boolean,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: IRoom['name'] | RegExp,
+		types: IRoom['t'][],
+		ids: string[],
+		options?: O,
+		includeFederatedRooms?: boolean,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		defaultValue: boolean,
+		types: IRoom['t'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		name: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		name: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: string[],
+		name: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	findByUsernamesOrUids(uids: IRoom['u']['_id'][], usernames: IRoom['u']['username'][]): FindCursor<IRoom>;
 	findDMsByUids(uids: IRoom['u']['_id'][]): FindCursor<IRoom>;
 	addImportIds(rid: string, importIds: string[]): Promise<UpdateResult>;
@@ -271,5 +451,8 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 	updateAbacAttributeValuesArrayFilteredById(rid: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null>;
 	removeAbacAttributeByRoomIdAndKey(rid: IRoom['_id'], key: string): Promise<UpdateResult>;
 	removeUserReferenceFromDMsById(roomId: string, username: string, userId: string): Promise<UpdateResult>;
-	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/ISessionsModel.ts
+++ b/packages/model-typings/src/models/ISessionsModel.ts
@@ -1,15 +1,8 @@
-import type {
-	ISession,
-	UserSessionAggregationResult,
-	DeviceSessionAggregationResult,
-	OSSessionAggregationResult,
-	IUser,
-	DeviceManagementPopulatedSession,
-	DeviceManagementSession,
-} from '@rocket.chat/core-typings';
-import type { BulkWriteResult, Document, FindOptions, UpdateResult, FindCursor, OptionalId } from 'mongodb';
+import type { ISession, UserSessionAggregationResult, DeviceSessionAggregationResult, OSSessionAggregationResult, IUser, DeviceManagementPopulatedSession, DeviceManagementSession, } from '@rocket.chat/core-typings';
+import type { BulkWriteResult, Document, UpdateResult, FindCursor, OptionalId } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export type DestructuredDate = { year: number; month: number; day: number };
 export type DestructuredDateWithType = {
@@ -143,9 +136,5 @@ export interface ISessionsModel extends IBaseModel<ISession> {
 
 	updateAllSessionsByDateToComputed({ start, end }: DestructuredRange): Promise<UpdateResult | Document>;
 
-	getLoggedInByUserIdAndSessionId<T extends Document = ISession>(
-		userId: string,
-		sessionId: string,
-		options?: FindOptions<T>,
-	): Promise<T | null>;
+	getLoggedInByUserIdAndSessionId<T extends Document = ISession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, sessionId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/ISessionsModel.ts
+++ b/packages/model-typings/src/models/ISessionsModel.ts
@@ -1,4 +1,12 @@
-import type { ISession, UserSessionAggregationResult, DeviceSessionAggregationResult, OSSessionAggregationResult, IUser, DeviceManagementPopulatedSession, DeviceManagementSession, } from '@rocket.chat/core-typings';
+import type {
+	ISession,
+	UserSessionAggregationResult,
+	DeviceSessionAggregationResult,
+	OSSessionAggregationResult,
+	IUser,
+	DeviceManagementPopulatedSession,
+	DeviceManagementSession,
+} from '@rocket.chat/core-typings';
 import type { BulkWriteResult, Document, UpdateResult, FindCursor, OptionalId } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
@@ -136,5 +144,9 @@ export interface ISessionsModel extends IBaseModel<ISession> {
 
 	updateAllSessionsByDateToComputed({ start, end }: DestructuredRange): Promise<UpdateResult | Document>;
 
-	getLoggedInByUserIdAndSessionId<T extends Document = ISession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, sessionId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	getLoggedInByUserIdAndSessionId<T extends Document = ISession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		sessionId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/ISettingsModel.ts
+++ b/packages/model-typings/src/models/ISettingsModel.ts
@@ -1,6 +1,5 @@
 import type { ISetting, ISettingColor, ISettingSelectOption, SettingValue } from '@rocket.chat/core-typings';
-import type {
-	FindCursor, UpdateFilter, UpdateResult, Document, FindOneAndUpdateOptions, WithId, UpdateOptions } from 'mongodb';
+import type { FindCursor, UpdateFilter, UpdateResult, Document, FindOneAndUpdateOptions, WithId, UpdateOptions } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
@@ -12,7 +11,10 @@ export interface ISettingsModel extends IBaseModel<ISetting> {
 
 	findOneNotHiddenById(_id: string): Promise<ISetting | null>;
 
-	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id?: string[] | string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id?: string[] | string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	updateValueById(
 		_id: string,

--- a/packages/model-typings/src/models/ISettingsModel.ts
+++ b/packages/model-typings/src/models/ISettingsModel.ts
@@ -1,16 +1,9 @@
 import type { ISetting, ISettingColor, ISettingSelectOption, SettingValue } from '@rocket.chat/core-typings';
 import type {
-	FindCursor,
-	UpdateFilter,
-	UpdateResult,
-	Document,
-	FindOptions,
-	FindOneAndUpdateOptions,
-	WithId,
-	UpdateOptions,
-} from 'mongodb';
+	FindCursor, UpdateFilter, UpdateResult, Document, FindOneAndUpdateOptions, WithId, UpdateOptions } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ISettingsModel extends IBaseModel<ISetting> {
 	getValueById<T extends SettingValue = SettingValue>(_id: string): Promise<T | undefined>;
@@ -19,7 +12,7 @@ export interface ISettingsModel extends IBaseModel<ISetting> {
 
 	findOneNotHiddenById(_id: string): Promise<ISetting | null>;
 
-	findByIds(_id?: string[] | string, options?: FindOptions<ISetting>): FindCursor<ISetting>;
+	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id?: string[] | string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	updateValueById(
 		_id: string,

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -261,7 +261,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
 
-	getMinimumLastSeenByRoomId(rid: string): Promise<ISubscription | null>;
+	getMinimumLastSeenByRoomId(rid: string): Promise<Pick<ISubscription, '_id' | 'ls'> | null>;
 
 	setAsUnreadByRoomIdAndUserId(roomId: string, userId: string, firstMessageUnreadTimestamp: Date): Promise<UpdateResult>;
 

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -17,20 +17,20 @@ import type {
 } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
-import type { DocumentWithProjection } from '../types/DocumentWithProjection';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	getBadgeCount(uid: string): Promise<number>;
 
-	findOneByRoomIdAndUserId(rid: string, uid: string, options?: FindOptions<ISubscription>): Promise<ISubscription | null>;
+	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, uid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findByUserIdAndRoomIds(userId: string, roomIds: Array<string>, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roomIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findUnarchivedByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomIdAndNotUserId(roomId: string, userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByRoomIdAndUserId(rid: string, uid: string | undefined, includeInvitations?: boolean): Promise<number>;
 
@@ -50,41 +50,24 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 
 	removeRolesByUserId(uid: IUser['_id'], roles: IRole['_id'][], rid: IRoom['_id']): Promise<UpdateResult>;
 
-	findUsersInRoles(roles: IRole['_id'][], rid: string | undefined): Promise<FindCursor<IUser>>;
-
-	findUsersInRoles(roles: IRole['_id'][], rid: string | undefined, options: FindOptions<IUser>): Promise<FindCursor<IUser>>;
-
-	findUsersInRoles<P extends Document = IUser>(
-		roles: IRole['_id'][],
-		rid: string | undefined,
-		options: FindOptions<P extends IUser ? IUser : P>,
-	): Promise<FindCursor<P>>;
-
-	findUsersInRoles<P extends Document = IUser>(
-		roles: IRole['_id'][],
-		rid: IRoom['_id'] | undefined,
-		options?: FindOptions<P extends IUser ? IUser : P>,
-	): Promise<FindCursor<P>>;
+	findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roles: IRole['_id'][], rid: string | undefined, options?: O): Promise<FindCursor<DocumentWithProjection<P, O>>>;
 
 	addRolesByUserId(uid: IUser['_id'], roles: IRole['_id'][], rid?: IRoom['_id']): Promise<UpdateResult>;
 
 	isUserInRoleScope(uid: IUser['_id'], rid?: IRoom['_id']): Promise<boolean>;
 
-	findByRolesAndRoomId({ roles, rid }: { roles: string; rid?: string }, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ roles, rid }: { roles: string; rid?: string }, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndTypes(userId: string, types: ISubscription['t'][], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findOpenByVisitorIds(visitorIds: string[], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomIdAndNotAlertOrOpenExcludingUserIds(
-		filter: {
+	findByRoomIdAndNotAlertOrOpenExcludingUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: {
 			roomId: ISubscription['rid'];
 			uidsExclude?: ISubscription['u']['_id'][];
 			uidsInclude?: ISubscription['u']['_id'][];
 			onlyRead: boolean;
-		},
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+		}, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	removeByRoomId(roomId: ISubscription['rid'], options?: DeleteOptions & { onTrash: (doc: ISubscription) => void }): Promise<DeleteResult>;
 
@@ -151,80 +134,59 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 
 	getAutoTranslateLanguagesByRoomAndNotUser(rid: string, userId: string): Promise<(string | undefined)[]>;
 
-	findByRidWithoutE2EKey(rid: string, options: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
 	findUsersWithPublicE2EKeyByRids(
 		rids: IRoom['_id'][],
 		excludeUserId: IUser['_id'],
 		usersLimit?: number,
 	): AggregationCursor<{ rid: IRoom['_id']; users: { _id: IUser['_id']; public_key: string }[] }>;
-	findByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	updateAutoTranslateById(_id: string, autoTranslate: boolean): Promise<UpdateResult>;
 
 	setAutoTranslateByUserId(userId: IUser['_id'], language: string | null): Promise<UpdateResult | Document>;
-	findByAutoTranslateAndUserId(
-		userId: ISubscription['u']['_id'],
-		autoTranslate?: ISubscription['autoTranslate'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], autoTranslate?: ISubscription['autoTranslate'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndRoomType(
-		userId: ISubscription['u']['_id'],
-		type: ISubscription['t'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
-	findByNameAndRoomType(
-		filter: Partial<Pick<ISubscription, 'name' | 't'>>,
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: Partial<Pick<ISubscription, 'name' | 't'>>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	disableAutoTranslateByRoomId(roomId: IRoom['_id']): Promise<UpdateResult | Document>;
 
-	findByUserIdWithoutE2E(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	resetUserE2EKey(userId: string): Promise<UpdateResult | Document>;
 
-	findOneByRoomIdAndUsername(roomId: string, username: string, options: FindOptions<ISubscription>): Promise<ISubscription | null>;
+	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, username: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findByTypeAndUserId(type: ISubscription['t'], userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: ISubscription['t'], userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByType(types: ISubscription['t'][], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndRoles(userId: string, roles: string[], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	getLastSeen(options?: FindOptions<ISubscription>): Promise<Date | undefined>;
-	findByRoomWithUserHighlights(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
-	findByUserIdAndType(userId: string, type: ISubscription['t'], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
-	findByUserIdExceptType(
-		userId: string,
-		typeException: ISubscription['t'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, typeException: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomIdAndRoles<P extends Document = ISubscription, O extends FindOptions<P> = FindOptions<P>>(
+	findByRoomIdAndRoles<P extends Document = ISubscription, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		roomId: string,
 		roles: string[],
 		options?: O,
 	): FindCursor<DocumentWithProjection<P, O>>;
-
-	findByRoomIdAndRoles(roomId: string, roles: string[], options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
-	findByRoomIdAndUserIds(
-		roomId: ISubscription['rid'],
-		userIds: ISubscription['u']['_id'][],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: ISubscription['rid'], userIds: ISubscription['u']['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	getMinimumLastSeenByRoomId(rid: string): Promise<ISubscription | null>;
 
 	setAsUnreadByRoomIdAndUserId(roomId: string, userId: string, firstMessageUnreadTimestamp: Date): Promise<UpdateResult>;
 
 	archiveByRoomId(roomId: string): Promise<UpdateResult | Document>;
-	findArchivedByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
-	findArchivedByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	unarchiveByIds(ids: string[]): Promise<UpdateResult | Document>;
 	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document>;
-	findByRoomIdWhenUsernameExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	setCustomFieldsDirectMessagesByUserId(userId: string, fields: Record<string, any>): Promise<UpdateResult | Document>;
 	setFavoriteByRoomIdAndUserId(roomId: string, userId: string, favorite?: boolean): Promise<UpdateResult>;
 	hideByRoomIdAndUserId(roomId: string, userId: string): Promise<UpdateResult>;
-	findByRoomIdWhenUserIdExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription>;
+	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	updateNameAndFnameById(_id: string, name: string, fname: string, options?: { session?: ClientSession }): Promise<UpdateResult | Document>;
 	setUserUsernameByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 	updateFnameByRoomId(rid: string, fname: string): Promise<UpdateResult | Document>;
@@ -267,12 +229,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 		notificationField: keyof ISubscription,
 		notificationOriginField: keyof ISubscription,
 	): Promise<UpdateResult | Document>;
-	findByUserPreferences(
-		userId: string,
-		notificationOriginField: keyof ISubscription,
-		originFieldNotEqualValue: 'user' | 'subscription',
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, notificationOriginField: keyof ISubscription, originFieldNotEqualValue: 'user' | 'subscription', options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	clearNotificationUserPreferences(
 		userId: string,
 		notificationField: string,
@@ -298,11 +255,7 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	removeUnreadThreadByRoomIdAndUserId(rid: string, userId: string, tmid: string, clearAlert?: boolean): Promise<UpdateResult>;
 
 	removeUnreadThreadsByRoomId(rid: string, tunread: string[]): Promise<UpdateResult | Document>;
-	findUnreadThreadsByRoomId(
-		rid: ISubscription['rid'],
-		tunread: ISubscription['tunread'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription>;
+	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: ISubscription['rid'], tunread: ISubscription['tunread'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByRoomIdAndRoles(roomId: string, roles: string[]): Promise<number>;
 	countByRoomId(roomId: string, options?: CountDocumentsOptions): Promise<number>;
@@ -318,5 +271,5 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	banByRoomIdAndUserId(roomId: string, userId: string): Promise<UpdateResult>;
 	unbanToInvitedById(subId: string, inviter: Required<Pick<IUser, '_id' | 'username'>> & Pick<IUser, 'name'>): Promise<UpdateResult>;
 	setAbacLastTimeCheckedByUserIdAndRoomId(userId: string, roomId: string, time: Date): Promise<UpdateResult>;
-	findJoinedByUserId<T extends Document = ISubscription>(userId: ISubscription['u']['_id'], options?: FindOptions<T>): FindCursor<T>;
+	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/ISubscriptionsModel.ts
+++ b/packages/model-typings/src/models/ISubscriptionsModel.ts
@@ -22,15 +22,33 @@ import type { DocumentWithProjection, FindOptionsWithProjection } from '../types
 export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	getBadgeCount(uid: string): Promise<number>;
 
-	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, uid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		uid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roomIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		roomIds: Array<string>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByRoomIdAndUserId(rid: string, uid: string | undefined, includeInvitations?: boolean): Promise<number>;
 
@@ -50,24 +68,44 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 
 	removeRolesByUserId(uid: IUser['_id'], roles: IRole['_id'][], rid: IRoom['_id']): Promise<UpdateResult>;
 
-	findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roles: IRole['_id'][], rid: string | undefined, options?: O): Promise<FindCursor<DocumentWithProjection<P, O>>>;
+	findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		roles: IRole['_id'][],
+		rid: string | undefined,
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<P, O>>>;
 
 	addRolesByUserId(uid: IUser['_id'], roles: IRole['_id'][], rid?: IRoom['_id']): Promise<UpdateResult>;
 
 	isUserInRoleScope(uid: IUser['_id'], rid?: IRoom['_id']): Promise<boolean>;
 
-	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ roles, rid }: { roles: string; rid?: string }, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		{ roles, rid }: { roles: string; rid?: string },
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		types: ISubscription['t'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByRoomIdAndNotAlertOrOpenExcludingUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: {
+	findByRoomIdAndNotAlertOrOpenExcludingUserIds<
+		T extends Document = ISubscription,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		filter: {
 			roomId: ISubscription['rid'];
 			uidsExclude?: ISubscription['u']['_id'][];
 			uidsInclude?: ISubscription['u']['_id'][];
 			onlyRead: boolean;
-		}, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+		},
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	removeByRoomId(roomId: ISubscription['rid'], options?: DeleteOptions & { onTrash: (doc: ISubscription) => void }): Promise<DeleteResult>;
 
@@ -134,59 +172,121 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 
 	getAutoTranslateLanguagesByRoomAndNotUser(rid: string, userId: string): Promise<(string | undefined)[]>;
 
-	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	findUsersWithPublicE2EKeyByRids(
 		rids: IRoom['_id'][],
 		excludeUserId: IUser['_id'],
 		usersLimit?: number,
 	): AggregationCursor<{ rid: IRoom['_id']; users: { _id: IUser['_id']; public_key: string }[] }>;
-	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	updateAutoTranslateById(_id: string, autoTranslate: boolean): Promise<UpdateResult>;
 
 	setAutoTranslateByUserId(userId: IUser['_id'], language: string | null): Promise<UpdateResult | Document>;
-	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], autoTranslate?: ISubscription['autoTranslate'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		autoTranslate?: ISubscription['autoTranslate'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: Partial<Pick<ISubscription, 'name' | 't'>>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		type: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		filter: Partial<Pick<ISubscription, 'name' | 't'>>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	disableAutoTranslateByRoomId(roomId: IRoom['_id']): Promise<UpdateResult | Document>;
 
-	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	resetUserE2EKey(userId: string): Promise<UpdateResult | Document>;
 
-	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, username: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		username: string,
+		options: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: ISubscription['t'], userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: ISubscription['t'],
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		types: ISubscription['t'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		roles: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	getLastSeen(options?: FindOptions<ISubscription>): Promise<Date | undefined>;
-	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, typeException: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		type: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		typeException: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	findByRoomIdAndRoles<P extends Document = ISubscription, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		roomId: string,
 		roles: string[],
 		options?: O,
 	): FindCursor<DocumentWithProjection<P, O>>;
-	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: ISubscription['rid'], userIds: ISubscription['u']['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: ISubscription['rid'],
+		userIds: ISubscription['u']['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	getMinimumLastSeenByRoomId(rid: string): Promise<ISubscription | null>;
 
 	setAsUnreadByRoomIdAndUserId(roomId: string, userId: string, firstMessageUnreadTimestamp: Date): Promise<UpdateResult>;
 
 	archiveByRoomId(roomId: string): Promise<UpdateResult | Document>;
-	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	unarchiveByIds(ids: string[]): Promise<UpdateResult | Document>;
 	updateNameAndAlertByRoomId(roomId: string, name: string, fname: string): Promise<UpdateResult | Document>;
-	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	setCustomFieldsDirectMessagesByUserId(userId: string, fields: Record<string, any>): Promise<UpdateResult | Document>;
 	setFavoriteByRoomIdAndUserId(roomId: string, userId: string, favorite?: boolean): Promise<UpdateResult>;
 	hideByRoomIdAndUserId(roomId: string, userId: string): Promise<UpdateResult>;
-	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	updateNameAndFnameById(_id: string, name: string, fname: string, options?: { session?: ClientSession }): Promise<UpdateResult | Document>;
 	setUserUsernameByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 	updateFnameByRoomId(rid: string, fname: string): Promise<UpdateResult | Document>;
@@ -229,7 +329,12 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 		notificationField: keyof ISubscription,
 		notificationOriginField: keyof ISubscription,
 	): Promise<UpdateResult | Document>;
-	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, notificationOriginField: keyof ISubscription, originFieldNotEqualValue: 'user' | 'subscription', options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		notificationOriginField: keyof ISubscription,
+		originFieldNotEqualValue: 'user' | 'subscription',
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	clearNotificationUserPreferences(
 		userId: string,
 		notificationField: string,
@@ -255,7 +360,11 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	removeUnreadThreadByRoomIdAndUserId(rid: string, userId: string, tmid: string, clearAlert?: boolean): Promise<UpdateResult>;
 
 	removeUnreadThreadsByRoomId(rid: string, tunread: string[]): Promise<UpdateResult | Document>;
-	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: ISubscription['rid'], tunread: ISubscription['tunread'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: ISubscription['rid'],
+		tunread: ISubscription['tunread'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	countByRoomIdAndRoles(roomId: string, roles: string[]): Promise<number>;
 	countByRoomId(roomId: string, options?: CountDocumentsOptions): Promise<number>;
@@ -271,5 +380,8 @@ export interface ISubscriptionsModel extends IBaseModel<ISubscription> {
 	banByRoomIdAndUserId(roomId: string, userId: string): Promise<UpdateResult>;
 	unbanToInvitedById(subId: string, inviter: Required<Pick<IUser, '_id' | 'username'>> & Pick<IUser, 'name'>): Promise<UpdateResult>;
 	setAbacLastTimeCheckedByUserIdAndRoomId(userId: string, roomId: string, time: Date): Promise<UpdateResult>;
-	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/ITeamMemberModel.ts
+++ b/packages/model-typings/src/models/ITeamMemberModel.ts
@@ -2,10 +2,18 @@ import type { ITeamMember, IUser, IRole } from '@rocket.chat/core-typings';
 import type { FindOptions, FindCursor, InsertOneResult, UpdateResult, DeleteResult, Filter, Document } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
-import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITeamMemberModel extends IBaseModel<ITeamMember> {
-	findByUserId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByUserId(userId: string): FindCursor<ITeamMember>;
+
+	findByUserId(userId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByUserId<P extends Document>(userId: string, options: FindOptions<P>): FindCursor<P>;
+
+	findByUserId<P extends Document>(
+		userId: string,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember>;
 
 	findOneByUserIdAndTeamId(userId: string, teamId: string): Promise<ITeamMember | null>;
 
@@ -16,17 +24,35 @@ export interface ITeamMemberModel extends IBaseModel<ITeamMember> {
 	findOneByUserIdAndTeamId<P extends Document>(
 		userId: string,
 		teamId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
 	): Promise<P | null | ITeamMember>;
 
-	findByTeamId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamId: string, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByTeamId(teamId: string): FindCursor<ITeamMember>;
+
+	findByTeamId(teamId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByTeamId<P extends Document>(teamId: string, options: FindOptions<P>): FindCursor<P>;
+
+	findByTeamId<P extends Document>(
+		teamId: string,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember>;
 
 	countByTeamId(teamId: string): Promise<number>;
-	findByTeamIds<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByTeamIds(teamIds: Array<string>): FindCursor<ITeamMember>;
+
+	findByTeamIds(teamIds: Array<string>, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByTeamIds<P extends Document>(teamIds: Array<string>, options: FindOptions<P>): FindCursor<P>;
+
+	findByTeamIds<P extends Document>(
+		teamIds: Array<string>,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember>;
 
 	countByTeamIdAndRole(teamId: string, role: IRole['_id']): Promise<number>;
 
-	findByUserIdAndTeamIds<T extends Document = ITeamMember, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUserIdAndTeamIds(userId: string, teamIds: Array<string>, options?: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
 
 	findPaginatedMembersInfoByTeamId(
 		teamId: string,

--- a/packages/model-typings/src/models/ITeamMemberModel.ts
+++ b/packages/model-typings/src/models/ITeamMemberModel.ts
@@ -2,18 +2,10 @@ import type { ITeamMember, IUser, IRole } from '@rocket.chat/core-typings';
 import type { FindOptions, FindCursor, InsertOneResult, UpdateResult, DeleteResult, Filter, Document } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITeamMemberModel extends IBaseModel<ITeamMember> {
-	findByUserId(userId: string): FindCursor<ITeamMember>;
-
-	findByUserId(userId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByUserId<P extends Document>(userId: string, options: FindOptions<P>): FindCursor<P>;
-
-	findByUserId<P extends Document>(
-		userId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember>;
+	findByUserId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
 	findOneByUserIdAndTeamId(userId: string, teamId: string): Promise<ITeamMember | null>;
 
@@ -27,32 +19,14 @@ export interface ITeamMemberModel extends IBaseModel<ITeamMember> {
 		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
 	): Promise<P | null | ITeamMember>;
 
-	findByTeamId(teamId: string): FindCursor<ITeamMember>;
-
-	findByTeamId(teamId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByTeamId<P extends Document>(teamId: string, options: FindOptions<P>): FindCursor<P>;
-
-	findByTeamId<P extends Document>(
-		teamId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember>;
+	findByTeamId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamId: string, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
 	countByTeamId(teamId: string): Promise<number>;
-	findByTeamIds(teamIds: Array<string>): FindCursor<ITeamMember>;
-
-	findByTeamIds(teamIds: Array<string>, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByTeamIds<P extends Document>(teamIds: Array<string>, options: FindOptions<P>): FindCursor<P>;
-
-	findByTeamIds<P extends Document>(
-		teamIds: Array<string>,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember>;
+	findByTeamIds<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
 	countByTeamIdAndRole(teamId: string, role: IRole['_id']): Promise<number>;
 
-	findByUserIdAndTeamIds(userId: string, teamIds: Array<string>, options?: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+	findByUserIdAndTeamIds<T extends Document = ITeamMember, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	findPaginatedMembersInfoByTeamId(
 		teamId: string,

--- a/packages/model-typings/src/models/ITeamMemberModel.ts
+++ b/packages/model-typings/src/models/ITeamMemberModel.ts
@@ -59,7 +59,7 @@ export interface ITeamMemberModel extends IBaseModel<ITeamMember> {
 		limit: number,
 		skip: number,
 		query?: Filter<ITeamMember>,
-	): FindPaginated<FindCursor<ITeamMember>>;
+	): FindPaginated<FindCursor<Pick<ITeamMember, '_id' | 'userId' | 'roles' | 'createdBy' | 'createdAt'>>>;
 
 	updateOneByUserIdAndTeamId(userId: string, teamId: string, update: Partial<ITeamMember>): Promise<UpdateResult>;
 	createOneByTeamIdAndUserId(

--- a/packages/model-typings/src/models/ITeamModel.ts
+++ b/packages/model-typings/src/models/ITeamModel.ts
@@ -1,25 +1,97 @@
 import type { ITeam, TeamType } from '@rocket.chat/core-typings';
-import type { FindCursor, UpdateResult, DeleteResult, Filter, Document } from 'mongodb';
+import type { FindCursor, UpdateResult, DeleteResult, Filter, Document, FindOptions } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITeamModel extends IBaseModel<ITeam> {
-	findByNames<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(names: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByNames(names: Array<string>): FindCursor<ITeam>;
 
-	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindCursor<DocumentWithProjection<P, O>>;
+	findByNames(names: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
 
-	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findByNames<P extends Document>(names: Array<string>, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
 
-	findByIdsAndType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, type: TeamType, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByNames<P extends Document>(
+		names: Array<string>,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam>;
 
-	findByType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(type: number, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		ids: Array<string>,
+		options?: O,
+		query?: Filter<ITeam>,
+	): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByNameAndTeamIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
+	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: Array<string>,
+		options?: O,
+		query?: Filter<ITeam>,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findOneByName<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findByIdsAndType(ids: Array<string>, type: TeamType): FindCursor<ITeam>;
 
-	findOneByMainRoomId<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roomId: string, options?: O): Promise<DocumentWithProjection<P, O> | null>;
+	findByIdsAndType(ids: Array<string>, type: TeamType, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByIdsAndType<P extends Document>(
+		ids: Array<string>,
+		type: TeamType,
+		options: FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P>;
+
+	findByIdsAndType<P extends Document>(
+		ids: Array<string>,
+		type: TeamType,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam>;
+
+	findByType(type: number): FindCursor<ITeam>;
+
+	findByType(type: number, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByType<P extends Document>(type: number, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
+
+	findByType<P extends Document>(
+		type: number,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<ITeam> | FindCursor<P>;
+
+	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>): FindCursor<ITeam>;
+
+	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByNameAndTeamIds<P extends Document>(
+		name: string | RegExp,
+		teamIds: Array<string>,
+		options: FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P>;
+
+	findByNameAndTeamIds<P extends Document>(
+		name: string | RegExp,
+		teamIds: Array<string>,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam>;
+
+	findOneByName(name: string | RegExp): Promise<ITeam | null>;
+
+	findOneByName(name: string | RegExp, options: FindOptions<ITeam>): Promise<ITeam | null>;
+
+	findOneByName<P extends Document>(name: string | RegExp, options: FindOptions<P>): Promise<P | null>;
+
+	findOneByName<P extends Document>(
+		name: string | RegExp,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): Promise<P | null> | Promise<ITeam | null>;
+
+	findOneByMainRoomId(roomId: string): Promise<ITeam | null>;
+
+	findOneByMainRoomId(roomId: string, options: FindOptions<ITeam>): Promise<ITeam | null>;
+
+	findOneByMainRoomId<P extends Document>(roomId: string, options: FindOptions<P>): Promise<P | null>;
+
+	findOneByMainRoomId<P extends Document>(
+		roomId: string,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): Promise<P | null> | Promise<ITeam | null>;
 
 	updateMainRoomForTeam(id: string, roomId: string): Promise<UpdateResult>;
 

--- a/packages/model-typings/src/models/ITeamModel.ts
+++ b/packages/model-typings/src/models/ITeamModel.ts
@@ -1,102 +1,25 @@
 import type { ITeam, TeamType } from '@rocket.chat/core-typings';
-import type { FindOptions, FindCursor, UpdateResult, DeleteResult, Filter, Document } from 'mongodb';
+import type { FindCursor, UpdateResult, DeleteResult, Filter, Document } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITeamModel extends IBaseModel<ITeam> {
-	findByNames(names: Array<string>): FindCursor<ITeam>;
+	findByNames<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(names: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByNames(names: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
+	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByNames<P extends Document>(names: Array<string>, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
+	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findByNames<P extends Document>(
-		names: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam>;
+	findByIdsAndType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, type: TeamType, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByIds(ids: Array<string>, query?: Filter<ITeam>): FindCursor<ITeam>;
+	findByType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(type: number, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByIds(ids: Array<string>, options: FindOptions<ITeam>, query?: Filter<ITeam>): FindCursor<ITeam>;
+	findByNameAndTeamIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>>;
 
-	findByIds<P extends Document>(
-		ids: Array<string>,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-		query?: Filter<ITeam>,
-	): FindCursor<P>;
+	findOneByName<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, options?: O): Promise<DocumentWithProjection<P, O> | null>;
 
-	findByIds<P extends Document>(
-		ids: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-		query?: Filter<ITeam>,
-	): FindCursor<P> | FindCursor<ITeam>;
-
-	findByIdsPaginated(ids: Array<string>, options?: undefined | FindOptions<ITeam>, query?: Filter<ITeam>): FindPaginated<FindCursor<ITeam>>;
-
-	findByIdsAndType(ids: Array<string>, type: TeamType): FindCursor<ITeam>;
-
-	findByIdsAndType(ids: Array<string>, type: TeamType, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByIdsAndType<P extends Document>(
-		ids: Array<string>,
-		type: TeamType,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P>;
-
-	findByIdsAndType<P extends Document>(
-		ids: Array<string>,
-		type: TeamType,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam>;
-
-	findByType(type: number): FindCursor<ITeam>;
-
-	findByType(type: number, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByType<P extends Document>(type: number, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
-
-	findByType<P extends Document>(
-		type: number,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<ITeam> | FindCursor<P>;
-
-	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>): FindCursor<ITeam>;
-
-	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByNameAndTeamIds<P extends Document>(
-		name: string | RegExp,
-		teamIds: Array<string>,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P>;
-
-	findByNameAndTeamIds<P extends Document>(
-		name: string | RegExp,
-		teamIds: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam>;
-
-	findOneByName(name: string | RegExp): Promise<ITeam | null>;
-
-	findOneByName(name: string | RegExp, options: FindOptions<ITeam>): Promise<ITeam | null>;
-
-	findOneByName<P extends Document>(name: string | RegExp, options: FindOptions<P>): Promise<P | null>;
-
-	findOneByName<P extends Document>(
-		name: string | RegExp,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): Promise<P | null> | Promise<ITeam | null>;
-
-	findOneByMainRoomId(roomId: string): Promise<ITeam | null>;
-
-	findOneByMainRoomId(roomId: string, options: FindOptions<ITeam>): Promise<ITeam | null>;
-
-	findOneByMainRoomId<P extends Document>(roomId: string, options: FindOptions<P>): Promise<P | null>;
-
-	findOneByMainRoomId<P extends Document>(
-		roomId: string,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): Promise<P | null> | Promise<ITeam | null>;
+	findOneByMainRoomId<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roomId: string, options?: O): Promise<DocumentWithProjection<P, O> | null>;
 
 	updateMainRoomForTeam(id: string, roomId: string): Promise<UpdateResult>;
 

--- a/packages/model-typings/src/models/ITwoFactorChallengesModel.ts
+++ b/packages/model-typings/src/models/ITwoFactorChallengesModel.ts
@@ -5,7 +5,13 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITwoFactorChallengesModel extends IBaseModel<ITwoFactorChallenge> {
-	findOneByPendingChallengeId<T extends Document = ITwoFactorChallenge, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByPendingChallengeId<
+		T extends Document = ITwoFactorChallenge,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		id: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	removeByPendingChallengeId(id: string): Promise<DeleteResult>;
 	createTwoFactorChallenge(userId: string, method: ITwoFactorChallenge['method']): Promise<string>;
 }

--- a/packages/model-typings/src/models/ITwoFactorChallengesModel.ts
+++ b/packages/model-typings/src/models/ITwoFactorChallengesModel.ts
@@ -1,10 +1,11 @@
 import type { ITwoFactorChallenge } from '@rocket.chat/core-typings';
-import type { DeleteResult, FindOptions } from 'mongodb';
+import type { DeleteResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface ITwoFactorChallengesModel extends IBaseModel<ITwoFactorChallenge> {
-	findOneByPendingChallengeId(id: string, options?: FindOptions<ITwoFactorChallenge>): Promise<ITwoFactorChallenge | null>;
+	findOneByPendingChallengeId<T extends Document = ITwoFactorChallenge, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	removeByPendingChallengeId(id: string): Promise<DeleteResult>;
 	createTwoFactorChallenge(userId: string, method: ITwoFactorChallenge['method']): Promise<string>;
 }

--- a/packages/model-typings/src/models/IUploadsModel.ts
+++ b/packages/model-typings/src/models/IUploadsModel.ts
@@ -20,5 +20,8 @@ export interface IUploadsModel extends IBaseUploadsModel<IUpload> {
 
 	setFederationRoomInfo(fileId: IUpload['_id'], rid: IRoom['_id'], mrid: string): Promise<UpdateResult>;
 
-	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(originalFileId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		originalFileId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/IUploadsModel.ts
+++ b/packages/model-typings/src/models/IUploadsModel.ts
@@ -1,8 +1,9 @@
 import type { IRoom, IUpload } from '@rocket.chat/core-typings';
-import type { FindCursor, WithId, Filter, FindOptions, UpdateResult } from 'mongodb';
+import type { FindCursor, WithId, Filter, FindOptions, UpdateResult, Document } from 'mongodb';
 
 import type { FindPaginated } from './IBaseModel';
 import type { IBaseUploadsModel } from './IBaseUploadsModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IUploadsModel extends IBaseUploadsModel<IUpload> {
 	findPaginatedWithoutThumbs(query: Filter<IUpload>, options?: any): FindPaginated<FindCursor<WithId<IUpload>>>;
@@ -19,5 +20,5 @@ export interface IUploadsModel extends IBaseUploadsModel<IUpload> {
 
 	setFederationRoomInfo(fileId: IUpload['_id'], rid: IRoom['_id'], mrid: string): Promise<UpdateResult>;
 
-	findAllByOriginalFileId(originalFileId: string, options?: FindOptions<IUpload>): FindCursor<IUpload>;
+	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(originalFileId: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 }

--- a/packages/model-typings/src/models/IUserDataFilesModel.ts
+++ b/packages/model-typings/src/models/IUserDataFilesModel.ts
@@ -5,5 +5,8 @@ import type { IBaseUploadsModel } from './IBaseUploadsModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IUserDataFilesModel extends IBaseUploadsModel<IUserDataFile> {
-	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IUserDataFilesModel.ts
+++ b/packages/model-typings/src/models/IUserDataFilesModel.ts
@@ -1,8 +1,9 @@
 import type { IUserDataFile } from '@rocket.chat/core-typings';
-import type { FindOptions } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import type { IBaseUploadsModel } from './IBaseUploadsModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IUserDataFilesModel extends IBaseUploadsModel<IUserDataFile> {
-	findLastFileByUser(userId: string, options?: FindOptions<IUserDataFile>): Promise<IUserDataFile | null>;
+	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -35,41 +35,129 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		_scope?: null,
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
-	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
-	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
-	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], options?: O, searchFields?: string[], extraQuery?: Filter<IUser>[], extra?: { startsWith: boolean; endsWith: boolean }): FindCursor<DocumentWithProjection<T, O>>;
-	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, searchFields?: string[], extraQuery?: Filter<IUser>[], extra?: { startsWith?: boolean; endsWith?: boolean }): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		query: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		query: Filter<IUser>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string | RegExp,
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions: string[],
+		options?: O,
+		searchFields?: string[],
+		extraQuery?: Filter<IUser>[],
+		extra?: { startsWith: boolean; endsWith: boolean },
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		searchFields?: string[],
+		extraQuery?: Filter<IUser>[],
+		extra?: { startsWith?: boolean; endsWith?: boolean },
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		forcedSearchFields?: string[],
+		localDomain?: string,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findPaginatedByActiveExternalUsersExcept<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		forcedSearchFields?: string[],
+		localDomain?: string,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: IUser['username'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneWithoutLDAPByUsernameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		username: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	findOneByLDAPId<T extends Document = IUser>(id: string, attribute?: string): Promise<T | null>;
 
-	findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(appId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(params: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] }, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		appId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		params: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] },
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
-	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	isUserInRole(userId: IUser['_id'], roleId: IRole['_id']): Promise<Pick<IUser, 'roles' | '_id'> | null>;
 
@@ -112,7 +200,15 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	findAllResumeTokensByUserId(userId: IUser['_id']): Promise<{ tokens: IMeteorLoginToken[] }[]>;
 
-	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(termRegex: { $regex: string; $options: string } | RegExp, exceptions?: string[], conditions?: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		termRegex: { $regex: string; $options: string } | RegExp,
+		exceptions?: string[],
+		conditions?: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	countAllAgentsStatus({
 		departmentId,
@@ -130,7 +226,10 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	setAbacAttributesById(userId: IUser['_id'], attributes: NonNullable<IUser['abacAttributes']>): Promise<IUser | null>;
 	unsetAbacAttributesById(userId: IUser['_id']): Promise<IUser | null>;
-	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: IRoom['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: IRoom['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	setCasExternalIdByUsername(username: string): Promise<IUser | null>;
 
 	updateStatusText(_id: IUser['_id'], statusText: string, options?: UpdateOptions): Promise<UpdateResult>;
@@ -202,7 +301,10 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	countActiveUsersEmail2faEnable(options: any): Promise<number>;
 
-	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	setAsFederated(userId: string): any;
 
@@ -230,7 +332,12 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		isLivechatEnabledWhenIdle?: boolean,
 		acceptChatsWithNoAgents?: boolean,
 	): Promise<Pick<AvailableAgentsAggregation, 'username'>[]>;
-	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userList: string[] | string, options?: O, isLivechatEnabledWhenAgentIdle?: boolean, acceptChatsWithNoAgents?: boolean): Promise<DocumentWithProjection<T, O> | null>;
+	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userList: string[] | string,
+		options?: O,
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	findBotAgents<T extends Document = ILivechatAgent>(usernameList?: string | string[]): FindCursor<T>;
 	countBotAgents(usernameList?: string | string[]): Promise<number>;
@@ -291,39 +398,122 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	update2FABackupCodesByUserId(userId: string, codes: string[]): Promise<UpdateResult>;
 	enableEmail2FAByUserId(userId: string): Promise<UpdateResult>;
 	disableEmail2FAByUserId(userId: string): Promise<UpdateResult>;
-	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	resetE2EKey(userId: string): Promise<UpdateResult>;
 	removeExpiredEmailCodeOfUserId(userId: string): Promise<UpdateResult>;
 	maxInvalidEmailCodeAttemptsReached(userId: string, maxAttemtps: number): Promise<boolean>;
 	addEmailCodeByUserId(userId: string, code: string, expire: Date): Promise<UpdateResult>;
-	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countActiveUsersInRoles(roles: string[], options?: FindOptions<IUser>): Promise<number>;
-	findOneByUsernameAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, userId: string, serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByEmailAddressAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, userId: string, serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, loginToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], type: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
-	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findOneByUsernameAndServiceNameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		username: string,
+		userId: string,
+		serviceName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByEmailAddressAndServiceNameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		emailAddress: string,
+		userId: string,
+		serviceName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emailAddress: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emailAddress: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		loginToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][],
+		type: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countUsersNotOffline(options?: FindOptions<IUser>): Promise<number>;
-	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, updatedFrom: Date, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
-	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		updatedFrom: Date,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	countActiveLocalGuests(idsExceptions: string[]): Promise<number>;
-	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	getLastLogin(options?: FindOptions<IUser>): Promise<Date | undefined>;
-	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	getSAMLByIdAndSAMLProvider(userId: string, samlProvider: string): Promise<IUser | null>;
-	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(samlNameId: string, idpSession: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
-	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(inResponseTo: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		samlNameId: string,
+		idpSession: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
+	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		inResponseTo: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	addImportIds(userId: string, importIds: string | string[]): Promise<UpdateResult>;
 	updateInviteToken(userId: string, token: string): Promise<UpdateResult>;
 	updateLastLoginById(userId: string): Promise<UpdateResult>;
@@ -339,7 +529,11 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	unsetAvatarData(userId: string): Promise<UpdateResult>;
 	setUserActive(userId: string, active: boolean): Promise<UpdateResult>;
 	setActiveNotLoggedInAfterWithRole(latestLastLoginDate: Date, role?: string, active?: boolean): Promise<UpdateResult | Document>;
-	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(latestLastLoginDate: Date, role?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		latestLastLoginDate: Date,
+		role?: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	unsetRequirePasswordChange(userId: string): Promise<UpdateResult>;
 	resetPasswordAndSetRequirePasswordChange(
 		userId: string,
@@ -371,7 +565,10 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findAllUsersWithPendingAvatar(): FindCursor<IUser>;
 	updateCustomFieldsById(userId: string, customFields: Record<string, unknown>): Promise<UpdateResult>;
 	countRoomMembers(roomId: string): Promise<number>;
-	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	removeAgent(_id: string): Promise<UpdateResult>;
 	findAgentsWithDepartments<T extends Document = ILivechatAgent>(
 		role: IRole['_id'][] | IRole['_id'],
@@ -384,12 +581,22 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOnlineButNotAvailableAgents<T extends Document = ILivechatAgent>(userIds?: IUser['_id'][]): FindCursor<T>;
 	findAgentsAvailableWithoutBusinessHours(userIds?: IUser['_id'][]): FindCursor<Pick<ILivechatAgent, '_id' | 'openBusinessHours'>>;
 	updateLivechatStatusByAgentIds(userIds: string[], status: ILivechatAgentStatus): Promise<UpdateResult | Document>;
-	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(freeSwitchExtension: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		freeSwitchExtension: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	countUsersInRoles(roles: IRole['_id'][]): Promise<number>;
 	countAllUsersWithPendingAvatar(): Promise<number>;
-	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], role: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		role: string,
+		options: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	countActiveUsersInNonDMRoom(rid: string): Promise<number>;
 	countActiveUsersInDMRoom(rid: string): Promise<number>;
 	verifyEmailByAddress(_id: IUser['_id'], emailAddress: string): Promise<UpdateResult>;
-	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -26,83 +26,50 @@ import type {
 } from 'mongodb';
 
 import type { FindPaginated, IBaseModel } from './IBaseModel';
-import type { DocumentWithProjection } from '../types/DocumentWithProjection';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IUsersModel extends IBaseModel<IUser> {
 	addRolesByUserId(uid: IUser['_id'], roles: IRole['_id'][]): Promise<UpdateResult>;
-	findUsersInRoles<T extends Document = IUser, O extends FindOptions<T> = FindOptions<T>>(
+	findUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roles: IRole['_id'][] | IRole['_id'],
 		_scope?: null,
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
-	findPaginatedUsersInRoles(roles: IRole['_id'][] | IRole['_id'], options?: FindOptions<IUser>): FindPaginated<FindCursor<IUser>>;
-	findOneByIdWithEmailAddress(uid: IUser['_id'], options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneByUsername<T extends Document = IUser>(username: string, options?: FindOptions<IUser>): Promise<T | null>;
-	findOneAgentById<T extends Document = ILivechatAgent>(_id: IUser['_id'], options?: FindOptions<IUser>): Promise<T | null>;
-	findUsersInRolesWithQuery(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: FindOptions<IUser>): FindCursor<IUser>;
-	findPaginatedUsersInRolesWithQuery<T extends Document = IUser>(
-		roles: IRole['_id'][] | IRole['_id'],
-		query: Filter<IUser>,
-		options?: FindOptions<IUser>,
-	): FindPaginated<FindCursor<WithId<T>>>;
-	findOneByUsernameAndRoomIgnoringCase(username: string | RegExp, rid: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneByIdAndLoginHashedToken(_id: IUser['_id'], token: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findByActiveUsersExcept(
-		searchTerm: string,
-		exceptions: string[],
-		options?: FindOptions<IUser>,
-		searchFields?: string[],
-		extraQuery?: Filter<IUser>[],
-		extra?: { startsWith: boolean; endsWith: boolean },
-	): FindCursor<IUser>;
-	findPaginatedByActiveUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		searchFields?: string[],
-		extraQuery?: Filter<IUser>[],
-		extra?: { startsWith?: boolean; endsWith?: boolean },
-	): FindPaginated<FindCursor<WithId<T>>>;
+	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
+	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], options?: O, searchFields?: string[], extraQuery?: Filter<IUser>[], extra?: { startsWith: boolean; endsWith: boolean }): FindCursor<DocumentWithProjection<T, O>>;
+	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, searchFields?: string[], extraQuery?: Filter<IUser>[], extra?: { startsWith?: boolean; endsWith?: boolean }): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		forcedSearchFields?: string[],
-		localDomain?: string,
-	): FindPaginated<FindCursor<WithId<T>>>;
+	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		forcedSearchFields?: string[],
-		localDomain?: string,
-	): FindPaginated<FindCursor<WithId<T>>>;
+	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
-	findActive(query: Filter<IUser>, options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveByIds(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findByIds<T extends Document = IUser>(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<T>;
+	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findOneByUsernameIgnoringCase<T extends Document = IUser>(username: IUser['username'], options?: FindOptions<IUser>): Promise<T | null>;
+	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser>(username: string, options?: FindOptions<IUser>): Promise<T | null>;
+	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 
 	findOneByLDAPId<T extends Document = IUser>(id: string, attribute?: string): Promise<T | null>;
 
-	findOneByAppId<T extends Document = IUser>(appId: string, options?: FindOptions<IUser>): Promise<T | null>;
-	findUsersByIdentifiers(
-		params: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] },
-		options?: FindOptions<IUser>,
-	): FindCursor<IUser>;
+	findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(appId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(params: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] }, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>): FindCursor<T>;
+	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findActiveLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<T>;
+	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
-	findConnectedLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>): FindCursor<T>;
+	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	isUserInRole(userId: IUser['_id'], roleId: IRole['_id']): Promise<Pick<IUser, 'roles' | '_id'> | null>;
 
@@ -145,12 +112,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	findAllResumeTokensByUserId(userId: IUser['_id']): Promise<{ tokens: IMeteorLoginToken[] }[]>;
 
-	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser>(
-		termRegex: { $regex: string; $options: string } | RegExp,
-		exceptions?: string[],
-		conditions?: Filter<IUser>,
-		options?: FindOptions<IUser>,
-	): FindCursor<T>;
+	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(termRegex: { $regex: string; $options: string } | RegExp, exceptions?: string[], conditions?: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	countAllAgentsStatus({
 		departmentId,
@@ -168,7 +130,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	setAbacAttributesById(userId: IUser['_id'], attributes: NonNullable<IUser['abacAttributes']>): Promise<IUser | null>;
 	unsetAbacAttributesById(userId: IUser['_id']): Promise<IUser | null>;
-	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: IRoom['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	setCasExternalIdByUsername(username: string): Promise<IUser | null>;
 
 	updateStatusText(_id: IUser['_id'], statusText: string, options?: UpdateOptions): Promise<UpdateResult>;
@@ -240,7 +202,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 
 	countActiveUsersEmail2faEnable(options: any): Promise<number>;
 
-	findActiveByIdsOrUsernames(userIds: IUser['_id'][], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	setAsFederated(userId: string): any;
 
@@ -268,12 +230,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		isLivechatEnabledWhenIdle?: boolean,
 		acceptChatsWithNoAgents?: boolean,
 	): Promise<Pick<AvailableAgentsAggregation, 'username'>[]>;
-	findOneOnlineAgentByUserList(
-		userList: string[] | string,
-		options?: FindOptions<IUser>,
-		isLivechatEnabledWhenAgentIdle?: boolean,
-		acceptChatsWithNoAgents?: boolean,
-	): Promise<IUser | null>;
+	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userList: string[] | string, options?: O, isLivechatEnabledWhenAgentIdle?: boolean, acceptChatsWithNoAgents?: boolean): Promise<DocumentWithProjection<T, O> | null>;
 
 	findBotAgents<T extends Document = ILivechatAgent>(usernameList?: string | string[]): FindCursor<T>;
 	countBotAgents(usernameList?: string | string[]): Promise<number>;
@@ -334,49 +291,39 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	update2FABackupCodesByUserId(userId: string, codes: string[]): Promise<UpdateResult>;
 	enableEmail2FAByUserId(userId: string): Promise<UpdateResult>;
 	disableEmail2FAByUserId(userId: string): Promise<UpdateResult>;
-	findByIdsWithPublicE2EKey(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	resetE2EKey(userId: string): Promise<UpdateResult>;
 	removeExpiredEmailCodeOfUserId(userId: string): Promise<UpdateResult>;
 	maxInvalidEmailCodeAttemptsReached(userId: string, maxAttemtps: number): Promise<boolean>;
 	addEmailCodeByUserId(userId: string, code: string, expire: Date): Promise<UpdateResult>;
-	findActiveUsersInRoles(roles: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	countActiveUsersInRoles(roles: string[], options?: FindOptions<IUser>): Promise<number>;
-	findOneByUsernameAndServiceNameIgnoringCase(
-		username: string,
-		userId: string,
-		serviceName: string,
-		options?: FindOptions<IUser>,
-	): Promise<IUser | null>;
-	findOneByEmailAddressAndServiceNameIgnoringCase(
-		emailAddress: string,
-		userId: string,
-		serviceName: string,
-		options?: FindOptions<IUser>,
-	): Promise<IUser | null>;
-	findOneByEmailAddress(emailAddress: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneWithoutLDAPByEmailAddress(emailAddress: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneAdmin(userId: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneByIdAndLoginToken(userId: string, loginToken: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneActiveById(userId: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneByIdOrUsername(userId: string, options?: FindOptions<IUser>): Promise<IUser | null>;
-	findOneByRolesAndType<T extends Document = IUser>(roles: IRole['_id'][], type: string, options?: FindOptions<IUser>): Promise<T | null>;
-	findPresenceUsersByIds(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
-	findUsersNotOffline(options?: FindOptions<IUser>): FindCursor<IUser>;
+	findOneByUsernameAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, userId: string, serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByEmailAddressAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, userId: string, serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, loginToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], type: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
+	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	countUsersNotOffline(options?: FindOptions<IUser>): Promise<number>;
-	findNotIdUpdatedFrom(userId: string, updatedFrom: Date, options?: FindOptions<IUser>): FindCursor<IUser>;
-	findByRoomId(roomId: string, options?: FindOptions<IUser>): Promise<FindCursor<IUser>>;
-	findByUsernames(usernames: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
-	findByUsernamesIgnoringCase(usernames: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
-	findActiveByUserIds(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
+	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, updatedFrom: Date, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>>;
+	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	countActiveLocalGuests(idsExceptions: string[]): Promise<number>;
-	findCrowdUsers(options?: FindOptions<IUser>): FindCursor<IUser>;
+	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	getLastLogin(options?: FindOptions<IUser>): Promise<Date | undefined>;
-	findUsersByUsernames<T extends Document = IUser>(usernames: string[], options?: FindOptions<IUser>): FindCursor<T>;
-	findUsersByIds(userIds: string[], options?: FindOptions<IUser>): FindCursor<IUser>;
-	getOldest(options?: FindOptions<IUser>): Promise<IUser | null>;
+	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	getSAMLByIdAndSAMLProvider(userId: string, samlProvider: string): Promise<IUser | null>;
-	findBySAMLNameIdOrIdpSession(samlNameId: string, idpSession: string, options?: FindOptions<IUser>): FindCursor<IUser>;
-	findBySAMLInResponseTo(inResponseTo: string, options?: FindOptions<IUser>): FindCursor<IUser>;
+	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(samlNameId: string, idpSession: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(inResponseTo: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	addImportIds(userId: string, importIds: string | string[]): Promise<UpdateResult>;
 	updateInviteToken(userId: string, token: string): Promise<UpdateResult>;
 	updateLastLoginById(userId: string): Promise<UpdateResult>;
@@ -392,7 +339,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	unsetAvatarData(userId: string): Promise<UpdateResult>;
 	setUserActive(userId: string, active: boolean): Promise<UpdateResult>;
 	setActiveNotLoggedInAfterWithRole(latestLastLoginDate: Date, role?: string, active?: boolean): Promise<UpdateResult | Document>;
-	findActiveNotLoggedInAfterWithRole(latestLastLoginDate: Date, role?: string, options?: FindOptions<IUser>): FindCursor<IUser>;
+	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(latestLastLoginDate: Date, role?: string, options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	unsetRequirePasswordChange(userId: string): Promise<UpdateResult>;
 	resetPasswordAndSetRequirePasswordChange(
 		userId: string,
@@ -424,7 +371,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findAllUsersWithPendingAvatar(): FindCursor<IUser>;
 	updateCustomFieldsById(userId: string, customFields: Record<string, unknown>): Promise<UpdateResult>;
 	countRoomMembers(roomId: string): Promise<number>;
-	findOneByImportId<T extends Document = IUser>(_id: IUser['_id'], options?: FindOptions<IUser>): Promise<T | null>;
+	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	removeAgent(_id: string): Promise<UpdateResult>;
 	findAgentsWithDepartments<T extends Document = ILivechatAgent>(
 		role: IRole['_id'][] | IRole['_id'],
@@ -437,12 +384,12 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOnlineButNotAvailableAgents<T extends Document = ILivechatAgent>(userIds?: IUser['_id'][]): FindCursor<T>;
 	findAgentsAvailableWithoutBusinessHours(userIds?: IUser['_id'][]): FindCursor<Pick<ILivechatAgent, '_id' | 'openBusinessHours'>>;
 	updateLivechatStatusByAgentIds(userIds: string[], status: ILivechatAgentStatus): Promise<UpdateResult | Document>;
-	findOneByFreeSwitchExtension<T extends Document = IUser>(freeSwitchExtension: string, options?: FindOptions<IUser>): Promise<T | null>;
+	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(freeSwitchExtension: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 	countUsersInRoles(roles: IRole['_id'][]): Promise<number>;
 	countAllUsersWithPendingAvatar(): Promise<number>;
-	findOneByIdAndRole(userId: IUser['_id'], role: string, options: FindOptions<IUser>): Promise<IUser | null>;
+	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], role: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
 	countActiveUsersInNonDMRoom(rid: string): Promise<number>;
 	countActiveUsersInDMRoom(rid: string): Promise<number>;
 	verifyEmailByAddress(_id: IUser['_id'], emailAddress: string): Promise<UpdateResult>;
-	findOneByEmailVerificationToken<T extends Document = IUser>(token: string, options?: FindOptions<T>): Promise<T | null>;
+	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null>;
 }

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -590,7 +590,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		userId: IUser['_id'],
 		role: string,
-		options: O,
+		options?: O,
 	): Promise<DocumentWithProjection<T, O> | null>;
 	countActiveUsersInNonDMRoom(rid: string): Promise<number>;
 	countActiveUsersInDMRoom(rid: string): Promise<number>;

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -47,7 +47,7 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		username: string,
 		options?: O,
 	): Promise<DocumentWithProjection<T, O> | null>;
-	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+	findOneAgentById<T extends Document = ILivechatAgent, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		_id: IUser['_id'],
 		options?: O,
 	): Promise<DocumentWithProjection<T, O> | null>;

--- a/packages/model-typings/src/models/IUsersSessionsModel.ts
+++ b/packages/model-typings/src/models/IUsersSessionsModel.ts
@@ -13,6 +13,9 @@ export interface IUsersSessionsModel extends IBaseModel<IUserSession> {
 		userId: string,
 		{ id, instanceId, status }: Pick<IUserSessionConnection, 'id' | 'instanceId' | 'status'>,
 	): ReturnType<IBaseModel<IUserSession>['updateOne']>;
-	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(instanceIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
+	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		instanceIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	removeConnectionsFromOtherInstanceIds(instanceIds: string[]): ReturnType<IBaseModel<IUserSession>['updateMany']>;
 }

--- a/packages/model-typings/src/models/IUsersSessionsModel.ts
+++ b/packages/model-typings/src/models/IUsersSessionsModel.ts
@@ -1,7 +1,8 @@
 import type { IUserSession, IUserSessionConnection } from '@rocket.chat/core-typings';
-import type { FindCursor, FindOptions } from 'mongodb';
+import type { FindCursor, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IUsersSessionsModel extends IBaseModel<IUserSession> {
 	updateConnectionStatusById(uid: string, connectionId: string, status: string): ReturnType<IBaseModel<IUserSession>['updateOne']>;
@@ -12,6 +13,6 @@ export interface IUsersSessionsModel extends IBaseModel<IUserSession> {
 		userId: string,
 		{ id, instanceId, status }: Pick<IUserSessionConnection, 'id' | 'instanceId' | 'status'>,
 	): ReturnType<IBaseModel<IUserSession>['updateOne']>;
-	findByOtherInstanceIds(instanceIds: string[], options?: FindOptions<IUserSession>): FindCursor<IUserSession>;
+	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(instanceIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>>;
 	removeConnectionsFromOtherInstanceIds(instanceIds: string[]): ReturnType<IBaseModel<IUserSession>['updateMany']>;
 }

--- a/packages/model-typings/src/models/IWebdavAccountsModel.ts
+++ b/packages/model-typings/src/models/IWebdavAccountsModel.ts
@@ -1,12 +1,12 @@
 import type { IWebdavAccount } from '@rocket.chat/core-typings';
-import type { FindOptions, FindCursor, DeleteResult } from 'mongodb';
+import type { FindCursor, DeleteResult, Document } from 'mongodb';
 
 import type { IBaseModel } from './IBaseModel';
+import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IWebdavAccountsModel extends IBaseModel<IWebdavAccount> {
-	findOneByIdAndUserId(_id: string, userId: string, options: FindOptions<IWebdavAccount>): Promise<IWebdavAccount | null>;
-	findOneByUserIdServerUrlAndUsername(
-		{
+	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, userId: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByUserIdServerUrlAndUsername<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
 			userId,
 			serverURL,
 			username,
@@ -14,11 +14,9 @@ export interface IWebdavAccountsModel extends IBaseModel<IWebdavAccount> {
 			userId: string;
 			serverURL: string;
 			username: string;
-		},
-		options: FindOptions<IWebdavAccount>,
-	): Promise<IWebdavAccount | null>;
+		}, options: O): Promise<DocumentWithProjection<T, O> | null>;
 
-	findWithUserId(userId: string, options: FindOptions<IWebdavAccount>): FindCursor<IWebdavAccount>;
+	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
 
 	removeByUserAndId(_id: string, userId: string): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/models/IWebdavAccountsModel.ts
+++ b/packages/model-typings/src/models/IWebdavAccountsModel.ts
@@ -5,8 +5,16 @@ import type { IBaseModel } from './IBaseModel';
 import type { DocumentWithProjection, FindOptionsWithProjection } from '../types/DocumentWithProjection';
 
 export interface IWebdavAccountsModel extends IBaseModel<IWebdavAccount> {
-	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, userId: string, options: O): Promise<DocumentWithProjection<T, O> | null>;
-	findOneByUserIdServerUrlAndUsername<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
+	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		userId: string,
+		options: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneByUserIdServerUrlAndUsername<
+		T extends Document = IWebdavAccount,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		{
 			userId,
 			serverURL,
 			username,
@@ -14,9 +22,14 @@ export interface IWebdavAccountsModel extends IBaseModel<IWebdavAccount> {
 			userId: string;
 			serverURL: string;
 			username: string;
-		}, options: O): Promise<DocumentWithProjection<T, O> | null>;
+		},
+		options: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
-	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options: O): FindCursor<DocumentWithProjection<T, O>>;
+	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 
 	removeByUserAndId(_id: string, userId: string): Promise<DeleteResult>;
 }

--- a/packages/model-typings/src/types/DocumentWithProjection.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.ts
@@ -43,8 +43,9 @@ type ExclusionKeys<P> = { [K in keyof P]-?: P[K] extends 0 | false ? K : never }
 
 /**
  * Applies a projection `P` to a document type `T`, mirroring what `BaseRaw` actually sends to the
- * server — see `doNotMixInclusionAndExclusionFields`, which strips every `0` key as soon as one key
- * is not `0`, so a mixed projection behaves as inclusion-only and still returns `_id`.
+ * server — see `doNotMixInclusionAndExclusionFields`, which strips every exclusion key (`0` or
+ * `false`) as soon as one key is an inclusion, so a mixed projection behaves as inclusion-only and
+ * still returns `_id`.
  *
  * Bails out to `T` whenever the projection cannot be read statically: dotted paths, `$`-operators,
  * computed keys, or values that are not `0`/`1`/`false`/`true` literals.

--- a/packages/model-typings/src/types/DocumentWithProjection.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.ts
@@ -31,7 +31,11 @@ export type FindOneAndUpdateOptionsWithProjection = WithProjectionSpec<FindOneAn
 
 export type FindOneAndDeleteOptionsWithProjection = WithProjectionSpec<FindOneAndDeleteOptions>;
 
-type IdKey<T> = Extract<keyof T, '_id'>;
+/**
+ * `Extract<keyof T, '_id'>` would miss documents with a string index signature (`keyof T` collapses
+ * to `string | number`, which `'_id'` is not a member of), so probe with `extends` instead.
+ */
+type IdKey<T> = '_id' extends keyof T ? '_id' : never;
 
 type InclusionKeys<P> = { [K in keyof P]-?: P[K] extends 1 | true ? K : never }[keyof P];
 
@@ -53,9 +57,16 @@ export type ApplyProjection<T, P> = [keyof P] extends [keyof T]
 		: T
 	: T;
 
+/**
+ * `NoInfer` blocks contextual inference through the return type: when a call sits in a typed
+ * position (argument, object literal property), the document type param would otherwise fall back
+ * to its `Document` constraint instead of its default, degenerating the result to `{ key: any }`.
+ * The bail-out branches must stay a bare `T` so the no-projection case reduces to exactly the
+ * document type — implementations that forward a legacy `<T>` generic rely on that identity.
+ */
 export type DocumentWithProjection<T extends Document, O> = O extends { projection: infer P }
 	? P extends ProjectionSpec
-		? ApplyProjection<T, P>
+		? ApplyProjection<NoInfer<T>, P>
 		: T
 	: T;
 
@@ -79,6 +90,6 @@ type ApplyDriverProjection<T, P> = [keyof P] extends [keyof T]
 
 export type DocumentWithDriverProjection<T extends Document, O> = O extends { projection: infer P }
 	? P extends ProjectionSpec
-		? ApplyDriverProjection<T, P>
+		? ApplyDriverProjection<NoInfer<T>, P>
 		: T
 	: T;

--- a/packages/model-typings/src/types/DocumentWithProjection.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.ts
@@ -1,4 +1,4 @@
-import type { Document, FindOneAndDeleteOptions, FindOneAndUpdateOptions, FindOptions } from 'mongodb';
+import type { Document, FindOneAndUpdateOptions, FindOptions } from 'mongodb';
 
 type Prettify<T> = {
 	[K in keyof T]: T[K];
@@ -28,8 +28,6 @@ export type WithProjectionSpec<O> = Omit<O, 'projection'> & {
 export type FindOptionsWithProjection<T extends Document = Document> = WithProjectionSpec<FindOptions<T>>;
 
 export type FindOneAndUpdateOptionsWithProjection = WithProjectionSpec<FindOneAndUpdateOptions>;
-
-export type FindOneAndDeleteOptionsWithProjection = WithProjectionSpec<FindOneAndDeleteOptions>;
 
 /**
  * `Extract<keyof T, '_id'>` would miss documents with a string index signature (`keyof T` collapses

--- a/packages/model-typings/src/types/DocumentWithProjection.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.ts
@@ -1,4 +1,4 @@
-import type { Document, FindOptions } from 'mongodb';
+import type { Document, FindOneAndDeleteOptions, FindOneAndUpdateOptions, FindOptions } from 'mongodb';
 
 type Prettify<T> = {
 	[K in keyof T]: T[K];
@@ -21,9 +21,15 @@ export type ProjectionSpec = Record<string, ProjectionValue | Document>;
  *    projections (which get no implicit index signature) keep compiling.
  * Do not collapse the union.
  */
-export type FindOptionsWithProjection<T extends Document = Document> = Omit<FindOptions<T>, 'projection'> & {
+export type WithProjectionSpec<O> = Omit<O, 'projection'> & {
 	projection?: ProjectionSpec | Document;
 };
+
+export type FindOptionsWithProjection<T extends Document = Document> = WithProjectionSpec<FindOptions<T>>;
+
+export type FindOneAndUpdateOptionsWithProjection = WithProjectionSpec<FindOneAndUpdateOptions>;
+
+export type FindOneAndDeleteOptionsWithProjection = WithProjectionSpec<FindOneAndDeleteOptions>;
 
 type IdKey<T> = Extract<keyof T, '_id'>;
 
@@ -50,5 +56,29 @@ export type ApplyProjection<T, P> = [keyof P] extends [keyof T]
 export type DocumentWithProjection<T extends Document, O> = O extends { projection: infer P }
 	? P extends ProjectionSpec
 		? ApplyProjection<T, P>
+		: T
+	: T;
+
+/**
+ * Applies a projection the way the **driver** sees it. `findOneAndUpdate` / `findOneAndDelete` go
+ * straight to the collection, so they get none of `BaseRaw`'s rewriting. Two consequences:
+ *  - `_id` comes back unless the projection excludes it explicitly, so `{ a: 1, _id: 0 }` really does
+ *    drop `_id` here, where the `find` path would have kept it;
+ *  - mixing inclusion with any other exclusion is a server error, so there is nothing useful to
+ *    describe and we fall back to `T`.
+ */
+type ApplyDriverProjection<T, P> = [keyof P] extends [keyof T]
+	? [keyof P] extends [InclusionKeys<P> | ExclusionKeys<P>]
+		? [InclusionKeys<P>] extends [never]
+			? Omit<T, ExclusionKeys<P> & keyof T>
+			: [Exclude<ExclusionKeys<P>, '_id'>] extends [never]
+				? Prettify<Pick<T, (InclusionKeys<P> & keyof T) | Exclude<IdKey<T>, ExclusionKeys<P>>>>
+				: T
+		: T
+	: T;
+
+export type DocumentWithDriverProjection<T extends Document, O> = O extends { projection: infer P }
+	? P extends ProjectionSpec
+		? ApplyDriverProjection<T, P>
 		: T
 	: T;

--- a/packages/model-typings/src/types/DocumentWithProjection.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.ts
@@ -1,15 +1,54 @@
-import type { FindOptions } from 'mongodb';
+import type { Document, FindOptions } from 'mongodb';
 
 type Prettify<T> = {
 	[K in keyof T]: T[K];
 } & {};
 
-export type DocumentWithProjection<T extends NonNullable<unknown>, O extends FindOptions<T>['projection']> = O extends {
-	projection: infer P;
-}
-	? P extends FindOptions<T>['projection']
-		? keyof P extends keyof T
-			? Prettify<Pick<T, keyof P & keyof T>>
-			: T
+export type ProjectionValue = 0 | 1 | boolean;
+
+/** Projection operators (`$slice`, `$elemMatch`, `$meta`, positional `$`) hold plain documents. */
+export type ProjectionSpec = Record<string, ProjectionValue | Document>;
+
+/**
+ * `FindOptions` with a projection type that keeps `0`/`1` as literal types when the options object
+ * is inferred into a generic parameter. The driver's own `FindOptions['projection']` is `Document`
+ * (`{ [key: string]: any }`), which contains no literal types, so `0` and `1` widen to `number` and
+ * inclusion becomes indistinguishable from exclusion.
+ *
+ * `ProjectionSpec | Document` looks redundant, but both members are load-bearing:
+ *  - `ProjectionSpec` supplies the literal contextual type that keeps `0`/`1` narrow;
+ *  - `Document` keeps assignability identical to the driver's `FindOptions`, so interface-typed
+ *    projections (which get no implicit index signature) keep compiling.
+ * Do not collapse the union.
+ */
+export type FindOptionsWithProjection<T extends Document = Document> = Omit<FindOptions<T>, 'projection'> & {
+	projection?: ProjectionSpec | Document;
+};
+
+type IdKey<T> = Extract<keyof T, '_id'>;
+
+type InclusionKeys<P> = { [K in keyof P]-?: P[K] extends 1 | true ? K : never }[keyof P];
+
+type ExclusionKeys<P> = { [K in keyof P]-?: P[K] extends 0 | false ? K : never }[keyof P];
+
+/**
+ * Applies a projection `P` to a document type `T`, mirroring what `BaseRaw` actually sends to the
+ * server — see `doNotMixInclusionAndExclusionFields`, which strips every `0` key as soon as one key
+ * is not `0`, so a mixed projection behaves as inclusion-only and still returns `_id`.
+ *
+ * Bails out to `T` whenever the projection cannot be read statically: dotted paths, `$`-operators,
+ * computed keys, or values that are not `0`/`1`/`false`/`true` literals.
+ */
+export type ApplyProjection<T, P> = [keyof P] extends [keyof T]
+	? [keyof P] extends [InclusionKeys<P> | ExclusionKeys<P>]
+		? [InclusionKeys<P>] extends [never]
+			? Omit<T, ExclusionKeys<P> & keyof T>
+			: Prettify<Pick<T, (InclusionKeys<P> & keyof T) | IdKey<T>>>
+		: T
+	: T;
+
+export type DocumentWithProjection<T extends Document, O> = O extends { projection: infer P }
+	? P extends ProjectionSpec
+		? ApplyProjection<T, P>
 		: T
 	: T;

--- a/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
@@ -1,7 +1,9 @@
 /**
- * Compile-time assertions for {@link DocumentWithProjection}. This file emits nothing; it exists so
- * that `tsc -p tsconfig.json` fails if the projection inference regresses.
+ * Compile-time assertions for {@link DocumentWithProjection}. Nothing here is meant to run; it
+ * exists so that `tsc -p tsconfig.json` fails if the projection inference regresses.
  */
+import type { Document } from 'mongodb';
+
 import type { DocumentWithDriverProjection, DocumentWithProjection, FindOptionsWithProjection } from './DocumentWithProjection';
 
 type Expect<T extends true> = T;
@@ -62,6 +64,33 @@ export type NonLiteralValueBailsOut = Expect<Equal<Project<{ name: number }>, Do
 export type UnknownKeyBailsOut = Expect<Equal<Project<{ name: 1; notInDoc: 1 }>, Doc>>;
 
 export type WideProjectionBailsOut = Expect<Equal<Project<Record<string, 0 | 1>>, Doc>>;
+
+// Documents with a string index signature collapse `keyof T` to `string | number`, which used to
+// make the implicit `_id` disappear from inclusion projections.
+
+type IndexedDoc = {
+	_id: string;
+	name: string;
+	[k: string]: any;
+};
+
+export type IndexSignatureKeepsId = Expect<
+	Equivalent<DocumentWithProjection<IndexedDoc, { projection: { name: 1 } }>, { _id: string; name: string }>
+>;
+
+// When a call sits in a contextually typed position (argument, object literal property), inference
+// through the return type would drive the document type param to its `Document` constraint instead
+// of its default. The `NoInfer` inside `DocumentWithProjection` blocks that.
+
+declare const contextualProbe: {
+	findOne<P extends Document = Doc, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		options?: O,
+	): DocumentWithProjection<P, O> | null;
+};
+
+export const contextualInferenceKeepsDefault: Pick<Doc, '_id' | 'username'> | null = contextualProbe.findOne({
+	projection: { username: 1 },
+});
 
 // `findOneAndUpdate` / `findOneAndDelete` reach the driver directly, so they get none of BaseRaw's
 // rewriting. The two rules below are where driver semantics diverge from the `find` path.

--- a/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
@@ -46,10 +46,20 @@ export type BooleanExclusion = Expect<Equivalent<Project<{ password: false; name
 
 export type ExclusionCanDropId = Expect<Equivalent<Project<{ _id: 0 }>, Omit<Doc, '_id'>>>;
 
-/** `doNotMixInclusionAndExclusionFields` drops the `0` keys at runtime, so `_id` survives a mix. */
+/** `doNotMixInclusionAndExclusionFields` drops the exclusion keys at runtime, so `_id` survives a mix. */
 export type MixedBehavesAsInclusion = Expect<Equivalent<Project<{ name: 1; password: 0 }>, Pick<Doc, '_id' | 'name'>>>;
 
+export type MixedBooleanBehavesAsInclusion = Expect<Equivalent<Project<{ name: true; password: false }>, Pick<Doc, '_id' | 'name'>>>;
+
+export type MixedNotationBehavesAsInclusion = Expect<Equivalent<Project<{ name: 1; password: false }>, Pick<Doc, '_id' | 'name'>>>;
+
+export type MixedNotationExclusionStaysExclusion = Expect<
+	Equivalent<Project<{ password: 0; name: false }>, Omit<Doc, 'password' | 'name'>>
+>;
+
 export type MixedKeepsIdEvenWhenExcluded = Expect<Equivalent<Project<{ _id: 0; name: 1 }>, Pick<Doc, '_id' | 'name'>>>;
+
+export type MixedKeepsIdEvenWhenExcludedWithBoolean = Expect<Equivalent<Project<{ _id: false; name: 1 }>, Pick<Doc, '_id' | 'name'>>>;
 
 // Everything below must bail out to the full document rather than guess.
 

--- a/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
@@ -2,7 +2,7 @@
  * Compile-time assertions for {@link DocumentWithProjection}. This file emits nothing; it exists so
  * that `tsc -p tsconfig.json` fails if the projection inference regresses.
  */
-import type { DocumentWithProjection, FindOptionsWithProjection } from './DocumentWithProjection';
+import type { DocumentWithDriverProjection, DocumentWithProjection, FindOptionsWithProjection } from './DocumentWithProjection';
 
 type Expect<T extends true> = T;
 
@@ -62,3 +62,20 @@ export type NonLiteralValueBailsOut = Expect<Equal<Project<{ name: number }>, Do
 export type UnknownKeyBailsOut = Expect<Equal<Project<{ name: 1; notInDoc: 1 }>, Doc>>;
 
 export type WideProjectionBailsOut = Expect<Equal<Project<Record<string, 0 | 1>>, Doc>>;
+
+// `findOneAndUpdate` / `findOneAndDelete` reach the driver directly, so they get none of BaseRaw's
+// rewriting. The two rules below are where driver semantics diverge from the `find` path.
+
+type DriverProject<P> = DocumentWithDriverProjection<Doc, { projection: P }>;
+
+export type DriverInclusion = Expect<Equivalent<DriverProject<{ username: 1 }>, Pick<Doc, '_id' | 'username'>>>;
+
+export type DriverExclusion = Expect<Equivalent<DriverProject<{ password: 0 }>, Omit<Doc, 'password'>>>;
+
+/** `find` keeps `_id` here because BaseRaw strips the `0`; the driver really drops it. */
+export type DriverExplicitIdExclusionDropsId = Expect<Equivalent<DriverProject<{ name: 1; _id: 0 }>, Pick<Doc, 'name'>>>;
+
+/** Mixing inclusion with a non-`_id` exclusion is a server error, so there is nothing to describe. */
+export type DriverGenuineMixBailsOut = Expect<Equal<DriverProject<{ name: 1; password: 0 }>, Doc>>;
+
+export type DriverNoProjectionCollapses = Expect<Equal<DocumentWithDriverProjection<Doc, undefined>, Doc>>;

--- a/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
+++ b/packages/model-typings/src/types/DocumentWithProjection.typetest.ts
@@ -1,0 +1,64 @@
+/**
+ * Compile-time assertions for {@link DocumentWithProjection}. This file emits nothing; it exists so
+ * that `tsc -p tsconfig.json` fails if the projection inference regresses.
+ */
+import type { DocumentWithProjection, FindOptionsWithProjection } from './DocumentWithProjection';
+
+type Expect<T extends true> = T;
+
+/** Strict type identity. */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+/** Mutual assignability — tolerant of `Prettify`/`Pick` representation differences. */
+type Equivalent<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+type Doc = {
+	_id: string;
+	username?: string;
+	password: string;
+	name: string;
+	roles: string[];
+};
+
+type Project<P> = DocumentWithProjection<Doc, { projection: P }>;
+
+/**
+ * The invariant the whole backward-compatibility story rests on: `projection` is optional in
+ * `FindOptionsWithProjection`, so the default `O` does not match `{ projection: infer P }` and the
+ * result collapses to the document type. Making `projection` required would silently change the
+ * meaning of every call site that passes an explicit generic.
+ */
+export type NoProjectionCollapsesToDocument = Expect<Equal<DocumentWithProjection<Doc, FindOptionsWithProjection<Doc>>, Doc>>;
+
+export type UndefinedOptionsCollapsesToDocument = Expect<Equal<DocumentWithProjection<Doc, undefined>, Doc>>;
+
+export type Inclusion = Expect<Equivalent<Project<{ username: 1 }>, Pick<Doc, '_id' | 'username'>>>;
+
+export type InclusionKeepsIdImplicitly = Expect<Equivalent<Project<{ name: 1 }>, Pick<Doc, '_id' | 'name'>>>;
+
+export type BooleanInclusion = Expect<Equivalent<Project<{ username: true }>, Pick<Doc, '_id' | 'username'>>>;
+
+export type Exclusion = Expect<Equivalent<Project<{ password: 0 }>, Omit<Doc, 'password'>>>;
+
+export type BooleanExclusion = Expect<Equivalent<Project<{ password: false; name: false }>, Omit<Doc, 'password' | 'name'>>>;
+
+export type ExclusionCanDropId = Expect<Equivalent<Project<{ _id: 0 }>, Omit<Doc, '_id'>>>;
+
+/** `doNotMixInclusionAndExclusionFields` drops the `0` keys at runtime, so `_id` survives a mix. */
+export type MixedBehavesAsInclusion = Expect<Equivalent<Project<{ name: 1; password: 0 }>, Pick<Doc, '_id' | 'name'>>>;
+
+export type MixedKeepsIdEvenWhenExcluded = Expect<Equivalent<Project<{ _id: 0; name: 1 }>, Pick<Doc, '_id' | 'name'>>>;
+
+// Everything below must bail out to the full document rather than guess.
+
+export type DottedPathBailsOut = Expect<Equal<Project<{ 'roles.0': 1 }>, Doc>>;
+
+export type OperatorBailsOut = Expect<Equal<Project<{ roles: { $slice: 5 } }>, Doc>>;
+
+export type MetaBailsOut = Expect<Equal<Project<{ $meta: 'textScore' }>, Doc>>;
+
+export type NonLiteralValueBailsOut = Expect<Equal<Project<{ name: number }>, Doc>>;
+
+export type UnknownKeyBailsOut = Expect<Equal<Project<{ name: 1; notInDoc: 1 }>, Doc>>;
+
+export type WideProjectionBailsOut = Expect<Equal<Project<Record<string, 0 | 1>>, Doc>>;

--- a/packages/model-typings/tsconfig.build.json
+++ b/packages/model-typings/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+	"extends": "./tsconfig.json",
+	// `*.typetest.ts` holds compile-time assertions only — `yarn typecheck` covers them, the build must not emit them.
+	"exclude": ["node_modules", "${configDir}/**/*.spec.ts", "${configDir}/**/*.typetest.ts"]
+}

--- a/packages/model-typings/tsconfig.json
+++ b/packages/model-typings/tsconfig.json
@@ -5,5 +5,8 @@
 		"rootDir": "./src",
 		"outDir": "./dist"
 	},
-	"include": ["./src/**/*"]
+	"include": ["./src/**/*"],
+	// restates the inherited exclusions: a child `exclude` replaces the parent's rather than adding to it.
+	// `*.typetest.ts` holds compile-time assertions only — `yarn typecheck` covers them, the build must not emit them.
+	"exclude": ["node_modules", "${configDir}/**/*.spec.ts", "${configDir}/**/*.typetest.ts"]
 }

--- a/packages/model-typings/tsconfig.json
+++ b/packages/model-typings/tsconfig.json
@@ -7,6 +7,6 @@
 	},
 	"include": ["./src/**/*"],
 	// restates the inherited exclusions: a child `exclude` replaces the parent's rather than adding to it.
-	// `*.typetest.ts` holds compile-time assertions only — `yarn typecheck` covers them, the build must not emit them.
-	"exclude": ["node_modules", "${configDir}/**/*.spec.ts", "${configDir}/**/*.typetest.ts"]
+	// keeping only `node_modules` lets ESLint and `yarn typecheck` cover the type tests; the build config drops them.
+	"exclude": ["node_modules"]
 }

--- a/packages/model-typings/tsconfig.typecheck.json
+++ b/packages/model-typings/tsconfig.typecheck.json
@@ -1,7 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"noEmit": true
-	},
-	"exclude": ["node_modules", "${configDir}/**/*.spec.ts"]
-}

--- a/packages/model-typings/tsconfig.typecheck.json
+++ b/packages/model-typings/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true
+	},
+	"exclude": ["node_modules", "${configDir}/**/*.spec.ts"]
+}

--- a/packages/models/src/dummy/BaseDummy.ts
+++ b/packages/models/src/dummy/BaseDummy.ts
@@ -8,7 +8,6 @@ import type {
 	InsertionModel,
 	DocumentWithDriverProjection,
 	FindOneAndUpdateOptionsWithProjection,
-	FindOneAndDeleteOptionsWithProjection,
 } from '@rocket.chat/model-typings';
 import type {
 	BulkWriteOptions,
@@ -63,17 +62,11 @@ export class BaseDummy<
 		return this.collectionName;
 	}
 
-	async findOneAndDelete<
-		P extends Document = T,
-		O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection,
-	>(): Promise<DocumentWithDriverProjection<P, O> | null> {
+	async findOneAndDelete(): Promise<WithId<T> | null> {
 		return null;
 	}
 
-	async findOneAndDeleteById<
-		P extends Document = T,
-		O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection,
-	>(_id: T['_id']): Promise<DocumentWithDriverProjection<P, O> | null> {
+	async findOneAndDeleteById(_id: T['_id']): Promise<WithId<T> | null> {
 		return null;
 	}
 

--- a/packages/models/src/dummy/BaseDummy.ts
+++ b/packages/models/src/dummy/BaseDummy.ts
@@ -1,5 +1,12 @@
 import type { RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { DefaultFields, FindPaginated, IBaseModel, InsertionModel, ResultFields } from '@rocket.chat/model-typings';
+import type {
+	DefaultFields,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+	FindPaginated,
+	IBaseModel,
+	InsertionModel,
+} from '@rocket.chat/model-typings';
 import type {
 	BulkWriteOptions,
 	ChangeStream,
@@ -65,36 +72,31 @@ export class BaseDummy<
 		return null;
 	}
 
-	findOneById(_id: T['_id'], options?: FindOptions<T> | undefined): Promise<T | null>;
-
-	findOneById<P extends Document = T>(_id: T['_id'], options?: FindOptions<P>): Promise<P | null>;
-
-	async findOneById(_id: T['_id'], _options?: any): Promise<T | null> {
+	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: T['_id'],
+		_options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		return null;
 	}
 
-	findOne(query?: Filter<T> | T['_id'], options?: undefined): Promise<T | null>;
-
-	findOne<P extends Document = T>(query: Filter<T> | T['_id'], options: FindOptions<P extends T ? T : P>): Promise<P | null>;
-
-	async findOne<P>(_query: Filter<T> | T['_id'], _options?: any): Promise<WithId<T> | WithId<P> | null> {
+	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_query?: Filter<T> | T['_id'],
+		_options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		return null;
 	}
 
-	find(query?: Filter<T>): FindCursor<ResultFields<T, C>>;
-
-	find<P extends Document = T>(query: Filter<T>, options: FindOptions<P extends T ? T : P>): FindCursor<P>;
-
-	find<P extends Document>(
-		_query: Filter<T> | undefined,
-		_options?: FindOptions<P extends T ? T : P>,
-	): FindCursor<WithId<P>> | FindCursor<WithId<T>> {
+	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_query?: Filter<T>,
+		_options?: O,
+	): FindCursor<DocumentWithProjection<P, O>> {
 		return undefined as any;
 	}
 
-	findPaginated<P extends Document = T>(query: Filter<T>, options?: FindOptions<P extends T ? T : P>): FindPaginated<FindCursor<WithId<P>>>;
-
-	findPaginated(_query: Filter<T>, _options?: any): FindPaginated<FindCursor<WithId<T>>> {
+	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_query?: Filter<T>,
+		_options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
 		return {
 			cursor: undefined as any,
 			totalCount: Promise.resolve(0),

--- a/packages/models/src/dummy/BaseDummy.ts
+++ b/packages/models/src/dummy/BaseDummy.ts
@@ -170,7 +170,7 @@ export class BaseDummy<
 		_query: Filter<TDeleted>,
 		_options?: FindOptions<P extends TDeleted ? TDeleted : P>,
 	): FindCursor<WithId<TDeleted>> | undefined {
-		return undefined as any;
+		return undefined;
 	}
 
 	trashFindOneById(_id: TDeleted['_id']): Promise<TDeleted | null>;

--- a/packages/models/src/dummy/BaseDummy.ts
+++ b/packages/models/src/dummy/BaseDummy.ts
@@ -6,6 +6,9 @@ import type {
 	FindPaginated,
 	IBaseModel,
 	InsertionModel,
+	DocumentWithDriverProjection,
+	FindOneAndUpdateOptionsWithProjection,
+	FindOneAndDeleteOptionsWithProjection,
 } from '@rocket.chat/model-typings';
 import type {
 	BulkWriteOptions,
@@ -60,15 +63,24 @@ export class BaseDummy<
 		return this.collectionName;
 	}
 
-	async findOneAndDelete(): Promise<WithId<T> | null> {
+	async findOneAndDelete<
+		P extends Document = T,
+		O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection,
+	>(): Promise<DocumentWithDriverProjection<P, O> | null> {
 		return null;
 	}
 
-	async findOneAndDeleteById(_id: T['_id']): Promise<WithId<T> | null> {
+	async findOneAndDeleteById<
+		P extends Document = T,
+		O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection,
+	>(_id: T['_id']): Promise<DocumentWithDriverProjection<P, O> | null> {
 		return null;
 	}
 
-	async findOneAndUpdate(): Promise<WithId<T> | null> {
+	async findOneAndUpdate<
+		P extends Document = T,
+		O extends FindOneAndUpdateOptionsWithProjection = FindOneAndUpdateOptionsWithProjection,
+	>(): Promise<DocumentWithDriverProjection<P, O> | null> {
 		return null;
 	}
 

--- a/packages/models/src/models/Banners.ts
+++ b/packages/models/src/models/Banners.ts
@@ -1,7 +1,7 @@
 import type { IBanner, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import { BannerPlatform } from '@rocket.chat/core-typings';
-import type { IBannersModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, FindOptions, IndexDescription, InsertOneResult, UpdateResult } from 'mongodb';
+import type { IBannersModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, InsertOneResult, UpdateResult, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -34,7 +34,7 @@ export class BannersRaw extends BaseRaw<IBanner> implements IBannersModel {
 		});
 	}
 
-	findActiveByRoleOrId(roles: string[], platform: BannerPlatform, bannerId?: string, options?: FindOptions<IBanner>): FindCursor<IBanner> {
+	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], platform: BannerPlatform, bannerId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const today = new Date();
 
 		const query = {
@@ -46,7 +46,7 @@ export class BannersRaw extends BaseRaw<IBanner> implements IBannersModel {
 			$or: [{ roles: { $in: roles } }, { roles: { $exists: false } }],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	disable(bannerId: string): Promise<UpdateResult> {

--- a/packages/models/src/models/Banners.ts
+++ b/packages/models/src/models/Banners.ts
@@ -34,7 +34,12 @@ export class BannersRaw extends BaseRaw<IBanner> implements IBannersModel {
 		});
 	}
 
-	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: string[], platform: BannerPlatform, bannerId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByRoleOrId<T extends Document = IBanner, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: string[],
+		platform: BannerPlatform,
+		bannerId?: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const today = new Date();
 
 		const query = {

--- a/packages/models/src/models/BannersDismiss.ts
+++ b/packages/models/src/models/BannersDismiss.ts
@@ -1,6 +1,6 @@
 import type { IBannerDismiss, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBannersDismissModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, FindOptions, IndexDescription } from 'mongodb';
+import type { IBannersDismissModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,21 +13,7 @@ export class BannersDismissRaw extends BaseRaw<IBannerDismiss> implements IBanne
 		return [{ key: { userId: 1, bannerId: 1 } }];
 	}
 
-	findByUserIdAndBannerId(userId: string, bannerIds: string[]): FindCursor<IBannerDismiss>;
-
-	findByUserIdAndBannerId(userId: string, bannerIds: string[], options: FindOptions<IBannerDismiss>): FindCursor<IBannerDismiss>;
-
-	findByUserIdAndBannerId<P extends Document>(
-		userId: string,
-		bannerIds: string[],
-		options: FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
-	): FindCursor<P>;
-
-	findByUserIdAndBannerId<P extends Document>(
-		userId: string,
-		bannerIds: string[],
-		options?: undefined | FindOptions<IBannerDismiss> | FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
-	): FindCursor<P> | FindCursor<IBannerDismiss> {
+	findByUserIdAndBannerId<P extends Document = IBannerDismiss, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, bannerIds: string[], options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		const query = {
 			userId,
 			bannerId: { $in: bannerIds },

--- a/packages/models/src/models/BannersDismiss.ts
+++ b/packages/models/src/models/BannersDismiss.ts
@@ -1,6 +1,6 @@
 import type { IBannerDismiss, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBannersDismissModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, IndexDescription, Document } from 'mongodb';
+import type { IBannersDismissModel } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, Document, FindOptions } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,7 +13,21 @@ export class BannersDismissRaw extends BaseRaw<IBannerDismiss> implements IBanne
 		return [{ key: { userId: 1, bannerId: 1 } }];
 	}
 
-	findByUserIdAndBannerId<P extends Document = IBannerDismiss, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, bannerIds: string[], options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByUserIdAndBannerId(userId: string, bannerIds: string[]): FindCursor<IBannerDismiss>;
+
+	findByUserIdAndBannerId(userId: string, bannerIds: string[], options: FindOptions<IBannerDismiss>): FindCursor<IBannerDismiss>;
+
+	findByUserIdAndBannerId<P extends Document>(
+		userId: string,
+		bannerIds: string[],
+		options: FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
+	): FindCursor<P>;
+
+	findByUserIdAndBannerId<P extends Document>(
+		userId: string,
+		bannerIds: string[],
+		options?: FindOptions<IBannerDismiss> | FindOptions<P extends IBannerDismiss ? IBannerDismiss : P>,
+	): FindCursor<P> | FindCursor<IBannerDismiss> {
 		const query = {
 			userId,
 			bannerId: { $in: bannerIds },

--- a/packages/models/src/models/BaseRaw.spec.ts
+++ b/packages/models/src/models/BaseRaw.spec.ts
@@ -41,4 +41,12 @@ describe('doNotMixInclusionAndExclusionFields', () => {
 		expect(projectionSentToDriver({ name: true, password: false })).toEqual({ name: true });
 		expect(projectionSentToDriver({ name: 1, _id: false })).toEqual({ name: 1 });
 	});
+
+	it('should not mutate the projection owned by the caller', () => {
+		const options = { projection: { name: 1, password: false } } as unknown as FindOptions<{ _id: string; name: string; password: string }>;
+
+		new TestModel().find({}, options);
+
+		expect(options.projection).toEqual({ name: 1, password: false });
+	});
 });

--- a/packages/models/src/models/BaseRaw.spec.ts
+++ b/packages/models/src/models/BaseRaw.spec.ts
@@ -1,0 +1,44 @@
+import type { Collection, Db, FindOptions } from 'mongodb';
+
+import { BaseRaw } from './BaseRaw';
+
+// `BaseRaw` imports `..`, whose barrel pulls in every model and cycles back here.
+jest.mock('..', () => ({
+	getCollectionName: (name: string) => name,
+	UpdaterImpl: class {},
+}));
+
+const find = jest.fn();
+
+class TestModel extends BaseRaw<{ _id: string; name: string; password: string }> {
+	constructor() {
+		super({ collection: () => ({ find }) } as unknown as Db, 'test');
+	}
+}
+
+const projectionSentToDriver = (projection: Record<string, unknown>): unknown => {
+	new TestModel().find({}, { projection } as FindOptions<{ _id: string; name: string; password: string }>);
+	return find.mock.calls.at(-1)?.[1]?.projection;
+};
+
+describe('doNotMixInclusionAndExclusionFields', () => {
+	beforeEach(() => find.mockReset().mockReturnValue({} as unknown as Collection<any>));
+
+	it('should keep an inclusion-only projection untouched', () => {
+		expect(projectionSentToDriver({ name: 1 })).toEqual({ name: 1 });
+		expect(projectionSentToDriver({ name: true })).toEqual({ name: true });
+	});
+
+	it('should keep an exclusion-only projection untouched, whichever notation is used', () => {
+		expect(projectionSentToDriver({ password: 0 })).toEqual({ password: 0 });
+		expect(projectionSentToDriver({ password: false })).toEqual({ password: false });
+		expect(projectionSentToDriver({ password: 0, name: false })).toEqual({ password: 0, name: false });
+	});
+
+	it('should drop the exclusions from a mixed projection, whichever notation is used', () => {
+		expect(projectionSentToDriver({ name: 1, password: 0 })).toEqual({ name: 1 });
+		expect(projectionSentToDriver({ name: 1, password: false })).toEqual({ name: 1 });
+		expect(projectionSentToDriver({ name: true, password: false })).toEqual({ name: true });
+		expect(projectionSentToDriver({ name: 1, _id: false })).toEqual({ name: 1 });
+	});
+});

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -7,6 +7,9 @@ import type {
 	InsertionModel,
 	DocumentWithProjection,
 	FindOptionsWithProjection,
+	DocumentWithDriverProjection,
+	FindOneAndUpdateOptionsWithProjection,
+	FindOneAndDeleteOptionsWithProjection,
 } from '@rocket.chat/model-typings';
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
@@ -179,7 +182,11 @@ export abstract class BaseRaw<
 		};
 	}
 
-	public findOneAndUpdate(query: Filter<T>, update: UpdateFilter<T> | T, options?: FindOneAndUpdateOptions): Promise<WithId<T> | null> {
+	public findOneAndUpdate<P extends Document = T, O extends FindOneAndUpdateOptionsWithProjection = FindOneAndUpdateOptionsWithProjection>(
+		query: Filter<T>,
+		update: UpdateFilter<T> | T,
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null> {
 		this.setUpdatedAt(update);
 
 		if (options?.upsert && !('_id' in update || (update.$set && '_id' in update.$set)) && !('_id' in query)) {
@@ -189,7 +196,7 @@ export abstract class BaseRaw<
 			} as Partial<T> & { _id: string };
 		}
 
-		return this.col.findOneAndUpdate(query, update, options || {});
+		return this.col.findOneAndUpdate(query, update, (options || {}) as FindOneAndUpdateOptions) as any;
 	}
 
 	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
@@ -338,11 +345,16 @@ export abstract class BaseRaw<
 		return this.col.deleteOne(filter);
 	}
 
-	async findOneAndDelete(filter: Filter<T>, options?: FindOneAndDeleteOptions): Promise<WithId<T> | null> {
+	async findOneAndDelete<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
+		filter: Filter<T>,
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null> {
 		if (!this.trash) {
-			return this.col.findOneAndDelete(filter, options || {});
+			return this.col.findOneAndDelete(filter, (options || {}) as FindOneAndDeleteOptions) as any;
 		}
 
+		// the trash path needs the whole document to archive it, so the projection is not applied here;
+		// returning more fields than the caller asked for is harmless
 		const doc = await this.col.findOne(filter);
 		if (!doc) {
 			return null;
@@ -370,11 +382,14 @@ export abstract class BaseRaw<
 			throw e;
 		}
 
-		return doc;
+		return doc as any;
 	}
 
-	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<WithId<T> | null> {
-		return this.findOneAndDelete({ _id } as Filter<T>, options);
+	findOneAndDeleteById<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
+		_id: T['_id'],
+		options?: O,
+	): Promise<DocumentWithDriverProjection<P, O> | null> {
+		return this.findOneAndDelete<P, O>({ _id } as Filter<T>, options);
 	}
 
 	async deleteMany(filter: Filter<T>, options?: DeleteOptions & { onTrash?: (record: ResultFields<T, C>) => void }): Promise<DeleteResult> {

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -1,5 +1,13 @@
 import type { RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBaseModel, DefaultFields, ResultFields, FindPaginated, InsertionModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type {
+	IBaseModel,
+	DefaultFields,
+	ResultFields,
+	FindPaginated,
+	InsertionModel,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+} from '@rocket.chat/model-typings';
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
 import type {
@@ -184,26 +192,38 @@ export abstract class BaseRaw<
 		return this.col.findOneAndUpdate(query, update, options || {});
 	}
 
-	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: T['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: T['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		return this.findOne<P, O>({ _id } as Filter<T>, options);
 	}
 
-	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> | T['_id'] = {}, options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> | T['_id'] = {},
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		const q: Filter<T> = typeof query === 'string' ? ({ _id: query } as Filter<T>) : query;
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
 		if (optionsDef) {
 			return this.col.findOne(q, optionsDef) as any;
 		}
 		return this.col.findOne(q) as any;
 	}
 
-	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> = {}, options?: O): FindCursor<DocumentWithProjection<P, O>> {
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
+	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> = {},
+		options?: O,
+	): FindCursor<DocumentWithProjection<P, O>> {
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
 		return this.col.find(query, optionsDef) as any;
 	}
 
-	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> = {}, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
+	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> = {},
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
 
 		const cursor = optionsDef ? this.col.find(query, optionsDef) : this.col.find(query);
 		const totalCount = this.col.countDocuments(query);
@@ -303,9 +323,13 @@ export abstract class BaseRaw<
 			} as unknown as TDeleted;
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-				upsert: true,
-			});
+			await this.trash?.updateOne(
+				{ _id } as Filter<TDeleted>,
+				{ $set: trash },
+				{
+					upsert: true,
+				},
+			);
 		}
 
 		if (options) {
@@ -331,9 +355,13 @@ export abstract class BaseRaw<
 			__collection__: this.name,
 		} as unknown as TDeleted;
 
-		await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-			upsert: true,
-		});
+		await this.trash?.updateOne(
+			{ _id } as Filter<TDeleted>,
+			{ $set: trash },
+			{
+				upsert: true,
+			},
+		);
 
 		try {
 			await this.col.deleteOne({ _id } as Filter<T>);
@@ -342,7 +370,7 @@ export abstract class BaseRaw<
 			throw e;
 		}
 
-		return doc as WithId<T>;
+		return doc;
 	}
 
 	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<WithId<T> | null> {
@@ -369,13 +397,17 @@ export abstract class BaseRaw<
 				__collection__: this.name,
 			} as unknown as TDeleted;
 
-			ids.push(_id as T['_id']);
+			ids.push(_id);
 
 			// since the operation is not atomic, we need to make sure that the record is not already deleted/inserted
-			await this.trash?.updateOne({ _id } as Filter<TDeleted>, { $set: trash } as UpdateFilter<TDeleted>, {
-				upsert: true,
-				session: options?.session,
-			});
+			await this.trash?.updateOne(
+				{ _id } as Filter<TDeleted>,
+				{ $set: trash },
+				{
+					upsert: true,
+					session: options?.session,
+				},
+			);
 
 			void options?.onTrash?.(doc);
 		}

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -1,13 +1,5 @@
 import type { RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type {
-	IBaseModel,
-	DefaultFields,
-	ResultFields,
-	FindPaginated,
-	InsertionModel,
-	DocumentWithProjection,
-	FindOptionsWithProjection,
-} from '@rocket.chat/model-typings';
+import type { IBaseModel, DefaultFields, ResultFields, FindPaginated, InsertionModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
 import type {
@@ -192,17 +184,11 @@ export abstract class BaseRaw<
 		return this.col.findOneAndUpdate(query, update, options || {});
 	}
 
-	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
-		_id: T['_id'],
-		options?: O,
-	): Promise<DocumentWithProjection<P, O> | null> {
+	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_id: T['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		return this.findOne<P, O>({ _id } as Filter<T>, options);
 	}
 
-	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
-		query: Filter<T> | T['_id'] = {},
-		options?: O,
-	): Promise<DocumentWithProjection<P, O> | null> {
+	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> | T['_id'] = {}, options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		const q: Filter<T> = typeof query === 'string' ? ({ _id: query } as Filter<T>) : query;
 		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
 		if (optionsDef) {
@@ -211,18 +197,12 @@ export abstract class BaseRaw<
 		return this.col.findOne(q) as any;
 	}
 
-	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
-		query: Filter<T> = {},
-		options?: O,
-	): FindCursor<DocumentWithProjection<P, O>> {
+	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> = {}, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
 		return this.col.find(query, optionsDef) as any;
 	}
 
-	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
-		query: Filter<T> = {},
-		options?: O,
-	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
+	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(query: Filter<T> = {}, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
 		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
 
 		const cursor = optionsDef ? this.col.find(query, optionsDef) : this.col.find(query);

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -182,6 +182,14 @@ export abstract class BaseRaw<
 		};
 	}
 
+	/*
+	 * Every finder below asserts its result. `this.col` is a `Collection<T>` and yields `WithId<T>`,
+	 * while the signatures return `DocumentWithProjection<P, O>` — a conditional type TS cannot reduce
+	 * while `P` and `O` are still type parameters, so it cannot verify the assignment either way.
+	 * Assert to the declared type rather than `any`, so a Promise/FindCursor mix-up still fails to compile.
+	 * The cursor cases need the `unknown` hop because `FindCursor` is invariant in its element type.
+	 */
+
 	public findOneAndUpdate<P extends Document = T, O extends FindOneAndUpdateOptionsWithProjection = FindOneAndUpdateOptionsWithProjection>(
 		query: Filter<T>,
 		update: UpdateFilter<T> | T,
@@ -196,7 +204,9 @@ export abstract class BaseRaw<
 			} as Partial<T> & { _id: string };
 		}
 
-		return this.col.findOneAndUpdate(query, update, (options || {}) as FindOneAndUpdateOptions) as any;
+		const result = this.col.findOneAndUpdate(query, update, (options || {}) as FindOneAndUpdateOptions);
+
+		return result as Promise<DocumentWithDriverProjection<P, O> | null>;
 	}
 
 	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
@@ -213,9 +223,9 @@ export abstract class BaseRaw<
 		const q: Filter<T> = typeof query === 'string' ? ({ _id: query } as Filter<T>) : query;
 		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
 		if (optionsDef) {
-			return this.col.findOne(q, optionsDef) as any;
+			return this.col.findOne(q, optionsDef) as Promise<DocumentWithProjection<P, O> | null>;
 		}
-		return this.col.findOne(q) as any;
+		return this.col.findOne(q) as Promise<DocumentWithProjection<P, O> | null>;
 	}
 
 	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
@@ -223,7 +233,7 @@ export abstract class BaseRaw<
 		options?: O,
 	): FindCursor<DocumentWithProjection<P, O>> {
 		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
-		return this.col.find(query, optionsDef) as any;
+		return this.col.find(query, optionsDef) as unknown as FindCursor<DocumentWithProjection<P, O>>;
 	}
 
 	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
@@ -236,7 +246,7 @@ export abstract class BaseRaw<
 		const totalCount = this.col.countDocuments(query);
 
 		return {
-			cursor: cursor as any,
+			cursor: cursor as unknown as FindCursor<DocumentWithProjection<P, O>>,
 			totalCount,
 		};
 	}
@@ -350,7 +360,9 @@ export abstract class BaseRaw<
 		options?: O,
 	): Promise<DocumentWithDriverProjection<P, O> | null> {
 		if (!this.trash) {
-			return this.col.findOneAndDelete(filter, (options || {}) as FindOneAndDeleteOptions) as any;
+			const result = this.col.findOneAndDelete(filter, (options || {}) as FindOneAndDeleteOptions);
+
+			return result as Promise<DocumentWithDriverProjection<P, O> | null>;
 		}
 
 		// the trash path needs the whole document to archive it, so the projection is not applied here;
@@ -382,7 +394,8 @@ export abstract class BaseRaw<
 			throw e;
 		}
 
-		return doc as any;
+		// unprojected, per the note above: more fields than the type claims, which is the safe direction
+		return doc as unknown as DocumentWithDriverProjection<P, O>;
 	}
 
 	findOneAndDeleteById<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -1,5 +1,13 @@
 import type { RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBaseModel, DefaultFields, ResultFields, FindPaginated, InsertionModel } from '@rocket.chat/model-typings';
+import type {
+	IBaseModel,
+	DefaultFields,
+	ResultFields,
+	FindPaginated,
+	InsertionModel,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+} from '@rocket.chat/model-typings';
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
 import type {
@@ -184,53 +192,44 @@ export abstract class BaseRaw<
 		return this.col.findOneAndUpdate(query, update, options || {});
 	}
 
-	async findOneById(_id: T['_id'], options?: FindOptions<T>): Promise<T | null>;
-
-	async findOneById<P extends Document = T>(_id: T['_id'], options?: FindOptions<P>): Promise<P | null>;
-
-	async findOneById(_id: T['_id'], options?: any): Promise<T | null> {
-		const query: Filter<T> = { _id } as Filter<T>;
-		if (options) {
-			return this.findOne(query, options);
-		}
-		return this.findOne(query);
+	async findOneById<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: T['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
+		return this.findOne<P, O>({ _id } as Filter<T>, options);
 	}
 
-	async findOne(query?: Filter<T> | T['_id'], options?: undefined): Promise<T | null>;
-
-	async findOne<P extends Document = T>(query: Filter<T> | T['_id'], options?: FindOptions<P extends T ? T : P>): Promise<P | null>;
-
-	async findOne<P>(query: Filter<T> | T['_id'] = {}, options?: any): Promise<WithId<T> | WithId<P> | null> {
+	async findOne<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> | T['_id'] = {},
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		const q: Filter<T> = typeof query === 'string' ? ({ _id: query } as Filter<T>) : query;
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
 		if (optionsDef) {
-			return this.col.findOne(q, optionsDef);
+			return this.col.findOne(q, optionsDef) as any;
 		}
-		return this.col.findOne(q);
+		return this.col.findOne(q) as any;
 	}
 
-	find(query?: Filter<T>): FindCursor<ResultFields<T, C>>;
-
-	find<P extends Document = T>(query: Filter<T>, options?: FindOptions<P extends T ? T : P>): FindCursor<P>;
-
-	find<P extends Document>(
+	find<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		query: Filter<T> = {},
-		options?: FindOptions<P extends T ? T : P>,
-	): FindCursor<WithId<P>> | FindCursor<WithId<T>> {
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
-		return this.col.find(query, optionsDef);
+		options?: O,
+	): FindCursor<DocumentWithProjection<P, O>> {
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
+		return this.col.find(query, optionsDef) as any;
 	}
 
-	findPaginated<P extends Document = T>(query: Filter<T>, options?: FindOptions<P extends T ? T : P>): FindPaginated<FindCursor<WithId<P>>>;
-
-	findPaginated(query: Filter<T> = {}, options?: any): FindPaginated<FindCursor<WithId<T>>> {
-		const optionsDef = this.doNotMixInclusionAndExclusionFields(options);
+	findPaginated<P extends Document = T, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		query: Filter<T> = {},
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
+		const optionsDef = this.doNotMixInclusionAndExclusionFields(options as FindOptions<T> | undefined);
 
 		const cursor = optionsDef ? this.col.find(query, optionsDef) : this.col.find(query);
 		const totalCount = this.col.countDocuments(query);
 
 		return {
-			cursor,
+			cursor: cursor as any,
 			totalCount,
 		};
 	}

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -145,15 +145,14 @@ export abstract class BaseRaw<
 		}
 
 		const projection: Record<string, any> = optionsDef?.projection;
-		const keys = Object.keys(projection);
-		const removeKeys = keys.filter((key) => projection[key] === 0 || projection[key] === false);
-		if (keys.length > removeKeys.length) {
-			removeKeys.forEach((key) => delete projection[key]);
-		}
+		const entries = Object.entries(projection);
+		const inclusionEntries = entries.filter(([, value]) => value !== 0 && value !== false);
+		const isMixed = inclusionEntries.length > 0 && inclusionEntries.length < entries.length;
 
 		return {
 			...optionsDef,
-			projection,
+			// a mixed projection gets its exclusions dropped into a new object; `projection` may be owned by the caller
+			projection: isMixed ? Object.fromEntries(inclusionEntries) : projection,
 		};
 	}
 

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -147,7 +147,7 @@ export abstract class BaseRaw<
 
 		const projection: Record<string, any> = optionsDef?.projection;
 		const keys = Object.keys(projection);
-		const removeKeys = keys.filter((key) => projection[key] === 0);
+		const removeKeys = keys.filter((key) => projection[key] === 0 || projection[key] === false);
 		if (keys.length > removeKeys.length) {
 			removeKeys.forEach((key) => delete projection[key]);
 		}

--- a/packages/models/src/models/BaseRaw.ts
+++ b/packages/models/src/models/BaseRaw.ts
@@ -9,7 +9,6 @@ import type {
 	FindOptionsWithProjection,
 	DocumentWithDriverProjection,
 	FindOneAndUpdateOptionsWithProjection,
-	FindOneAndDeleteOptionsWithProjection,
 } from '@rocket.chat/model-typings';
 import { traceInstanceMethods } from '@rocket.chat/tracing';
 import { ObjectId } from 'mongodb';
@@ -355,18 +354,17 @@ export abstract class BaseRaw<
 		return this.col.deleteOne(filter);
 	}
 
-	async findOneAndDelete<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
-		filter: Filter<T>,
-		options?: O,
-	): Promise<DocumentWithDriverProjection<P, O> | null> {
+	/**
+	 * No projection narrowing: whether the model archives to a trash collection is a runtime detail
+	 * (a constructor argument), and the trash path has to read the whole document to archive it, so
+	 * it returns every field regardless of the projection. Narrowing here would claim a filtering
+	 * that only happens for models without a trash collection.
+	 */
+	async findOneAndDelete(filter: Filter<T>, options?: FindOneAndDeleteOptions): Promise<WithId<T> | null> {
 		if (!this.trash) {
-			const result = this.col.findOneAndDelete(filter, (options || {}) as FindOneAndDeleteOptions);
-
-			return result as Promise<DocumentWithDriverProjection<P, O> | null>;
+			return this.col.findOneAndDelete(filter, options || {});
 		}
 
-		// the trash path needs the whole document to archive it, so the projection is not applied here;
-		// returning more fields than the caller asked for is harmless
 		const doc = await this.col.findOne(filter);
 		if (!doc) {
 			return null;
@@ -394,15 +392,11 @@ export abstract class BaseRaw<
 			throw e;
 		}
 
-		// unprojected, per the note above: more fields than the type claims, which is the safe direction
-		return doc as unknown as DocumentWithDriverProjection<P, O>;
+		return doc as WithId<T>;
 	}
 
-	findOneAndDeleteById<P extends Document = T, O extends FindOneAndDeleteOptionsWithProjection = FindOneAndDeleteOptionsWithProjection>(
-		_id: T['_id'],
-		options?: O,
-	): Promise<DocumentWithDriverProjection<P, O> | null> {
-		return this.findOneAndDelete<P, O>({ _id } as Filter<T>, options);
+	findOneAndDeleteById(_id: T['_id'], options?: FindOneAndDeleteOptions): Promise<WithId<T> | null> {
+		return this.findOneAndDelete({ _id } as Filter<T>, options);
 	}
 
 	async deleteMany(filter: Filter<T>, options?: DeleteOptions & { onTrash?: (record: ResultFields<T, C>) => void }): Promise<DeleteResult> {

--- a/packages/models/src/models/BaseUploadModel.ts
+++ b/packages/models/src/models/BaseUploadModel.ts
@@ -1,6 +1,16 @@
 import type { EncryptedContent, IUpload } from '@rocket.chat/core-typings';
 import type { IBaseUploadsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
-import type { DeleteResult, IndexDescription, UpdateResult, Document, InsertOneResult, WithId, Filter, FindCursor, ClientSession } from 'mongodb';
+import type {
+	DeleteResult,
+	IndexDescription,
+	UpdateResult,
+	Document,
+	InsertOneResult,
+	WithId,
+	Filter,
+	FindCursor,
+	ClientSession,
+} from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -81,7 +91,10 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.updateOne(filter, update);
 	}
 
-	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(_ids: string[], options?: O): FindCursor<DocumentWithProjection<T_, O>> {
+	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		_ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T_, O>> {
 		const query = {
 			_id: {
 				$in: _ids,
@@ -99,7 +112,9 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.findOne({ rid });
 	}
 
-	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(options?: O): FindCursor<DocumentWithProjection<T_, O>> {
+	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T_, O>> {
 		return this.find<T_, O>(
 			{
 				expiresAt: {
@@ -124,7 +139,12 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.deleteOne({ _id: fileId }, { session: options?.session });
 	}
 
-	async findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(fileId: string, userId: string, rid: string, options?: O): Promise<DocumentWithProjection<T_, O> | null> {
+	async findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
+		fileId: string,
+		userId: string,
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T_, O> | null> {
 		return this.findOne<T_, O>({ _id: fileId, userId, rid }, options);
 	}
 

--- a/packages/models/src/models/BaseUploadModel.ts
+++ b/packages/models/src/models/BaseUploadModel.ts
@@ -1,17 +1,6 @@
 import type { EncryptedContent, IUpload } from '@rocket.chat/core-typings';
-import type { IBaseUploadsModel } from '@rocket.chat/model-typings';
-import type {
-	DeleteResult,
-	IndexDescription,
-	UpdateResult,
-	Document,
-	InsertOneResult,
-	WithId,
-	Filter,
-	FindOptions,
-	FindCursor,
-	ClientSession,
-} from 'mongodb';
+import type { IBaseUploadsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { DeleteResult, IndexDescription, UpdateResult, Document, InsertOneResult, WithId, Filter, FindCursor, ClientSession } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -92,14 +81,14 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.updateOne(filter, update);
 	}
 
-	findByIds(_ids: string[], options?: FindOptions<T>): FindCursor<T> {
+	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(_ids: string[], options?: O): FindCursor<DocumentWithProjection<T_, O>> {
 		const query = {
 			_id: {
 				$in: _ids,
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T_, O>(query, options);
 	}
 
 	async findOneByName(name: string, options?: { session?: ClientSession }): Promise<T | null> {
@@ -110,8 +99,8 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.findOne({ rid });
 	}
 
-	findExpiredTemporaryFiles(options?: FindOptions<T>): FindCursor<T> {
-		return this.find(
+	findExpiredTemporaryFiles<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(options?: O): FindCursor<DocumentWithProjection<T_, O>> {
+		return this.find<T_, O>(
 			{
 				expiresAt: {
 					$lte: new Date(),
@@ -135,8 +124,8 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.deleteOne({ _id: fileId }, { session: options?.session });
 	}
 
-	async findOneByIdAndUserIdAndRoomId(fileId: string, userId: string, rid: string, options?: FindOptions<T>): Promise<T | null> {
-		return this.findOne({ _id: fileId, userId, rid }, options);
+	async findOneByIdAndUserIdAndRoomId<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(fileId: string, userId: string, rid: string, options?: O): Promise<DocumentWithProjection<T_, O> | null> {
+		return this.findOne<T_, O>({ _id: fileId, userId, rid }, options);
 	}
 
 	async updateFileMetadata(

--- a/packages/models/src/models/CalendarEvent.ts
+++ b/packages/models/src/models/CalendarEvent.ts
@@ -146,7 +146,8 @@ export class CalendarEventRaw extends BaseRaw<ICalendarEvent> implements ICalend
 	}
 
 	public async findNextFutureEvent(startTime: Date): Promise<ICalendarEvent | null> {
-		return this.findOne(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findOne<ICalendarEvent>(
 			{
 				startTime: { $gte: startTime },
 				busy: { $ne: false },
@@ -162,7 +163,8 @@ export class CalendarEventRaw extends BaseRaw<ICalendarEvent> implements ICalend
 	}
 
 	public findEventsStartingNow({ now, offset = 1000 }: { now: Date; offset?: number }): FindCursor<ICalendarEvent> {
-		return this.find(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.find<ICalendarEvent>(
 			{
 				startTime: {
 					$gte: new Date(now.getTime() - offset),

--- a/packages/models/src/models/CalendarEvent.ts
+++ b/packages/models/src/models/CalendarEvent.ts
@@ -145,9 +145,8 @@ export class CalendarEventRaw extends BaseRaw<ICalendarEvent> implements ICalend
 		});
 	}
 
-	public async findNextFutureEvent(startTime: Date): Promise<ICalendarEvent | null> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.findOne<ICalendarEvent>(
+	public async findNextFutureEvent(startTime: Date): Promise<Pick<ICalendarEvent, '_id' | 'startTime'> | null> {
+		return this.findOne(
 			{
 				startTime: { $gte: startTime },
 				busy: { $ne: false },
@@ -162,9 +161,14 @@ export class CalendarEventRaw extends BaseRaw<ICalendarEvent> implements ICalend
 		);
 	}
 
-	public findEventsStartingNow({ now, offset = 1000 }: { now: Date; offset?: number }): FindCursor<ICalendarEvent> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.find<ICalendarEvent>(
+	public findEventsStartingNow({
+		now,
+		offset = 1000,
+	}: {
+		now: Date;
+		offset?: number;
+	}): FindCursor<Pick<ICalendarEvent, '_id' | 'uid' | 'startTime' | 'endTime'>> {
+		return this.find(
 			{
 				startTime: {
 					$gte: new Date(now.getTime() - offset),

--- a/packages/models/src/models/CallHistory.ts
+++ b/packages/models/src/models/CallHistory.ts
@@ -1,7 +1,7 @@
 import type { CallHistoryItem, IRegisterUser, IUser } from '@rocket.chat/core-typings';
-import type { FindPaginated, ICallHistoryModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, ICallHistoryModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
-import type { Db, Filter, FindCursor, FindOptions, IndexDescription } from 'mongodb';
+import type { Db, Filter, FindCursor, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -14,20 +14,20 @@ export class CallHistoryRaw extends BaseRaw<CallHistoryItem> implements ICallHis
 		return [{ key: { uid: 1, callId: 1 }, unique: true }, { key: { uid: 1, ts: -1 } }];
 	}
 
-	async findOneByIdAndUid(
+	async findOneByIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		_id: CallHistoryItem['_id'],
 		uid: CallHistoryItem['uid'],
-		options?: FindOptions<CallHistoryItem>,
-	): Promise<CallHistoryItem | null> {
-		return this.findOne({ _id, uid }, options);
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id, uid }, options);
 	}
 
-	async findOneByCallIdAndUid(
+	async findOneByCallIdAndUid<T extends Document = CallHistoryItem, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		callId: CallHistoryItem['callId'],
 		uid: CallHistoryItem['uid'],
-		options?: FindOptions<CallHistoryItem>,
-	): Promise<CallHistoryItem | null> {
-		return this.findOne({ callId, uid }, options);
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ callId, uid }, options);
 	}
 
 	public async updateUserReferences(
@@ -48,7 +48,10 @@ export class CallHistoryRaw extends BaseRaw<CallHistoryItem> implements ICallHis
 		);
 	}
 
-	public findAllByUserIdAndSearchFilters(
+	public findAllByUserIdAndSearchFilters<
+		T extends Document = CallHistoryItem,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		uid: IUser['_id'],
 		filters: {
 			type?: CallHistoryItem['type'];
@@ -56,8 +59,8 @@ export class CallHistoryRaw extends BaseRaw<CallHistoryItem> implements ICallHis
 			direction?: CallHistoryItem['direction'];
 			inStates?: CallHistoryItem['state'][];
 		},
-		options: FindOptions<CallHistoryItem>,
-	): FindPaginated<FindCursor<CallHistoryItem>> {
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const { type, direction, inStates, searchTerm } = filters;
 
 		const textSearch = searchTerm ? { $regex: escapeRegExp(searchTerm), $options: 'i' } : null;
@@ -84,6 +87,6 @@ export class CallHistoryRaw extends BaseRaw<CallHistoryItem> implements ICallHis
 			}),
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 }

--- a/packages/models/src/models/CustomSounds.ts
+++ b/packages/models/src/models/CustomSounds.ts
@@ -14,7 +14,11 @@ export class CustomSoundsRaw extends BaseRaw<ICustomSound> implements ICustomSou
 	}
 
 	// find
-	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		exceptId?: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			name,
 			...(exceptId && { _id: { $nin: [exceptId] } }),
@@ -23,7 +27,11 @@ export class CustomSoundsRaw extends BaseRaw<ICustomSound> implements ICustomSou
 		return this.find<T, O>(query, options);
 	}
 
-	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		exceptId?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			name,
 			...(exceptId && { _id: { $nin: [exceptId] } }),

--- a/packages/models/src/models/CustomSounds.ts
+++ b/packages/models/src/models/CustomSounds.ts
@@ -1,6 +1,6 @@
 import type { ICustomSound, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { ICustomSoundsModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, FindOptions, IndexDescription, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { ICustomSoundsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -14,22 +14,22 @@ export class CustomSoundsRaw extends BaseRaw<ICustomSound> implements ICustomSou
 	}
 
 	// find
-	findByName(name: string, exceptId?: string, options?: FindOptions<ICustomSound>): FindCursor<ICustomSound> {
+	findByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			name,
 			...(exceptId && { _id: { $nin: [exceptId] } }),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneByName(name: string, exceptId?: string, options?: FindOptions<ICustomSound>): Promise<ICustomSound | null> {
+	findOneByName<T extends Document = ICustomSound, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			name,
 			...(exceptId && { _id: { $nin: [exceptId] } }),
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	// INSERT

--- a/packages/models/src/models/CustomUserStatus.ts
+++ b/packages/models/src/models/CustomUserStatus.ts
@@ -13,11 +13,18 @@ export class CustomUserStatusRaw extends BaseRaw<ICustomUserStatus> implements I
 		return [{ key: { name: 1 } }];
 	}
 
-	async findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return options ? this.findOne<T, O>({ name }, options) : this.findOne<T, O>({ name });
 	}
 
-	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: { $nin: [except] },
 			name,
@@ -27,7 +34,10 @@ export class CustomUserStatusRaw extends BaseRaw<ICustomUserStatus> implements I
 	}
 
 	// find
-	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			name,
 		};
@@ -35,7 +45,11 @@ export class CustomUserStatusRaw extends BaseRaw<ICustomUserStatus> implements I
 		return this.find<T, O>(query, options);
 	}
 
-	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $nin: [except] },
 			name,

--- a/packages/models/src/models/CustomUserStatus.ts
+++ b/packages/models/src/models/CustomUserStatus.ts
@@ -1,6 +1,6 @@
 import type { ICustomUserStatus, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { ICustomUserStatusModel, InsertionModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, FindOptions, IndexDescription, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { ICustomUserStatusModel, InsertionModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,39 +13,35 @@ export class CustomUserStatusRaw extends BaseRaw<ICustomUserStatus> implements I
 		return [{ key: { name: 1 } }];
 	}
 
-	// find one by name
-
-	async findOneByName(name: string, options?: undefined): Promise<ICustomUserStatus | null>;
-
-	async findOneByName(name: string, options?: FindOptions<ICustomUserStatus>): Promise<ICustomUserStatus | null> {
-		return options ? this.findOne({ name }, options) : this.findOne({ name });
+	async findOneByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return options ? this.findOne<T, O>({ name }, options) : this.findOne<T, O>({ name });
 	}
 
-	findOneByNameExceptId(name: string, except: string, options?: FindOptions<ICustomUserStatus>): Promise<ICustomUserStatus | null> {
+	findOneByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: { $nin: [except] },
 			name,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	// find
-	findByName(name: string, options?: FindOptions<ICustomUserStatus>): FindCursor<ICustomUserStatus> {
+	findByName<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			name,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByNameExceptId(name: string, except: string, options?: FindOptions<ICustomUserStatus>): FindCursor<ICustomUserStatus> {
+	findByNameExceptId<T extends Document = ICustomUserStatus, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $nin: [except] },
 			name,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	// update

--- a/packages/models/src/models/EmailInbox.ts
+++ b/packages/models/src/models/EmailInbox.ts
@@ -26,7 +26,7 @@ export class EmailInboxRaw extends BaseRaw<IEmailInbox> implements IEmailInboxMo
 		return this.findOneAndUpdate({ _id: id }, data, {
 			returnDocument: 'after',
 			projection: { _id: 1 },
-		}) as unknown as Promise<null | WithId<Pick<IEmailInbox, '_id'>>>;
+		});
 	}
 
 	findActive(): FindCursor<IEmailInbox> {

--- a/packages/models/src/models/EmojiCustom.ts
+++ b/packages/models/src/models/EmojiCustom.ts
@@ -1,6 +1,6 @@
 import type { IEmojiCustom, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IEmojiCustomModel, InsertionModel } from '@rocket.chat/model-typings';
-import type { Collection, Filter, FindCursor, Db, FindOptions, IndexDescription, InsertOneResult, UpdateResult, WithId } from 'mongodb';
+import type { IEmojiCustomModel, InsertionModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, Filter, FindCursor, Db, IndexDescription, InsertOneResult, UpdateResult, WithId, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -14,7 +14,7 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 	}
 
 	// find
-	findByNameOrAlias(emojiName: string, options?: FindOptions<IEmojiCustom>): FindCursor<IEmojiCustom> {
+	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emojiName: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		let name = emojiName;
 
 		if (typeof emojiName === 'string') {
@@ -25,25 +25,25 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 			$or: [{ name }, { aliases: name }],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneByNamesOrAliases(names: string[], exceptId?: string, options?: FindOptions<IEmojiCustom>): Promise<IEmojiCustom | null> {
+	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(names: string[], exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IEmojiCustom> = {
 			...(exceptId && { _id: { $nin: [exceptId] } }),
 			$or: [{ name: { $in: names } }, { aliases: { $in: names } }],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByNameOrAliasExceptID(name: string, except: string, options?: FindOptions<IEmojiCustom>): FindCursor<IEmojiCustom> {
+	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $nin: [except] },
 			$or: [{ name }, { aliases: name }],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	// update
@@ -101,7 +101,7 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 	}
 
 	// TODO: convert name: string to branded type using to enforce validation also replace this type cross the models/apis
-	findOneByName(name: string, options?: FindOptions<IEmojiCustom>): Promise<IEmojiCustom | null> {
-		return this.findOne({ name }, options);
+	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ name }, options);
 	}
 }

--- a/packages/models/src/models/EmojiCustom.ts
+++ b/packages/models/src/models/EmojiCustom.ts
@@ -14,7 +14,10 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 	}
 
 	// find
-	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emojiName: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameOrAlias<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emojiName: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		let name = emojiName;
 
 		if (typeof emojiName === 'string') {
@@ -28,7 +31,11 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 		return this.find<T, O>(query, options);
 	}
 
-	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(names: string[], exceptId?: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByNamesOrAliases<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		names: string[],
+		exceptId?: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IEmojiCustom> = {
 			...(exceptId && { _id: { $nin: [exceptId] } }),
 			$or: [{ name: { $in: names } }, { aliases: { $in: names } }],
@@ -37,7 +44,11 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, except: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameOrAliasExceptID<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		except: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $nin: [except] },
 			$or: [{ name }, { aliases: name }],
@@ -101,7 +112,10 @@ export class EmojiCustomRaw extends BaseRaw<IEmojiCustom> implements IEmojiCusto
 	}
 
 	// TODO: convert name: string to branded type using to enforce validation also replace this type cross the models/apis
-	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByName<T extends Document = IEmojiCustom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ name }, options);
 	}
 }

--- a/packages/models/src/models/Integrations.ts
+++ b/packages/models/src/models/Integrations.ts
@@ -1,5 +1,11 @@
 import type { IIntegration, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBaseModel, IIntegrationsModel, IntegrationsStatistics, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type {
+	IBaseModel,
+	IIntegrationsModel,
+	IntegrationsStatistics,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+} from '@rocket.chat/model-typings';
 import type { AggregateOptions, Collection, Db, FindCursor, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
@@ -65,7 +71,11 @@ export class IntegrationsRaw extends BaseRaw<IIntegration> implements IIntegrati
 		return this.find({ channel: { $in: channels } });
 	}
 
-	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(id: IIntegration['_id'], token: string, options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		id: IIntegration['_id'],
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		return this.findOne<P, O>({ _id: id, token }, options);
 	}
 

--- a/packages/models/src/models/Integrations.ts
+++ b/packages/models/src/models/Integrations.ts
@@ -1,6 +1,6 @@
 import type { IIntegration, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IBaseModel, IIntegrationsModel, IntegrationsStatistics } from '@rocket.chat/model-typings';
-import type { AggregateOptions, Collection, Db, FindCursor, FindOptions, IndexDescription } from 'mongodb';
+import type { IBaseModel, IIntegrationsModel, IntegrationsStatistics, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { AggregateOptions, Collection, Db, FindCursor, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -65,12 +65,8 @@ export class IntegrationsRaw extends BaseRaw<IIntegration> implements IIntegrati
 		return this.find({ channel: { $in: channels } });
 	}
 
-	findOneByIdAndToken<P extends IIntegration = IIntegration>(
-		id: IIntegration['_id'],
-		token: string,
-		options?: FindOptions<P>,
-	): Promise<P | null> {
-		return this.findOne<P>({ _id: id, token }, options);
+	findOneByIdAndToken<P extends Document = IIntegration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(id: IIntegration['_id'], token: string, options?: O): Promise<DocumentWithProjection<P, O> | null> {
+		return this.findOne<P, O>({ _id: id, token }, options);
 	}
 
 	async getStatistics(options?: AggregateOptions): Promise<IntegrationsStatistics> {

--- a/packages/models/src/models/LivechatBusinessHours.ts
+++ b/packages/models/src/models/LivechatBusinessHours.ts
@@ -1,7 +1,7 @@
 import type { ILivechatBusinessHour, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import { LivechatBusinessHourTypes } from '@rocket.chat/core-typings';
-import type { ILivechatBusinessHoursModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, Document, FindOptions } from 'mongodb';
+import type { ILivechatBusinessHoursModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, Db, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -20,20 +20,12 @@ export class LivechatBusinessHoursRaw extends BaseRaw<ILivechatBusinessHour> imp
 		super(db, 'livechat_business_hours', trash);
 	}
 
-	async findOneDefaultBusinessHour(options?: undefined): Promise<ILivechatBusinessHour | null>;
-
-	async findOneDefaultBusinessHour(options: FindOptions<ILivechatBusinessHour>): Promise<ILivechatBusinessHour | null>;
-
-	async findOneDefaultBusinessHour<P extends Document>(
-		options: FindOptions<P extends ILivechatBusinessHour ? ILivechatBusinessHour : P>,
-	): Promise<P | null>;
-
-	findOneDefaultBusinessHour<P>(options?: any): Promise<ILivechatBusinessHour | P | null> {
-		return this.findOne({ type: LivechatBusinessHourTypes.DEFAULT }, options);
+	findOneDefaultBusinessHour<P extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(options?: O): Promise<DocumentWithProjection<P, O> | null> {
+		return this.findOne<P, O>({ type: LivechatBusinessHourTypes.DEFAULT }, options);
 	}
 
-	findActiveAndOpenBusinessHoursByDay(day: string, options?: any): Promise<ILivechatBusinessHour[]> {
-		return this.find(
+	findActiveAndOpenBusinessHoursByDay<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(day: string, options?: O): Promise<DocumentWithProjection<T, O>[]> {
+		return this.find<T, O>(
 			{
 				active: true,
 				workHours: {
@@ -47,8 +39,8 @@ export class LivechatBusinessHoursRaw extends BaseRaw<ILivechatBusinessHour> imp
 		).toArray();
 	}
 
-	findActiveBusinessHours(options: FindOptions<ILivechatBusinessHour> = {}): Promise<ILivechatBusinessHour[]> {
-		return this.find(
+	findActiveBusinessHours<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O>[]> {
+		return this.find<T, O>(
 			{
 				active: true,
 			},

--- a/packages/models/src/models/LivechatBusinessHours.ts
+++ b/packages/models/src/models/LivechatBusinessHours.ts
@@ -20,11 +20,17 @@ export class LivechatBusinessHoursRaw extends BaseRaw<ILivechatBusinessHour> imp
 		super(db, 'livechat_business_hours', trash);
 	}
 
-	findOneDefaultBusinessHour<P extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	findOneDefaultBusinessHour<
+		P extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		return this.findOne<P, O>({ type: LivechatBusinessHourTypes.DEFAULT }, options);
 	}
 
-	findActiveAndOpenBusinessHoursByDay<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(day: string, options?: O): Promise<DocumentWithProjection<T, O>[]> {
+	findActiveAndOpenBusinessHoursByDay<
+		T extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(day: string, options?: O): Promise<DocumentWithProjection<T, O>[]> {
 		return this.find<T, O>(
 			{
 				active: true,
@@ -39,7 +45,10 @@ export class LivechatBusinessHoursRaw extends BaseRaw<ILivechatBusinessHour> imp
 		).toArray();
 	}
 
-	findActiveBusinessHours<T extends Document = ILivechatBusinessHour, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): Promise<DocumentWithProjection<T, O>[]> {
+	findActiveBusinessHours<
+		T extends Document = ILivechatBusinessHour,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(options?: O): Promise<DocumentWithProjection<T, O>[]> {
 		return this.find<T, O>(
 			{
 				active: true,

--- a/packages/models/src/models/LivechatContacts.ts
+++ b/packages/models/src/models/LivechatContacts.ts
@@ -165,13 +165,10 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 			enabled: { $ne: false },
 		};
 
-		return this.findPaginated<T, O>(
-			{ ...match },
-			{
-				allowDiskUse: true,
-				...options,
-			},
-		);
+		return this.findPaginated<T, O>({ ...match }, {
+			allowDiskUse: true,
+			...options,
+		} as unknown as O);
 	}
 
 	async findContactMatchingVisitor(visitor: AtLeast<ILivechatVisitor, 'visitorEmails' | 'phone'>): Promise<ILivechatContact | null> {

--- a/packages/models/src/models/LivechatContacts.ts
+++ b/packages/models/src/models/LivechatContacts.ts
@@ -6,7 +6,14 @@ import type {
 	ILivechatVisitor,
 	RocketChatRecordDeleted,
 } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatContactsModel, InsertionModel, Updater } from '@rocket.chat/model-typings';
+import type {
+	FindPaginated,
+	ILivechatContactsModel,
+	InsertionModel,
+	Updater,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+} from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	Document,
@@ -14,7 +21,6 @@ import type {
 	Db,
 	RootFilterOperators,
 	Filter,
-	FindOptions,
 	FindCursor,
 	IndexDescription,
 	UpdateResult,
@@ -143,10 +149,10 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 		return this.updateOne({ _id: contactId, enabled: { $ne: false } }, update, options);
 	}
 
-	findPaginatedContacts(
+	findPaginatedContacts<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		search: { searchText?: string; unknown?: boolean },
-		options?: FindOptions,
-	): FindPaginated<FindCursor<ILivechatContact>> {
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const { searchText, unknown = false } = search;
 		const searchRegex = escapeRegExp(searchText || '');
 		const match: Filter<ILivechatContact & RootFilterOperators<ILivechatContact>> = {
@@ -159,7 +165,7 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 			enabled: { $ne: false },
 		};
 
-		return this.findPaginated(
+		return this.findPaginated<T, O>(
 			{ ...match },
 			{
 				allowDiskUse: true,
@@ -216,11 +222,11 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 		};
 	}
 
-	async findOneByVisitor<T extends Document = ILivechatContact>(
+	async findOneByVisitor<T extends Document = ILivechatContact, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		visitor: ILivechatContactVisitorAssociation,
-		options: FindOptions<ILivechatContact> = {},
-	): Promise<T | null> {
-		return this.findOne<T>(this.makeQueryForVisitor(visitor), options);
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(this.makeQueryForVisitor(visitor), options);
 	}
 
 	async addChannel(contactId: string, channel: ILivechatContactChannel): Promise<void> {
@@ -278,12 +284,15 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 		return this.updateFromUpdater(this.makeQueryForVisitor(visitor), contactUpdater, options);
 	}
 
-	async findSimilarVerifiedContacts(
+	async findSimilarVerifiedContacts<
+		T extends Document = ILivechatContact,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		{ field, value }: Pick<ILivechatContactChannel, 'field' | 'value'>,
 		originalContactId: string,
-		options?: FindOptions<ILivechatContact>,
-	): Promise<ILivechatContact[]> {
-		return this.find(
+		options?: O,
+	): Promise<DocumentWithProjection<T, O>[]> {
+		return this.find<T, O>(
 			{
 				channels: {
 					$elemMatch: {
@@ -304,12 +313,11 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 		});
 	}
 
-	async findOneEnabledById(_id: ILivechatContact['_id'], options?: FindOptions<ILivechatContact>): Promise<ILivechatContact | null>;
-
-	async findOneEnabledById<P extends Document = ILivechatContact>(_id: P['_id'], options?: FindOptions<P>): Promise<P | null>;
-
-	async findOneEnabledById(_id: ILivechatContact['_id'], options?: any): Promise<ILivechatContact | null> {
-		return this.findOne({ _id, enabled: { $ne: false } }, options);
+	async findOneEnabledById<P extends Document = ILivechatContact, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_id: ILivechatContact['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
+		return this.findOne<P, O>({ _id, enabled: { $ne: false } }, options);
 	}
 
 	disableByVisitorId(visitorId: string): Promise<UpdateResult | Document> {

--- a/packages/models/src/models/LivechatContacts.ts
+++ b/packages/models/src/models/LivechatContacts.ts
@@ -165,6 +165,7 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 			enabled: { $ne: false },
 		};
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
 		return this.findPaginated<T, O>({ ...match }, {
 			allowDiskUse: true,
 			...options,

--- a/packages/models/src/models/LivechatCustomField.ts
+++ b/packages/models/src/models/LivechatCustomField.ts
@@ -13,11 +13,18 @@ export class LivechatCustomFieldRaw extends BaseRaw<ILivechatCustomField> implem
 		return [{ key: { scope: 1 } }];
 	}
 
-	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], options?: O, includeHidden = true): FindCursor<DocumentWithProjection<T, O>> {
+	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		scope: ILivechatCustomField['scope'],
+		options?: O,
+		includeHidden = true,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ scope, ...(includeHidden === true ? {} : { visibility: { $ne: 'hidden' } }) }, options);
 	}
 
-	findMatchingCustomFields<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], searchable = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findMatchingCustomFields<
+		T extends Document = ILivechatCustomField,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(scope: ILivechatCustomField['scope'], searchable = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope,
 			searchable,
@@ -26,7 +33,15 @@ export class LivechatCustomFieldRaw extends BaseRaw<ILivechatCustomField> implem
 		return this.find<T, O>(query, options);
 	}
 
-	findMatchingCustomFieldsByIds<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: ILivechatCustomField['_id'][], scope: ILivechatCustomField['scope'], searchable = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findMatchingCustomFieldsByIds<
+		T extends Document = ILivechatCustomField,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		ids: ILivechatCustomField['_id'][],
+		scope: ILivechatCustomField['scope'],
+		searchable = true,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 			scope,

--- a/packages/models/src/models/LivechatCustomField.ts
+++ b/packages/models/src/models/LivechatCustomField.ts
@@ -1,6 +1,6 @@
 import type { ILivechatCustomField, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { ILivechatCustomFieldModel } from '@rocket.chat/model-typings';
-import type { Db, Collection, IndexDescription, FindOptions, FindCursor } from 'mongodb';
+import type { ILivechatCustomFieldModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, Collection, IndexDescription, FindCursor, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,40 +13,27 @@ export class LivechatCustomFieldRaw extends BaseRaw<ILivechatCustomField> implem
 		return [{ key: { scope: 1 } }];
 	}
 
-	findByScope<T extends ILivechatCustomField>(
-		scope: ILivechatCustomField['scope'],
-		options?: FindOptions<ILivechatCustomField>,
-		includeHidden = true,
-	): FindCursor<T> {
-		return this.find<T>({ scope, ...(includeHidden === true ? {} : { visibility: { $ne: 'hidden' } }) }, options);
+	findByScope<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], options?: O, includeHidden = true): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ scope, ...(includeHidden === true ? {} : { visibility: { $ne: 'hidden' } }) }, options);
 	}
 
-	findMatchingCustomFields(
-		scope: ILivechatCustomField['scope'],
-		searchable = true,
-		options?: FindOptions<ILivechatCustomField>,
-	): FindCursor<ILivechatCustomField> {
+	findMatchingCustomFields<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: ILivechatCustomField['scope'], searchable = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope,
 			searchable,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findMatchingCustomFieldsByIds(
-		ids: ILivechatCustomField['_id'][],
-		scope: ILivechatCustomField['scope'],
-		searchable = true,
-		options?: FindOptions<ILivechatCustomField>,
-	): FindCursor<ILivechatCustomField> {
+	findMatchingCustomFieldsByIds<T extends Document = ILivechatCustomField, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: ILivechatCustomField['_id'][], scope: ILivechatCustomField['scope'], searchable = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 			scope,
 			searchable,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async createOrUpdateCustomField(

--- a/packages/models/src/models/LivechatDepartment.ts
+++ b/packages/models/src/models/LivechatDepartment.ts
@@ -1,5 +1,5 @@
 import type { ILivechatDepartment, LivechatDepartmentDTO, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { ILivechatDepartmentModel } from '@rocket.chat/model-typings';
+import type { ILivechatDepartmentModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type { Collection, FindCursor, Db, Filter, FindOptions, UpdateResult, Document, IndexDescription, AggregationCursor } from 'mongodb';
 
@@ -65,17 +65,23 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 		return this.estimatedDocumentCount();
 	}
 
-	findInIds(departmentsIds: string[], options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment> {
+	findInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentsIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { _id: { $in: departmentsIds } };
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByNameRegexWithExceptionsAndConditions(
+	findByNameRegexWithExceptionsAndConditions<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		searchTerm: string,
 		exceptions: string[] = [],
 		conditions: Filter<ILivechatDepartment> = {},
-		options: FindOptions<ILivechatDepartment> = {},
-	): FindCursor<ILivechatDepartment> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		if (!Array.isArray(exceptions)) {
 			exceptions = [exceptions];
 		}
@@ -90,12 +96,15 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 			...conditions,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByBusinessHourId(businessHourId: string, options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment> {
+	findByBusinessHourId<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		businessHourId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { businessHourId };
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countByBusinessHourIdExcludingDepartmentId(businessHourId: string, departmentId: string): Promise<number> {
@@ -103,22 +112,31 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 		return this.countDocuments(query);
 	}
 
-	findEnabledByBusinessHourId(businessHourId: string, options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment> {
+	findEnabledByBusinessHourId<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(businessHourId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { businessHourId, enabled: true };
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findActiveDepartmentsWithoutBusinessHour(options: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment> {
+	findActiveDepartmentsWithoutBusinessHour<
+		T extends Document = ILivechatDepartment,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			enabled: true,
 			businessHourId: { $exists: false },
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findEnabledInIds(departmentsIds: string[], options?: FindOptions<ILivechatDepartment>): FindCursor<ILivechatDepartment> {
+	findEnabledInIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentsIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { _id: { $in: departmentsIds }, enabled: true };
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	addBusinessHourToDepartmentsByIds(ids: string[] = [], businessHourId: string): Promise<Document | UpdateResult> {
@@ -262,7 +280,10 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 		return this.findEnabledWithAgents(projection);
 	}
 
-	findOneByIdOrName(_idOrName: string, options: FindOptions<ILivechatDepartment> = {}): Promise<ILivechatDepartment | null> {
+	findOneByIdOrName<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -274,10 +295,13 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByUnitIds(unitIds: string[], options: FindOptions<ILivechatDepartment> = {}): FindCursor<ILivechatDepartment> {
+	findByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		unitIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			parentId: {
 				$exists: true,
@@ -285,21 +309,26 @@ export class LivechatDepartmentRaw extends BaseRaw<ILivechatDepartment> implemen
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countDepartmentsInUnit(unitId: string): Promise<number> {
 		return this.countDocuments({ parentId: unitId });
 	}
 
-	findActiveByUnitIds<T extends Document = ILivechatDepartment>(_unitIds: string[], _options: FindOptions<T> = {}): FindCursor<T> {
+	findActiveByUnitIds<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_unitIds: string[],
+		_options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		throw new Error('not-implemented');
 	}
 
-	findNotArchived(options: FindOptions<ILivechatDepartment> = {}): FindCursor<ILivechatDepartment> {
+	findNotArchived<T extends Document = ILivechatDepartment, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { archived: { $ne: false } };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	getBusinessHoursWithDepartmentStatuses(): Promise<

--- a/packages/models/src/models/LivechatDepartmentAgents.ts
+++ b/packages/models/src/models/LivechatDepartmentAgents.ts
@@ -1,18 +1,6 @@
 import type { AvailableAgentsAggregation, ILivechatDepartmentAgents, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatDepartmentAgentsModel } from '@rocket.chat/model-typings';
-import type {
-	Collection,
-	FindCursor,
-	Db,
-	Filter,
-	FindOptions,
-	Document,
-	UpdateResult,
-	DeleteResult,
-	IndexDescription,
-	SortDirection,
-	AggregationCursor,
-} from 'mongodb';
+import type { FindPaginated, ILivechatDepartmentAgentsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, Filter, Document, UpdateResult, DeleteResult, IndexDescription, SortDirection, AggregationCursor } from 'mongodb';
 
 import { Users } from '../index';
 import { BaseRaw } from './BaseRaw';
@@ -47,37 +35,22 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		];
 	}
 
-	findByAgentIds(agentIds: string[], options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents> {
-		return this.find({ agentId: { $in: agentIds } }, options);
+	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ agentId: { $in: agentIds } }, options);
 	}
 
-	findByAgentId(agentId: string, options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents> {
-		return this.find({ agentId }, options);
+	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ agentId }, options);
 	}
 
-	findAgentsByDepartmentId(departmentId: string): FindPaginated<FindCursor<ILivechatDepartmentAgents>>;
-
-	findAgentsByDepartmentId(
-		departmentId: string,
-		options: FindOptions<ILivechatDepartmentAgents>,
-	): FindPaginated<FindCursor<ILivechatDepartmentAgents>>;
-
-	findAgentsByDepartmentId<P extends Document>(
-		departmentId: string,
-		options: FindOptions<P extends ILivechatDepartmentAgents ? ILivechatDepartmentAgents : P>,
-	): FindPaginated<FindCursor<P>>;
-
-	findAgentsByDepartmentId(
-		departmentId: string,
-		options?: undefined | FindOptions<ILivechatDepartmentAgents>,
-	): FindPaginated<FindCursor<ILivechatDepartmentAgents>> {
+	findAgentsByDepartmentId<P extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(departmentId: string, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
 		const query = { departmentId };
 
 		if (options === undefined) {
-			return this.findPaginated(query);
+			return this.findPaginated<P, O>(query);
 		}
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<P, O>(query, options);
 	}
 
 	findByDepartmentIds(departmentIds: string[], options = {}): FindCursor<ILivechatDepartmentAgents> {
@@ -92,16 +65,12 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		return this.deleteMany({ departmentId });
 	}
 
-	findByDepartmentId(departmentId: string, options?: FindOptions<ILivechatDepartmentAgents>): FindCursor<ILivechatDepartmentAgents> {
-		return this.find({ departmentId }, options);
+	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ departmentId }, options);
 	}
 
-	findOneByAgentIdAndDepartmentId(
-		agentId: string,
-		departmentId: string,
-		options?: FindOptions<ILivechatDepartmentAgents>,
-	): Promise<ILivechatDepartmentAgents | null> {
-		return this.findOne({ agentId, departmentId }, options);
+	findOneByAgentIdAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ agentId, departmentId }, options);
 	}
 
 	saveAgent(agent: {
@@ -272,12 +241,8 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		return this.col.distinct('agentId', { departmentId: { $in: departmentIds }, departmentEnabled: true });
 	}
 
-	findByAgentsAndDepartmentId(
-		agentsIds: ILivechatDepartmentAgents['agentId'][],
-		departmentId: ILivechatDepartmentAgents['departmentId'],
-		options?: FindOptions<ILivechatDepartmentAgents>,
-	): FindCursor<ILivechatDepartmentAgents> {
-		return this.find({ agentId: { $in: agentsIds }, departmentId }, options);
+	findByAgentsAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentsIds: ILivechatDepartmentAgents['agentId'][], departmentId: ILivechatDepartmentAgents['departmentId'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ agentId: { $in: agentsIds }, departmentId }, options);
 	}
 
 	findDepartmentsOfAgent(agentId: string, enabled = false): AggregationCursor<ILivechatDepartmentAgents & { departmentName: string }> {

--- a/packages/models/src/models/LivechatDepartmentAgents.ts
+++ b/packages/models/src/models/LivechatDepartmentAgents.ts
@@ -185,7 +185,7 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 			agentId: 1,
 			departmentId: 1,
 			username: 1,
-		};
+		} as const;
 
 		return this.findOneAndUpdate(query, update, { sort, projection, returnDocument: 'after' });
 	}
@@ -239,7 +239,7 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 			agentId: 1,
 			departmentId: 1,
 			username: 1,
-		};
+		} as const;
 
 		return this.findOneAndUpdate(query, update, { sort, projection, returnDocument: 'after' });
 	}

--- a/packages/models/src/models/LivechatDepartmentAgents.ts
+++ b/packages/models/src/models/LivechatDepartmentAgents.ts
@@ -1,6 +1,22 @@
 import type { AvailableAgentsAggregation, ILivechatDepartmentAgents, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatDepartmentAgentsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, Filter, Document, UpdateResult, DeleteResult, IndexDescription, SortDirection, AggregationCursor } from 'mongodb';
+import type {
+	FindPaginated,
+	ILivechatDepartmentAgentsModel,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+} from '@rocket.chat/model-typings';
+import type {
+	Collection,
+	FindCursor,
+	Db,
+	Filter,
+	Document,
+	UpdateResult,
+	DeleteResult,
+	IndexDescription,
+	SortDirection,
+	AggregationCursor,
+} from 'mongodb';
 
 import { Users } from '../index';
 import { BaseRaw } from './BaseRaw';
@@ -35,15 +51,24 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		];
 	}
 
-	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByAgentIds<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		agentIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ agentId: { $in: agentIds } }, options);
 	}
 
-	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByAgentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		agentId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ agentId }, options);
 	}
 
-	findAgentsByDepartmentId<P extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(departmentId: string, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
+	findAgentsByDepartmentId<
+		P extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(departmentId: string, options?: O): FindPaginated<FindCursor<DocumentWithProjection<P, O>>> {
 		const query = { departmentId };
 
 		if (options === undefined) {
@@ -65,11 +90,17 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		return this.deleteMany({ departmentId });
 	}
 
-	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(departmentId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ departmentId }, options);
 	}
 
-	findOneByAgentIdAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentId: string, departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByAgentIdAndDepartmentId<
+		T extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(agentId: string, departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ agentId, departmentId }, options);
 	}
 
@@ -241,7 +272,14 @@ export class LivechatDepartmentAgentsRaw extends BaseRaw<ILivechatDepartmentAgen
 		return this.col.distinct('agentId', { departmentId: { $in: departmentIds }, departmentEnabled: true });
 	}
 
-	findByAgentsAndDepartmentId<T extends Document = ILivechatDepartmentAgents, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(agentsIds: ILivechatDepartmentAgents['agentId'][], departmentId: ILivechatDepartmentAgents['departmentId'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByAgentsAndDepartmentId<
+		T extends Document = ILivechatDepartmentAgents,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		agentsIds: ILivechatDepartmentAgents['agentId'][],
+		departmentId: ILivechatDepartmentAgents['departmentId'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ agentId: { $in: agentsIds }, departmentId }, options);
 	}
 

--- a/packages/models/src/models/LivechatInquiry.ts
+++ b/packages/models/src/models/LivechatInquiry.ts
@@ -117,11 +117,6 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.findOne<T, O>(query, options);
 	}
 
-	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<ILivechatInquiryRecord> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.find<ILivechatInquiryRecord>({ 'v._id': _id }, { projection: { _id: 1 } });
-	}
-
 	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]> {
 		return this.col
 			.aggregate<{ _id: string | null }>(

--- a/packages/models/src/models/LivechatInquiry.ts
+++ b/packages/models/src/models/LivechatInquiry.ts
@@ -6,7 +6,7 @@ import type {
 	SelectedAgent,
 } from '@rocket.chat/core-typings';
 import { LivechatInquiryStatus } from '@rocket.chat/core-typings';
-import type { ILivechatInquiryModel } from '@rocket.chat/model-typings';
+import type { ILivechatInquiryModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type {
 	Collection,
 	Db,
@@ -107,14 +107,11 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		];
 	}
 
-	findOneByRoomId<T extends Document = ILivechatInquiryRecord>(
-		rid: string,
-		options?: FindOptions<T extends ILivechatInquiryRecord ? ILivechatInquiryRecord : T>,
-	): Promise<T | null> {
+	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			rid,
 		};
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<ILivechatInquiryRecord> {
@@ -288,8 +285,8 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.deleteOne({ rid }, options);
 	}
 
-	getQueuedInquiries(options?: FindOptions<ILivechatInquiryRecord>): FindCursor<ILivechatInquiryRecord> {
-		return this.find({ status: LivechatInquiryStatus.QUEUED }, options);
+	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ status: LivechatInquiryStatus.QUEUED }, options);
 	}
 
 	takeInquiry(inquiryId: string, lockedAt?: Date): Promise<UpdateResult> {
@@ -459,7 +456,7 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.updateMany(query, update);
 	}
 
-	findByVisitorIds(visitorIds: string[], options?: FindOptions<ILivechatInquiryRecord>): FindCursor<ILivechatInquiryRecord> {
-		return this.find({ 'v._id': { $in: visitorIds } }, options);
+	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ 'v._id': { $in: visitorIds } }, options);
 	}
 }

--- a/packages/models/src/models/LivechatInquiry.ts
+++ b/packages/models/src/models/LivechatInquiry.ts
@@ -107,7 +107,10 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		];
 	}
 
-	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRoomId<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			rid,
 		};
@@ -115,7 +118,8 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 	}
 
 	findIdsByVisitorId(_id: ILivechatInquiryRecord['v']['_id']): FindCursor<ILivechatInquiryRecord> {
-		return this.find({ 'v._id': _id }, { projection: { _id: 1 } });
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.find<ILivechatInquiryRecord>({ 'v._id': _id }, { projection: { _id: 1 } });
 	}
 
 	getDistinctQueuedDepartments(options: AggregateOptions): Promise<{ _id: string | null }[]> {
@@ -285,7 +289,9 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.deleteOne({ rid }, options);
 	}
 
-	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	getQueuedInquiries<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ status: LivechatInquiryStatus.QUEUED }, options);
 	}
 
@@ -456,7 +462,10 @@ export class LivechatInquiryRaw extends BaseRaw<ILivechatInquiryRecord> implemen
 		return this.updateMany(query, update);
 	}
 
-	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByVisitorIds<T extends Document = ILivechatInquiryRecord, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ 'v._id': { $in: visitorIds } }, options);
 	}
 }

--- a/packages/models/src/models/LivechatRooms.ts
+++ b/packages/models/src/models/LivechatRooms.ts
@@ -13,7 +13,7 @@ import type {
 	AtLeast,
 } from '@rocket.chat/core-typings';
 import { UserStatus } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatRoomsModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, ILivechatRoomsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	Db,
@@ -1660,7 +1660,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.updateMany({ departmentId }, { $unset: { departmentId: 1, departmentAncestors: 1 } });
 	}
 
-	findOneByIdOrName(_idOrName: string, options: FindOptions<IOmnichannelRoom>) {
+	findOneByIdOrName<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			t: 'l',
 			$or: [
@@ -1673,7 +1676,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	updateSurveyFeedbackById(_id: string, surveyFeedback: string) {
@@ -1814,12 +1817,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.findOne(query, options);
 	}
 
-	findOneByVisitorTokenAndEmailThreadAndDepartment(
-		visitorToken: string,
-		emailThread: string[],
-		departmentId: string,
-		options: FindOptions<IOmnichannelRoom>,
-	) {
+	findOneByVisitorTokenAndEmailThreadAndDepartment<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(visitorToken: string, emailThread: string[], departmentId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'v.token': visitorToken,
@@ -1830,7 +1831,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...(departmentId && { departmentId }),
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	updateEmailThreadByRoomId(roomId: string, threadIds: string[]) {
@@ -1843,7 +1844,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.updateOne({ _id: roomId }, query);
 	}
 
-	findOneLastServedAndClosedByVisitorToken(visitorToken: string, options: FindOptions<IOmnichannelRoom> = {}) {
+	findOneLastServedAndClosedByVisitorToken<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'v.token': visitorToken,
@@ -1852,7 +1856,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		};
 
 		options.sort = { closedAt: -1 };
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	findOneByVisitorToken(visitorToken: string, fields: FindOptions<IOmnichannelRoom>['projection']) {
@@ -1870,7 +1874,11 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.findOne(query, options);
 	}
 
-	findOpenByVisitorToken(visitorToken: string, options: FindOptions<IOmnichannelRoom> = {}, extraQuery: Filter<IOmnichannelRoom> = {}) {
+	findOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorToken: string,
+		options?: O,
+		extraQuery: Filter<IOmnichannelRoom> = {},
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -1878,13 +1886,13 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneOpenByContactChannelVisitor(
-		association: ILivechatContactVisitorAssociation,
-		options: FindOptions<IOmnichannelRoom> = {},
-	): Promise<IOmnichannelRoom | null> {
+	findOneOpenByContactChannelVisitor<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(association: ILivechatContactVisitorAssociation, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -1893,10 +1901,14 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...(association.source.id ? { 'source.id': association.source.id } : {}),
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneOpenByVisitorToken(visitorToken: string, options: FindOptions<IOmnichannelRoom> = {}, extraQuery: Filter<IOmnichannelRoom> = {}) {
+	findOneOpenByVisitorToken<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorToken: string,
+		options?: O,
+		extraQuery: Filter<IOmnichannelRoom> = {},
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -1904,15 +1916,13 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneOpenByVisitorTokenAndDepartmentIdAndSource(
-		visitorToken: string,
-		departmentId?: string,
-		source?: string,
-		options: FindOptions<IOmnichannelRoom> = {},
-	) {
+	findOneOpenByVisitorTokenAndDepartmentIdAndSource<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(visitorToken: string, departmentId?: string, source?: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -1921,15 +1931,18 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...(source && { 'source.type': source }),
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOpenByVisitorTokenAndDepartmentId(
+	findOpenByVisitorTokenAndDepartmentId<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		visitorToken: string,
 		departmentId: string,
-		options: FindOptions<IOmnichannelRoom> = {},
+		options?: O,
 		extraQuery: Filter<IOmnichannelRoom> = {},
-	) {
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -1938,15 +1951,15 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByVisitorIdAndAgentId(
+	findByVisitorIdAndAgentId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		visitorId?: string,
 		agentId?: string,
-		options: FindOptions<IOmnichannelRoom> = {},
+		options?: O,
 		extraQuery: Filter<IOmnichannelRoom> = {},
-	) {
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IOmnichannelRoom> = {
 			t: 'l',
 			...(visitorId && { 'v._id': visitorId }),
@@ -1954,7 +1967,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async findNewestByContactVisitorAssociation<T extends Document = IOmnichannelRoom>(
@@ -1974,7 +1987,10 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		});
 	}
 
-	findOneOpenByRoomIdAndVisitorToken(roomId: string, visitorToken: string, options: FindOptions<IOmnichannelRoom> = {}) {
+	findOneOpenByRoomIdAndVisitorToken<
+		T extends Document = IOmnichannelRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(roomId: string, visitorToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'_id': roomId,
@@ -1982,10 +1998,14 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			'v.token': visitorToken,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findClosedRooms(departmentIds?: string[], options: FindOptions<IOmnichannelRoom> = {}, extraQuery: Filter<IOmnichannelRoom> = {}) {
+	findClosedRooms<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		departmentIds?: string[],
+		options?: O,
+		extraQuery: Filter<IOmnichannelRoom> = {},
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IOmnichannelRoom> = {
 			t: 'l',
 			open: { $exists: false },
@@ -1994,7 +2014,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	getResponseByRoomIdUpdateQuery(responseBy: IOmnichannelRoom['responseBy'], updater: Updater<IOmnichannelRoom> = this.getUpdater()) {
@@ -2275,7 +2295,11 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.countDocuments(query);
 	}
 
-	findOpenByAgent(userId: string, extraQuery: Filter<IOmnichannelRoom> = {}, options: FindOptions<IOmnichannelRoom> = {}) {
+	findOpenByAgent<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		extraQuery: Filter<IOmnichannelRoom> = {},
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IOmnichannelRoom> = {
 			't': 'l',
 			'open': true,
@@ -2283,7 +2307,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			...extraQuery,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	changeAgentByRoomId(roomId: string, newAgent: { agentId: string; username: string; ts?: Date }) {
@@ -2733,8 +2757,11 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		throw new Error('Method not implemented.');
 	}
 
-	findOpenByContactId(contactId: ILivechatContact['_id'], options?: FindOptions<IOmnichannelRoom>): FindCursor<IOmnichannelRoom> {
-		return this.find({ open: true, contactId }, options);
+	findOpenByContactId<T extends Document = IOmnichannelRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		contactId: ILivechatContact['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ open: true, contactId }, options);
 	}
 
 	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null> {

--- a/packages/models/src/models/LivechatRooms.ts
+++ b/packages/models/src/models/LivechatRooms.ts
@@ -1855,6 +1855,8 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			'servedBy': { $exists: true },
 		};
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `sort` wins over a caller-supplied one.
 		return this.findOne<T, O>(query, { ...options, sort: { closedAt: -1 } } as unknown as O);
 	}
 

--- a/packages/models/src/models/LivechatRooms.ts
+++ b/packages/models/src/models/LivechatRooms.ts
@@ -2765,8 +2765,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 		return this.find<T, O>({ open: true, contactId }, options);
 	}
 
-	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.findOne<IOmnichannelRoom>({ contactId, open: true }, { projection: { _id: 1 } });
+	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<Pick<IOmnichannelRoom, '_id'> | null> {
+		return this.findOne({ contactId, open: true }, { projection: { _id: 1 } });
 	}
 }

--- a/packages/models/src/models/LivechatRooms.ts
+++ b/packages/models/src/models/LivechatRooms.ts
@@ -1855,8 +1855,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 			'servedBy': { $exists: true },
 		};
 
-		options.sort = { closedAt: -1 };
-		return this.findOne<T, O>(query, options);
+		return this.findOne<T, O>(query, { ...options, sort: { closedAt: -1 } } as unknown as O);
 	}
 
 	findOneByVisitorToken(visitorToken: string, fields: FindOptions<IOmnichannelRoom>['projection']) {
@@ -2765,6 +2764,7 @@ export class LivechatRoomsRaw extends BaseRaw<IOmnichannelRoom> implements ILive
 	}
 
 	checkContactOpenRooms(contactId: ILivechatContact['_id']): Promise<IOmnichannelRoom | null> {
-		return this.findOne({ contactId, open: true }, { projection: { _id: 1 } });
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findOne<IOmnichannelRoom>({ contactId, open: true }, { projection: { _id: 1 } });
 	}
 }

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -1,5 +1,5 @@
 import type { IVisitorExternalIdentifier, ILivechatVisitor, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { FindPaginated, ILivechatVisitorsModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, ILivechatVisitorsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	AggregationCursor,
@@ -111,16 +111,22 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 	 * Find visitors by _id
 	 * @param {string} token - Visitor token
 	 */
-	findById(_id: string, options: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor> {
+	findById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findEnabled(query: Filter<ILivechatVisitor>, options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor> {
-		return this.find(
+	findEnabled<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<ILivechatVisitor>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				...query,
 				disabled: { $ne: true },
@@ -129,21 +135,27 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 		);
 	}
 
-	findOneEnabledById<T extends Document = ILivechatVisitor>(_id: string, options?: FindOptions<ILivechatVisitor>): Promise<T | null> {
+	findOneEnabledById<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			disabled: { $ne: true },
 		};
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	getVisitorByToken(token: string, options: FindOptions<ILivechatVisitor>): Promise<ILivechatVisitor | null> {
+	getVisitorByToken<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			token,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	countVisitorsBetweenDate({ start, end, department }: { start: Date; end: Date; department?: string }): Promise<number> {
@@ -216,14 +228,17 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 	/**
 	 * Find visitors by their email or phone or username or name
 	 */
-	async findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField(
+	async findPaginatedVisitorsByEmailOrPhoneOrNameOrUsernameOrCustomField<
+		T extends Document = ILivechatVisitor,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		emailOrPhone?: string,
 		nameOrUsername?: RegExp,
 		allowedCustomFields: string[] = [],
-		options?: FindOptions<ILivechatVisitor>,
-	): Promise<FindPaginated<FindCursor<ILivechatVisitor>>> {
+		options?: O,
+	): Promise<FindPaginated<FindCursor<DocumentWithProjection<T, O>>>> {
 		if (!emailOrPhone && !nameOrUsername && allowedCustomFields.length === 0) {
-			return this.findPaginated({ disabled: { $ne: true } }, options);
+			return this.findPaginated<T, O>({ disabled: { $ne: true } }, options);
 		}
 
 		const query: Filter<ILivechatVisitor> = {
@@ -253,7 +268,7 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			disabled: { $ne: true },
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
 	async findOneByEmailAndPhoneAndCustomField(
@@ -498,11 +513,14 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 		return this.findOneAndUpdate({ _id }, { $set: { department } }, { returnDocument: 'after' });
 	}
 
-	findByIds(ids: string[], options?: FindOptions<ILivechatVisitor>): FindCursor<ILivechatVisitor> {
+	findByIds<T extends Document = ILivechatVisitor, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 }
 

--- a/packages/models/src/models/LoginServiceConfiguration.ts
+++ b/packages/models/src/models/LoginServiceConfiguration.ts
@@ -48,7 +48,10 @@ export class LoginServiceConfigurationRaw extends BaseRaw<LoginServiceConfigurat
 		return this.findOneAndDelete({ service: serviceName.toLowerCase() }, { projection: { _id: 1 } });
 	}
 
-	async findOneByService<P extends Document = LoginServiceConfiguration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(serviceName: LoginServiceConfiguration['service'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	async findOneByService<
+		P extends Document = LoginServiceConfiguration,
+		O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>,
+	>(serviceName: LoginServiceConfiguration['service'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		return this.findOne<P, O>({ service: serviceName.toLowerCase() }, options);
 	}
 }

--- a/packages/models/src/models/LoginServiceConfiguration.ts
+++ b/packages/models/src/models/LoginServiceConfiguration.ts
@@ -1,6 +1,6 @@
 import type { LoginServiceConfiguration, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { ILoginServiceConfigurationModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, Document, FindOptions } from 'mongodb';
+import type { ILoginServiceConfigurationModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, Db, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -48,10 +48,7 @@ export class LoginServiceConfigurationRaw extends BaseRaw<LoginServiceConfigurat
 		return this.findOneAndDelete({ service: serviceName.toLowerCase() }, { projection: { _id: 1 } });
 	}
 
-	async findOneByService<P extends Document = LoginServiceConfiguration>(
-		serviceName: LoginServiceConfiguration['service'],
-		options?: FindOptions<P>,
-	): Promise<P | null> {
-		return this.findOne({ service: serviceName.toLowerCase() }, options);
+	async findOneByService<P extends Document = LoginServiceConfiguration, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(serviceName: LoginServiceConfiguration['service'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
+		return this.findOne<P, O>({ service: serviceName.toLowerCase() }, options);
 	}
 }

--- a/packages/models/src/models/MediaCallNegotiations.ts
+++ b/packages/models/src/models/MediaCallNegotiations.ts
@@ -18,7 +18,10 @@ export class MediaCallNegotiationsRaw extends BaseRaw<IMediaCallNegotiation> imp
 		return [{ key: { callId: 1, requestTimestamp: -1 }, unique: false }];
 	}
 
-	public async findLatestByCallId<T extends Document = IMediaCallNegotiation, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: IMediaCallNegotiation['callId'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	public async findLatestByCallId<
+		T extends Document = IMediaCallNegotiation,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(callId: IMediaCallNegotiation['callId'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				callId,
@@ -29,7 +32,7 @@ export class MediaCallNegotiationsRaw extends BaseRaw<IMediaCallNegotiation> imp
 					requestTimestamp: -1,
 				},
 				limit: 1,
-			},
+			} as unknown as O,
 		);
 	}
 

--- a/packages/models/src/models/MediaCallNegotiations.ts
+++ b/packages/models/src/models/MediaCallNegotiations.ts
@@ -4,8 +4,8 @@ import type {
 	MediaCallNegotiationStream,
 	RTCSessionDescriptionInit,
 } from '@rocket.chat/core-typings';
-import type { IMediaCallNegotiationsModel } from '@rocket.chat/model-typings';
-import type { IndexDescription, Collection, Db, FindOptions, Document, UpdateResult } from 'mongodb';
+import type { IMediaCallNegotiationsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { IndexDescription, Collection, Db, Document, UpdateResult } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -18,11 +18,8 @@ export class MediaCallNegotiationsRaw extends BaseRaw<IMediaCallNegotiation> imp
 		return [{ key: { callId: 1, requestTimestamp: -1 }, unique: false }];
 	}
 
-	public async findLatestByCallId<T extends Document = IMediaCallNegotiation>(
-		callId: IMediaCallNegotiation['callId'],
-		options?: FindOptions<T>,
-	): Promise<T | null> {
-		return this.findOne(
+	public async findLatestByCallId<T extends Document = IMediaCallNegotiation, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(callId: IMediaCallNegotiation['callId'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				callId,
 			},

--- a/packages/models/src/models/MediaCallNegotiations.ts
+++ b/packages/models/src/models/MediaCallNegotiations.ts
@@ -26,6 +26,8 @@ export class MediaCallNegotiationsRaw extends BaseRaw<IMediaCallNegotiation> imp
 			{
 				callId,
 			},
+			// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+			// note the model's `sort`/`limit` win over caller-supplied ones.
 			{
 				...options,
 				sort: {

--- a/packages/models/src/models/MediaCalls.ts
+++ b/packages/models/src/models/MediaCalls.ts
@@ -7,18 +7,8 @@ import type {
 	IUser,
 	MediaCallActor,
 } from '@rocket.chat/core-typings';
-import type { IMediaCallsModel } from '@rocket.chat/model-typings';
-import type {
-	IndexDescription,
-	Collection,
-	Db,
-	UpdateFilter,
-	UpdateOptions,
-	UpdateResult,
-	FindOptions,
-	Document,
-	FindCursor,
-} from 'mongodb';
+import type { IMediaCallsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { IndexDescription, Collection, Db, UpdateFilter, UpdateOptions, UpdateResult, Document, FindCursor } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -38,12 +28,8 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		];
 	}
 
-	public async findOneByIdAndCallee<T extends Document = IMediaCall>(
-		id: IMediaCall['_id'],
-		callee: MediaCallActor,
-		options?: FindOptions<IMediaCall>,
-	): Promise<T | null> {
-		return this.findOne<T>(
+	public async findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: IMediaCall['_id'], callee: MediaCallActor, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				'_id': id,
 				'callee.type': callee.type,
@@ -54,12 +40,8 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public async findOneByCallerRequestedId<T extends Document = IMediaCall>(
-		id: Required<IMediaCall>['callerRequestedId'],
-		caller: { type: MediaCallActorType; id: string },
-		options?: FindOptions<T>,
-	): Promise<T | null> {
-		return this.findOne(
+	public async findOneByCallerRequestedId<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: Required<IMediaCall>['callerRequestedId'], caller: { type: MediaCallActorType; id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				'caller.type': caller.type,
 				'caller.id': caller.id,
@@ -184,8 +166,8 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public findAllExpiredCalls<T extends Document = IMediaCall>(options?: FindOptions<T>): FindCursor<T> {
-		return this.find(
+	public findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				ended: false,
 				expiresAt: {
@@ -196,8 +178,8 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public findAllNotOverByUid<T extends Document = IMediaCall>(uid: IUser['_id'], options?: FindOptions<T>): FindCursor<T> {
-		return this.find(
+	public findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				ended: false,
 				expiresAt: {

--- a/packages/models/src/models/MediaCalls.ts
+++ b/packages/models/src/models/MediaCalls.ts
@@ -28,7 +28,11 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		];
 	}
 
-	public async findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: IMediaCall['_id'], callee: MediaCallActor, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	public async findOneByIdAndCallee<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		id: IMediaCall['_id'],
+		callee: MediaCallActor,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				'_id': id,
@@ -40,7 +44,14 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public async findOneByCallerRequestedId<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(id: Required<IMediaCall>['callerRequestedId'], caller: { type: MediaCallActorType; id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	public async findOneByCallerRequestedId<
+		T extends Document = IMediaCall,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		id: Required<IMediaCall>['callerRequestedId'],
+		caller: { type: MediaCallActorType; id: string },
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				'caller.type': caller.type,
@@ -166,7 +177,9 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	public findAllExpiredCalls<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				ended: false,
@@ -178,7 +191,10 @@ export class MediaCallsRaw extends BaseRaw<IMediaCall> implements IMediaCallsMod
 		);
 	}
 
-	public findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	public findAllNotOverByUid<T extends Document = IMediaCall, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IUser['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				ended: false,

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -9,7 +9,7 @@ import type {
 	IMessageWithPendingFileImport,
 	DeepWritable,
 } from '@rocket.chat/core-typings';
-import type { FindPaginated, IMessagesModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, IMessagesModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type { PaginatedRequest } from '@rocket.chat/rest-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
@@ -78,65 +78,72 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		];
 	}
 
-	findVisibleByMentionAndRoomId(username: IUser['username'], rid: IRoom['_id'], options?: FindOptions<IMessage>): FindCursor<IMessage> {
-		const query: Filter<IMessage> = {
-			'_hidden': { $ne: true },
-			'mentions.username': username,
-			rid,
-		};
-
-		return this.find(query, options);
-	}
-
-	findPaginatedVisibleByMentionAndRoomId(
+	findVisibleByMentionAndRoomId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		username: IUser['username'],
 		rid: IRoom['_id'],
-		options?: FindOptions<IMessage>,
-	): FindPaginated<FindCursor<IMessage>> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			'_hidden': { $ne: true },
 			'mentions.username': username,
 			rid,
 		};
 
-		return this.findPaginated(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findStarredByUserAtRoom(
+	findPaginatedVisibleByMentionAndRoomId<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(username: IUser['username'], rid: IRoom['_id'], options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+		const query: Filter<IMessage> = {
+			'_hidden': { $ne: true },
+			'mentions.username': username,
+			rid,
+		};
+
+		return this.findPaginated<T, O>(query, options);
+	}
+
+	findStarredByUserAtRoom<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		userId: IUser['_id'],
 		roomId: IRoom['_id'],
-		options?: FindOptions<IMessage>,
-	): FindPaginated<FindCursor<IMessage>> {
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IMessage> = {
 			'_hidden': { $ne: true },
 			'starred._id': userId,
 			'rid': roomId,
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedByRoomIdAndType(
+	findPaginatedByRoomIdAndType<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: IRoom['_id'],
 		type: IMessage['t'],
-		options: FindOptions<IMessage> = {},
-	): FindPaginated<FindCursor<IMessage>> {
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query = {
 			rid: roomId,
 			t: type,
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findDiscussionsByRoomAndText(rid: IRoom['_id'], text: string, options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>> {
+	findDiscussionsByRoomAndText<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		text: string,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IMessage> = {
 			rid,
 			drid: { $exists: true },
 			msg: new RegExp(escapeRegExp(text), 'i'),
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
 	findAllNumberOfTransferredRooms({
@@ -320,8 +327,12 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.col.aggregate(params, { allowDiskUse: true, readPreference: readSecondaryPreferred() }).toArray();
 	}
 
-	findLivechatClosedMessages(rid: IRoom['_id'], searchTerm?: string, options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>> {
-		return this.findPaginated(
+	findLivechatClosedMessages<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		searchTerm?: string,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+		return this.findPaginated<T, O>(
 			{
 				rid,
 				$or: [{ t: { $exists: false } }, { t: 'livechat-close' }],
@@ -331,8 +342,11 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		);
 	}
 
-	findLivechatClosingMessage(rid: IRoom['_id'], options?: FindOptions<IMessage>): Promise<IMessage | null> {
-		return this.findOne<IMessage>(
+	findLivechatClosingMessage<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				rid,
 				t: 'livechat-close',
@@ -341,14 +355,17 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		);
 	}
 
-	findVisibleByRoomIdNotContainingTypesBeforeTs(
+	findVisibleByRoomIdNotContainingTypesBeforeTs<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: IRoom['_id'],
 		types: IMessage['t'][],
 		ts: Date,
 		showSystemMessages: boolean,
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages = true,
-	): FindCursor<IMessage> {
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			_hidden: {
 				$ne: true,
@@ -375,15 +392,15 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			query.t = { $exists: false };
 		}
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findLivechatMessagesWithoutTypes(
+	findLivechatMessagesWithoutTypes<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		rid: IRoom['_id'],
 		ignoredTypes: IMessage['t'][],
 		showSystemMessages: boolean,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			rid,
 		};
@@ -396,7 +413,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			query.t = { $exists: false };
 		}
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async setBlocksById(_id: string, blocks: Required<IMessage>['blocks']): Promise<void> {
@@ -484,7 +501,10 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.countDocuments(query, options);
 	}
 
-	findPaginatedPinnedByRoom(roomId: IMessage['rid'], options?: FindOptions<IMessage>): FindPaginated<FindCursor<IMessage>> {
+	findPaginatedPinnedByRoom<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IMessage['rid'],
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IMessage> = {
 			t: { $ne: 'rm' },
 			_hidden: { $ne: true },
@@ -492,7 +512,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			rid: roomId,
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
 	countStarred(options?: CountDocumentsOptions): Promise<number> {
@@ -636,10 +656,13 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 	}
 
 	// FIND
-	findByMention(username: string, options?: FindOptions<IMessage>): FindCursor<IMessage> {
+	findByMention<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { 'mentions.username': username };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	findFilesByUserId(userId: string, options: FindOptions<IMessage> = {}): FindCursor<Pick<IMessage, 'file' | 'files'>> {
@@ -650,15 +673,18 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.find(query, { projection: { 'file._id': 1, 'files._id': 1 }, ...options });
 	}
 
-	findFilesByRoomIdPinnedTimestampAndUsers(
+	findFilesByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		rid: string,
 		excludePinned: boolean,
 		ignoreDiscussion = true,
 		ts: Filter<IMessage>['ts'],
 		users: string[] = [],
 		ignoreThreads = true,
-		options: FindOptions<IMessage> = {},
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			rid,
 			ts,
@@ -676,16 +702,19 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			...(users.length ? { 'u.username': { $in: users } } : {}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findDiscussionByRoomIdPinnedTimestampAndUsers(
+	findDiscussionByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		rid: string,
 		excludePinned: boolean,
 		ts: Filter<IMessage>['ts'],
 		users: string[] = [],
-		options: FindOptions<IMessage> = {},
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			rid,
 			ts,
@@ -694,10 +723,13 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			...(users.length ? { 'u.username': { $in: users } } : {}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByRoomId<T extends IMessage = IMessage>(rid: string, options?: FindOptions<T>): FindCursor<T> {
+	findVisibleByRoomId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -706,10 +738,13 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			rid,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByIds(ids: string[], options?: FindOptions<IMessage>): FindCursor<IMessage> {
+	findVisibleByIds<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 			_hidden: {
@@ -717,10 +752,13 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleThreadByThreadId(tmid: string, options?: FindOptions<IMessage>): FindCursor<IMessage> {
+	findVisibleThreadByThreadId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		tmid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -729,15 +767,13 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			tmid,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByRoomIdNotContainingTypes(
-		roomId: string,
-		types: MessageTypesValues[],
-		options?: FindOptions<IMessage>,
-		showThreadMessages = true,
-	): FindCursor<IMessage> {
+	findVisibleByRoomIdNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(roomId: string, types: MessageTypesValues[], options?: O, showThreadMessages = true): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			_hidden: {
 				$ne: true,
@@ -759,7 +795,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 				}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countVisibleByRoomIdContainingTypes(roomId: string, types: MessageTypesValues[]): Promise<number> {
@@ -774,12 +810,12 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.countDocuments(query);
 	}
 
-	findVisibleByRoomIdAfterTimestamp(
+	findVisibleByRoomIdAfterTimestamp<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: string,
 		timestamp: Date,
 		showThreadMessages = true,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -800,14 +836,14 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findForUpdates(
+	findForUpdates<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: IMessage['rid'],
 		{ updatedAt, minTs }: { updatedAt: { $lt: Date } | { $gt: Date }; minTs?: Date },
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid: roomId,
 			_hidden: { $ne: true },
@@ -815,15 +851,15 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			...(minTs && { ts: { $gte: minTs } }),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByRoomIdBeforeTimestamp(
+	findVisibleByRoomIdBeforeTimestamp<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: string,
 		timestamp: Date,
 		showThreadMessages = true,
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -844,17 +880,20 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByRoomIdBeforeTimestampNotContainingTypes(
+	findVisibleByRoomIdBeforeTimestampNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: string,
 		timestamp: Date,
 		types: MessageTypesValues[],
-		options?: FindOptions<IMessage>,
+		options?: O,
 		showThreadMessages = true,
 		inclusive = false,
-	): FindCursor<IMessage> {
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -879,18 +918,21 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 				}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+	findVisibleByRoomIdBetweenTimestampsNotContainingTypes<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		roomId: string,
 		afterTimestamp: Date,
 		beforeTimestamp: Date,
 		types: MessageTypesValues[],
-		options: FindOptions<IMessage> = {},
+		options?: O,
 		showThreadMessages = true,
 		inclusive = false,
-	): FindCursor<IMessage> {
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_hidden: {
 				$ne: true,
@@ -916,7 +958,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 				}),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countVisibleByRoomIdBetweenTimestampsNotContainingTypes(
@@ -962,7 +1004,11 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return message?.ts;
 	}
 
-	findByRoomIdAndMessageIds(rid: string, messageIds: string[], options?: FindOptions<IMessage>): FindCursor<IMessage> {
+	findByRoomIdAndMessageIds<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid,
 			_id: {
@@ -970,7 +1016,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	findOneBySlackBotIdAndSlackTs(slackBotId: string, slackTs: Date): Promise<IMessage | null> {
@@ -988,13 +1034,17 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.findOne(query);
 	}
 
-	findOneByRoomIdAndMessageId(rid: string, messageId: string, options?: FindOptions<IMessage>): Promise<IMessage | null> {
+	findOneByRoomIdAndMessageId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			rid,
 			_id: messageId,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	getLastVisibleUserMessageSentByRoomId(rid: string, messageId?: string): Promise<IMessage | null> {
@@ -1319,7 +1369,10 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.deleteMany({ rid: { $in: rids } });
 	}
 
-	findThreadsByRoomIdPinnedTimestampAndUsers(
+	findThreadsByRoomIdPinnedTimestampAndUsers<
+		T extends Document = IMessage,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
 		{
 			rid,
 			pinned,
@@ -1327,8 +1380,8 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			ts,
 			users = [],
 		}: { rid: string; pinned: boolean; ignoreDiscussion?: boolean; ts: Filter<IMessage>['ts']; users: string[] },
-		options?: FindOptions<IMessage>,
-	): FindCursor<IMessage> {
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IMessage> = {
 			rid,
 			ts,
@@ -1345,7 +1398,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			query.drid = { $exists: false };
 		}
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async findByIdPinnedTimestampLimitAndUsers(

--- a/packages/models/src/models/NpsVote.ts
+++ b/packages/models/src/models/NpsVote.ts
@@ -15,7 +15,10 @@ export class NpsVoteRaw extends BaseRaw<INpsVote> implements INpsVoteModel {
 		return [{ key: { npsId: 1, status: 1, sentAt: 1 } }, { key: { npsId: 1, identifier: 1 }, unique: true }];
 	}
 
-	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 			status: INpsVoteStatus.NEW,
@@ -25,7 +28,11 @@ export class NpsVoteRaw extends BaseRaw<INpsVote> implements INpsVoteModel {
 		return cursor.sort({ ts: 1 }).limit(1000);
 	}
 
-	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, status: INpsVoteStatus, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		status: INpsVoteStatus,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 			status,
@@ -36,7 +43,10 @@ export class NpsVoteRaw extends BaseRaw<INpsVote> implements INpsVoteModel {
 		return this.find<T, O>(query);
 	}
 
-	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		npsId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 		};

--- a/packages/models/src/models/NpsVote.ts
+++ b/packages/models/src/models/NpsVote.ts
@@ -15,9 +15,11 @@ export class NpsVoteRaw extends BaseRaw<INpsVote> implements INpsVoteModel {
 		return [{ key: { npsId: 1, status: 1, sentAt: 1 } }, { key: { npsId: 1, identifier: 1 }, unique: true }];
 	}
 
+	// `sort` and `limit` are branded away because the cursor below overwrites both; a caller passing
+	// them would have them silently dropped
 	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		npsId: string,
-		options?: O,
+		options?: O & { sort?: never; limit?: never },
 	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,

--- a/packages/models/src/models/NpsVote.ts
+++ b/packages/models/src/models/NpsVote.ts
@@ -1,7 +1,7 @@
 import type { INpsVote, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import { INpsVoteStatus } from '@rocket.chat/core-typings';
-import type { INpsVoteModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, Document, FindOptions, IndexDescription, UpdateResult } from 'mongodb';
+import type { INpsVoteModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, Document, IndexDescription, UpdateResult } from 'mongodb';
 import { ObjectId } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
@@ -15,35 +15,35 @@ export class NpsVoteRaw extends BaseRaw<INpsVote> implements INpsVoteModel {
 		return [{ key: { npsId: 1, status: 1, sentAt: 1 } }, { key: { npsId: 1, identifier: 1 }, unique: true }];
 	}
 
-	findNotSentByNpsId(npsId: string, options?: Omit<FindOptions<INpsVote>, 'sort' | 'limit'>): FindCursor<INpsVote> {
+	findNotSentByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 			status: INpsVoteStatus.NEW,
 		};
-		const cursor = options ? this.find(query, options) : this.find(query);
+		const cursor = options ? this.find<T, O>(query, options) : this.find<T, O>(query);
 
 		return cursor.sort({ ts: 1 }).limit(1000);
 	}
 
-	findByNpsIdAndStatus(npsId: string, status: INpsVoteStatus, options?: FindOptions<INpsVote>): FindCursor<INpsVote> {
+	findByNpsIdAndStatus<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, status: INpsVoteStatus, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 			status,
 		};
 		if (options) {
-			return this.find(query, options);
+			return this.find<T, O>(query, options);
 		}
-		return this.find(query);
+		return this.find<T, O>(query);
 	}
 
-	findByNpsId(npsId: string, options?: FindOptions<INpsVote>): FindCursor<INpsVote> {
+	findByNpsId<T extends Document = INpsVote, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(npsId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			npsId,
 		};
 		if (options) {
-			return this.find(query, options);
+			return this.find<T, O>(query, options);
 		}
-		return this.find(query);
+		return this.find<T, O>(query);
 	}
 
 	save(vote: Omit<INpsVote, '_id' | '_updatedAt'>): Promise<UpdateResult> {

--- a/packages/models/src/models/OAuthAccessTokens.ts
+++ b/packages/models/src/models/OAuthAccessTokens.ts
@@ -19,14 +19,20 @@ export class OAuthAccessTokensRaw extends BaseRaw<IOAuthAccessToken> implements 
 		];
 	}
 
-	async findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(accessToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		accessToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof accessToken !== 'string' || !accessToken) {
 			return null;
 		}
 		return this.findOne<T, O>({ accessToken }, options);
 	}
 
-	async findOneByRefreshToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findOneByRefreshToken<
+		T extends Document = IOAuthAccessToken,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof refreshToken !== 'string' || !refreshToken) {
 			return null;
 		}

--- a/packages/models/src/models/OAuthAccessTokens.ts
+++ b/packages/models/src/models/OAuthAccessTokens.ts
@@ -1,6 +1,6 @@
 import type { IOAuthAccessToken, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IOAuthAccessTokensModel } from '@rocket.chat/model-typings';
-import type { Db, Collection, DeleteResult, FindOptions, IndexDescription } from 'mongodb';
+import type { IOAuthAccessTokensModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, Collection, DeleteResult, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -19,18 +19,18 @@ export class OAuthAccessTokensRaw extends BaseRaw<IOAuthAccessToken> implements 
 		];
 	}
 
-	async findOneByAccessToken(accessToken: string, options?: FindOptions<IOAuthAccessToken>): Promise<IOAuthAccessToken | null> {
+	async findOneByAccessToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(accessToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof accessToken !== 'string' || !accessToken) {
 			return null;
 		}
-		return this.findOne({ accessToken }, options);
+		return this.findOne<T, O>({ accessToken }, options);
 	}
 
-	async findOneByRefreshToken(refreshToken: string, options?: FindOptions<IOAuthAccessToken>): Promise<IOAuthAccessToken | null> {
+	async findOneByRefreshToken<T extends Document = IOAuthAccessToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof refreshToken !== 'string' || !refreshToken) {
 			return null;
 		}
-		return this.findOne({ refreshToken }, options);
+		return this.findOne<T, O>({ refreshToken }, options);
 	}
 
 	async deleteByUserId(userId: string): Promise<DeleteResult> {

--- a/packages/models/src/models/OAuthApps.ts
+++ b/packages/models/src/models/OAuthApps.ts
@@ -1,6 +1,6 @@
 import type { IOAuthApps, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IOAuthAppsModel } from '@rocket.chat/model-typings';
-import type { Db, Collection, FindOptions, IndexDescription } from 'mongodb';
+import type { IOAuthAppsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, Collection, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,11 +13,8 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		return [{ key: { clientId: 1, clientSecret: 1 } }, { key: { appId: 1 } }];
 	}
 
-	findOneAuthAppByIdOrClientId(
-		props: { clientId: string } | { appId: string } | { _id: string },
-		options?: FindOptions<IOAuthApps>,
-	): Promise<IOAuthApps | null> {
-		return this.findOne(
+	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(props: { clientId: string } | { appId: string } | { _id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				...('_id' in props && { _id: props._id }),
 				...('appId' in props && { _id: props.appId }),
@@ -27,11 +24,11 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		);
 	}
 
-	findOneActiveByClientId(clientId: string, options?: FindOptions<IOAuthApps>): Promise<IOAuthApps | null> {
+	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof clientId !== 'string' || !clientId) {
 			return Promise.resolve(null);
 		}
-		return this.findOne(
+		return this.findOne<T, O>(
 			{
 				active: true,
 				clientId,
@@ -47,15 +44,11 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		return this.findOneAndUpdate({ _id }, { $set: data }, { returnDocument: 'after' });
 	}
 
-	findOneActiveByClientIdAndClientSecret(
-		clientId: string,
-		clientSecret: string,
-		options?: FindOptions<IOAuthApps>,
-	): Promise<IOAuthApps | null> {
+	findOneActiveByClientIdAndClientSecret<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, clientSecret: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof clientId !== 'string' || !clientId || typeof clientSecret !== 'string' || !clientSecret) {
 			return Promise.resolve(null);
 		}
-		return this.findOne(
+		return this.findOne<T, O>(
 			{
 				active: true,
 				clientId,

--- a/packages/models/src/models/OAuthApps.ts
+++ b/packages/models/src/models/OAuthApps.ts
@@ -13,7 +13,10 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		return [{ key: { clientId: 1, clientSecret: 1 } }, { key: { appId: 1 } }];
 	}
 
-	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(props: { clientId: string } | { appId: string } | { _id: string }, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneAuthAppByIdOrClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		props: { clientId: string } | { appId: string } | { _id: string },
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				...('_id' in props && { _id: props._id }),
@@ -24,7 +27,10 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		);
 	}
 
-	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneActiveByClientId<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		clientId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof clientId !== 'string' || !clientId) {
 			return Promise.resolve(null);
 		}
@@ -44,7 +50,10 @@ export class OAuthAppsRaw extends BaseRaw<IOAuthApps> implements IOAuthAppsModel
 		return this.findOneAndUpdate({ _id }, { $set: data }, { returnDocument: 'after' });
 	}
 
-	findOneActiveByClientIdAndClientSecret<T extends Document = IOAuthApps, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(clientId: string, clientSecret: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneActiveByClientIdAndClientSecret<
+		T extends Document = IOAuthApps,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(clientId: string, clientSecret: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof clientId !== 'string' || !clientId || typeof clientSecret !== 'string' || !clientSecret) {
 			return Promise.resolve(null);
 		}

--- a/packages/models/src/models/OAuthAuthCodes.ts
+++ b/packages/models/src/models/OAuthAuthCodes.ts
@@ -1,6 +1,6 @@
 import type { IOAuthAuthCode, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IOAuthAuthCodesModel } from '@rocket.chat/model-typings';
-import type { Db, Collection, DeleteResult, FindOptions, IndexDescription } from 'mongodb';
+import type { IOAuthAuthCodesModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, Collection, DeleteResult, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,11 +13,11 @@ export class OAuthAuthCodesRaw extends BaseRaw<IOAuthAuthCode> implements IOAuth
 		return [{ key: { authCode: 1 } }, { key: { userId: 1 } }, { key: { expires: 1 }, expireAfterSeconds: 60 * 5 }];
 	}
 
-	findOneByAuthCode(authCode: string, options?: FindOptions<IOAuthAuthCode>): Promise<IOAuthAuthCode | null> {
+	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(authCode: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof authCode !== 'string' || !authCode) {
 			return Promise.resolve(null);
 		}
-		return this.findOne({ authCode }, options);
+		return this.findOne<T, O>({ authCode }, options);
 	}
 
 	async deleteByUserId(userId: string): Promise<DeleteResult> {

--- a/packages/models/src/models/OAuthAuthCodes.ts
+++ b/packages/models/src/models/OAuthAuthCodes.ts
@@ -13,7 +13,10 @@ export class OAuthAuthCodesRaw extends BaseRaw<IOAuthAuthCode> implements IOAuth
 		return [{ key: { authCode: 1 } }, { key: { userId: 1 } }, { key: { expires: 1 }, expireAfterSeconds: 60 * 5 }];
 	}
 
-	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(authCode: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByAuthCode<T extends Document = IOAuthAuthCode, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		authCode: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof authCode !== 'string' || !authCode) {
 			return Promise.resolve(null);
 		}

--- a/packages/models/src/models/OAuthRefreshTokens.ts
+++ b/packages/models/src/models/OAuthRefreshTokens.ts
@@ -1,6 +1,6 @@
 import type { IOAuthRefreshToken, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IOAuthRefreshTokensModel } from '@rocket.chat/model-typings';
-import type { Db, Collection, DeleteResult, FindOptions, IndexDescription } from 'mongodb';
+import type { IOAuthRefreshTokensModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, Collection, DeleteResult, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,11 +13,11 @@ export class OAuthRefreshTokensRaw extends BaseRaw<IOAuthRefreshToken> implement
 		return [{ key: { refreshToken: 1 } }, { key: { userId: 1 } }, { key: { expires: 1 }, expireAfterSeconds: 60 * 60 * 24 * 30 }];
 	}
 
-	findOneByRefreshToken(refreshToken: string, options?: FindOptions<IOAuthRefreshToken>): Promise<IOAuthRefreshToken | null> {
+	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof refreshToken !== 'string' || !refreshToken) {
 			return Promise.resolve(null);
 		}
-		return this.findOne({ refreshToken }, options);
+		return this.findOne<T, O>({ refreshToken }, options);
 	}
 
 	async deleteByUserId(userId: string): Promise<DeleteResult> {

--- a/packages/models/src/models/OAuthRefreshTokens.ts
+++ b/packages/models/src/models/OAuthRefreshTokens.ts
@@ -13,7 +13,10 @@ export class OAuthRefreshTokensRaw extends BaseRaw<IOAuthRefreshToken> implement
 		return [{ key: { refreshToken: 1 } }, { key: { userId: 1 } }, { key: { expires: 1 }, expireAfterSeconds: 60 * 60 * 24 * 30 }];
 	}
 
-	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(refreshToken: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRefreshToken<T extends Document = IOAuthRefreshToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		refreshToken: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof refreshToken !== 'string' || !refreshToken) {
 			return Promise.resolve(null);
 		}

--- a/packages/models/src/models/PushToken.ts
+++ b/packages/models/src/models/PushToken.ts
@@ -42,11 +42,17 @@ export class PushTokenRaw extends BaseRaw<IPushToken> implements IPushTokenModel
 		return this.countDocuments(query);
 	}
 
-	async findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ userId }, options);
 	}
 
-	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				userId,
@@ -56,7 +62,11 @@ export class PushTokenRaw extends BaseRaw<IPushToken> implements IPushTokenModel
 		);
 	}
 
-	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], idToIgnore: IPushToken['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		idToIgnore: IPushToken['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				_id: { $ne: idToIgnore },

--- a/packages/models/src/models/PushToken.ts
+++ b/packages/models/src/models/PushToken.ts
@@ -1,6 +1,6 @@
 import type { IPushToken, IUser, AtLeast } from '@rocket.chat/core-typings';
-import type { IPushTokenModel } from '@rocket.chat/model-typings';
-import type { Db, DeleteResult, FindOptions, IndexDescription, InsertOneResult, UpdateResult, FindCursor } from 'mongodb';
+import type { IPushTokenModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, DeleteResult, IndexDescription, InsertOneResult, UpdateResult, FindCursor, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -42,12 +42,12 @@ export class PushTokenRaw extends BaseRaw<IPushToken> implements IPushTokenModel
 		return this.countDocuments(query);
 	}
 
-	async findFirstByUserId<T extends IPushToken>(userId: IUser['_id'], options: FindOptions<IPushToken> = {}): Promise<T | null> {
-		return this.findOne<T>({ userId }, options);
+	async findFirstByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ userId }, options);
 	}
 
-	findAllTokensByUserId<T extends IPushToken>(userId: IUser['_id'], options?: FindOptions<IPushToken>): FindCursor<T> {
-		return this.find<T>(
+	findAllTokensByUserId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				userId,
 				$or: [{ 'token.apn': { $exists: true } }, { 'token.gcm': { $exists: true } }],
@@ -56,12 +56,8 @@ export class PushTokenRaw extends BaseRaw<IPushToken> implements IPushTokenModel
 		);
 	}
 
-	findTokensByUserIdExceptId<T extends IPushToken>(
-		userId: IUser['_id'],
-		idToIgnore: IPushToken['_id'],
-		options?: FindOptions<IPushToken>,
-	): FindCursor<T> {
-		return this.find<T>(
+	findTokensByUserIdExceptId<T extends Document = IPushToken, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], idToIgnore: IPushToken['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				_id: { $ne: idToIgnore },
 				userId,

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -10,7 +10,10 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		super(db, 'roles', trash);
 	}
 
-	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(updatedAfterDate: Date, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		updatedAfterDate: Date,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_updatedAt: { $gte: new Date(updatedAfterDate) },
 		};
@@ -46,7 +49,10 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return false;
 	}
 
-	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_idOrName: IRole['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		_idOrName: IRole['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<P, O> | null> {
 		const query: Filter<IRole> = {
 			$or: [
 				{
@@ -66,7 +72,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 			name,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<IRole>(query, options);
 	}
 
 	findInIds<P>(ids: IRole['_id'][], options?: FindOptions<IRole>): P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole> {
@@ -101,12 +107,15 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return this.find(query, options || {}) as P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
 	}
 
-	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: IRole['scope'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		scope: IRole['scope'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope,
 		};
 
-		return this.find<T, O>(query, options || {});
+		return this.find<T, O>(query, options);
 	}
 
 	countByScope(scope: IRole['scope'], options?: CountDocumentsOptions): Promise<number> {
@@ -117,12 +126,14 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return this.countDocuments(query, options);
 	}
 
-	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRole> = {
 			protected: false,
 		};
 
-		return this.find<T, O>(query, options || {});
+		return this.find<T, O>(query, options);
 	}
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -1,5 +1,5 @@
 import type { IRole, IRoom, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IRolesModel } from '@rocket.chat/model-typings';
+import type { IRolesModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type { Collection, FindCursor, Db, Filter, FindOptions, Document, CountDocumentsOptions } from 'mongodb';
 
 import { Subscriptions, Users } from '../index';
@@ -10,12 +10,12 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		super(db, 'roles', trash);
 	}
 
-	findByUpdatedDate(updatedAfterDate: Date, options?: FindOptions<IRole>): FindCursor<IRole> {
+	findByUpdatedDate<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(updatedAfterDate: Date, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_updatedAt: { $gte: new Date(updatedAfterDate) },
 		};
 
-		return options ? this.find(query, options) : this.find(query);
+		return options ? this.find<T, O>(query, options) : this.find<T, O>(query);
 	}
 
 	async isUserInRoles(userId: IUser['_id'], roles: IRole['_id'][], scope?: IRoom['_id']): Promise<boolean> {
@@ -46,16 +46,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return false;
 	}
 
-	async findOneByIdOrName(_idOrName: IRole['_id'], options?: undefined): Promise<IRole | null>;
-
-	async findOneByIdOrName(_idOrName: IRole['_id'], options: FindOptions<IRole>): Promise<IRole | null>;
-
-	async findOneByIdOrName<P extends Document>(
-		_idOrName: IRole['_id'],
-		options: FindOptions<P extends IRole ? IRole : P>,
-	): Promise<P | null>;
-
-	findOneByIdOrName<P>(_idOrName: IRole['_id'], options?: any): Promise<IRole | P | null> {
+	findOneByIdOrName<P extends Document = IRole, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(_idOrName: IRole['_id'], options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		const query: Filter<IRole> = {
 			$or: [
 				{
@@ -67,7 +58,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<P, O>(query, options);
 	}
 
 	async findOneByName<P = IRole>(name: IRole['name'], options?: any): Promise<IRole | P | null> {
@@ -110,12 +101,12 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return this.find(query, options || {}) as P extends Pick<IRole, '_id'> ? FindCursor<P> : FindCursor<IRole>;
 	}
 
-	findByScope(scope: IRole['scope'], options?: FindOptions<IRole>): FindCursor<IRole> {
+	findByScope<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(scope: IRole['scope'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			scope,
 		};
 
-		return this.find(query, options || {});
+		return this.find<T, O>(query, options || {});
 	}
 
 	countByScope(scope: IRole['scope'], options?: CountDocumentsOptions): Promise<number> {
@@ -126,12 +117,12 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 		return this.countDocuments(query, options);
 	}
 
-	findCustomRoles(options?: FindOptions<IRole>): FindCursor<IRole> {
+	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRole> = {
 			protected: false,
 		};
 
-		return this.find(query, options || {});
+		return this.find<T, O>(query, options || {});
 	}
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1909,9 +1909,12 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateOne(query, update);
 	}
 
-	insertAbacAttributeIfNotExistsById(_id: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.findOneAndUpdate<IRoom>(
+	insertAbacAttributeIfNotExistsById(
+		_id: IRoom['_id'],
+		key: string,
+		values: string[],
+	): Promise<Pick<IRoom, '_id' | 'abacAttributes'> | null> {
+		return this.findOneAndUpdate(
 			{ _id, 'abacAttributes.key': { $ne: key } },
 			{ $push: { abacAttributes: { key, values } } },
 			{ returnDocument: 'after', projection: { abacAttributes: 1 } },

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -137,7 +137,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return !!room;
 	}
 
-	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		uid: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			'_id': rid,
 			'u._id': uid,
@@ -146,7 +150,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: roomIds,
@@ -156,7 +163,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: roomIds,
@@ -209,7 +219,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return statistic;
 	}
 
-	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, types: Array<IRoom['t']>, discussion = false, teams = false, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		types: Array<IRoom['t']>,
+		discussion = false,
+		teams = false,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const nameCondition: Filter<IRoom> = {
@@ -247,7 +263,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const nameCondition: Filter<IRoom> = {
@@ -267,7 +286,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		teamId: ITeam['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			teamMain: {
@@ -289,7 +311,16 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.countDocuments(query);
 	}
 
-	findPaginatedByTeamIdContainingNameAndDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], name: IRoom['name'], teamDefault: boolean, ids: Array<IRoom['_id']> | undefined, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByTeamIdContainingNameAndDefault<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		teamId: ITeam['_id'],
+		name: IRoom['name'],
+		teamDefault: boolean,
+		ids: Array<IRoom['_id']> | undefined,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			teamMain: {
@@ -303,7 +334,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		teamId: ITeam['_id'],
+		rids: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			_id: {
@@ -314,7 +349,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -334,7 +372,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -366,7 +408,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findPaginatedRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedRoomsWithoutDiscussionsByRoomIds<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -399,7 +444,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'], groupsToAccept: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(name: IRoom['name'], groupsToAccept: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = name && new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -451,7 +499,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateOne({ _id: rid }, { $set: { teamDefault } }, options);
 	}
 
-	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -466,7 +517,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(joinCode: string, rid: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		joinCode: string,
+		rid: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			_id: rid,
 			joinCode,
@@ -475,7 +530,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	async findOneByNonValidatedName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findOneByNonValidatedName(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}) {
 		const room = await this.findOneByNameOrFname(name, options);
 		if (room) {
 			return room;
@@ -484,7 +539,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOneByName(name, options);
 	}
 
-	findOneByName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByName(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
 		return this.col.findOne({ name }, options);
 	}
 
@@ -567,7 +622,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		);
 	}
 
-	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				_id: roomId,
@@ -589,7 +647,15 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.countDocuments({ t });
 	}
 
-	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, teamIds: Array<ITeam['_id']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: RegExp | null,
+		teamIds: Array<ITeam['_id']>,
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			$and: [
 				{ teamMain: { $exists: false } },
@@ -635,7 +701,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedContainingNameOrFNameInIdsAsTeamMain<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, rids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedContainingNameOrFNameInIdsAsTeamMain<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(searchTerm: RegExp | null, rids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			teamMain: true,
 			$and: [
@@ -671,7 +740,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: Array<IRoom['_id']>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			t: type,
 			_id: {
@@ -682,7 +755,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IDirectMessageRoom['uids'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IDirectMessageRoom['uids'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: 'd',
 			uids: { $size: uid.length, $all: uid },
@@ -694,10 +770,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 				federated: 1,
 				ts: 1,
 			},
-		});
+		} as unknown as O);
 	}
 
-	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 			federated: true,
@@ -706,7 +785,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(mrid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		mrid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			'federated': true,
 			'federation.mrid': mrid,
@@ -782,7 +864,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.incMsgCountById(_id, -count);
 	}
 
-	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: IRoom['_id'] | IRoom['name'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_idOrName: IRoom['_id'] | IRoom['name'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			$or: [
 				{
@@ -797,7 +882,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], type: IRoom['t'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IRoom['_id'],
+		type: IRoom['t'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ _id: roomId, t: type }, options);
 	}
 
@@ -928,7 +1017,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateMany(query, update);
 	}
 
-	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IRoom['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IRoom['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ t: 'd', uids: { $size: 2, $in: [_id] } }, options);
 	}
 
@@ -1006,7 +1098,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOneAndUpdate(query, update, { returnDocument: 'after', ...options });
 	}
 
-	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = { importIds: _id };
 
 		return this.findOne<T, O>(query, options);
@@ -1021,13 +1116,21 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne(query);
 	}
 
-	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(fname: IRoom['fname'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		fname: IRoom['fname'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = { fname };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, type: IRoom['t'], options?: O, includeFederatedRooms = false): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: NonNullable<IRoom['name']>,
+		type: IRoom['t'],
+		options?: O,
+		includeFederatedRooms = false,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: type,
 			teamId: {
@@ -1042,21 +1145,34 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 	}
 
 	// FIND
-	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ _id: roomId }, options);
 	}
 
-	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ _id: { $in: roomIds } }, options);
 	}
 
-	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = { t: type };
 
 		return this.find<T, O>(query, options);
 	}
 
-	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: ids,
@@ -1067,7 +1183,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findPrivateRoomsByIdsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findPrivateRoomsByIdsWithAbacAttributes<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: { $in: ids },
 			t: 'p',
@@ -1077,7 +1196,9 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: 'p',
 			abacAttributes: { $exists: true, $ne: [] },
@@ -1086,7 +1207,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	async findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
+	async findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const data = (await Subscriptions.findByUserId(userId, { projection: { rid: 1 } }).toArray()).map((item) => item.rid);
 
 		const query: Filter<IRoom> = {
@@ -1113,7 +1237,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	async findBySubscriptionUserIdUpdatedAfter<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], _updatedAt: IRoom['_updatedAt'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
+	async findBySubscriptionUserIdUpdatedAfter<
+		T extends Document = IRoom,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(userId: IUser['_id'], _updatedAt: IRoom['_updatedAt'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const ids = (await Subscriptions.findByUserId(userId, { projection: { rid: 1 } }).toArray()).map((item) => item.rid);
 
 		const query: Filter<IRoom> = {
@@ -1143,7 +1270,12 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, type: IRoom['t'], options?: O, includeFederatedRooms = false): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: IRoom['name'] | RegExp,
+		type: IRoom['t'],
+		options?: O,
+		includeFederatedRooms = false,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: type,
 			default: {
@@ -1175,7 +1307,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 	}
 
 	// 3
-	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, types: Array<IRoom['t']>, ids: Array<IRoom['_id']>, options?: O, includeFederatedRooms = false): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		name: IRoom['name'] | RegExp,
+		types: Array<IRoom['t']>,
+		ids: Array<IRoom['_id']>,
+		options?: O,
+		includeFederatedRooms = false,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const nameCondition: Filter<IRoom> = {
 			$or: [{ name }, { fname: name }],
 		};
@@ -1225,7 +1363,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(defaultValue: boolean, types: Array<IRoom['t']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		defaultValue: boolean,
+		types: Array<IRoom['t']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: {
 				$in: types,
@@ -1236,7 +1378,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: NonNullable<IRoom['usernames']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: NonNullable<IRoom['usernames']>,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: 'd',
 			usernames: { $size: usernames.length, $all: usernames },
@@ -1246,7 +1391,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], identifier: NonNullable<IRoom['name'] | IRoom['_id']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		identifier: NonNullable<IRoom['name'] | IRoom['_id']>,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: type,
 			$or: [{ name: identifier }, { _id: identifier }],
@@ -1255,7 +1404,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const query: Filter<IRoom> = {
@@ -1266,7 +1419,12 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: IRoom['t'],
+		ids: Array<IRoom['_id']>,
+		name: NonNullable<IRoom['name']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const query: Filter<IRoom> = {
@@ -1280,7 +1438,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uids: NonNullable<IRoom['uids']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uids: NonNullable<IRoom['uids']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				usersCount: { $gt: 2 },
@@ -1297,7 +1458,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		});
 	}
 
-	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IRoom['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IRoom['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				uids: userId,
@@ -2032,11 +2196,14 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		]);
 	}
 
-	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filters: {
+	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		filters: {
 			types?: Array<IRoom['t']>;
 			discussions?: boolean;
 			teams?: boolean;
-		} = {}, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		} = {},
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const { types, discussions, teams } = filters;
 
 		const query: Filter<IRoom> = {};

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -764,8 +764,6 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			uids: { $size: uid.length, $all: uid },
 		};
 
-		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
-		// note the model's `sort` wins over a caller-supplied one.
 		return this.findOne<T, O>(query, {
 			...options,
 			sort: {
@@ -1146,7 +1144,6 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne<T, O>(query, options);
 	}
 
-	// FIND
 	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		roomId: IRoom['_id'],
 		options?: O,
@@ -1308,7 +1305,6 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>(query, options);
 	}
 
-	// 3
 	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		name: IRoom['name'] | RegExp,
 		types: Array<IRoom['t']>,

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -764,6 +764,8 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			uids: { $size: uid.length, $all: uid },
 		};
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `sort` wins over a caller-supplied one.
 		return this.findOne<T, O>(query, {
 			...options,
 			sort: {

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -9,7 +9,7 @@ import type {
 	IUser,
 	RocketChatRecordDeleted,
 } from '@rocket.chat/core-typings';
-import type { FindPaginated, IRoomsModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, IRoomsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	AggregationCursor,
@@ -137,26 +137,26 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return !!room;
 	}
 
-	findOneByRoomIdAndUserId(rid: IRoom['_id'], uid: IUser['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByRoomIdAndUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], uid: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			'_id': rid,
 			'u._id': uid,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findManyByRoomIds(roomIds: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findManyByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: roomIds,
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findManyArchivedByRoomIds(roomIds: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findManyArchivedByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: roomIds,
@@ -164,7 +164,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			archived: true,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	findPaginatedByIds(
@@ -209,13 +209,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return statistic;
 	}
 
-	findByNameOrFnameContainingAndTypes(
-		name: NonNullable<IRoom['name']>,
-		types: Array<IRoom['t']>,
-		discussion = false,
-		teams = false,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findByNameOrFnameContainingAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, types: Array<IRoom['t']>, discussion = false, teams = false, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const nameCondition: Filter<IRoom> = {
@@ -250,10 +244,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			...(!teams ? { teamMain: { $exists: false } } : {}),
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPrivateRoomsAndTeamsPaginated(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): FindPaginated<FindCursor<IRoom>> {
+	findPrivateRoomsAndTeamsPaginated<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const nameCondition: Filter<IRoom> = {
@@ -270,10 +264,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			prid: { $exists: false },
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findByTeamId(teamId: ITeam['_id'], options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByTeamId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			teamMain: {
@@ -281,7 +275,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countByTeamId(teamId: ITeam['_id']): Promise<number> {
@@ -295,13 +289,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.countDocuments(query);
 	}
 
-	findPaginatedByTeamIdContainingNameAndDefault(
-		teamId: ITeam['_id'],
-		name: IRoom['name'],
-		teamDefault: boolean,
-		ids: Array<IRoom['_id']> | undefined,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findPaginatedByTeamIdContainingNameAndDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], name: IRoom['name'], teamDefault: boolean, ids: Array<IRoom['_id']> | undefined, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			teamMain: {
@@ -312,10 +300,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			...(ids ? { $or: [{ t: 'c' }, { _id: { $in: ids } }] } : {}),
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findByTeamIdAndRoomsId(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByTeamIdAndRoomsId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(teamId: ITeam['_id'], rids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			teamId,
 			_id: {
@@ -323,10 +311,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findRoomsByNameOrFnameStarting(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findRoomsByNameOrFnameStarting<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -343,14 +331,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findRoomsWithoutDiscussionsByRoomIds(
-		name: NonNullable<IRoom['name']>,
-		roomIds: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindCursor<IRoom> {
+	findRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -379,14 +363,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			prid: { $exists: false },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findPaginatedRoomsWithoutDiscussionsByRoomIds(
-		name: NonNullable<IRoom['name']>,
-		roomIds: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findPaginatedRoomsWithoutDiscussionsByRoomIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const nameRegex = new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -416,14 +396,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			$and: [{ $or: [{ federated: { $exists: false } }, { federated: false }] }],
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findChannelAndGroupListWithoutTeamsByNameStartingByOwner(
-		name: IRoom['name'],
-		groupsToAccept: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindCursor<IRoom> {
+	findChannelAndGroupListWithoutTeamsByNameStartingByOwner<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'], groupsToAccept: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = name && new RegExp(`^${escapeRegExp(name).trim()}`, 'i');
 
 		const query: Filter<IRoom> = {
@@ -439,7 +415,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			...(name && { name: nameRegex }),
 			$and: [{ $or: [{ federated: { $exists: false } }, { federated: false }] }],
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	unsetTeamId(teamId: ITeam['_id'], options: UpdateOptions = {}): Promise<Document | UpdateResult> {
@@ -475,7 +451,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateOne({ _id: rid }, { $set: { teamDefault } }, options);
 	}
 
-	findOneByNameOrFname(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByNameOrFname<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -487,19 +463,19 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByJoinCodeAndId(joinCode: string, rid: IRoom['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByJoinCodeAndId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(joinCode: string, rid: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			_id: rid,
 			joinCode,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	async findOneByNonValidatedName(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}) {
+	async findOneByNonValidatedName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const room = await this.findOneByNameOrFname(name, options);
 		if (room) {
 			return room;
@@ -508,7 +484,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOneByName(name, options);
 	}
 
-	findOneByName(name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		return this.col.findOne({ name }, options);
 	}
 
@@ -591,8 +567,8 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		);
 	}
 
-	findE2ERoomById(roomId: IRoom['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
-		return this.findOne(
+	findE2ERoomById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				_id: roomId,
 				encrypted: true,
@@ -613,12 +589,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.countDocuments({ t });
 	}
 
-	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms(
-		searchTerm: RegExp | null,
-		teamIds: Array<ITeam['_id']>,
-		roomIds: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findPaginatedByNameOrFNameAndRoomIdsIncludingTeamRooms<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, teamIds: Array<ITeam['_id']>, roomIds: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			$and: [
 				{ teamMain: { $exists: false } },
@@ -661,14 +632,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedContainingNameOrFNameInIdsAsTeamMain(
-		searchTerm: RegExp | null,
-		rids: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findPaginatedContainingNameOrFNameInIdsAsTeamMain<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: RegExp | null, rids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			teamMain: true,
 			$and: [
@@ -701,14 +668,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			});
 		}
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedByTypeAndIds(
-		type: IRoom['t'],
-		ids: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): FindPaginated<FindCursor<IRoom>> {
+	findPaginatedByTypeAndIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const query: Filter<IRoom> = {
 			t: type,
 			_id: {
@@ -716,16 +679,16 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			},
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findOneDirectRoomContainingAllUserIDs(uid: IDirectMessageRoom['uids'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneDirectRoomContainingAllUserIDs<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IDirectMessageRoom['uids'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: 'd',
 			uids: { $size: uid.length, $all: uid },
 		};
 
-		return this.findOne<IRoom>(query, {
+		return this.findOne<T, O>(query, {
 			...options,
 			sort: {
 				federated: 1,
@@ -734,22 +697,22 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		});
 	}
 
-	findFederatedByIds<T extends Document = IRoomNativeFederated>(ids: Array<IRoom['_id']>, options: FindOptions<T> = {}): FindCursor<T> {
+	findFederatedByIds<T extends Document = IRoomNativeFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: ids },
 			federated: true,
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneFederatedByMrid(mrid: string, options: FindOptions<IRoomFederated> = {}): Promise<IRoomFederated | null> {
+	findOneFederatedByMrid<T extends Document = IRoomFederated, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(mrid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			'federated': true,
 			'federation.mrid': mrid,
 		};
 
-		return this.findOne<IRoomFederated>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	async findBiggestFederatedRoomInNumberOfUsers(options?: FindOptions<IRoom>): Promise<IRoom | undefined> {
@@ -819,7 +782,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.incMsgCountById(_id, -count);
 	}
 
-	findOneByIdOrName(_idOrName: IRoom['_id'] | IRoom['name'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByIdOrName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_idOrName: IRoom['_id'] | IRoom['name'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			$or: [
 				{
@@ -831,11 +794,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndType<T extends Document = IRoom>(roomId: IRoom['_id'], type: IRoom['t'], options: FindOptions<T> = {}): Promise<T | null> {
-		return this.findOne<T>({ _id: roomId, t: type }, options);
+	findOneByIdAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], type: IRoom['t'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id: roomId, t: type }, options);
 	}
 
 	setReactionsInLastMessage(roomId: IRoom['_id'], reactions: IMessage['reactions']): Promise<UpdateResult> {
@@ -965,8 +928,8 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.updateMany(query, update);
 	}
 
-	getDirectConversationsByUserId(_id: IRoom['_id'], options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
-		return this.find({ t: 'd', uids: { $size: 2, $in: [_id] } }, options);
+	getDirectConversationsByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IRoom['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ t: 'd', uids: { $size: 2, $in: [_id] } }, options);
 	}
 
 	// 2
@@ -1043,10 +1006,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOneAndUpdate(query, update, { returnDocument: 'after', ...options });
 	}
 
-	findOneByImportId(_id: IRoom['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByImportId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = { importIds: _id };
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	findOneByNameAndNotId(name: NonNullable<IRoom['name']>, rid: IRoom['_id']): Promise<IRoom | null> {
@@ -1058,18 +1021,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.findOne(query);
 	}
 
-	findOneByDisplayName(fname: IRoom['fname'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
+	findOneByDisplayName<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(fname: IRoom['fname'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = { fname };
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByNameAndType(
-		name: NonNullable<IRoom['name']>,
-		type: IRoom['t'],
-		options: FindOptions<IRoom> = {},
-		includeFederatedRooms = false,
-	): Promise<IRoom | null> {
+	findOneByNameAndType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: NonNullable<IRoom['name']>, type: IRoom['t'], options?: O, includeFederatedRooms = false): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: type,
 			teamId: {
@@ -1080,25 +1038,25 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 				: { $or: [{ federated: { $exists: false } }, { federated: false }], name }),
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	// FIND
-	findById(roomId: IRoom['_id'], options: FindOptions<IRoom> = {}): Promise<IRoom | null> {
-		return this.findOne({ _id: roomId }, options);
+	findById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: IRoom['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id: roomId }, options);
 	}
 
-	findByIds(roomIds: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
-		return this.find({ _id: { $in: roomIds } }, options);
+	findByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ _id: { $in: roomIds } }, options);
 	}
 
-	findByType(type: IRoom['t'], options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = { t: type };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByTypeInIds(type: IRoom['t'], ids: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByTypeInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: {
 				$in: ids,
@@ -1106,29 +1064,29 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			t: type,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findPrivateRoomsByIdsWithAbacAttributes(ids: Array<IRoom['_id']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findPrivateRoomsByIdsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<IRoom['_id']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			_id: { $in: ids },
 			t: 'p',
 			abacAttributes: { $exists: true, $ne: [] },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findAllPrivateRoomsWithAbacAttributes(options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findAllPrivateRoomsWithAbacAttributes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: 'p',
 			abacAttributes: { $exists: true, $ne: [] },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	async findBySubscriptionUserId(userId: IUser['_id'], options: FindOptions<IRoom> = {}): Promise<FindCursor<IRoom>> {
+	async findBySubscriptionUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const data = (await Subscriptions.findByUserId(userId, { projection: { rid: 1 } }).toArray()).map((item) => item.rid);
 
 		const query: Filter<IRoom> = {
@@ -1152,14 +1110,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	async findBySubscriptionUserIdUpdatedAfter(
-		userId: IUser['_id'],
-		_updatedAt: IRoom['_updatedAt'],
-		options: FindOptions<IRoom> = {},
-	): Promise<FindCursor<IRoom>> {
+	async findBySubscriptionUserIdUpdatedAfter<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], _updatedAt: IRoom['_updatedAt'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const ids = (await Subscriptions.findByUserId(userId, { projection: { rid: 1 } }).toArray()).map((item) => item.rid);
 
 		const query: Filter<IRoom> = {
@@ -1186,15 +1140,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByNameAndTypeNotDefault(
-		name: IRoom['name'] | RegExp,
-		type: IRoom['t'],
-		options: FindOptions<IRoom> = {},
-		includeFederatedRooms = false,
-	): FindCursor<IRoom> {
+	findByNameAndTypeNotDefault<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, type: IRoom['t'], options?: O, includeFederatedRooms = false): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: type,
 			default: {
@@ -1222,17 +1171,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		};
 
 		// do not use cache
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	// 3
-	findByNameOrFNameAndTypesNotInIds(
-		name: IRoom['name'] | RegExp,
-		types: Array<IRoom['t']>,
-		ids: Array<IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-		includeFederatedRooms = false,
-	): FindCursor<IRoom> {
+	findByNameOrFNameAndTypesNotInIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(name: IRoom['name'] | RegExp, types: Array<IRoom['t']>, ids: Array<IRoom['_id']>, options?: O, includeFederatedRooms = false): FindCursor<DocumentWithProjection<T, O>> {
 		const nameCondition: Filter<IRoom> = {
 			$or: [{ name }, { fname: name }],
 		};
@@ -1279,10 +1222,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		};
 
 		// do not use cache
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByDefaultAndTypes(defaultValue: boolean, types: Array<IRoom['t']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByDefaultAndTypes<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(defaultValue: boolean, types: Array<IRoom['t']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IRoom> = {
 			t: {
 				$in: types,
@@ -1290,36 +1233,29 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			...(defaultValue ? { default: true } : { default: { $ne: true } }),
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findDirectRoomContainingAllUsernames(
-		usernames: NonNullable<IRoom['usernames']>,
-		options: FindOptions<IRoom> = {},
-	): Promise<IRoom | null> {
+	findDirectRoomContainingAllUsernames<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: NonNullable<IRoom['usernames']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: 'd',
 			usernames: { $size: usernames.length, $all: usernames },
 			usersCount: usernames.length,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByTypeAndNameOrId(
-		type: IRoom['t'],
-		identifier: NonNullable<IRoom['name'] | IRoom['_id']>,
-		options: FindOptions<IRoom> = {},
-	): Promise<IRoom | null> {
+	findByTypeAndNameOrId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], identifier: NonNullable<IRoom['name'] | IRoom['_id']>, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query: Filter<IRoom> = {
 			t: type,
 			$or: [{ name: identifier }, { _id: identifier }],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByTypeAndNameContaining(type: IRoom['t'], name: NonNullable<IRoom['name']>, options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
+	findByTypeAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const query: Filter<IRoom> = {
@@ -1327,15 +1263,10 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			t: type,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByTypeInIdsAndNameContaining(
-		type: IRoom['t'],
-		ids: Array<IRoom['_id']>,
-		name: NonNullable<IRoom['name']>,
-		options: FindOptions<IRoom> = {},
-	): FindCursor<IRoom> {
+	findByTypeInIdsAndNameContaining<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: IRoom['t'], ids: Array<IRoom['_id']>, name: NonNullable<IRoom['name']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const nameRegex = new RegExp(escapeRegExp(name).trim(), 'i');
 
 		const query: Filter<IRoom> = {
@@ -1346,11 +1277,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			t: type,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findGroupDMsByUids(uids: NonNullable<IRoom['uids']>, options: FindOptions<IDirectMessageRoom> = {}): FindCursor<IDirectMessageRoom> {
-		return this.find(
+	findGroupDMsByUids<T extends Document = IDirectMessageRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uids: NonNullable<IRoom['uids']>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				usersCount: { $gt: 2 },
 				uids: { $in: uids },
@@ -1366,8 +1297,8 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		});
 	}
 
-	find1On1ByUserId(userId: IRoom['_id'], options: FindOptions<IRoom> = {}): FindCursor<IRoom> {
-		return this.find(
+	find1On1ByUserId<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IRoom['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				uids: userId,
 				usersCount: 2,
@@ -2101,14 +2032,11 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		]);
 	}
 
-	findAllByTypesAndDiscussionAndTeam(
-		filters: {
+	findAllByTypesAndDiscussionAndTeam<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filters: {
 			types?: Array<IRoom['t']>;
 			discussions?: boolean;
 			teams?: boolean;
-		} = {},
-		options: FindOptions<IRoom> = {},
-	): FindCursor<IRoom> {
+		} = {}, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const { types, discussions, teams } = filters;
 
 		const query: Filter<IRoom> = {};
@@ -2125,7 +2053,7 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 			query.teamMain = { $exists: teams };
 		}
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	resetRoomKeyAndSetE2EEQueueByRoomId(

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1908,7 +1908,8 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 	}
 
 	insertAbacAttributeIfNotExistsById(_id: IRoom['_id'], key: string, values: string[]): Promise<IRoom | null> {
-		return this.findOneAndUpdate(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findOneAndUpdate<IRoom>(
 			{ _id, 'abacAttributes.key': { $ne: key } },
 			{ $push: { abacAttributes: { key, values } } },
 			{ returnDocument: 'after', projection: { abacAttributes: 1 } },

--- a/packages/models/src/models/ServerEvents.ts
+++ b/packages/models/src/models/ServerEvents.ts
@@ -89,7 +89,7 @@ export class ServerEventsRaw extends BaseRaw<IServerEvent> implements IServerEve
 			t: key,
 			ts: new Date(),
 			actor,
-			data: Object.entries(data).map(([key, value]) => ({ key, value })) as E['data'],
+			data: Object.entries(data).map(([key, value]) => ({ key, value })),
 			// deprecated just to keep backward compatibility
 			ip: '0.0.0.0',
 			...(actor.type === 'user' && { ip: actor?.ip || '0.0.0.0', u: { _id: actor._id, username: actor.username } }),

--- a/packages/models/src/models/Sessions.ts
+++ b/packages/models/src/models/Sessions.ts
@@ -13,7 +13,19 @@ import type {
 } from '@rocket.chat/core-typings';
 import type { ISessionsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type { PaginatedResult, WithItemCount } from '@rocket.chat/rest-typings';
-import type { AggregationCursor, AnyBulkWriteOperation, BulkWriteResult, Collection, Document, FindCursor, Db, Filter, IndexDescription, UpdateResult, OptionalId } from 'mongodb';
+import type {
+	AggregationCursor,
+	AnyBulkWriteOperation,
+	BulkWriteResult,
+	Collection,
+	Document,
+	FindCursor,
+	Db,
+	Filter,
+	IndexDescription,
+	UpdateResult,
+	OptionalId,
+} from 'mongodb';
 
 import { getCollectionName } from '../index';
 import { BaseRaw } from './BaseRaw';
@@ -1559,7 +1571,10 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 		);
 	}
 
-	async getLoggedInByUserIdAndSessionId<T extends Document = ISession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, sessionId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async getLoggedInByUserIdAndSessionId<
+		T extends Document = ISession,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(userId: string, sessionId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ userId, sessionId, logoutAt: { $exists: false } }, options);
 	}
 }

--- a/packages/models/src/models/Sessions.ts
+++ b/packages/models/src/models/Sessions.ts
@@ -11,22 +11,9 @@ import type {
 	IUser,
 	RocketChatRecordDeleted,
 } from '@rocket.chat/core-typings';
-import type { ISessionsModel } from '@rocket.chat/model-typings';
+import type { ISessionsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type { PaginatedResult, WithItemCount } from '@rocket.chat/rest-typings';
-import type {
-	AggregationCursor,
-	AnyBulkWriteOperation,
-	BulkWriteResult,
-	Collection,
-	Document,
-	FindCursor,
-	Db,
-	Filter,
-	IndexDescription,
-	UpdateResult,
-	OptionalId,
-	FindOptions,
-} from 'mongodb';
+import type { AggregationCursor, AnyBulkWriteOperation, BulkWriteResult, Collection, Document, FindCursor, Db, Filter, IndexDescription, UpdateResult, OptionalId } from 'mongodb';
 
 import { getCollectionName } from '../index';
 import { BaseRaw } from './BaseRaw';
@@ -1572,11 +1559,7 @@ export class SessionsRaw extends BaseRaw<ISession> implements ISessionsModel {
 		);
 	}
 
-	async getLoggedInByUserIdAndSessionId<T extends Document = ISession>(
-		userId: string,
-		sessionId: string,
-		options?: FindOptions<T>,
-	): Promise<T | null> {
-		return this.findOne({ userId, sessionId, logoutAt: { $exists: false } }, options);
+	async getLoggedInByUserIdAndSessionId<T extends Document = ISession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, sessionId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ userId, sessionId, logoutAt: { $exists: false } }, options);
 	}
 }

--- a/packages/models/src/models/Settings.ts
+++ b/packages/models/src/models/Settings.ts
@@ -1,8 +1,23 @@
 import type { ISetting, ISettingColor, ISettingSelectOption, RocketChatRecordDeleted, SettingValue } from '@rocket.chat/core-typings';
 import type { ISettingsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, Filter, UpdateFilter, UpdateResult, Document, FindOneAndUpdateOptions, WithId, UpdateOptions } from 'mongodb';
+import type {
+	Collection,
+	FindCursor,
+	Db,
+	Filter,
+	UpdateFilter,
+	UpdateResult,
+	Document,
+	FindOneAndUpdateOptions,
+	WithId,
+	UpdateOptions,
+} from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
+
+type PublicSettingFields<T extends ISetting> = T extends ISettingColor
+	? Pick<T, '_id' | 'value' | 'editor' | 'enterprise' | 'invalidValue' | 'modules' | 'requiredOnWizard'>
+	: Pick<T, '_id' | 'value' | 'enterprise' | 'invalidValue' | 'modules' | 'requiredOnWizard'>;
 
 export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 	constructor(db: Db, trash?: Collection<RocketChatRecordDeleted<ISetting>>) {
@@ -36,7 +51,10 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 		return this.findOne(query);
 	}
 
-	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string[] | string = [], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string[] | string = [],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		if (typeof _id === 'string') {
 			_id = [_id];
 		}
@@ -162,13 +180,7 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 		return this.updateOne(query, update);
 	}
 
-	findNotHiddenPublic<T extends ISetting = ISetting>(
-		ids: ISetting['_id'][] = [],
-	): FindCursor<
-		T extends ISettingColor
-			? Pick<T, '_id' | 'value' | 'editor' | 'enterprise' | 'invalidValue' | 'modules' | 'requiredOnWizard'>
-			: Pick<T, '_id' | 'value' | 'enterprise' | 'invalidValue' | 'modules' | 'requiredOnWizard'>
-	> {
+	findNotHiddenPublic<T extends ISetting = ISetting>(ids: ISetting['_id'][] = []): FindCursor<PublicSettingFields<T>> {
 		const filter: Filter<ISetting> = {
 			hidden: { $ne: true },
 			public: true,
@@ -178,6 +190,8 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 			filter._id = { $in: ids };
 		}
 
+		// the projection below matches PublicSettingFields, but TypeScript cannot check that against
+		// a conditional type whose input is still a type parameter
 		return this.find(filter, {
 			projection: {
 				_id: 1,
@@ -188,7 +202,7 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 				modules: 1,
 				requiredOnWizard: 1,
 			},
-		});
+		}) as unknown as FindCursor<PublicSettingFields<T>>;
 	}
 
 	findSetupWizardSettings(): FindCursor<ISetting> {

--- a/packages/models/src/models/Settings.ts
+++ b/packages/models/src/models/Settings.ts
@@ -1,18 +1,6 @@
 import type { ISetting, ISettingColor, ISettingSelectOption, RocketChatRecordDeleted, SettingValue } from '@rocket.chat/core-typings';
-import type { ISettingsModel } from '@rocket.chat/model-typings';
-import type {
-	Collection,
-	FindCursor,
-	Db,
-	Filter,
-	UpdateFilter,
-	UpdateResult,
-	Document,
-	FindOptions,
-	FindOneAndUpdateOptions,
-	WithId,
-	UpdateOptions,
-} from 'mongodb';
+import type { ISettingsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, Filter, UpdateFilter, UpdateResult, Document, FindOneAndUpdateOptions, WithId, UpdateOptions } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -48,7 +36,7 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 		return this.findOne(query);
 	}
 
-	findByIds(_id: string[] | string = [], options?: FindOptions<ISetting>): FindCursor<ISetting> {
+	findByIds<T extends Document = ISetting, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string[] | string = [], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		if (typeof _id === 'string') {
 			_id = [_id];
 		}
@@ -59,7 +47,7 @@ export class SettingsRaw extends BaseRaw<ISetting> implements ISettingsModel {
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	updateValueById(

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -77,7 +77,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return result?.total || 0;
 	}
 
-	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, uid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		uid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			rid,
 			'u._id': uid,
@@ -86,7 +90,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roomIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		roomIds: Array<string>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'rid': {
@@ -97,7 +105,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid: roomId,
 		};
@@ -105,7 +116,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'archived': { $ne: true },
@@ -115,7 +129,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'u._id': {
@@ -218,18 +236,23 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	async findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roles: IRole['_id'][], rid: IRoom['_id'] | undefined, options?: O): Promise<FindCursor<DocumentWithProjection<P, O>>> {
+	async findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		roles: IRole['_id'][],
+		rid: IRoom['_id'] | undefined,
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<P, O>>> {
 		const query = {
 			roles: { $in: roles },
 			...(rid && { rid }),
 		};
 
-		const subscriptions = await this.find<P, O>(query, { projection: { 'u._id': 1 } }).toArray();
+		// this projection is internal to the lookup below, so it must not be typed against the caller's `O`
+		const subscriptions = await this.find(query, { projection: { 'u._id': 1 } }).toArray();
 
 		const users = compact(subscriptions.map((subscription) => subscription.u?._id).filter(Boolean));
 
 		// TODO remove dependency to other models - this logic should be inside a function/service
-		return Users.find<P>({ _id: { $in: users } }, options || {});
+		return Users.find<P, O>({ _id: { $in: users } }, options);
 	}
 
 	async countUsersInRoles(roles: IRole['_id'][], rid: IRoom['_id'] | undefined): Promise<number> {
@@ -280,17 +303,24 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return !!found;
 	}
 
-	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ roles, rid }: { roles: string; rid?: string }, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		{ roles, rid }: { roles: string; rid?: string },
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				roles,
 				...(rid && { rid }),
 			},
-			options || {},
+			options,
 		);
 	}
 
-	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		types: ISubscription['t'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			't': {
@@ -298,19 +328,26 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find<T, O>(query, options || {});
+		return this.find<T, O>(query, options);
 	}
 
-	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		visitorIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'open': true,
 			'v._id': { $in: visitorIds },
 		};
 
-		return this.find<T, O>(query, options || {});
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdAndNotAlertOrOpenExcludingUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
+	findByRoomIdAndNotAlertOrOpenExcludingUserIds<
+		T extends Document = ISubscription,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		{
 			roomId,
 			uidsExclude,
 			uidsInclude,
@@ -320,7 +357,9 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			uidsExclude?: ISubscription['u']['_id'][];
 			uidsInclude?: ISubscription['u']['_id'][];
 			onlyRead: boolean;
-		}, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		},
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid: roomId,
 			...(uidsExclude?.length && {
@@ -331,7 +370,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			}),
 		};
 
-		return this.find<T, O>(query, options || {});
+		return this.find<T, O>(query, options);
 	}
 
 	async removeByRoomId(
@@ -650,7 +689,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany({ 'u._id': userId, 'autoTranslate': true }, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
 	}
 
-	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], autoTranslate: ISubscription['autoTranslate'] = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		autoTranslate: ISubscription['autoTranslate'] = true,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			autoTranslate,
@@ -690,7 +733,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.col.distinct('autoTranslateLanguage', query);
 	}
 
-	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid,
 			E2EKey: {
@@ -913,7 +959,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		);
 	}
 
-	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'E2EKey': {
@@ -924,7 +973,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		username: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'rid': roomId,
 			'u.username': username,
@@ -934,13 +987,20 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	}
 
 	// FIND
-	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = { 'u._id': userId, 'status': { $ne: 'BANNED' as const } };
 
 		return this.find<T, O>(query, options);
 	}
 
-	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, typeException: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		typeException: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			'u._id': userId,
 			't': { $ne: typeException },
@@ -949,7 +1009,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		type: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			'u._id': userId,
 			't': type,
@@ -963,7 +1027,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	 * @param {IRole['_id'][]} roles
 	 * @param {any} options
 	 */
-	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		roles: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'roles': { $in: roles },
@@ -975,21 +1043,19 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	/**
 	 * @param {string} roomId
 	 * @param {IRole['_id'][]} roles the list of roles
-	 * @param {any} options
 	 */
-	findByRoomIdAndRoles: ISubscriptionsModel['findByRoomIdAndRoles'] = (
+	findByRoomIdAndRoles<P extends Document = ISubscription, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
 		roomId: string,
 		roles: string[],
-		options?: FindOptions<ISubscription>,
-	) => {
-		const rolesArray = ([] as string[]).concat(roles);
+		options?: O,
+	): FindCursor<DocumentWithProjection<P, O>> {
 		const query = {
 			rid: roomId,
-			roles: { $in: rolesArray },
+			roles: { $in: ([] as string[]).concat(roles) },
 		};
 
-		return this.find(query, options);
-	};
+		return this.find<P, O>(query, options);
+	}
 
 	countByRoomIdAndRoles(roomId: string, roles: string[]): Promise<number> {
 		roles = ([] as string[]).concat(roles);
@@ -1022,7 +1088,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.countDocuments(query);
 	}
 
-	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		types: ISubscription['t'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			t: {
 				$in: types,
@@ -1032,7 +1101,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: ISubscription['t'], userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		type: ISubscription['t'],
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			't': type,
 			'u._id': userId,
@@ -1041,7 +1114,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'userHighlights.0': { $exists: true },
@@ -1057,7 +1133,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return subscription?.ls;
 	}
 
-	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: ISubscription['rid'], userIds: ISubscription['u']['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: ISubscription['rid'],
+		userIds: ISubscription['u']['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'u._id': {
@@ -1068,13 +1148,19 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { rid, 'u._id': { $exists: true } };
 
 		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { rid, 'u.username': { $exists: true } };
 
 		return this.find<T, O>(query, options);
@@ -1087,7 +1173,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	}
 
 	getMinimumLastSeenByRoomId(rid: string): Promise<ISubscription | null> {
-		return this.findOne(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findOne<ISubscription>(
 			{
 				rid,
 				archived: { $ne: true },
@@ -1118,11 +1205,17 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ rid: roomId, archived: true }, options);
 	}
 
-	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ 'u._id': userId, 'archived': true }, options);
 	}
 
@@ -1184,7 +1277,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		type: ISubscription['t'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			't': type,
@@ -1193,7 +1290,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.find<T, O>(query, options);
 	}
 
-	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: Partial<Pick<ISubscription, 'name' | 't'>>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		filter: Partial<Pick<ISubscription, 'name' | 't'>>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		if (!filter.name && !filter.t) {
 			throw new Error('invalid filter');
 		}
@@ -1599,7 +1699,12 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, notificationOriginField: keyof ISubscription, notificationOriginValue: 'user' | 'subscription', options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		notificationOriginField: keyof ISubscription,
+		notificationOriginValue: 'user' | 'subscription',
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const value = notificationOriginValue === 'user' ? 'user' : { $ne: 'subscription' };
 
 		const query: Filter<ISubscription> = {
@@ -1809,7 +1914,11 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: ISubscription['rid'], tunread: ISubscription['tunread'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: ISubscription['rid'],
+		tunread: ISubscription['tunread'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid,
 			tunread: { $in: tunread },
@@ -1929,7 +2038,10 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: ISubscription['u']['_id'],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				'u._id': userId,

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -1172,9 +1172,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.countDocuments(query);
 	}
 
-	getMinimumLastSeenByRoomId(rid: string): Promise<ISubscription | null> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.findOne<ISubscription>(
+	getMinimumLastSeenByRoomId(rid: string): Promise<Pick<ISubscription, '_id' | 'ls'> | null> {
+		return this.findOne(
 			{
 				rid,
 				archived: { $ne: true },

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -1,5 +1,5 @@
 import type { AtLeast, IRole, IRoom, ISubscription, IUser, RocketChatRecordDeleted, SpotlightUser } from '@rocket.chat/core-typings';
-import type { ISubscriptionsModel } from '@rocket.chat/model-typings';
+import type { ISubscriptionsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import { compact } from 'lodash';
 import type {
@@ -77,16 +77,16 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return result?.total || 0;
 	}
 
-	findOneByRoomIdAndUserId(rid: string, uid: string, options: FindOptions<ISubscription> = {}): Promise<ISubscription | null> {
+	findOneByRoomIdAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, uid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			rid,
 			'u._id': uid,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByUserIdAndRoomIds(userId: string, roomIds: Array<string>, options: FindOptions<ISubscription> = {}): FindCursor<ISubscription> {
+	findByUserIdAndRoomIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roomIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'rid': {
@@ -94,28 +94,28 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomId(roomId: string, options: FindOptions<ISubscription> = {}): FindCursor<ISubscription> {
+	findByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid: roomId,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findUnarchivedByRoomId(roomId: string, options: FindOptions<ISubscription> = {}): FindCursor<ISubscription> {
+	findUnarchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'archived': { $ne: true },
 			'u._id': { $exists: true },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdAndNotUserId(roomId: string, userId: string, options: FindOptions<ISubscription> = {}): FindCursor<ISubscription> {
+	findByRoomIdAndNotUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'u._id': {
@@ -123,7 +123,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countByRoomIdAndUserId(rid: string, uid: string | undefined, includeInvitations = false): Promise<number> {
@@ -218,27 +218,13 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	findUsersInRoles(roles: IRole['_id'][], rid: string | undefined): Promise<FindCursor<IUser>>;
-
-	findUsersInRoles(roles: IRole['_id'][], rid: string | undefined, options: FindOptions<IUser>): Promise<FindCursor<IUser>>;
-
-	findUsersInRoles<P extends Document = IUser>(
-		roles: IRole['_id'][],
-		rid: string | undefined,
-		options: FindOptions<P extends IUser ? IUser : P>,
-	): Promise<FindCursor<P>>;
-
-	async findUsersInRoles<P extends Document = IUser>(
-		roles: IRole['_id'][],
-		rid: IRoom['_id'] | undefined,
-		options?: FindOptions<P extends IUser ? IUser : P>,
-	): Promise<FindCursor<P>> {
+	async findUsersInRoles<P extends Document = IUser, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roles: IRole['_id'][], rid: IRoom['_id'] | undefined, options?: O): Promise<FindCursor<DocumentWithProjection<P, O>>> {
 		const query = {
 			roles: { $in: roles },
 			...(rid && { rid }),
 		};
 
-		const subscriptions = await this.find(query, { projection: { 'u._id': 1 } }).toArray();
+		const subscriptions = await this.find<P, O>(query, { projection: { 'u._id': 1 } }).toArray();
 
 		const users = compact(subscriptions.map((subscription) => subscription.u?._id).filter(Boolean));
 
@@ -294,8 +280,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return !!found;
 	}
 
-	findByRolesAndRoomId({ roles, rid }: { roles: string; rid?: string }, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
-		return this.find(
+	findByRolesAndRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ roles, rid }: { roles: string; rid?: string }, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				roles,
 				...(rid && { rid }),
@@ -304,7 +290,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		);
 	}
 
-	findByUserIdAndTypes(userId: string, types: ISubscription['t'][], options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByUserIdAndTypes<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			't': {
@@ -312,20 +298,19 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options || {});
+		return this.find<T, O>(query, options || {});
 	}
 
-	findOpenByVisitorIds(visitorIds: string[], options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findOpenByVisitorIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(visitorIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'open': true,
 			'v._id': { $in: visitorIds },
 		};
 
-		return this.find(query, options || {});
+		return this.find<T, O>(query, options || {});
 	}
 
-	findByRoomIdAndNotAlertOrOpenExcludingUserIds(
-		{
+	findByRoomIdAndNotAlertOrOpenExcludingUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
 			roomId,
 			uidsExclude,
 			uidsInclude,
@@ -335,9 +320,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			uidsExclude?: ISubscription['u']['_id'][];
 			uidsInclude?: ISubscription['u']['_id'][];
 			onlyRead: boolean;
-		},
-		options?: FindOptions<ISubscription>,
-	) {
+		}, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid: roomId,
 			...(uidsExclude?.length && {
@@ -348,7 +331,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			}),
 		};
 
-		return this.find(query, options || {});
+		return this.find<T, O>(query, options || {});
 	}
 
 	async removeByRoomId(
@@ -667,17 +650,13 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany({ 'u._id': userId, 'autoTranslate': true }, { $unset: { autoTranslate: 1, autoTranslateLanguage: 1 } });
 	}
 
-	findByAutoTranslateAndUserId(
-		userId: ISubscription['u']['_id'],
-		autoTranslate: ISubscription['autoTranslate'] = true,
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByAutoTranslateAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], autoTranslate: ISubscription['autoTranslate'] = true, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			autoTranslate,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	disableAutoTranslateByRoomId(roomId: IRoom['_id']): Promise<UpdateResult | Document> {
@@ -711,7 +690,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.col.distinct('autoTranslateLanguage', query);
 	}
 
-	findByRidWithoutE2EKey(rid: string, options: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByRidWithoutE2EKey<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid,
 			E2EKey: {
@@ -719,7 +698,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	findUsersWithPublicE2EKeyByRids(
@@ -934,7 +913,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		);
 	}
 
-	findByUserIdWithoutE2E(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByUserIdWithoutE2E<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'E2EKey': {
@@ -942,45 +921,41 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneByRoomIdAndUsername(roomId: string, username: string, options: FindOptions<ISubscription>): Promise<ISubscription | null> {
+	findOneByRoomIdAndUsername<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'rid': roomId,
 			'u.username': username,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	// FIND
-	findByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = { 'u._id': userId, 'status': { $ne: 'BANNED' as const } };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByUserIdExceptType(
-		userId: string,
-		typeException: ISubscription['t'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByUserIdExceptType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, typeException: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			'u._id': userId,
 			't': { $ne: typeException },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByUserIdAndType(userId: string, type: ISubscription['t'], options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByUserIdAndType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			'u._id': userId,
 			't': type,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	/**
@@ -988,13 +963,13 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 	 * @param {IRole['_id'][]} roles
 	 * @param {any} options
 	 */
-	findByUserIdAndRoles(userId: string, roles: string[], options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByUserIdAndRoles<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, roles: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			'roles': { $in: roles },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	/**
@@ -1047,32 +1022,32 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.countDocuments(query);
 	}
 
-	findByType(types: ISubscription['t'][], options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(types: ISubscription['t'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			t: {
 				$in: types,
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByTypeAndUserId(type: ISubscription['t'], userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByTypeAndUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(type: ISubscription['t'], userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<ISubscription> = {
 			't': type,
 			'u._id': userId,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomWithUserHighlights(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByRoomWithUserHighlights<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'userHighlights.0': { $exists: true },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async getLastSeen(options: FindOptions<ISubscription> = { projection: { _id: 0, ls: 1 } }): Promise<Date | undefined> {
@@ -1082,11 +1057,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return subscription?.ls;
 	}
 
-	findByRoomIdAndUserIds(
-		roomId: ISubscription['rid'],
-		userIds: ISubscription['u']['_id'][],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByRoomIdAndUserIds<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: ISubscription['rid'], userIds: ISubscription['u']['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'rid': roomId,
 			'u._id': {
@@ -1094,19 +1065,19 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdWhenUserIdExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByRoomIdWhenUserIdExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { rid, 'u._id': { $exists: true } };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByRoomIdWhenUsernameExists(rid: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
+	findByRoomIdWhenUsernameExists<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { rid, 'u.username': { $exists: true } };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countByRoomIdWhenUsernameExists(rid: string): Promise<number> {
@@ -1147,12 +1118,12 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findArchivedByRoomId(roomId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
-		return this.find({ rid: roomId, archived: true }, options);
+	findArchivedByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ rid: roomId, archived: true }, options);
 	}
 
-	findArchivedByUserId(userId: string, options?: FindOptions<ISubscription>): FindCursor<ISubscription> {
-		return this.find({ 'u._id': userId, 'archived': true }, options);
+	findArchivedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ 'u._id': userId, 'archived': true }, options);
 	}
 
 	unarchiveByIds(ids: string[]): Promise<UpdateResult | Document> {
@@ -1213,23 +1184,16 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findByUserIdAndRoomType(
-		userId: ISubscription['u']['_id'],
-		type: ISubscription['t'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByUserIdAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], type: ISubscription['t'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'u._id': userId,
 			't': type,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByNameAndRoomType(
-		filter: Partial<Pick<ISubscription, 'name' | 't'>>,
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByNameAndRoomType<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(filter: Partial<Pick<ISubscription, 'name' | 't'>>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		if (!filter.name && !filter.t) {
 			throw new Error('invalid filter');
 		}
@@ -1237,7 +1201,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			...(filter.name && { name: filter.name }),
 			...(filter.t && { t: filter.t }),
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	setFavoriteByRoomIdAndUserId(roomId: string, userId: string, favorite?: boolean): Promise<UpdateResult> {
@@ -1635,12 +1599,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findByUserPreferences(
-		userId: string,
-		notificationOriginField: keyof ISubscription,
-		notificationOriginValue: 'user' | 'subscription',
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findByUserPreferences<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, notificationOriginField: keyof ISubscription, notificationOriginValue: 'user' | 'subscription', options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const value = notificationOriginValue === 'user' ? 'user' : { $ne: 'subscription' };
 
 		const query: Filter<ISubscription> = {
@@ -1648,7 +1607,7 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			[notificationOriginField]: value,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	updateUserHighlights(userId: string, userHighlights: any): Promise<UpdateResult | Document> {
@@ -1850,17 +1809,13 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateMany(query, update);
 	}
 
-	findUnreadThreadsByRoomId(
-		rid: ISubscription['rid'],
-		tunread: ISubscription['tunread'],
-		options?: FindOptions<ISubscription>,
-	): FindCursor<ISubscription> {
+	findUnreadThreadsByRoomId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: ISubscription['rid'], tunread: ISubscription['tunread'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			rid,
 			tunread: { $in: tunread },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	openByRoomIdAndUserId(roomId: string, userId: string): Promise<UpdateResult> {
@@ -1974,8 +1929,8 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 		return this.updateOne(query, update);
 	}
 
-	findJoinedByUserId<T extends Document = ISubscription>(userId: ISubscription['u']['_id'], options?: FindOptions<T>): FindCursor<T> {
-		return this.find(
+	findJoinedByUserId<T extends Document = ISubscription, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: ISubscription['u']['_id'], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				'u._id': userId,
 				'status': { $exists: false },

--- a/packages/models/src/models/Team.ts
+++ b/packages/models/src/models/Team.ts
@@ -1,6 +1,6 @@
 import type { ITeam, RocketChatRecordDeleted, TeamType } from '@rocket.chat/core-typings';
-import type { FindPaginated, ITeamModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, DeleteResult, Document, Filter, FindOptions, IndexDescription, UpdateResult } from 'mongodb';
+import type { FindPaginated, ITeamModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, DeleteResult, Document, Filter, IndexDescription, UpdateResult } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,108 +13,44 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		return [{ key: { name: 1 }, unique: true }];
 	}
 
-	findByNames(names: Array<string>): FindCursor<ITeam>;
-
-	findByNames(names: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByNames<P extends Document>(names: Array<string>, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
-
-	findByNames<P extends Document>(
-		names: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam> {
+	findByNames<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(names: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
 			return this.col.find({ name: { $in: names } });
 		}
 		return this.col.find({ name: { $in: names } }, options);
 	}
 
-	findByIds(ids: Array<string>, query?: Filter<ITeam>): FindCursor<ITeam>;
-
-	findByIds(ids: Array<string>, options: FindOptions<ITeam>, query?: Filter<ITeam>): FindCursor<ITeam>;
-
-	findByIds<P extends Document>(
-		ids: Array<string>,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-		query?: Filter<ITeam>,
-	): FindCursor<P>;
-
-	findByIds<P extends Document>(
-		ids: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-		query?: Filter<ITeam>,
-	): FindCursor<P> | FindCursor<ITeam> {
+	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
-			return this.find({ ...query, _id: { $in: ids } });
+			return this.find<P, O>({ ...query, _id: { $in: ids } });
 		}
 
-		return this.find({ ...query, _id: { $in: ids } }, options);
+		return this.find<P, O>({ ...query, _id: { $in: ids } }, options);
 	}
 
-	findByIdsPaginated(
-		ids: Array<string>,
-		options?: undefined | FindOptions<ITeam>,
-		query?: Filter<ITeam>,
-	): FindPaginated<FindCursor<ITeam>> {
+	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		if (options === undefined) {
-			return this.findPaginated({ ...query, _id: { $in: ids } });
+			return this.findPaginated<T, O>({ ...query, _id: { $in: ids } });
 		}
 
-		return this.findPaginated({ ...query, _id: { $in: ids } }, options);
+		return this.findPaginated<T, O>({ ...query, _id: { $in: ids } }, options);
 	}
 
-	findByIdsAndType(ids: Array<string>, type: TeamType): FindCursor<ITeam>;
-
-	findByIdsAndType(ids: Array<string>, type: TeamType, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByIdsAndType<P extends Document>(
-		ids: Array<string>,
-		type: TeamType,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P>;
-
-	findByIdsAndType<P extends Document>(
-		ids: Array<string>,
-		type: TeamType,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam> {
+	findByIdsAndType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, type: TeamType, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
 			return this.col.find({ _id: { $in: ids }, type });
 		}
 		return this.col.find({ _id: { $in: ids }, type }, options);
 	}
 
-	findByType(type: number): FindCursor<ITeam>;
-
-	findByType(type: number, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByType<P extends Document>(type: number, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
-
-	findByType<P extends Document>(
-		type: number,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<ITeam> | FindCursor<P> {
+	findByType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(type: number, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
 			return this.col.find({ type }, options);
 		}
 		return this.col.find({ type }, options);
 	}
 
-	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>): FindCursor<ITeam>;
-
-	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
-
-	findByNameAndTeamIds<P extends Document>(
-		name: string | RegExp,
-		teamIds: Array<string>,
-		options: FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P>;
-
-	findByNameAndTeamIds<P extends Document>(
-		name: string | RegExp,
-		teamIds: Array<string>,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): FindCursor<P> | FindCursor<ITeam> {
+	findByNameAndTeamIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
 			return this.col.find({
 				name,
@@ -148,32 +84,14 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		);
 	}
 
-	findOneByName(name: string | RegExp): Promise<ITeam | null>;
-
-	findOneByName(name: string | RegExp, options: FindOptions<ITeam>): Promise<ITeam | null>;
-
-	findOneByName<P extends Document>(name: string | RegExp, options: FindOptions<P>): Promise<P | null>;
-
-	findOneByName<P extends Document>(
-		name: string | RegExp,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): Promise<P | null> | Promise<ITeam | null> {
+	findOneByName<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		if (options === undefined) {
 			return this.col.findOne({ name });
 		}
 		return this.col.findOne({ name }, options);
 	}
 
-	findOneByMainRoomId(roomId: string): Promise<ITeam | null>;
-
-	findOneByMainRoomId(roomId: string, options: FindOptions<ITeam>): Promise<ITeam | null>;
-
-	findOneByMainRoomId<P extends Document>(roomId: string, options: FindOptions<P>): Promise<P | null>;
-
-	findOneByMainRoomId<P extends Document>(
-		roomId: string,
-		options?: undefined | FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
-	): Promise<P | null> | Promise<ITeam | null> {
+	findOneByMainRoomId<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roomId: string, options?: O): Promise<DocumentWithProjection<P, O> | null> {
 		return options ? this.col.findOne({ roomId }, options) : this.col.findOne({ roomId });
 	}
 

--- a/packages/models/src/models/Team.ts
+++ b/packages/models/src/models/Team.ts
@@ -1,6 +1,6 @@
 import type { ITeam, RocketChatRecordDeleted, TeamType } from '@rocket.chat/core-typings';
 import type { FindPaginated, ITeamModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, DeleteResult, Document, Filter, IndexDescription, UpdateResult } from 'mongodb';
+import type { Collection, FindCursor, Db, DeleteResult, Document, Filter, IndexDescription, UpdateResult, FindOptions } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,14 +13,27 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		return [{ key: { name: 1 }, unique: true }];
 	}
 
-	findByNames<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(names: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByNames(names: Array<string>): FindCursor<ITeam>;
+
+	findByNames(names: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByNames<P extends Document>(names: Array<string>, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
+
+	findByNames<P extends Document>(
+		names: Array<string>,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam> {
 		if (options === undefined) {
 			return this.col.find({ name: { $in: names } });
 		}
 		return this.col.find({ name: { $in: names } }, options);
 	}
 
-	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindCursor<DocumentWithProjection<P, O>> {
+	findByIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(
+		ids: Array<string>,
+		options?: O,
+		query?: Filter<ITeam>,
+	): FindCursor<DocumentWithProjection<P, O>> {
 		if (options === undefined) {
 			return this.find<P, O>({ ...query, _id: { $in: ids } });
 		}
@@ -28,7 +41,11 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		return this.find<P, O>({ ...query, _id: { $in: ids } }, options);
 	}
 
-	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: Array<string>, options?: O, query?: Filter<ITeam>): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findByIdsPaginated<T extends Document = ITeam, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: Array<string>,
+		options?: O,
+		query?: Filter<ITeam>,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		if (options === undefined) {
 			return this.findPaginated<T, O>({ ...query, _id: { $in: ids } });
 		}
@@ -36,21 +53,58 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		return this.findPaginated<T, O>({ ...query, _id: { $in: ids } }, options);
 	}
 
-	findByIdsAndType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(ids: Array<string>, type: TeamType, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByIdsAndType(ids: Array<string>, type: TeamType): FindCursor<ITeam>;
+
+	findByIdsAndType(ids: Array<string>, type: TeamType, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByIdsAndType<P extends Document>(
+		ids: Array<string>,
+		type: TeamType,
+		options: FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P>;
+
+	findByIdsAndType<P extends Document>(
+		ids: Array<string>,
+		type: TeamType,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam> {
 		if (options === undefined) {
 			return this.col.find({ _id: { $in: ids }, type });
 		}
 		return this.col.find({ _id: { $in: ids }, type }, options);
 	}
 
-	findByType<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(type: number, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByType(type: number): FindCursor<ITeam>;
+
+	findByType(type: number, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByType<P extends Document>(type: number, options: FindOptions<P extends ITeam ? ITeam : P>): FindCursor<P>;
+
+	findByType<P extends Document>(
+		type: number,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<ITeam> | FindCursor<P> {
 		if (options === undefined) {
 			return this.col.find({ type }, options);
 		}
 		return this.col.find({ type }, options);
 	}
 
-	findByNameAndTeamIds<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>): FindCursor<ITeam>;
+
+	findByNameAndTeamIds(name: string | RegExp, teamIds: Array<string>, options: FindOptions<ITeam>): FindCursor<ITeam>;
+
+	findByNameAndTeamIds<P extends Document>(
+		name: string | RegExp,
+		teamIds: Array<string>,
+		options: FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P>;
+
+	findByNameAndTeamIds<P extends Document>(
+		name: string | RegExp,
+		teamIds: Array<string>,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): FindCursor<P> | FindCursor<ITeam> {
 		if (options === undefined) {
 			return this.col.find({
 				name,
@@ -84,14 +138,32 @@ export class TeamRaw extends BaseRaw<ITeam> implements ITeamModel {
 		);
 	}
 
-	findOneByName<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(name: string | RegExp, options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	findOneByName(name: string | RegExp): Promise<ITeam | null>;
+
+	findOneByName(name: string | RegExp, options: FindOptions<ITeam>): Promise<ITeam | null>;
+
+	findOneByName<P extends Document>(name: string | RegExp, options: FindOptions<P>): Promise<P | null>;
+
+	findOneByName<P extends Document>(
+		name: string | RegExp,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): Promise<P | null> | Promise<ITeam | null> {
 		if (options === undefined) {
 			return this.col.findOne({ name });
 		}
 		return this.col.findOne({ name }, options);
 	}
 
-	findOneByMainRoomId<P extends Document = ITeam, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(roomId: string, options?: O): Promise<DocumentWithProjection<P, O> | null> {
+	findOneByMainRoomId(roomId: string): Promise<ITeam | null>;
+
+	findOneByMainRoomId(roomId: string, options: FindOptions<ITeam>): Promise<ITeam | null>;
+
+	findOneByMainRoomId<P extends Document>(roomId: string, options: FindOptions<P>): Promise<P | null>;
+
+	findOneByMainRoomId<P extends Document>(
+		roomId: string,
+		options?: FindOptions<ITeam> | FindOptions<P extends ITeam ? ITeam : P>,
+	): Promise<P | null> | Promise<ITeam | null> {
 		return options ? this.col.findOne({ roomId }, options) : this.col.findOne({ roomId });
 	}
 

--- a/packages/models/src/models/TeamMember.ts
+++ b/packages/models/src/models/TeamMember.ts
@@ -109,9 +109,8 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		limit: number,
 		skip: number,
 		query?: Filter<ITeamMember>,
-	): FindPaginated<FindCursor<ITeamMember>> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
-		return this.findPaginated<ITeamMember>(
+	): FindPaginated<FindCursor<Pick<ITeamMember, '_id' | 'userId' | 'roles' | 'createdBy' | 'createdAt'>>> {
+		return this.findPaginated(
 			{ ...query, teamId },
 			{
 				limit,

--- a/packages/models/src/models/TeamMember.ts
+++ b/packages/models/src/models/TeamMember.ts
@@ -1,5 +1,5 @@
 import type { IRole, ITeamMember, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { FindPaginated, ITeamMemberModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { FindPaginated, ITeamMemberModel } from '@rocket.chat/model-typings';
 import type {
 	Collection,
 	FindCursor,
@@ -32,7 +32,16 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		];
 	}
 
-	findByUserId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByUserId(userId: string): FindCursor<ITeamMember>;
+
+	findByUserId(userId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByUserId<P extends Document>(userId: string, options: FindOptions<P>): FindCursor<P>;
+
+	findByUserId<P extends Document>(
+		userId: string,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember> {
 		return options ? this.col.find({ userId }, options) : this.col.find({ userId }, options);
 	}
 
@@ -45,12 +54,21 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 	findOneByUserIdAndTeamId<P extends Document>(
 		userId: string,
 		teamId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
 	): Promise<P | null | ITeamMember> {
 		return options ? this.col.findOne({ userId, teamId }, options) : this.col.findOne({ userId, teamId }, options);
 	}
 
-	findByTeamId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamId: string, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByTeamId(teamId: string): FindCursor<ITeamMember>;
+
+	findByTeamId(teamId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByTeamId<P extends Document>(teamId: string, options: FindOptions<P>): FindCursor<P>;
+
+	findByTeamId<P extends Document>(
+		teamId: string,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember> {
 		return options ? this.col.find({ teamId }, options) : this.col.find({ teamId }, options);
 	}
 
@@ -58,7 +76,16 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		return this.countDocuments({ teamId });
 	}
 
-	findByTeamIds<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
+	findByTeamIds(teamIds: Array<string>): FindCursor<ITeamMember>;
+
+	findByTeamIds(teamIds: Array<string>, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
+
+	findByTeamIds<P extends Document>(teamIds: Array<string>, options: FindOptions<P>): FindCursor<P>;
+
+	findByTeamIds<P extends Document>(
+		teamIds: Array<string>,
+		options?: FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
+	): FindCursor<P> | FindCursor<ITeamMember> {
 		return options ? this.col.find({ teamId: { $in: teamIds } }, options) : this.col.find({ teamId: { $in: teamIds } }, options);
 	}
 
@@ -66,7 +93,7 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		return this.countDocuments({ teamId, roles: role });
 	}
 
-	findByUserIdAndTeamIds<T extends Document = ITeamMember, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUserIdAndTeamIds(userId: string, teamIds: Array<string>, options: FindOptions<ITeamMember> = {}): FindCursor<ITeamMember> {
 		const query = {
 			userId,
 			teamId: {
@@ -83,7 +110,8 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		skip: number,
 		query?: Filter<ITeamMember>,
 	): FindPaginated<FindCursor<ITeamMember>> {
-		return this.findPaginated(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findPaginated<ITeamMember>(
 			{ ...query, teamId },
 			{
 				limit,

--- a/packages/models/src/models/TeamMember.ts
+++ b/packages/models/src/models/TeamMember.ts
@@ -1,5 +1,5 @@
 import type { IRole, ITeamMember, IUser, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { FindPaginated, ITeamMemberModel } from '@rocket.chat/model-typings';
+import type { FindPaginated, ITeamMemberModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
 import type {
 	Collection,
 	FindCursor,
@@ -32,16 +32,7 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		];
 	}
 
-	findByUserId(userId: string): FindCursor<ITeamMember>;
-
-	findByUserId(userId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByUserId<P extends Document>(userId: string, options: FindOptions<P>): FindCursor<P>;
-
-	findByUserId<P extends Document>(
-		userId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember> {
+	findByUserId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(userId: string, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		return options ? this.col.find({ userId }, options) : this.col.find({ userId }, options);
 	}
 
@@ -59,16 +50,7 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		return options ? this.col.findOne({ userId, teamId }, options) : this.col.findOne({ userId, teamId }, options);
 	}
 
-	findByTeamId(teamId: string): FindCursor<ITeamMember>;
-
-	findByTeamId(teamId: string, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByTeamId<P extends Document>(teamId: string, options: FindOptions<P>): FindCursor<P>;
-
-	findByTeamId<P extends Document>(
-		teamId: string,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember> {
+	findByTeamId<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamId: string, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		return options ? this.col.find({ teamId }, options) : this.col.find({ teamId }, options);
 	}
 
@@ -76,16 +58,7 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		return this.countDocuments({ teamId });
 	}
 
-	findByTeamIds(teamIds: Array<string>): FindCursor<ITeamMember>;
-
-	findByTeamIds(teamIds: Array<string>, options: FindOptions<ITeamMember>): FindCursor<ITeamMember>;
-
-	findByTeamIds<P extends Document>(teamIds: Array<string>, options: FindOptions<P>): FindCursor<P>;
-
-	findByTeamIds<P extends Document>(
-		teamIds: Array<string>,
-		options?: undefined | FindOptions<ITeamMember> | FindOptions<P extends ITeamMember ? ITeamMember : P>,
-	): FindCursor<P> | FindCursor<ITeamMember> {
+	findByTeamIds<P extends Document = ITeamMember, O extends FindOptionsWithProjection<P> = FindOptionsWithProjection<P>>(teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<P, O>> {
 		return options ? this.col.find({ teamId: { $in: teamIds } }, options) : this.col.find({ teamId: { $in: teamIds } }, options);
 	}
 
@@ -93,7 +66,7 @@ export class TeamMemberRaw extends BaseRaw<ITeamMember> implements ITeamMemberMo
 		return this.countDocuments({ teamId, roles: role });
 	}
 
-	findByUserIdAndTeamIds(userId: string, teamIds: Array<string>, options: FindOptions<ITeamMember> = {}): FindCursor<ITeamMember> {
+	findByUserIdAndTeamIds<T extends Document = ITeamMember, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, teamIds: Array<string>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			userId,
 			teamId: {

--- a/packages/models/src/models/TwoFactorChallenges.ts
+++ b/packages/models/src/models/TwoFactorChallenges.ts
@@ -15,7 +15,10 @@ export class TwoFactorChallengesRaw extends BaseRaw<ITwoFactorChallenge> impleme
 		return [{ key: { expireAt: 1 }, expireAfterSeconds: 0 }];
 	}
 
-	findOneByPendingChallengeId<T extends Document = ITwoFactorChallenge, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(pendingChallengeId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByPendingChallengeId<
+		T extends Document = ITwoFactorChallenge,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(pendingChallengeId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ _id: pendingChallengeId }, options);
 	}
 

--- a/packages/models/src/models/TwoFactorChallenges.ts
+++ b/packages/models/src/models/TwoFactorChallenges.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from 'crypto';
 
 import type { ITwoFactorChallenge } from '@rocket.chat/core-typings';
-import type { ITwoFactorChallengesModel } from '@rocket.chat/model-typings';
-import type { Db, FindOptions, IndexDescription } from 'mongodb';
+import type { ITwoFactorChallengesModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Db, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -15,8 +15,8 @@ export class TwoFactorChallengesRaw extends BaseRaw<ITwoFactorChallenge> impleme
 		return [{ key: { expireAt: 1 }, expireAfterSeconds: 0 }];
 	}
 
-	findOneByPendingChallengeId(pendingChallengeId: string, options?: FindOptions<ITwoFactorChallenge>) {
-		return this.findOne({ _id: pendingChallengeId }, options);
+	findOneByPendingChallengeId<T extends Document = ITwoFactorChallenge, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(pendingChallengeId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id: pendingChallengeId }, options);
 	}
 
 	removeByPendingChallengeId(pendingChallengeId: string) {

--- a/packages/models/src/models/Uploads.ts
+++ b/packages/models/src/models/Uploads.ts
@@ -1,6 +1,6 @@
 import type { IUpload, RocketChatRecordDeleted, IRoom } from '@rocket.chat/core-typings';
-import type { FindPaginated, IUploadsModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, IndexDescription, WithId, Filter, FindOptions, UpdateResult } from 'mongodb';
+import type { FindPaginated, IUploadsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, IndexDescription, WithId, Filter, FindOptions, UpdateResult, Document } from 'mongodb';
 
 import { BaseUploadModelRaw } from './BaseUploadModel';
 
@@ -64,7 +64,7 @@ export class UploadsRaw extends BaseUploadModelRaw implements IUploadsModel {
 		);
 	}
 
-	findAllByOriginalFileId(originalFileId: string, options: FindOptions<IUpload> = {}): FindCursor<IUpload> {
-		return this.find({ originalFileId }, options);
+	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(originalFileId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ originalFileId }, options);
 	}
 }

--- a/packages/models/src/models/Uploads.ts
+++ b/packages/models/src/models/Uploads.ts
@@ -64,7 +64,10 @@ export class UploadsRaw extends BaseUploadModelRaw implements IUploadsModel {
 		);
 	}
 
-	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(originalFileId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findAllByOriginalFileId<T extends Document = IUpload, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		originalFileId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ originalFileId }, options);
 	}
 }

--- a/packages/models/src/models/UserDataFiles.ts
+++ b/packages/models/src/models/UserDataFiles.ts
@@ -1,6 +1,6 @@
 import type { IUserDataFile, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IUserDataFilesModel } from '@rocket.chat/model-typings';
-import type { Collection, Db, FindOptions, IndexDescription } from 'mongodb';
+import type { IUserDataFilesModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, Db, IndexDescription, Document } from 'mongodb';
 
 import { BaseUploadModelRaw } from './BaseUploadModel';
 
@@ -13,12 +13,12 @@ export class UserDataFilesRaw extends BaseUploadModelRaw implements IUserDataFil
 		return [...super.modelIndexes(), { key: { userId: 1 } }];
 	}
 
-	findLastFileByUser(userId: string, options: FindOptions<IUserDataFile> = {}): Promise<IUserDataFile | null> {
+	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			userId,
 		};
 
 		options.sort = { _updatedAt: -1 };
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 }

--- a/packages/models/src/models/UserDataFiles.ts
+++ b/packages/models/src/models/UserDataFiles.ts
@@ -21,6 +21,8 @@ export class UserDataFilesRaw extends BaseUploadModelRaw implements IUserDataFil
 			userId,
 		};
 
+		// merging into `O` is a lie only about `sort`; `DocumentWithProjection` reads `O['projection']`
+		// alone, and that comes straight from `options`, so the declared return type stays accurate
 		return this.findOne<T, O>(query, { ...options, sort: { _updatedAt: -1 } } as unknown as O);
 	}
 }

--- a/packages/models/src/models/UserDataFiles.ts
+++ b/packages/models/src/models/UserDataFiles.ts
@@ -13,12 +13,14 @@ export class UserDataFilesRaw extends BaseUploadModelRaw implements IUserDataFil
 		return [...super.modelIndexes(), { key: { userId: 1 } }];
 	}
 
-	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findLastFileByUser<T extends Document = IUserDataFile, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			userId,
 		};
 
-		options.sort = { _updatedAt: -1 };
-		return this.findOne<T, O>(query, options);
+		return this.findOne<T, O>(query, { ...options, sort: { _updatedAt: -1 } } as unknown as O);
 	}
 }

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -238,7 +238,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+	findOneAgentById<T extends Document = ILivechatAgent, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		_id: IUser['_id'],
 		options?: O,
 	): Promise<DocumentWithProjection<T, O> | null> {

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -12,7 +12,7 @@ import type {
 	RocketChatRecordDeleted,
 } from '@rocket.chat/core-typings';
 import { ILivechatAgentStatus, UserStatus } from '@rocket.chat/core-typings';
-import type { DefaultFields, InsertionModel, IUsersModel } from '@rocket.chat/model-typings';
+import type { DefaultFields, InsertionModel, IUsersModel, DocumentWithProjection, FindOptionsWithProjection, FindPaginated } from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	Collection,
@@ -104,10 +104,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		];
 	}
 
-	findUsersByIdentifiers(
-		{ usernames, ids, emails, ldapIds }: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] },
-		options: FindOptions<IUser> = {},
-	): FindCursor<IUser> {
+	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ usernames, ids, emails, ldapIds }: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] }, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const normalizedIds = (ids ?? []).filter(Boolean);
 		const normalizedUsernames = (usernames ?? []).filter(Boolean);
 		const normalizedEmails = (emails ?? []).map((e) => String(e).trim()).filter(Boolean);
@@ -133,7 +130,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			$or: or,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	setAbacAttributesById(_id: IUser['_id'], attributes: NonNullable<IUser['abacAttributes']>) {
@@ -144,8 +141,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOneAndUpdate({ _id }, { $unset: { abacAttributes: 1 } }, { returnDocument: 'after' });
 	}
 
-	findActiveByRoomIds(roomIds: IRoom['_id'][], options?: FindOptions<IUser>) {
-		return this.find({ active: true, __rooms: { $in: roomIds } }, options);
+	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: IRoom['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ active: true, __rooms: { $in: roomIds } }, options);
 	}
 
 	setCasExternalIdByUsername(username: string): Promise<IUser | null> {
@@ -205,29 +202,29 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query);
 	}
 
-	findPaginatedUsersInRoles(roles: IRole['_id'][] | IRole['_id'], options?: FindOptions<IUser>) {
+	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		roles = ([] as string[]).concat(roles);
 
 		const query = {
 			roles: { $in: roles },
 		};
 
-		return this.findPaginated(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findOneByUsername<T extends Document = IUser>(username: string, options?: FindOptions<IUser>) {
+	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { username };
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneAgentById<T extends Document = ILivechatAgent>(_id: IUser['_id'], options?: FindOptions<IUser>) {
+	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			roles: 'livechat-agent',
 		};
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	/**
@@ -235,12 +232,12 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {any} query
 	 * @param {any} options
 	 */
-	findUsersInRolesWithQuery(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: FindOptions<IUser>) {
+	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		roles = ([] as string[]).concat(roles);
 
 		Object.assign(query, { roles: { $in: roles } });
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	/**
@@ -248,16 +245,12 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {any} query
 	 * @param {any} options
 	 */
-	findPaginatedUsersInRolesWithQuery<T extends Document = IUser>(
-		roles: IRole['_id'][] | IRole['_id'],
-		query: Filter<IUser>,
-		options?: FindOptions<IUser>,
-	) {
+	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		roles = ([] as string[]).concat(roles);
 
 		Object.assign(query, { roles: { $in: roles } });
 
-		return this.findPaginated<T>(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
 	findAgentsWithDepartments<T extends Document = ILivechatAgent>(
@@ -310,7 +303,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.col.aggregate<{ sortedResults: (T & { departments: string[] })[]; totalCount: { total: number }[] }>(aggregate).toArray();
 	}
 
-	findOneByUsernameAndRoomIgnoringCase(username: string | RegExp, rid: string, options?: FindOptions<IUser>) {
+	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 		}
@@ -320,26 +313,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			username,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndLoginHashedToken(_id: IUser['_id'], token: string, options: FindOptions<IUser> = {}) {
+	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			'services.resume.loginTokens.hashedToken': token,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findByActiveUsersExcept(
-		searchTerm: string,
-		exceptions: string[],
-		options?: FindOptions<IUser>,
-		searchFields?: string[],
-		extraQuery: Filter<IUser>[] = [],
-		{ startsWith = false, endsWith = false } = {},
-	) {
+	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], options?: O, searchFields?: string[], extraQuery: Filter<IUser>[] = [], { startsWith = false, endsWith = false } = {}): FindCursor<DocumentWithProjection<T, O>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
@@ -375,17 +361,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			],
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findPaginatedByActiveUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		searchFields: string[] = [],
-		extraQuery: Filter<IUser>[] = [],
-		{ startsWith = false, endsWith = false } = {},
-	) {
+	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, searchFields: string[] = [], extraQuery: Filter<IUser>[] = [], { startsWith = false, endsWith = false } = {}): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
@@ -421,16 +400,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			],
 		};
 
-		return this.findPaginated<T>(query, options);
+		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		forcedSearchFields?: string[],
-		localDomain?: string,
-	) {
+	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const extraQuery = [
 			{
 				$or: [{ federation: { $exists: false } }, { 'federation.origin': localDomain }],
@@ -439,67 +412,61 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findPaginatedByActiveUsersExcept<T>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 
-	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser>(
-		searchTerm: string,
-		exceptions?: string[],
-		options?: FindOptions<IUser>,
-		forcedSearchFields?: string[],
-		localDomain?: string,
-	) {
+	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const extraQuery = [{ federation: { $exists: true } }, { 'federation.origin': { $ne: localDomain } }];
 		return this.findPaginatedByActiveUsersExcept<T>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 
-	findActive(query: Filter<IUser>, options: FindOptions<IUser> = {}) {
+	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		Object.assign(query, { active: true });
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findActiveByIds(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
+	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: userIds },
 			active: true,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findActiveByIdsOrUsernames(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
+	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			$or: [{ _id: { $in: userIds } }, { username: { $in: userIds } }],
 			active: true,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByIds<T extends Document = IUser>(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
+	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: userIds },
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneByImportId<T extends Document = IUser>(_id: IUser['_id'], options?: FindOptions<IUser>) {
-		return this.findOne<T>({ importIds: _id }, options);
+	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ importIds: _id }, options);
 	}
 
-	findOneByUsernameIgnoringCase<T extends Document = IUser>(username: IUser['username'], options?: FindOptions<IUser>) {
+	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (!username) {
 			throw new Error('invalid username');
 		}
 
 		const query = { username };
 
-		return this.findOne<T>(query, {
+		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
 		});
 	}
 
-	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser>(username: string, options?: FindOptions<IUser>) {
+	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const expression = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 
 		const query = {
@@ -509,7 +476,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	async findOneByLDAPId<T extends Document = IUser>(id: string, attribute?: string) {
@@ -521,19 +488,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T>(query);
 	}
 
-	async findOneByAppId<T extends Document = IUser>(appId: string, options?: FindOptions<IUser>) {
+	async findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(appId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { appId };
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>) {
+	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { ldap: true };
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findActiveLDAPUsersExceptIds<T extends Document = IUser>(userIds: IUser['_id'][], options: FindOptions<IUser> = {}) {
+	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			ldap: true,
 			active: true,
@@ -542,10 +509,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findConnectedLDAPUsers<T extends Document = IUser>(options?: FindOptions<IUser>) {
+	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'ldap': true,
 			'services.resume.loginTokens': {
@@ -554,7 +521,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	isUserInRole(userId: IUser['_id'], roleId: IRole['_id']) {
@@ -880,12 +847,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			.toArray();
 	}
 
-	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser>(
-		termRegex: { $regex: string; $options: string } | RegExp,
-		exceptions?: string[],
-		conditions?: Filter<IUser>,
-		options?: FindOptions<IUser>,
-	) {
+	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(termRegex: { $regex: string; $options: string } | RegExp, exceptions?: string[], conditions?: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
@@ -932,7 +894,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			],
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countAllAgentsStatus({
@@ -1559,8 +1521,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByIdWithEmailAddress(userId: IUser['_id'], options?: FindOptions<IUser>) {
-		return this.findOne(
+	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				_id: userId,
 				emails: { $exists: true, $ne: [] },
@@ -1590,12 +1552,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T>(query);
 	}
 
-	findOneOnlineAgentByUserList(
-		userList: string | string[],
-		options?: FindOptions<IUser>,
-		isLivechatEnabledWhenAgentIdle?: boolean,
-		acceptChatsWithNoAgents?: boolean,
-	) {
+	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userList: string | string[], options?: O, isLivechatEnabledWhenAgentIdle?: boolean, acceptChatsWithNoAgents?: boolean): Promise<DocumentWithProjection<T, O> | null> {
 		// TODO:: Create class Agent
 		const username = {
 			$in: ([] as string[]).concat(userList),
@@ -1603,7 +1560,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 		const query = queryStatusAgentOnline({ username }, isLivechatEnabledWhenAgentIdle, acceptChatsWithNoAgents);
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	async getUnavailableAgents(
@@ -2118,7 +2075,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findByIdsWithPublicE2EKey(ids: IUser['_id'][], options?: FindOptions<IUser>) {
+	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'_id': {
 				$in: ids,
@@ -2128,7 +2085,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	resetE2EKey(userId: IUser['_id']) {
@@ -2209,7 +2166,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {IRole['_id'][]} roles the list of role ids
 	 * @param {any} options
 	 */
-	findActiveUsersInRoles(roles: IRole['_id'][], options?: FindOptions<IUser>) {
+	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		roles = ([] as string[]).concat(roles);
 
 		const query = {
@@ -2217,7 +2174,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			active: true,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countActiveUsersInRoles(roles: IRole['_id'][], options?: FindOptions<IUser>) {
@@ -2231,48 +2188,38 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query, options);
 	}
 
-	findOneByUsernameAndServiceNameIgnoringCase(
-		username: string | RegExp,
-		userId: IUser['_id'],
-		serviceName: string,
-		options?: FindOptions<IUser>,
-	) {
+	findOneByUsernameAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 		}
 
 		const query = { username, [`services.${serviceName}.id`]: userId };
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByEmailAddressAndServiceNameIgnoringCase(
-		emailAddress: string,
-		userId: IUser['_id'],
-		serviceName: string,
-		options?: FindOptions<IUser>,
-	) {
+	findOneByEmailAddressAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'emails.address': String(emailAddress).trim(),
 			[`services.${serviceName}.id`]: userId,
 		};
 
-		return this.findOne(query, {
+		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
 		});
 	}
 
-	findOneByEmailAddress(emailAddress: string, options?: FindOptions<IUser>) {
+	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { 'emails.address': String(emailAddress).trim() };
 
-		return this.findOne(query, {
+		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
 		});
 	}
 
-	findOneWithoutLDAPByEmailAddress(emailAddress: string, options?: FindOptions<IUser>) {
+	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'emails.address': emailAddress.trim().toLowerCase(),
 			'services.ldap': {
@@ -2280,22 +2227,22 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneAdmin(userId: IUser['_id'], options?: FindOptions<IUser>) {
+	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { roles: { $in: ['admin'] }, _id: userId };
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndLoginToken(_id: IUser['_id'], token: string, options?: FindOptions<IUser>) {
+	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			'services.resume.loginTokens.hashedToken': token,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	override findOneById(userId: IUser['_id'], options: FindOptions<IUser> = {}) {
@@ -2304,16 +2251,16 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne(query, options);
 	}
 
-	findOneActiveById(userId?: IUser['_id'], options?: FindOptions<IUser>) {
+	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId?: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: userId,
 			active: true,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdOrUsername(idOrUsername: IUser['_id'] | IUser['username'], options?: FindOptions<IUser>) {
+	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(idOrUsername: IUser['_id'] | IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -2325,16 +2272,16 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			],
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByRolesAndType<T extends Document = IUser>(roles: IRole['_id'][], type: string, options?: FindOptions<IUser>) {
+	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], type: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { roles, type };
 
-		return this.findOne<T>(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	findPresenceUsersByIds(users: IUser['_id'][], options?: FindOptions<IUser>) {
+	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(users: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: users },
 			$or: [
@@ -2343,10 +2290,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 				{ statusExpiresAt: { $exists: true } },
 			],
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findUsersNotOffline(options?: FindOptions<IUser>) {
+	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$exists: true,
@@ -2356,7 +2303,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	countUsersNotOffline(options?: FindOptions<IUser>) {
@@ -2372,7 +2319,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.col.countDocuments(query, options);
 	}
 
-	findNotIdUpdatedFrom(uid: IUser['_id'], from: Date, options?: FindOptions<IUser>) {
+	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], from: Date, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IUser> = {
 			_id: { $ne: uid },
 			username: {
@@ -2381,16 +2328,16 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			_updatedAt: { $gte: from },
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findOneByIdAndRole(userId: IUser['_id'], role: string, options: FindOptions<IUser> = {}) {
+	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], role: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { _id: userId, roles: role };
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
-	async findByRoomId(rid: IRoom['_id'], options?: FindOptions<IUser>) {
+	async findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const data = (await Subscriptions.findByRoomId(rid).toArray()).map((item) => item.u._id);
 		const query = {
 			_id: {
@@ -2398,27 +2345,27 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByUsernames(usernames: string[], options?: FindOptions<IUser>) {
+	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { username: { $in: usernames } };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findByUsernamesIgnoringCase(usernames: string[], options?: FindOptions<IUser>) {
+	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$in: usernames.filter(Boolean).map((u) => new RegExp(`^${escapeRegExp(u)}$`, 'i')),
 			},
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findActiveByUserIds(ids: IUser['_id'][], options: FindOptions<IUser> = {}) {
-		return this.find(
+	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				active: true,
 				type: { $nin: ['app'] },
@@ -2450,10 +2397,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query);
 	}
 
-	findCrowdUsers(options?: FindOptions<IUser>) {
+	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { crowd: true };
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	async getLastLogin(options: FindOptions<IUser> = { projection: { _id: 0, lastLogin: 1 } }) {
@@ -2462,29 +2409,29 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return user?.lastLogin;
 	}
 
-	findUsersByUsernames<T extends Document = IUser>(usernames: string[], options?: FindOptions<IUser>) {
+	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$in: usernames,
 			},
 		};
 
-		return this.find<T>(query, options);
+		return this.find<T, O>(query, options);
 	}
 
-	findUsersByIds(ids: IUser['_id'][], options?: FindOptions<IUser>) {
+	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: {
 				$in: ids,
 			},
 		};
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	/**
 	 * @param {import('mongodb').Filter<import('@rocket.chat/core-typings').IStats>} projection
 	 */
-	getOldest(optionsParams?: FindOptions<IUser>) {
+	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(optionsParams?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: {
 				$ne: 'rocket.cat',
@@ -2498,7 +2445,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 
 	getSAMLByIdAndSAMLProvider(_id: IUser['_id'], provider: string) {
@@ -2513,8 +2460,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findBySAMLNameIdOrIdpSession(nameID: string, idpSession: string, options?: FindOptions<IUser>) {
-		return this.find(
+	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(nameID: string, idpSession: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				$or: [{ 'services.saml.nameID': nameID }, { 'services.saml.idpSession': idpSession }],
 			},
@@ -2522,8 +2469,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findBySAMLInResponseTo(inResponseTo: string, options?: FindOptions<IUser>) {
-		return this.find(
+	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(inResponseTo: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				'services.saml.inResponseTo': inResponseTo,
 			},
@@ -2531,8 +2478,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByFreeSwitchExtension<T extends Document = IUser>(freeSwitchExtension: string, options: FindOptions<IUser> = {}) {
-		return this.findOne<T>(
+	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(freeSwitchExtension: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>(
 			{
 				freeSwitchExtension,
 			},
@@ -2737,7 +2684,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.updateMany(query, update);
 	}
 
-	findActiveNotLoggedInAfterWithRole(latestLastLoginDate: Date, role: IRole['_id'] = 'user', options: FindOptions<IUser> = {}) {
+	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(latestLastLoginDate: Date, role: IRole['_id'] = 'user', options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const neverActive = { lastLogin: { $exists: false }, createdAt: { $lte: latestLastLoginDate } };
 		const idleTooLong = { lastLogin: { $lte: latestLastLoginDate } };
 
@@ -2747,7 +2694,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			roles: role,
 		};
 
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	unsetRequirePasswordChange(_id: IUser['_id']) {
@@ -3137,11 +3084,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByEmailVerificationToken<T extends Document = IUser>(token: string, options?: FindOptions<T>) {
+	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'services.email.verificationTokens.token': token,
 		};
 
-		return this.findOne(query, options);
+		return this.findOne<T, O>(query, options);
 	}
 }

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -376,6 +376,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [];
 		}
 		if (options == null) {
+			// `{}` is not assignable to `O` (a caller could pin it to a narrower type), but under-projecting only
+			// ever returns more fields than the declared type claims
 			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
@@ -422,6 +424,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [];
 		}
 		if (options == null) {
+			// `{}` is not assignable to `O` (a caller could pin it to a narrower type), but under-projecting only
+			// ever returns more fields than the declared type claims
 			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
@@ -546,6 +550,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 		const query = { username };
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
@@ -962,6 +967,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			conditions = {};
 		}
 		if (options == null) {
+			// `{}` is not assignable to `O` (a caller could pin it to a narrower type), but under-projecting only
+			// ever returns more fields than the declared type claims
 			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
@@ -2331,6 +2338,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			[`services.${serviceName}.id`]: userId,
 		};
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
@@ -2343,6 +2351,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { 'emails.address': String(emailAddress).trim() };
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
@@ -2617,6 +2626,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			},
 		};
 
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `sort` wins over a caller-supplied one.
 		const options = {
 			...optionsParams,
 			sort: {

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -12,7 +12,14 @@ import type {
 	RocketChatRecordDeleted,
 } from '@rocket.chat/core-typings';
 import { ILivechatAgentStatus, UserStatus } from '@rocket.chat/core-typings';
-import type { DefaultFields, InsertionModel, IUsersModel, DocumentWithProjection, FindOptionsWithProjection, FindPaginated } from '@rocket.chat/model-typings';
+import type {
+	DefaultFields,
+	InsertionModel,
+	IUsersModel,
+	DocumentWithProjection,
+	FindOptionsWithProjection,
+	FindPaginated,
+} from '@rocket.chat/model-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import type {
 	Collection,
@@ -104,7 +111,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		];
 	}
 
-	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({ usernames, ids, emails, ldapIds }: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] }, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUsersByIdentifiers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		{ usernames, ids, emails, ldapIds }: { usernames?: string[]; ids?: string[]; emails?: string[]; ldapIds?: string[] },
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const normalizedIds = (ids ?? []).filter(Boolean);
 		const normalizedUsernames = (usernames ?? []).filter(Boolean);
 		const normalizedEmails = (emails ?? []).map((e) => String(e).trim()).filter(Boolean);
@@ -141,7 +151,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOneAndUpdate({ _id }, { $unset: { abacAttributes: 1 } }, { returnDocument: 'after' });
 	}
 
-	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roomIds: IRoom['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByRoomIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: IRoom['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>({ active: true, __rooms: { $in: roomIds } }, options);
 	}
 
@@ -180,17 +193,18 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	/**
 	 * @param {IRole['_id'][]} roles list of role ids
 	 * @param {null} scope the value for the role scope (room id) - not used in the users collection
-	 * @param {any} options
 	 */
-	findUsersInRoles: IUsersModel['findUsersInRoles'] = (roles: IRole['_id'][] | IRole['_id'], _scope?: null, options?: any) => {
-		roles = ([] as string[]).concat(roles);
-
+	findUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		_scope?: null,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
-			roles: { $in: roles },
+			roles: { $in: ([] as string[]).concat(roles) },
 		};
 
-		return this.find(query, options);
-	};
+		return this.find<T, O>(query, options);
+	}
 
 	countUsersInRoles(roles: IRole['_id'][] | IRole['_id']) {
 		roles = ([] as string[]).concat(roles);
@@ -202,7 +216,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query);
 	}
 
-	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		roles = ([] as string[]).concat(roles);
 
 		const query = {
@@ -212,13 +229,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { username };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneAgentById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			roles: 'livechat-agent',
@@ -232,7 +255,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {any} query
 	 * @param {any} options
 	 */
-	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		query: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		roles = ([] as string[]).concat(roles);
 
 		Object.assign(query, { roles: { $in: roles } });
@@ -245,7 +272,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {any} query
 	 * @param {any} options
 	 */
-	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][] | IRole['_id'], query: Filter<IUser>, options?: O): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedUsersInRolesWithQuery<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][] | IRole['_id'],
+		query: Filter<IUser>,
+		options?: O,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		roles = ([] as string[]).concat(roles);
 
 		Object.assign(query, { roles: { $in: roles } });
@@ -303,7 +334,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.col.aggregate<{ sortedResults: (T & { departments: string[] })[]; totalCount: { total: number }[] }>(aggregate).toArray();
 	}
 
-	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, rid: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByUsernameAndRoomIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: string | RegExp,
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 		}
@@ -316,7 +351,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdAndLoginHashedToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			'services.resume.loginTokens.hashedToken': token,
@@ -325,12 +364,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions: string[], options?: O, searchFields?: string[], extraQuery: Filter<IUser>[] = [], { startsWith = false, endsWith = false } = {}): FindCursor<DocumentWithProjection<T, O>> {
+	findByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions: string[],
+		options?: O,
+		searchFields?: string[],
+		extraQuery: Filter<IUser>[] = [],
+		{ startsWith = false, endsWith = false } = {},
+	): FindCursor<DocumentWithProjection<T, O>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
 		if (options == null) {
-			options = {};
+			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
 			exceptions = [exceptions];
@@ -364,12 +410,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, searchFields: string[] = [], extraQuery: Filter<IUser>[] = [], { startsWith = false, endsWith = false } = {}): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByActiveUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		searchFields: string[] = [],
+		extraQuery: Filter<IUser>[] = [],
+		{ startsWith = false, endsWith = false } = {},
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
 		if (options == null) {
-			options = {};
+			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
 			exceptions = [exceptions];
@@ -403,27 +456,48 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findPaginated<T, O>(query, options);
 	}
 
-	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByActiveLocalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		forcedSearchFields?: string[],
+		localDomain?: string,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const extraQuery = [
 			{
 				$or: [{ federation: { $exists: false } }, { 'federation.origin': localDomain }],
 			},
 		];
-		return this.findPaginatedByActiveUsersExcept<T>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
+		return this.findPaginatedByActiveUsersExcept<T, O>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 
-	findPaginatedByActiveExternalUsersExcept<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(searchTerm: string, exceptions?: string[], options?: O, forcedSearchFields?: string[], localDomain?: string): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
+	findPaginatedByActiveExternalUsersExcept<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		searchTerm: string,
+		exceptions?: string[],
+		options?: O,
+		forcedSearchFields?: string[],
+		localDomain?: string,
+	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
 		const extraQuery = [{ federation: { $exists: true } }, { 'federation.origin': { $ne: localDomain } }];
-		return this.findPaginatedByActiveUsersExcept<T>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
+		return this.findPaginatedByActiveUsersExcept<T, O>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 
-	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(query: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		query: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		Object.assign(query, { active: true });
 
 		return this.find<T, O>(query, options);
 	}
 
-	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: userIds },
 			active: true,
@@ -432,7 +506,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByIdsOrUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			$or: [{ _id: { $in: userIds } }, { username: { $in: userIds } }],
 			active: true,
@@ -441,7 +518,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: userIds },
 		};
@@ -449,11 +529,17 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByImportId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ importIds: _id }, options);
 	}
 
-	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		username: IUser['username'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		if (!username) {
 			throw new Error('invalid username');
 		}
@@ -463,10 +549,13 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
-		});
+		} as unknown as O);
 	}
 
-	findOneWithoutLDAPByUsernameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneWithoutLDAPByUsernameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(username: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const expression = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 
 		const query = {
@@ -488,19 +577,27 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T>(query);
 	}
 
-	async findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(appId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	async findOneByAppId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		appId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { appId };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { ldap: true };
 
 		return this.find<T, O>(query, options);
 	}
 
-	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userIds: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveLDAPUsersExceptIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userIds: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			ldap: true,
 			active: true,
@@ -512,7 +609,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findConnectedLDAPUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'ldap': true,
 			'services.resume.loginTokens': {
@@ -847,7 +946,15 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			.toArray();
 	}
 
-	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(termRegex: { $regex: string; $options: string } | RegExp, exceptions?: string[], conditions?: Filter<IUser>, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByUsernameOrNameRegexWithExceptionsAndConditions<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		termRegex: { $regex: string; $options: string } | RegExp,
+		exceptions?: string[],
+		conditions?: Filter<IUser>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		if (exceptions == null) {
 			exceptions = [];
 		}
@@ -855,7 +962,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			conditions = {};
 		}
 		if (options == null) {
-			options = {};
+			options = {} as O;
 		}
 		if (!Array.isArray(exceptions)) {
 			exceptions = [exceptions];
@@ -1521,7 +1628,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdWithEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				_id: userId,
@@ -1552,7 +1662,12 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T>(query);
 	}
 
-	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userList: string | string[], options?: O, isLivechatEnabledWhenAgentIdle?: boolean, acceptChatsWithNoAgents?: boolean): Promise<DocumentWithProjection<T, O> | null> {
+	findOneOnlineAgentByUserList<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userList: string | string[],
+		options?: O,
+		isLivechatEnabledWhenAgentIdle?: boolean,
+		acceptChatsWithNoAgents?: boolean,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		// TODO:: Create class Agent
 		const username = {
 			$in: ([] as string[]).concat(userList),
@@ -2075,7 +2190,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByIdsWithPublicE2EKey<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			'_id': {
 				$in: ids,
@@ -2166,7 +2284,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	 * @param {IRole['_id'][]} roles the list of role ids
 	 * @param {any} options
 	 */
-	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveUsersInRoles<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		roles = ([] as string[]).concat(roles);
 
 		const query = {
@@ -2188,7 +2309,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query, options);
 	}
 
-	findOneByUsernameAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(username: string | RegExp, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByUsernameAndServiceNameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(username: string | RegExp, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		if (typeof username === 'string') {
 			username = new RegExp(`^${escapeRegExp(username)}$`, 'i');
 		}
@@ -2198,7 +2322,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByEmailAddressAndServiceNameIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByEmailAddressAndServiceNameIgnoringCase<
+		T extends Document = IUser,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(emailAddress: string, userId: IUser['_id'], serviceName: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'emails.address': String(emailAddress).trim(),
 			[`services.${serviceName}.id`]: userId,
@@ -2207,19 +2334,25 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
-		});
+		} as unknown as O);
 	}
 
-	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emailAddress: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { 'emails.address': String(emailAddress).trim() };
 
 		return this.findOne<T, O>(query, {
 			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
-		});
+		} as unknown as O);
 	}
 
-	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(emailAddress: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneWithoutLDAPByEmailAddress<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		emailAddress: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'emails.address': emailAddress.trim().toLowerCase(),
 			'services.ldap': {
@@ -2230,13 +2363,20 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneAdmin<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { roles: { $in: ['admin'] }, _id: userId };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: IUser['_id'], token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdAndLoginToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IUser['_id'],
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id,
 			'services.resume.loginTokens.hashedToken': token,
@@ -2245,13 +2385,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	override findOneById(userId: IUser['_id'], options: FindOptions<IUser> = {}) {
-		const query = { _id: userId };
-
-		return this.findOne(query, options);
-	}
-
-	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId?: IUser['_id'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneActiveById<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId?: IUser['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: userId,
 			active: true,
@@ -2260,7 +2397,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(idOrUsername: IUser['_id'] | IUser['username'], options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdOrUsername<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		idOrUsername: IUser['_id'] | IUser['username'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			$or: [
 				{
@@ -2275,13 +2415,20 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.findOne<T, O>(query, options);
 	}
 
-	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(roles: IRole['_id'][], type: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByRolesAndType<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roles: IRole['_id'][],
+		type: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { roles, type };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(users: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findPresenceUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		users: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: { $in: users },
 			$or: [
@@ -2293,7 +2440,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUsersNotOffline<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$exists: true,
@@ -2319,7 +2468,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.col.countDocuments(query, options);
 	}
 
-	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(uid: IUser['_id'], from: Date, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findNotIdUpdatedFrom<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		uid: IUser['_id'],
+		from: Date,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query: Filter<IUser> = {
 			_id: { $ne: uid },
 			username: {
@@ -2331,13 +2484,20 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: IUser['_id'], role: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdAndRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: IUser['_id'],
+		role: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { _id: userId, roles: role };
 
 		return this.findOne<T, O>(query, options);
 	}
 
-	async findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(rid: IRoom['_id'], options?: O): Promise<FindCursor<DocumentWithProjection<T, O>>> {
+	async findByRoomId<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: IRoom['_id'],
+		options?: O,
+	): Promise<FindCursor<DocumentWithProjection<T, O>>> {
 		const data = (await Subscriptions.findByRoomId(rid).toArray()).map((item) => item.u._id);
 		const query = {
 			_id: {
@@ -2348,13 +2508,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { username: { $in: usernames } };
 
 		return this.find<T, O>(query, options);
 	}
 
-	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByUsernamesIgnoringCase<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$in: usernames.filter(Boolean).map((u) => new RegExp(`^${escapeRegExp(u)}$`, 'i')),
@@ -2364,7 +2530,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveByUserIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				active: true,
@@ -2397,7 +2566,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.countDocuments(query);
 	}
 
-	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findCrowdUsers<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { crowd: true };
 
 		return this.find<T, O>(query, options);
@@ -2409,7 +2580,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return user?.lastLogin;
 	}
 
-	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(usernames: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUsersByUsernames<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		usernames: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			username: {
 				$in: usernames,
@@ -2419,7 +2593,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.find<T, O>(query, options);
 	}
 
-	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(ids: IUser['_id'][], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findUsersByIds<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		ids: IUser['_id'][],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = {
 			_id: {
 				$in: ids,
@@ -2431,19 +2608,21 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	/**
 	 * @param {import('mongodb').Filter<import('@rocket.chat/core-typings').IStats>} projection
 	 */
-	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(optionsParams?: O): Promise<DocumentWithProjection<T, O> | null> {
+	getOldest<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		optionsParams?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			_id: {
 				$ne: 'rocket.cat',
 			},
 		};
 
-		const options: FindOptions<IUser> = {
+		const options = {
 			...optionsParams,
 			sort: {
 				createdAt: 1,
 			},
-		};
+		} as unknown as O;
 
 		return this.findOne<T, O>(query, options);
 	}
@@ -2460,7 +2639,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(nameID: string, idpSession: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findBySAMLNameIdOrIdpSession<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		nameID: string,
+		idpSession: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				$or: [{ 'services.saml.nameID': nameID }, { 'services.saml.idpSession': idpSession }],
@@ -2469,7 +2652,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(inResponseTo: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findBySAMLInResponseTo<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		inResponseTo: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				'services.saml.inResponseTo': inResponseTo,
@@ -2478,7 +2664,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(freeSwitchExtension: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByFreeSwitchExtension<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		freeSwitchExtension: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>(
 			{
 				freeSwitchExtension,
@@ -2684,7 +2873,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		return this.updateMany(query, update);
 	}
 
-	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(latestLastLoginDate: Date, role: IRole['_id'] = 'user', options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findActiveNotLoggedInAfterWithRole<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		latestLastLoginDate: Date,
+		role: IRole['_id'] = 'user',
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const neverActive = { lastLogin: { $exists: false }, createdAt: { $lte: latestLastLoginDate } };
 		const idleTooLong = { lastLogin: { $lte: latestLastLoginDate } };
 
@@ -3084,7 +3277,10 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		);
 	}
 
-	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(token: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByEmailVerificationToken<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		token: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = {
 			'services.email.verificationTokens.token': token,
 		};

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -550,10 +550,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 
 		const query = { username };
 
-		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `collation` wins over a caller-supplied one, so the lookup stays case insensitive.
 		return this.findOne<T, O>(query, {
-			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
+			collation: { locale: 'en', strength: 2 }, // Case insensitive
 		} as unknown as O);
 	}
 
@@ -2338,10 +2339,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			[`services.${serviceName}.id`]: userId,
 		};
 
-		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `collation` wins over a caller-supplied one, so the lookup stays case insensitive.
 		return this.findOne<T, O>(query, {
-			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
+			collation: { locale: 'en', strength: 2 }, // Case insensitive
 		} as unknown as O);
 	}
 
@@ -2351,10 +2353,11 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	): Promise<DocumentWithProjection<T, O> | null> {
 		const query = { 'emails.address': String(emailAddress).trim() };
 
-		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread
+		// safe to merge into `O`: only `O['projection']` feeds the return type, and it survives the spread.
+		// note the model's `collation` wins over a caller-supplied one, so the lookup stays case insensitive.
 		return this.findOne<T, O>(query, {
-			collation: { locale: 'en', strength: 2 }, // Case insensitive
 			...options,
+			collation: { locale: 'en', strength: 2 }, // Case insensitive
 		} as unknown as O);
 	}
 

--- a/packages/models/src/models/UsersSessions.ts
+++ b/packages/models/src/models/UsersSessions.ts
@@ -102,7 +102,10 @@ export class UsersSessionsRaw extends BaseRaw<IUserSession> implements IUsersSes
 		return this.updateOne({ _id: userId }, update, { upsert: true });
 	}
 
-	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(instanceIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		instanceIds: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		return this.find<T, O>(
 			{
 				'connections.instanceId': {

--- a/packages/models/src/models/UsersSessions.ts
+++ b/packages/models/src/models/UsersSessions.ts
@@ -1,6 +1,6 @@
 import type { IUserSession, IUserSessionConnection, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IUsersSessionsModel } from '@rocket.chat/model-typings';
-import type { FindCursor, Collection, Db, FindOptions } from 'mongodb';
+import type { IUsersSessionsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { FindCursor, Collection, Db, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -102,8 +102,8 @@ export class UsersSessionsRaw extends BaseRaw<IUserSession> implements IUsersSes
 		return this.updateOne({ _id: userId }, update, { upsert: true });
 	}
 
-	findByOtherInstanceIds(instanceIds: string[], options?: FindOptions<IUserSession>): FindCursor<IUserSession> {
-		return this.find(
+	findByOtherInstanceIds<T extends Document = IUserSession, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(instanceIds: string[], options?: O): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>(
 			{
 				'connections.instanceId': {
 					$exists: true,

--- a/packages/models/src/models/VideoConference.ts
+++ b/packages/models/src/models/VideoConference.ts
@@ -39,7 +39,8 @@ export class VideoConferenceRaw extends BaseRaw<VideoConference> implements IVid
 		rid: IRoom['_id'],
 		{ offset, count }: { offset?: number; count?: number } = {},
 	): FindPaginated<FindCursor<VideoConference>> {
-		// TODO: this projection is narrower than the declared return type — narrow the signature
+		// No data is lost — `providerData` is optional — but `Omit` over the `VideoConference` union collapses it into a single
+		// object type, so the explicit type argument opts out of projection inference to preserve the discriminated union.
 		return this.findPaginated<VideoConference>(
 			{ rid },
 			{

--- a/packages/models/src/models/VideoConference.ts
+++ b/packages/models/src/models/VideoConference.ts
@@ -39,7 +39,8 @@ export class VideoConferenceRaw extends BaseRaw<VideoConference> implements IVid
 		rid: IRoom['_id'],
 		{ offset, count }: { offset?: number; count?: number } = {},
 	): FindPaginated<FindCursor<VideoConference>> {
-		return this.findPaginated(
+		// TODO: this projection is narrower than the declared return type — narrow the signature
+		return this.findPaginated<VideoConference>(
 			{ rid },
 			{
 				sort: { createdAt: -1 },
@@ -229,7 +230,7 @@ export class VideoConferenceRaw extends BaseRaw<VideoConference> implements IVid
 			$set: {
 				[`messages.${messageType}`]: messageId,
 			},
-		} as UpdateFilter<VideoConference>); // TODO: Remove this cast when TypeScript is updated
+		}); // TODO: Remove this cast when TypeScript is updated
 		// TypeScript is not smart enough to infer that `messages.${'start' | 'end'}` matches two keys of `VideoConference`
 	}
 

--- a/packages/models/src/models/WebdavAccounts.ts
+++ b/packages/models/src/models/WebdavAccounts.ts
@@ -1,6 +1,6 @@
 import type { IWebdavAccount, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
-import type { IWebdavAccountsModel } from '@rocket.chat/model-typings';
-import type { Collection, FindCursor, Db, DeleteResult, FindOptions, IndexDescription } from 'mongodb';
+import type { IWebdavAccountsModel, DocumentWithProjection, FindOptionsWithProjection } from '@rocket.chat/model-typings';
+import type { Collection, FindCursor, Db, DeleteResult, IndexDescription, Document } from 'mongodb';
 
 import { BaseRaw } from './BaseRaw';
 
@@ -13,12 +13,11 @@ export class WebdavAccountsRaw extends BaseRaw<IWebdavAccount> implements IWebda
 		return [{ key: { userId: 1 } }];
 	}
 
-	findOneByIdAndUserId(_id: string, userId: string, options: FindOptions<IWebdavAccount>): Promise<IWebdavAccount | null> {
-		return this.findOne({ _id, userId }, options);
+	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id, userId }, options);
 	}
 
-	findOneByUserIdServerUrlAndUsername(
-		{
+	findOneByUserIdServerUrlAndUsername<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
 			userId,
 			serverURL,
 			username,
@@ -26,15 +25,13 @@ export class WebdavAccountsRaw extends BaseRaw<IWebdavAccount> implements IWebda
 			userId: string;
 			serverURL: string;
 			username: string;
-		},
-		options: FindOptions<IWebdavAccount>,
-	): Promise<IWebdavAccount | null> {
-		return this.findOne({ userId, serverURL, username }, options);
+		}, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ userId, serverURL, username }, options);
 	}
 
-	findWithUserId(userId: string, options: FindOptions<IWebdavAccount>): FindCursor<IWebdavAccount> {
+	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { userId };
-		return this.find(query, options);
+		return this.find<T, O>(query, options);
 	}
 
 	removeByUserAndId(_id: string, userId: string): Promise<DeleteResult> {

--- a/packages/models/src/models/WebdavAccounts.ts
+++ b/packages/models/src/models/WebdavAccounts.ts
@@ -13,11 +13,19 @@ export class WebdavAccountsRaw extends BaseRaw<IWebdavAccount> implements IWebda
 		return [{ key: { userId: 1 } }];
 	}
 
-	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(_id: string, userId: string, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+	findOneByIdAndUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: string,
+		userId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ _id, userId }, options);
 	}
 
-	findOneByUserIdServerUrlAndUsername<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>({
+	findOneByUserIdServerUrlAndUsername<
+		T extends Document = IWebdavAccount,
+		O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>,
+	>(
+		{
 			userId,
 			serverURL,
 			username,
@@ -25,11 +33,16 @@ export class WebdavAccountsRaw extends BaseRaw<IWebdavAccount> implements IWebda
 			userId: string;
 			serverURL: string;
 			username: string;
-		}, options?: O): Promise<DocumentWithProjection<T, O> | null> {
+		},
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
 		return this.findOne<T, O>({ userId, serverURL, username }, options);
 	}
 
-	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(userId: string, options?: O): FindCursor<DocumentWithProjection<T, O>> {
+	findWithUserId<T extends Document = IWebdavAccount, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		userId: string,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
 		const query = { userId };
 		return this.find<T, O>(query, options);
 	}

--- a/packages/models/src/updater.ts
+++ b/packages/models/src/updater.ts
@@ -18,7 +18,7 @@ export class UpdaterImpl<T extends { _id: string }> implements Updater<T> {
 
 	set<K extends keyof SetProps<T>>(key: K, value: SetProps<T>[K]) {
 		this._set = this._set ?? new Map<Keys<T>, any>();
-		this._set.set(key as Keys<T>, value);
+		this._set.set(key, value);
 		return this;
 	}
 

--- a/packages/omni-core/src/visitor/create.spec.ts
+++ b/packages/omni-core/src/visitor/create.spec.ts
@@ -299,7 +299,7 @@ describe('registerGuest', () => {
 
 			await registerGuest(guestData, { shouldConsiderIdleAgent: false, shouldConsiderOfflineAgent: false });
 
-			expect(getVisitorByTokenSpy).toHaveBeenCalledWith(token, { projection: { _id: 1 } });
+			expect(getVisitorByTokenSpy).toHaveBeenCalledWith(token, { projection: { _id: 1, department: 1, token: 1 } });
 
 			// Verify existing visitor data is used and updated
 			expect(updateOneByIdOrTokenSpy).toHaveBeenCalledWith(

--- a/packages/omni-core/src/visitor/create.ts
+++ b/packages/omni-core/src/visitor/create.ts
@@ -55,7 +55,7 @@ export const registerGuest = makeFunction(
 			}
 		}
 
-		const livechatVisitor = await LivechatVisitors.getVisitorByToken(token, { projection: { _id: 1 } });
+		const livechatVisitor = await LivechatVisitors.getVisitorByToken(token, { projection: { _id: 1, department: 1, token: 1 } });
 
 		if (department && livechatVisitor?.department !== department) {
 			logger.debug({ msg: 'Attempt to find a department with id/name', department });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

### Goal

A find that passes a `projection` still returns the **full** document type, so TypeScript believes fields are present that the server never sent — with no build error.

The existing workaround is a hand-written generic per call site:

```ts
Users.findOneByUsername<Pick<IUser, '_id' | 'username'>>(name, { projection: { _id: 1, username: 1 } });
```

It covers only 192 of 834 `projection:` sites, and the generic sits *beside* the projection with nothing checking the two agree.

This PR derives the return type **from** the projection instead, so it cannot drift:

```ts
const u = await Users.findOneByUsername(name, { projection: { _id: 1, username: 1 } });
// u: { _id: string; username?: string } | null
```

**No call sites were edited.** ~640 sites narrow on their own; the 192 with an explicit generic keep their exact previous meaning.

### Why it wasn't possible before

The driver's type parameter is phantom — `mongodb@6.10.0` declares `FindOptions<TSchema>` with `projection?: Document` and never references `TSchema`. So `options?: FindOptions<P extends T ? T : P>` carries no information and `P` can only ever be supplied by hand. Inference needs the options object to reach a **naked** type parameter.

### Required changes

1. **`FindOptionsWithProjection`** — `FindOptions` with a projection whose value position contains the `0`/`1` literals. Under the driver's `Document` (`[key: string]: any`) they widen to `number`, making inclusion and exclusion indistinguishable.
2. **Hardened `DocumentWithProjection`** — handles exclusion, mixed projections (mirroring `BaseRaw`'s runtime rewrite) and implicit `_id`; bails to the full document for anything not statically readable (dotted paths, `$`-operators). It previously turned `{ password: 0 }` into `Pick<T, 'password'>` — the inverse. Now exported, with compile-time assertions.
3. **`IBaseModel` core finders** + `BaseRaw` / `BaseDummy`. `findOneById`'s no-options overload became `options?: undefined`; it previously swallowed every call with options and returned the full document — the reason call sites needed a generic. `WithId<>` dropped from projected overloads (it resolves `_id` to `ObjectId`).
4. **`findOneAndUpdate` / `findOneAndDelete` / `findOneAndDeleteById`** — same treatment, but they reach the collection directly and get none of `BaseRaw`'s rewriting, so they use a separate resolver. Two rules differ: `_id` is dropped when excluded explicitly (the `find` path keeps it), and inclusion mixed with any other exclusion is a server error, so the type falls back to the document.
5. **274 interface signatures** across 45 interfaces (19 overload groups collapsed), plus the matching implementations in 43 files. Both were codemodded from the same source of truth.
6. **13 methods deliberately excluded** — Team, TeamMember, BannersDismiss, `Rooms.findOneByName`, LivechatUnit. They reach `this.col` directly, bypassing `doNotMixInclusionAndExclusionFields`, so the `_id` guarantee doesn't hold. They keep explicit generics.

Also fixes `ResultFields`, whose exclusion branch `Omit<Defaults, keyof Defaults>` was unconditionally `{}`.

## Issue(s)

[ARCH-2378]

## Steps to test or reproduce

Type-level change only — no runtime behaviour changes.

```bash
yarn workspace @rocket.chat/model-typings run build      # 0 errors (its build is the typecheck)
yarn workspace @rocket.chat/models run typecheck         # 0 errors
yarn workspace @rocket.chat/models run build             # 0 errors (declaration emit)
```

Then hover any call passing a `projection` — e.g. `apps/meteor/ee/server/apps/communication/rest.ts:461`, unchanged by this PR — and confirm the type is narrowed.

## Further comments

**`apps/meteor` typecheck reports 81 errors in 50 files, `omni-core` 2, and `federation-matrix` 1. These are the point of the change, not regressions** — call sites that receive a projected document and pass it somewhere expecting the full one. They are left unfixed here to keep this PR reviewable; every other dependent package is clean.

Two follow-ups, marked with TODOs:
- ~8 model methods whose declared return is wider than the projection their body applies. The narrow type is the correct one; tightening them touches call sites.
- ~86 sites inference can't reach — 38 dotted-path projections, and ~48 hoisted `const options: FindOptions<X>` whose annotation erases the literal keys before the call. Both bail to the wide type, so they're status quo.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added projection-aware query support across model APIs, enabling callers to request specific fields with accurately typed results.
  * Added shared utilities for describing and inferring projected document shapes.
  * Narrowed several query results to return only the fields requested or used.
* **Bug Fixes**
  * Improved handling of inclusion, exclusion, mixed, and driver-specific projections.
  * Prevented internal sorting and filtering from mutating caller-provided options.
* **Tests**
  * Added compile-time and runtime coverage for projection behavior and inferred result types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ARCH-2378]: https://rocketchat.atlassian.net/browse/ARCH-2378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ