### PR TITLE
fix: trim team channel search filter before listing channels

### DIFF
--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.spec.ts
@@ -65,4 +65,31 @@ describe('useSearchItems', () => {
 			expect(result.current.items).toHaveLength(2);
 		});
 	});
+
+	it('should ignore leading and trailing whitespace in the search term', async () => {
+		const wrapper = mockAppRoot()
+			.withSubscriptions([
+				{
+					_id: 'room_123',
+					t: 'c',
+					name: 'general',
+					fname: 'general',
+				} as unknown as SubscriptionWithRoom,
+			])
+			.withEndpoint('GET', '/v1/spotlight', () => ({
+				users: [],
+				rooms: [],
+			}))
+			.build();
+
+		const { result } = renderHook(() => useSearchItems('  general  '), {
+			wrapper,
+		});
+
+		await waitFor(() => {
+			expect(result.current.items).toHaveLength(1);
+		});
+
+		expect(result.current.items[0].name).toBe('general');
+	});
 });

--- a/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
+++ b/apps/meteor/client/navbar/NavBarSearch/hooks/useSearchItems.ts
@@ -18,7 +18,12 @@ const options = {
 } as const;
 
 export const useSearchItems = (filterText = ''): { items: SubscriptionWithRoom[]; isLoading: boolean } => {
-	const [, mention, name] = useMemo(() => filterText.match(/(@|#)?(.*)/i) || [], [filterText]);
+	const [, mention, rawName = ''] = useMemo(
+		() => filterText.match(/(@|#)?(.*)/i) || [],
+		[filterText],
+	);
+
+	const name = rawName.trim();
 
 	const query = useMemo(() => {
 		const filterRegex = new RegExp(escapeRegExp(name), 'i');

--- a/apps/meteor/server/api/lib/users.ts
+++ b/apps/meteor/server/api/lib/users.ts
@@ -185,14 +185,31 @@ export async function findPaginatedUsersByStatus({
 		freeSwitchExtension: 1,
 	};
 
-	if (searchTerm?.trim()) {
+	const normalizedSearchTerm = searchTerm?.trim();
+
+	if (normalizedSearchTerm) {
 		match.$or = [
-			...(canSeeAllUserInfo ? [{ 'emails.address': { $regex: escapeRegExp(searchTerm || ''), $options: 'i' } }] : []),
+			...(canSeeAllUserInfo
+				? [
+					{
+						'emails.address': {
+							$regex: escapeRegExp(normalizedSearchTerm),
+							$options: 'i',
+						},
+					},
+				]
+				: []),
 			{
-				username: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				username: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 			{
-				name: { $regex: escapeRegExp(searchTerm || ''), $options: 'i' },
+				name: {
+					$regex: escapeRegExp(normalizedSearchTerm),
+					$options: 'i',
+				},
 			},
 		];
 	}

--- a/apps/meteor/server/lib/findUsersOfRoomOrderedByRole.ts
+++ b/apps/meteor/server/lib/findUsersOfRoomOrderedByRole.ts
@@ -31,8 +31,16 @@ export async function findUsersOfRoomOrderedByRole({
 	extraQuery = [],
 }: FindUsersParam): Promise<{ members: UserWithRoleAndSubscriptionData[]; total: number }> {
 	const searchFields = settings.get<string>('Accounts_SearchFields').trim().split(',');
-	const termRegex = new RegExp(escapeRegExp(filter), 'i');
-	const orStmt = filter && searchFields.length ? searchFields.map((field) => ({ [field.trim()]: termRegex })) : [];
+	const normalizedFilter = filter.trim();
+
+	const termRegex = new RegExp(escapeRegExp(normalizedFilter), 'i');
+
+	const orStmt =
+		normalizedFilter && searchFields.length
+			? searchFields.map((field) => ({
+				[field.trim()]: termRegex,
+			}))
+			: [];
 
 	const { rolePriority: rolePrioritySort, username: usernameSort } = sort;
 
@@ -42,8 +50,8 @@ export async function findUsersOfRoomOrderedByRole({
 		...(usernameSort
 			? { username: usernameSort }
 			: {
-					...(settings.get('UI_Use_Real_Name') ? { name: 1 } : { username: 1 }),
-				}),
+				...(settings.get('UI_Use_Real_Name') ? { name: 1 } : { username: 1 }),
+			}),
 	};
 
 	const matchUserFilter = {
@@ -56,7 +64,7 @@ export async function findUsersOfRoomOrderedByRole({
 					...(exceptions.length > 0 && { $nin: exceptions }),
 				},
 				...(status && { status }),
-				...(filter && orStmt.length > 0 && { $or: orStmt }),
+				...(normalizedFilter && orStmt.length > 0 && { $or: orStmt }),
 			},
 			...extraQuery,
 		],

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -522,6 +522,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		const { getAllRooms, allowPrivateTeam, name, isDefault } = filter;
+		const normalizedName = name?.trim();
 
 		const isMember = await TeamMember.findOneByUserIdAndTeamId(uid, teamId);
 		if (team.type === TeamType.PRIVATE && !allowPrivateTeam && !isMember) {
@@ -529,7 +530,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		if (getAllRooms) {
-			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, name, isDefault, undefined, {
+			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId,normalizedName || undefined, name, isDefault, undefined, {
 				skip,
 				limit,
 			});
@@ -545,7 +546,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		});
 		const userRooms = user?.__rooms;
 
-		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, name, isDefault, userRooms, { skip, limit });
+		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId,normalizedName || undefined, name, isDefault, userRooms, { skip, limit });
 
 		const [records, total] = await Promise.all([cursor.toArray(), totalCount]);
 

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -530,7 +530,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		if (getAllRooms) {
-			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId,normalizedName || undefined, name, isDefault, undefined, {
+			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, normalizedName || undefined, isDefault, undefined, {
 				skip,
 				limit,
 			});
@@ -546,7 +546,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		});
 		const userRooms = user?.__rooms;
 
-		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId,normalizedName || undefined, name, isDefault, userRooms, { skip, limit });
+		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, normalizedName || undefined, isDefault, userRooms, { skip, limit });
 
 		const [records, total] = await Promise.all([cursor.toArray(), totalCount]);
 

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -350,6 +350,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
+		const normalizedSearchTerm = searchTerm.trim();
+
 		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
@@ -369,7 +371,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],
@@ -396,7 +398,9 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 			exceptions = [exceptions];
 		}
 
-		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(searchTerm) + (endsWith ? '$' : ''), 'i');
+		const normalizedSearchTerm = searchTerm.trim();
+
+		const termRegex = new RegExp((startsWith ? '^' : '') + escapeRegExp(normalizedSearchTerm) + (endsWith ? '$' : ''), 'i');
 
 		const orStmt = (searchFields || []).reduce(
 			(acc, el) => {
@@ -415,7 +419,7 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 						...(exceptions.length > 0 && { $nin: exceptions }),
 					},
 					// if the search term is empty, don't need to have the $or statement (because it would be an empty regex)
-					...(searchTerm && orStmt.length > 0 && { $or: orStmt }),
+					...(normalizedSearchTerm  && orStmt.length > 0 && { $or: orStmt }),
 				},
 				...extraQuery,
 			],


### PR DESCRIPTION
## Proposed changes 

This PR normalizes the Team Channels search filter by trimming leading and trailing whitespace before it is used to retrieve matching channels.

Previously, searches containing leading or trailing whitespace (for example, `general ` or ` general`) returned no results even though the trimmed search term matched correctly.

The search filter is now normalized before listing team channels, providing consistent search behavior while preserving the existing behavior for empty searches.

## Issue(s)

Closes #41697

## Steps to test or reproduce

1. Open any team.
2. Open the **Team Channels** panel.
3. Search for an existing channel (for example, `general`) and verify that it is returned.
4. Search again using:
   - ` general`
   - `general `
   - `  general  `
5. Verify the same matching channel is returned.
6. Verify that an empty search and a search containing only whitespace continue to display all available team channels.

## Further comments

The search filter is trimmed before it is passed to the room lookup logic, ensuring that leading and trailing whitespace does not affect search results while preserving the existing behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior by ignoring leading and trailing spaces in user, room, and subscription searches.
  * Prevented empty or whitespace-only searches from applying unnecessary filters.
  * Preserved case-insensitive matching across supported search fields.
  * Improved handling of optional mention prefixes in navigation search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->