### PR TITLE
fix: load room history on insecure origins

### DIFF
--- a/.changeset/room-history-insecure-origin.md
+++ b/.changeset/room-history-insecure-origin.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix message history loading on non-secure HTTP origins where `crypto.randomUUID` is unavailable.

--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -1,5 +1,6 @@
 import type { IMessage, IRoom, ISubscription } from '@rocket.chat/core-typings';
 import { Emitter } from '@rocket.chat/emitter';
+import { Random } from '@rocket.chat/random';
 import { differenceInMilliseconds } from 'date-fns';
 import { useCallback, useSyncExternalStore } from 'react';
 
@@ -91,7 +92,7 @@ class RoomHistoryManagerClass extends Emitter {
 
 	private async queue(): Promise<void> {
 		return new Promise((resolve) => {
-			const requestId = crypto.randomUUID();
+			const requestId = Random.id();
 			const done = () => {
 				this.lastRequest = new Date();
 				resolve();

--- a/apps/meteor/client/lib/RoomHistoryManager.spec.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.spec.ts
@@ -1,0 +1,57 @@
+import { callWithErrorHandling } from './utils/callWithErrorHandling';
+import { RoomHistoryManager } from '../../app/ui-utils/client/lib/RoomHistoryManager';
+
+jest.mock('./onClientMessageReceived', () => ({
+	onClientMessageReceived: jest.fn((message) => message),
+}));
+
+jest.mock('./user', () => ({
+	getUserId: jest.fn(() => 'user-id'),
+}));
+
+jest.mock('./utils/callWithErrorHandling', () => ({
+	callWithErrorHandling: jest.fn(),
+}));
+
+jest.mock('./utils/getConfig', () => ({
+	getConfig: jest.fn(() => undefined),
+}));
+
+jest.mock('../stores', () => ({
+	Messages: {
+		state: {
+			store: jest.fn(),
+			storeMany: jest.fn(),
+			findFirst: jest.fn(),
+			remove: jest.fn(),
+			some: jest.fn(),
+		},
+	},
+	Subscriptions: {
+		state: {
+			find: jest.fn(),
+		},
+	},
+}));
+
+jest.mock('../../app/utils/client', () => ({
+	getUserPreference: jest.fn(() => false),
+}));
+
+const mockedCallWithErrorHandling = jest.mocked(callWithErrorHandling);
+
+describe('RoomHistoryManager', () => {
+	it('loads history when crypto.randomUUID is unavailable', async () => {
+		const originalRandomUUID = globalThis.crypto.randomUUID;
+		Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: undefined });
+		mockedCallWithErrorHandling.mockResolvedValue({ messages: [], unreadNotLoaded: 0 } as never);
+
+		try {
+			await expect(RoomHistoryManager.getMore('room-id')).resolves.toBeUndefined();
+			expect(mockedCallWithErrorHandling).toHaveBeenCalledWith('loadHistory', 'room-id', undefined, 50, undefined, false);
+		} finally {
+			Object.defineProperty(globalThis.crypto, 'randomUUID', { configurable: true, value: originalRandomUUID });
+			RoomHistoryManager.close('room-id');
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- replace the secure-context-only `crypto.randomUUID()` call in `RoomHistoryManager` with Rocket.Chat's browser-safe `Random.id()` utility
- add a regression test proving message history loads when `crypto.randomUUID` is unavailable
- add a patch changeset for `@rocket.chat/meteor`

## Root cause

`RoomHistoryManager.queue()` generated an internal emitter key with `crypto.randomUUID()`. Browsers expose that API only in secure contexts, so opening Rocket.Chat over plain HTTP on a non-localhost origin rejected the history-loading promise before `loadHistory` could run.

The queue only requires a collision-resistant internal identifier, not UUID formatting. `@rocket.chat/random` is already used throughout the client and generates IDs with `crypto.getRandomValues()` when available, with its established fallback otherwise.

## User impact

Message history can load again for self-hosted workspaces accessed through non-secure HTTP origins, while secure-origin behavior remains unchanged.

## Validation

- reproduced the original failure with a regression test: `TypeError: crypto.randomUUID is not a function`
- `yarn workspace @rocket.chat/meteor .testunit:jest --selectProjects client --runInBand client/lib/RoomHistoryManager.spec.ts`
- `yarn workspace @rocket.chat/random test --runInBand`
- `yarn eslint apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts apps/meteor/client/lib/RoomHistoryManager.spec.ts`
- `yarn changeset status`

The full Meteor typecheck was also attempted; current `develop` reports unrelated existing errors in thread drafts, TOTP/OAuth endpoint typings, file-upload typings, and other untouched areas. No error referenced the changed files.

Fixes #41666


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed message history loading on insecure HTTP connections when `crypto.randomUUID` is unavailable.
  - Improved compatibility for queued history requests across supported environments.

- **Tests**
  - Added coverage to verify message history loads correctly without `crypto.randomUUID`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->