### PR TITLE
regression(ui-voip): Switching between alternate voice call views breaks widget visibility

### DIFF
--- a/.changeset/available-view-tracker-mutation.md
+++ b/.changeset/available-view-tracker-mutation.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/ui-voip': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the media call widget and popout not opening or closing when the views they are registered under change

--- a/.changeset/available-view-tracker-mutation.md
+++ b/.changeset/available-view-tracker-mutation.md
@@ -1,6 +1,0 @@
----
-'@rocket.chat/ui-voip': patch
-'@rocket.chat/meteor': patch
----
-
-Fixes the media call widget and popout not opening or closing when the views they are registered under change

--- a/packages/ui-voip/src/providers/useAvailableViewTracker.spec.ts
+++ b/packages/ui-voip/src/providers/useAvailableViewTracker.spec.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { StrictMode } from 'react';
+
+import useAvailableViewTracker from './useAvailableViewTracker';
+
+describe('useAvailableViewTracker', () => {
+	it('should track registered views under StrictMode, which calls state updaters twice', () => {
+		const { result } = renderHook(() => useAvailableViewTracker(), { wrapper: StrictMode });
+
+		act(() => result.current.registerView('popout'));
+		expect(result.current.currentViews.has('popout')).toBe(true);
+
+		act(() => result.current.unregisterView('popout'));
+		expect(result.current.currentViews.has('popout')).toBe(false);
+	});
+
+	it('should hide the widget while the room view is registered', () => {
+		const { result } = renderHook(() => useAvailableViewTracker(), { wrapper: StrictMode });
+
+		act(() => result.current.registerView('widget'));
+		expect(result.current.currentViews.has('widget')).toBe(true);
+
+		act(() => result.current.registerView('room'));
+		expect(result.current.currentViews.has('widget')).toBe(false);
+
+		act(() => result.current.unregisterView('room'));
+		expect(result.current.currentViews.has('widget')).toBe(true);
+	});
+
+	it('should return a new set only when the registered views change', () => {
+		const { result } = renderHook(() => useAvailableViewTracker(), { wrapper: StrictMode });
+
+		act(() => result.current.registerView('popout'));
+		const views = result.current.currentViews;
+
+		act(() => result.current.registerView('popout'));
+		expect(result.current.currentViews).toBe(views);
+
+		act(() => result.current.registerView('room'));
+		expect(result.current.currentViews).not.toBe(views);
+	});
+});

--- a/packages/ui-voip/src/providers/useAvailableViewTracker.ts
+++ b/packages/ui-voip/src/providers/useAvailableViewTracker.ts
@@ -13,37 +13,31 @@ const filter = (view: AvailableViews, _index: number, array: AvailableViews[]) =
 	}
 };
 
+const withFilteredViews = (currentViews: Set<AvailableViews>) => ({
+	currentViews,
+	filteredViews: new Set(Array.from(currentViews).filter(filter)),
+});
+
 const useAvailableViewTracker = () => {
-	// keep in mind views.currentViews is a stable set, so please if you are going to use it in a useEffect, make sure to create a new set from it, otherwise you will not be able to track changes in the set.
 	const [views, setViews] = useState<{
 		currentViews: Set<AvailableViews>;
 		filteredViews: Set<AvailableViews>;
-	}>({
-		currentViews: new Set<AvailableViews>(),
-		filteredViews: new Set<AvailableViews>(),
-	});
+	}>(() => withFilteredViews(new Set<AvailableViews>()));
 
 	const registerView = useCallback((view: AvailableViews) => {
-		setViews((prev) => {
-			if (prev.currentViews.has(view)) return prev;
-
-			prev.currentViews.add(view);
-			return {
-				currentViews: prev.currentViews,
-				filteredViews: new Set(Array.from(prev.currentViews).filter(filter)),
-			};
-		});
+		// the updater must not touch prev: StrictMode calls it twice, and a mutated set would make the second call bail out
+		setViews((prev) => (prev.currentViews.has(view) ? prev : withFilteredViews(new Set(prev.currentViews).add(view))));
 	}, []);
 
 	const unregisterView = useCallback((view: AvailableViews) => {
 		setViews((prev) => {
-			if (!prev.currentViews.has(view)) return prev;
+			if (!prev.currentViews.has(view)) {
+				return prev;
+			}
 
-			prev.currentViews.delete(view);
-			return {
-				currentViews: prev.currentViews,
-				filteredViews: new Set(Array.from(prev.currentViews).filter(filter)),
-			};
+			const currentViews = new Set(prev.currentViews);
+			currentViews.delete(view);
+			return withFilteredViews(currentViews);
 		});
 	}, []);
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Follow-up to #41616, from [this review comment](https://github.com/RocketChat/Rocket.Chat/pull/41616#discussion_r3715512909).

`registerView` / `unregisterView` mutated `prev.currentViews` inside the `useState` updater. Under `StrictMode` — which the app runs in (`apps/meteor/client/startup/appRoot.tsx`) — React calls state updaters twice to surface impure ones, and the result of the second call is the one that lands:

1. first call: `prev.currentViews.add(view)`, returns a new object with a fresh `filteredViews`;
2. second call: `prev.currentViews.has(view)` is now `true` because of the mutation, so it bails out and returns `prev`.

State keeps the old object, `filteredViews` never changes, and consumers reading `currentViews` (the filtered set) never see the view. So in development `registerView('popout')` / `registerView('widget')` were effectively no-ops, and `unregisterView` had the mirrored problem: the view stayed in the filtered set after the first call deleted it from the raw one.

The updater now copies the set instead of mutating it, and both fields are built by a single `withFilteredViews` helper so the raw and filtered sets can't drift.

Also removes the comment asking consumers to build a new `Set` before using it in a `useEffect`: the exposed set already gets a new identity whenever its contents change, and a `new Set(...)` on the consumer side would change identity on every render, firing the effect regardless of whether anything changed.

## Issue(s)
[DMVPR-26](https://rocketchat.atlassian.net/browse/DMVPR-26)
## Steps to test or reproduce

Covered by the new `useAvailableViewTracker.spec.ts`, which renders the hook inside `StrictMode`. Against the previous implementation 2 of its 3 cases fail.

Manually, with a call ongoing:

1. Open the call in the popout window and close it again — both transitions work.
2. Open the room where the call is happening: the widget hides while the room view is registered and comes back when it unregisters.

## Further comments

The third test asserts identity stability (same set when nothing changed, new set when it does), since `MediaCallInstanceProvider` puts `currentViews` in a `useMemo` dependency list — a set rebuilt on every update would rebuild the whole context value.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved view tracking reliability in React StrictMode.
  - Prevented duplicate registrations and missing unregistrations from causing unnecessary updates.
  - Ensured the widget hides correctly when the room view is registered.
  - Preserved view state consistency when available views do not change.

- **Tests**
  - Added coverage for registration, unregistration, widget visibility, and state reference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[DMVPR-26]: https://rocketchat.atlassian.net/browse/DMVPR-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ