### PR TITLE
fix: read receipts of thread messages stuck as "sent"

### DIFF
--- a/.changeset/kind-peas-greet.md
+++ b/.changeset/kind-peas-greet.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes thread replies keeping the "sent" single checkmark after everyone had read the thread, only switching to the "viewed" double checkmark once a new message was sent in that thread.

--- a/apps/meteor/server/hooks/messages/processThreads.ts
+++ b/apps/meteor/server/hooks/messages/processThreads.ts
@@ -62,6 +62,11 @@ export async function processThreads(message: IMessage, room: IRoom, options?: S
 
 	await notifyUsersOnReply(message, replies);
 	await metaData(message, parentMessage, replies);
+
+	if (!isEditedMessage(message)) {
+		callbacks.runAsync('afterReadMessages', room, { uid: message.u._id, tmid: message.tmid });
+	}
+
 	if (!options?.skipNotifications) {
 		await notification(message, room, replies);
 	}

--- a/apps/meteor/tests/unit/server/hooks/messages/processThreads.spec.ts
+++ b/apps/meteor/tests/unit/server/hooks/messages/processThreads.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import p from 'proxyquire';
+import sinon from 'sinon';
+
+import { createFakeMessage, createFakeRoom } from '../../../../mocks/data';
+
+const modelsMock = { Messages: { findOneById: sinon.stub() } };
+const getMentionsMock = sinon.stub();
+const replyMock = sinon.stub();
+const callbacksRunAsyncMock = sinon.stub();
+
+const { processThreads } = p.noCallThru().load('../../../../../server/hooks/messages/processThreads.ts', {
+	'@rocket.chat/models': modelsMock,
+	'meteor/meteor': { Meteor: { startup: sinon.stub() } },
+	'./notifyUsersOnMessage': { updateThreadUsersSubscriptions: sinon.stub(), getMentions: getMentionsMock },
+	'./sendNotificationsOnMessage': { sendMessageNotifications: sinon.stub() },
+	'../../lib/callbacks': {
+		callbacks: { runAsync: callbacksRunAsyncMock, add: sinon.stub(), remove: sinon.stub(), priority: { LOW: 'low' } },
+	},
+	'../../lib/messaging/threads/functions': { reply: replyMock },
+	'../../lib/notifyListener': { notifyOnMessageChange: sinon.stub() },
+	'../../settings': { settings: { watch: sinon.stub() } },
+});
+
+describe('processThreads', () => {
+	const room = createFakeRoom();
+	const parentMessage = createFakeMessage({ rid: room._id, tcount: 1, replies: [] });
+	const author = { _id: 'authorId', username: 'author' };
+
+	const threadReply = (overrides: Record<string, unknown> = {}) =>
+		createFakeMessage({ rid: room._id, tmid: parentMessage._id, u: author, ...overrides });
+
+	beforeEach(() => {
+		callbacksRunAsyncMock.reset();
+		replyMock.reset();
+		modelsMock.Messages.findOneById.reset();
+		modelsMock.Messages.findOneById.resolves(parentMessage);
+		getMentionsMock.reset();
+		getMentionsMock.resolves({ mentionIds: [] });
+	});
+
+	it('should mark the thread as read for the author of the reply', async () => {
+		await processThreads(threadReply(), room);
+
+		expect(callbacksRunAsyncMock.calledWith('afterReadMessages', room, { uid: author._id, tmid: parentMessage._id })).to.be.true;
+	});
+
+	it('should mark the thread as read only after the thread metadata is updated', async () => {
+		await processThreads(threadReply(), room);
+
+		expect(replyMock.calledBefore(callbacksRunAsyncMock)).to.be.true;
+	});
+
+	it('should not mark anything as read when the message is not a thread reply', async () => {
+		await processThreads(createFakeMessage({ rid: room._id, u: author }), room);
+
+		expect(callbacksRunAsyncMock.called).to.be.false;
+	});
+
+	it('should not mark anything as read when the message was edited', async () => {
+		await processThreads(threadReply({ editedAt: new Date(), editedBy: author }), room);
+
+		expect(callbacksRunAsyncMock.called).to.be.false;
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

**The problem.** A thread reply only turns into a double check once the server has a read record from **every** member of the room, and it then clears messages up to the oldest of those records. Nothing ever wrote that record for the **author of the reply**, so the author stayed missing from the count and the gate never closed. Rooms don't have this problem: sending already counts as reading there, since `notifyUsersOnMessage` sets the sender's own `ls` right after saving. **#27074** (`e9667ed`, 6.0.0) gave threads the gate, in `MessageReadsService.readThread`, without the equivalent write.

**Why it usually looked fine.** The record was written by a client side effect: the author's browser receives its own message back over the WebSocket and, while its local copy is still the unconfirmed (`temp`) one, treats it as new and calls `chat.readThread` on itself. Not a designed path — the receipt was riding on a dedup heuristic.

**Why it broke.** Whenever that heuristic doesn't run:

1. **No web client at all** — replies posted through the API, a bot or a webhook. Nothing compensates, so it fails every time.
2. **The server's two replies arrive out of order.** The browser gets its own message back twice: the POST response, which marks the local copy confirmed, and the WebSocket copy, which triggers `readThread` — but only while that copy is still unconfirmed, a check that keeps the client from treating its own message as one that just arrived from someone else. Response first, and the WebSocket copy is dismissed as already known, so `readThread` never runs. That is the normal order in a scaled deployment, where a separate process terminates the socket and the message travels farther back than the response does; bursts produce it too.
3. **The author leaves before the echo** — closes the pane, switches room, reloads.

The call is skipped, not delayed: no retry, no catch-up. The only recovery was reopening the thread, which calls `readThread` regardless of any echo (`useThreadMessagesQuery`) — that writes the record late, the gate closes, and the stuck replies jump to double check at once.

**The fix.** `processThreads` now writes the record when the reply is saved, through `afterReadMessages`, the same hook the canonical read path uses. It runs after the metadata update, since `readThread` bails out while the parent's `tlm` is unset, and skips edits. The write happens before any broadcast, so arrival order stops mattering and the echo goes back to being just rendering.

## Issue(s)

- [CORE-2508](https://rocketchat.atlassian.net/browse/CORE-2508)
- Introduced by #27074

## Steps to test or reproduce

Requires an EE license with `Message_Read_Receipt_Enabled` and `Message_Read_Receipt_Store_Users` on, and a channel with two members, **A** and **B**.

On a single-process dev instance the echo always wins, so the compensation always hides the bug. Emulating the extra hop of a scaled deployment makes it deterministic — in `notifyOnMessageChange`, `apps/meteor/server/lib/notifyListener.ts`:

```ts
// local only, revert afterwards
setTimeout(() => void api.broadcast('watch.messages', { message }), 300);
```

Restart, then:

1. As A, post a message and open it as a thread.
2. As B, reply **once**, from the UI.
3. As A, open the thread and react to the reply, without replying.
4. On `develop` the reply stays on a single check, every time. With this branch it turns into a double check.

Without touching code: have B reply through `chat.sendMessage` passing `tmid` — no browser to compensate, so it fails on a plain instance too. In the failing state, "Read receipts" lists only A. Use a fresh channel per round, and don't reopen the thread as B — that calls `readThread` and heals it.

## Further comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thread replies now correctly update to “viewed” after the thread is read, instead of remaining marked as “sent.”
  * Edited replies and non-thread messages retain their existing read-status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2508]: https://rocketchat.atlassian.net/browse/CORE-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ