### PR TITLE
fix: thread pagination not loading when dragging the scrollbar

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.spec.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.spec.tsx
@@ -1,0 +1,181 @@
+import type { IMessage, IThreadMainMessage, IThreadMessage } from '@rocket.chat/core-typings';
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+
+import ThreadMessageList from './ThreadMessageList';
+import { createFakeMessage, createFakeRoom } from '../../../../../../tests/mocks/data';
+import { useThreadMessagesQuery } from '../hooks/useThreadMessagesQuery';
+
+const room = createFakeRoom({ _id: 'room-id', t: 'c' });
+const mockVirtualizerHandle = {
+	scrollToIndex: jest.fn(),
+	findItemIndex: jest.fn(() => 0),
+	scrollOffset: 100,
+	scrollSize: 1000,
+	viewportSize: 300,
+};
+
+jest.mock('virtua', () => {
+	const { forwardRef, useImperativeHandle } = jest.requireActual<typeof import('react')>('react');
+
+	return {
+		VList: forwardRef(
+			(
+				{
+					children,
+					onScroll,
+					shift: _shift,
+					keepMounted: _keepMounted,
+					...props
+				}: {
+					children: ReactNode;
+					onScroll?: (offset: number) => void;
+					shift?: boolean;
+					keepMounted?: number[];
+				},
+				ref: any,
+			) => {
+				useImperativeHandle(ref, () => mockVirtualizerHandle);
+				return (
+					<ul data-testid='thread-message-list' onScroll={() => onScroll?.(mockVirtualizerHandle.scrollOffset)} {...props}>
+						{children}
+					</ul>
+				);
+			},
+		),
+	};
+});
+
+jest.mock('@rocket.chat/fuselage-hooks', () => ({
+	...jest.requireActual('@rocket.chat/fuselage-hooks'),
+	useDebouncedCallback: (callback: (...args: any[]) => void) => callback,
+}));
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	clientCallbacks: {
+		add: jest.fn(),
+		remove: jest.fn(),
+		priority: { MEDIUM: 0 },
+	},
+	CustomVirtuaScrollbars: forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(function CustomVirtuaScrollbars(
+		{ children, ...props },
+		ref,
+	) {
+		return (
+			<div {...props}>
+				<div ref={ref}>{children}</div>
+				<div data-testid='overlay-scrollbar-handle' />
+			</div>
+		);
+	}),
+}));
+
+jest.mock('../hooks/useThreadMessagesQuery', () => ({
+	useThreadMessagesQuery: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useDateScroll', () => ({
+	useDateScroll: () => ({
+		bubbleRef: { current: null },
+		handleDateScroll: jest.fn(),
+	}),
+}));
+
+jest.mock('../../../contexts/RoomContext', () => ({
+	useRoom: () => room,
+}));
+
+jest.mock('../../../MessageList/hooks/useKeepAtBottom', () => ({
+	useKeepAtBottom: () => ({ keepAtBottomRef: jest.fn(), setKeepAtBottom: jest.fn() }),
+}));
+
+jest.mock('../../../MessageList/hooks/useKeepMountedMessages', () => ({
+	useKeepMountedMessages: () => [],
+}));
+
+jest.mock('../../../hooks/useFirstUnreadMessageId', () => ({
+	useFirstUnreadMessageId: () => undefined,
+}));
+
+jest.mock('../../../hooks/useMessageListNavigation', () => ({
+	useMessageListNavigation: () => ({ messageListRef: { current: null } }),
+}));
+
+jest.mock('../../../MessageList/providers/MessageListProvider', () => ({ children }: { children: ReactNode }) => <>{children}</>);
+
+jest.mock('../../../../../lib/utils/setMessageJumpQueryStringParameter', () => ({
+	setMessageJumpQueryStringParameter: jest.fn(),
+}));
+
+jest.mock('./ThreadMessageItem', () => ({
+	ThreadMessageItem: ({ message }: { message: IMessage }) => <li>{message._id}</li>,
+}));
+
+jest.mock('../../../BubbleDate', () => ({
+	BubbleDate: forwardRef(function BubbleDate(_, ref) {
+		return <time ref={ref as any} />;
+	}),
+}));
+
+const createThreadMessage = (index: number): IThreadMessage => {
+	const ts = new Date(Date.UTC(2026, 0, index));
+
+	return createFakeMessage<IThreadMessage>({
+		_id: `reply-${index}`,
+		rid: room._id,
+		tmid: 'thread-id',
+		msg: `reply ${index}`,
+		ts,
+		_updatedAt: ts,
+		u: {
+			_id: 'user-id',
+			username: 'user',
+			name: 'User',
+		},
+	});
+};
+
+describe('ThreadMessageList', () => {
+	it('fetches the previous page after a pointer interaction with the overlay scrollbar', async () => {
+		const user = userEvent.setup();
+		const fetchPreviousPage = jest.fn().mockResolvedValue(undefined);
+		const mainMessage = createFakeMessage<IThreadMainMessage>({
+			_id: 'thread-id',
+			rid: room._id,
+			msg: 'main message',
+			tcount: 1,
+			u: {
+				_id: 'user-id',
+				username: 'user',
+				name: 'User',
+			},
+		});
+		(useThreadMessagesQuery as jest.Mock).mockReturnValue({
+			data: { messages: [createThreadMessage(1)] },
+			isLoading: false,
+			fetchNextPage: jest.fn(),
+			hasNextPage: false,
+			isFetchingNextPage: false,
+			fetchPreviousPage,
+			hasPreviousPage: true,
+			isFetchingPreviousPage: false,
+			loadMessageAround: jest.fn(),
+		});
+
+		render(<ThreadMessageList mainMessage={mainMessage} shouldJumpToBottom setShouldJumpToBottom={jest.fn()} />, {
+			wrapper: mockAppRoot().withJohnDoe().withSetting('Message_GroupingPeriod', 300).withUserPreference('displayAvatars', true).build(),
+		});
+
+		fireEvent.scroll(screen.getByTestId('thread-message-list'));
+		expect(fetchPreviousPage).not.toHaveBeenCalled();
+
+		await user.pointer({ keys: '[MouseLeft>]', target: screen.getByTestId('overlay-scrollbar-handle') });
+		fireEvent.scroll(screen.getByTestId('thread-message-list'));
+		await user.pointer({ keys: '[/MouseLeft]' });
+
+		expect(fetchPreviousPage).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.spec.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.spec.tsx
@@ -92,10 +92,6 @@ jest.mock('../../../MessageList/hooks/useKeepAtBottom', () => ({
 	useKeepAtBottom: () => ({ keepAtBottomRef: jest.fn(), setKeepAtBottom: jest.fn() }),
 }));
 
-jest.mock('../../../MessageList/hooks/useKeepMountedMessages', () => ({
-	useKeepMountedMessages: () => [],
-}));
-
 jest.mock('../../../hooks/useFirstUnreadMessageId', () => ({
 	useFirstUnreadMessageId: () => undefined,
 }));

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -170,12 +170,14 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 					userInteractedRef.current = true;
 				}
 			};
+			const parent = element.parentElement;
+
+			parent?.addEventListener('pointerdown', markInteracted);
 			element.addEventListener('wheel', markInteracted, { passive: true });
-			element.addEventListener('touchmove', markInteracted, { passive: true });
 			element.addEventListener('keydown', handleKeydown);
 			return () => {
+				parent?.removeEventListener('pointerdown', markInteracted);
 				element.removeEventListener('wheel', markInteracted);
-				element.removeEventListener('touchmove', markInteracted);
 				element.removeEventListener('keydown', handleKeydown);
 			};
 		}, []),


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Thread pagination was guarded until the user interacted with the message list. However, dragging the custom overlay scrollbar did not count as an interaction because the scrollbar is rendered outside the scrollable viewport.

This change listens for `pointerdown` on the viewport's parent, where events from the overlay scrollbar are received. The listener is removed during cleanup. This matches the existing room-history pagination behavior in [#41098](https://github.com/RocketChat/Rocket.Chat/pull/41098).

The test verifies that:

- Scrolling before a recognized user interaction does not fetch another page.
- Interacting with the overlay scrollbar and reaching the upper pagination threshold fetches the previous page.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2512](https://rocketchat.atlassian.net/browse/CORE-2512)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Open a channel with a thread containing enough replies to have unloaded pages.
2. Open the thread.
3. Without using the mouse wheel, drag the overlay scrollbar to the top.
4. Confirm that reaching the pagination threshold fetches the previous page.
5. Confirm that wheel, touch, and keyboard scrolling continue to work as expected.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2512]: https://rocketchat.atlassian.net/browse/CORE-2512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread message scrolling behavior so older messages load only after intentional scrollbar interaction followed by scrolling.
  * Prevented unintended message fetches from scrolling alone.
* **Tests**
  * Added coverage for scrollbar interaction and ensured previous-page requests occur exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->