### PR TITLE
fix: forgot password email DDP method doesn't have strict rate limits

### DIFF
--- a/.changeset/fuzzy-ends-refuse.md
+++ b/.changeset/fuzzy-ends-refuse.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Adds per-client rate limiting to the unauthenticated sendForgotPasswordEmail method, matching the REST users.forgotPassword endpoint

--- a/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
+++ b/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
@@ -2,6 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Users } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
+import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
 import { Meteor } from 'meteor/meteor';
 
 import { SystemLogger } from '../../lib/logger/system';
@@ -44,3 +45,23 @@ Meteor.methods<ServerMethods>({
 		return sendForgotPasswordEmail(to);
 	},
 });
+
+// This method is unauthenticated (callable over DDP and via method.callAnon), so we key the
+// rate limit on `clientAddress` rather than `userId` — keying on the (always-null) anonymous
+// userId would collapse every caller into a single global bucket. Correct per-client bucketing
+// relies on `HTTP_FORWARDED_COUNT` being set to the real number of trusted proxies, the same
+// assumption the generic DDP IP rate limit and login-attempt throttling already depend on.
+// The 10/60s allowance mirrors the REST `users.forgotPassword` endpoint (which inherits the
+// API_Enable_Rate_Limiter_Limit_Calls_Default / _Time_Default defaults) so the same operation
+// has the same per-client allowance regardless of the path it is called through.
+DDPRateLimiter.addRule(
+	{
+		type: 'method',
+		name: 'sendForgotPasswordEmail',
+		clientAddress() {
+			return true;
+		},
+	},
+	10,
+	60000,
+);

--- a/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
+++ b/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
@@ -46,14 +46,6 @@ Meteor.methods<ServerMethods>({
 	},
 });
 
-// This method is unauthenticated (callable over DDP and via method.callAnon), so we key the
-// rate limit on `clientAddress` rather than `userId` — keying on the (always-null) anonymous
-// userId would collapse every caller into a single global bucket. Correct per-client bucketing
-// relies on `HTTP_FORWARDED_COUNT` being set to the real number of trusted proxies, the same
-// assumption the generic DDP IP rate limit and login-attempt throttling already depend on.
-// The 10/60s allowance mirrors the REST `users.forgotPassword` endpoint (which inherits the
-// API_Enable_Rate_Limiter_Limit_Calls_Default / _Time_Default defaults) so the same operation
-// has the same per-client allowance regardless of the path it is called through.
 DDPRateLimiter.addRule(
 	{
 		type: 'method',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

The `sendForgotPasswordEmail` Meteor method (callable unauthenticated over DDP and `method.callAnon`) had no dedicated rate limit, relying only on the generic per-connection DDP limiter. This could be sidestepped by opening multiple connections or varying the anonymous connection ID, allowing password-reset emails to be triggered far faster than the REST `users.forgotPassword` endpoint permits.

Adds a `DDPRateLimiter` rule of 10 requests per 60 seconds per `clientAddress`, matching the REST endpoint's allowance. The limiter is keyed on `clientAddress` (rather than the always-null anonymous `userId`) so the limit is enforced per client instead of as a single global bucket.

## Issue(s)
https://rocketchat.atlassian.net/browse/VLN-549

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-client rate limiting to the “forgot password” email request, helping reduce abuse and improve service stability.
  * The password recovery flow now follows the same request limits as the related REST endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->