### PR TITLE
fix: "Jump to message" not navigating to cross-room messages

### DIFF
--- a/.changeset/proud-garlics-open.md
+++ b/.changeset/proud-garlics-open.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes "Jump to message" not navigating to the message's room when the message belongs to a room other than the currently opened one (e.g. global search results).

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
@@ -77,26 +77,26 @@ const message = {
 };
 
 it('should navigate to the message room when the message belongs to another room', async () => {
-		renderJumpHook('room-1', { ...message, rid: 'room-2' });
+	renderJumpHook('room-1', { ...message, rid: 'room-2' });
 
-		await waitFor(() => expect(mockedGoToRoom).toHaveBeenCalledWith('room-2'));
+	await waitFor(() => expect(mockedGoToRoom).toHaveBeenCalledWith('room-2'));
 
-		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
-	});
+	expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
+});
 
-	it('should load surrounding messages in place when the message belongs to the current room', async () => {
-		renderJumpHook('room-1', { ...message, rid: 'room-1' });
+it('should load surrounding messages in place when the message belongs to the current room', async () => {
+	renderJumpHook('room-1', { ...message, rid: 'room-1' });
 
-		await waitFor(() => expect(mockedRoomHistoryManager.getSurroundingChannelMessages).toHaveBeenCalled());
+	await waitFor(() => expect(mockedRoomHistoryManager.getSurroundingChannelMessages).toHaveBeenCalled());
 
-		expect(mockedGoToRoom).not.toHaveBeenCalled();
-	});
+	expect(mockedGoToRoom).not.toHaveBeenCalled();
+});
 
-	it('should not navigate for a cross-room thread message, as it is handled by useTryToJumpToThreadMessage', async () => {
-		renderJumpHook('room-1', { ...message, rid: 'room-2', tmid: 'parent-msg-1', tshow: true });
+it('should not navigate for a cross-room thread message, as it is handled by useTryToJumpToThreadMessage', async () => {
+	renderJumpHook('room-1', { ...message, rid: 'room-2', tmid: 'parent-msg-1', tshow: true });
 
-		await waitFor(() => expect(mockedSetIsJumpingToMessage).toHaveBeenCalledWith(true));
+	await waitFor(() => expect(mockedSetIsJumpingToMessage).toHaveBeenCalledWith(true));
 
-		expect(mockedGoToRoom).not.toHaveBeenCalled();
-		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
-	});
+	expect(mockedGoToRoom).not.toHaveBeenCalled();
+	expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
+});

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
@@ -1,0 +1,103 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { MutableRefObject } from 'react';
+import type { WindowVirtualizerHandle } from 'virtua';
+
+import useTryToJumpToMessage from './useTryToJumpToMessage';
+import { RoomHistoryManager } from '../../../../../app/ui-utils/client';
+import { RoomContext } from '../../contexts/RoomContext';
+import { useGoToRoom } from '../../hooks/useGoToRoom';
+
+jest.mock('../../../../../app/ui-utils/client', () => ({
+	RoomHistoryManager: {
+		getSurroundingChannelMessages: jest.fn().mockResolvedValue(undefined),
+	},
+}));
+
+jest.mock('../../hooks/useGoToRoom', () => ({
+	useGoToRoom: jest.fn(),
+}));
+
+jest.mock('../../../../providers/RouterProvider', () => ({
+	router: {
+		getSearchParameters: jest.fn().mockReturnValue({}),
+	},
+}));
+
+const mockedRoomHistoryManager = jest.mocked(RoomHistoryManager);
+const mockedGoToRoom = jest.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+	jest.mocked(useGoToRoom).mockReturnValue(mockedGoToRoom);
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+const renderJumpHook = (rid: string, message: unknown) =>
+	renderHook(
+		() =>
+			useTryToJumpToMessage({
+				rid,
+				virtualizerRef: { current: { scrollToIndex: jest.fn() } } as unknown as MutableRefObject<WindowVirtualizerHandle | null>,
+				setIsJumpingToMessage: jest.fn(),
+				messages: [{ _id: 'another-msg' }],
+			}),
+		{
+			wrapper: mockAppRoot()
+				.withRouter({ getSearchParameters: () => ({ msg: 'msg-1' }) })
+				.withEndpoint('GET', '/v1/chat.getMessage', (() => ({ message })) as any)
+				.wrap((children) => (
+					<RoomContext.Provider
+						value={
+							{
+								rid,
+								room: { _id: rid, t: 'c', name: 'general' },
+								hasMorePreviousMessages: false,
+								hasMoreNextMessages: false,
+								isLoadingMoreMessages: false,
+							} as any
+						}
+					>
+						{children}
+					</RoomContext.Provider>
+				))
+				.build(),
+		},
+	);
+
+const message = {
+	_id: 'msg-1',
+	ts: new Date('2024-01-01T00:00:00Z').toISOString(),
+	u: { _id: 'user-1', username: 'john' },
+	msg: 'Hello',
+	_updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+};
+
+describe('useTryToJumpToMessage', () => {
+	it('should navigate to the message room when the message belongs to another room', async () => {
+		renderJumpHook('room-1', { ...message, rid: 'room-2' });
+
+		await waitFor(() => expect(mockedGoToRoom).toHaveBeenCalledWith('room-2'));
+
+		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
+	});
+
+	it('should load surrounding messages in place when the message belongs to the current room', async () => {
+		renderJumpHook('room-1', { ...message, rid: 'room-1' });
+
+		await waitFor(() => expect(mockedRoomHistoryManager.getSurroundingChannelMessages).toHaveBeenCalled());
+
+		expect(mockedGoToRoom).not.toHaveBeenCalled();
+	});
+
+	it('should not navigate for a cross-room thread message, as it is handled by useTryToJumpToThreadMessage', async () => {
+		renderJumpHook('room-1', { ...message, rid: 'room-2', tmid: 'parent-msg-1', tshow: true });
+
+		await waitFor(() => new Promise((resolve) => setTimeout(resolve, 100)));
+
+		expect(mockedGoToRoom).not.toHaveBeenCalled();
+		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
+	});
+});

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
@@ -76,8 +76,7 @@ const message = {
 	_updatedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
 };
 
-describe('useTryToJumpToMessage', () => {
-	it('should navigate to the message room when the message belongs to another room', async () => {
+it('should navigate to the message room when the message belongs to another room', async () => {
 		renderJumpHook('room-1', { ...message, rid: 'room-2' });
 
 		await waitFor(() => expect(mockedGoToRoom).toHaveBeenCalledWith('room-2'));
@@ -101,4 +100,3 @@ describe('useTryToJumpToMessage', () => {
 		expect(mockedGoToRoom).not.toHaveBeenCalled();
 		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();
 	});
-});

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.spec.tsx
@@ -26,6 +26,7 @@ jest.mock('../../../../providers/RouterProvider', () => ({
 
 const mockedRoomHistoryManager = jest.mocked(RoomHistoryManager);
 const mockedGoToRoom = jest.fn().mockResolvedValue(undefined);
+const mockedSetIsJumpingToMessage = jest.fn();
 
 beforeEach(() => {
 	jest.mocked(useGoToRoom).mockReturnValue(mockedGoToRoom);
@@ -41,7 +42,7 @@ const renderJumpHook = (rid: string, message: unknown) =>
 			useTryToJumpToMessage({
 				rid,
 				virtualizerRef: { current: { scrollToIndex: jest.fn() } } as unknown as MutableRefObject<WindowVirtualizerHandle | null>,
-				setIsJumpingToMessage: jest.fn(),
+				setIsJumpingToMessage: mockedSetIsJumpingToMessage,
 				messages: [{ _id: 'another-msg' }],
 			}),
 		{
@@ -95,7 +96,7 @@ describe('useTryToJumpToMessage', () => {
 	it('should not navigate for a cross-room thread message, as it is handled by useTryToJumpToThreadMessage', async () => {
 		renderJumpHook('room-1', { ...message, rid: 'room-2', tmid: 'parent-msg-1', tshow: true });
 
-		await waitFor(() => new Promise((resolve) => setTimeout(resolve, 100)));
+		await waitFor(() => expect(mockedSetIsJumpingToMessage).toHaveBeenCalledWith(true));
 
 		expect(mockedGoToRoom).not.toHaveBeenCalled();
 		expect(mockedRoomHistoryManager.getSurroundingChannelMessages).not.toHaveBeenCalled();

--- a/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useTryToJumpToMessage.ts
@@ -10,6 +10,7 @@ import { messagesQueryKeys } from '../../../../lib/queryKeys';
 import { mapMessageFromApi } from '../../../../lib/utils/mapMessageFromApi';
 import { setMessageJumpQueryStringParameter } from '../../../../lib/utils/setMessageJumpQueryStringParameter';
 import { useRoomMessages } from '../../contexts/RoomContext';
+import { useGoToRoom } from '../../hooks/useGoToRoom';
 import { clearHighlightMessage, setHighlightMessage } from '../providers/messageHighlightSubscription';
 
 type UseTryToJumpToMessageProps = {
@@ -25,6 +26,8 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 	const { isLoadingMoreMessages } = useRoomMessages();
 
 	const getMessage = useEndpoint('GET', '/v1/chat.getMessage');
+
+	const goToRoom = useGoToRoom();
 
 	const { data: message } = useQuery({
 		queryKey: messageJumpParam ? messagesQueryKeys.message(messageJumpParam) : [],
@@ -48,6 +51,11 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 		// If tshow is true, there is a preview on the main list, in this case we scroll to it
 		if (message && isThreadMessage(message) && !isThreadMainMessage(message) && message.tshow !== true) {
 			setIsJumpingToMessage(false);
+			return;
+		}
+		if (!isThreadMessage(message) && !isThreadMainMessage(message) && message.rid !== rid) {
+			setIsJumpingToMessage(false);
+			goToRoom(message.rid);
 			return;
 		}
 		if (!virtualizerRef.current) {
@@ -84,7 +92,7 @@ const useTryToJumpToMessage = ({ rid, virtualizerRef, setIsJumpingToMessage, mes
 			setIsJumpingToMessage(false);
 			setMessageJumpQueryStringParameter(null);
 		}, 500);
-	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message, isLoadingMoreMessages]);
+	}, [messageJumpParam, virtualizerRef, setIsJumpingToMessage, rid, messages, message, isLoadingMoreMessages, goToRoom]);
 };
 
 export default useTryToJumpToMessage;

--- a/apps/meteor/tests/e2e/global-search.spec.ts
+++ b/apps/meteor/tests/e2e/global-search.spec.ts
@@ -71,9 +71,9 @@ test.describe.serial('Global Search', () => {
 		await poHomeChannel.navbar.openChat(targetGroup.name);
 		await poHomeChannel.roomToolbar.btnSearchMessages.click();
 
-		await poHomeChannel.tabs.searchMessages.search(threadMessage.msg.slice(10), { global: true }); 
+		await poHomeChannel.tabs.searchMessages.search(threadMessage.msg.slice(10), { global: true });
 		await poHomeChannel.tabs.searchMessages.jumpToMessage(threadMessage.msg);
-		
+
 		await expect(poHomeChannel.content.channelHeader).toContainText(targetChannel.name);
 		await expect(poHomeChannel.tabs.threads.getThreadMessageByText(threadMessage.msg)).toBeVisible();
 	});

--- a/apps/meteor/tests/e2e/global-search.spec.ts
+++ b/apps/meteor/tests/e2e/global-search.spec.ts
@@ -13,6 +13,7 @@ test.describe.serial('Global Search', () => {
 	let targetChannel: { name: string; _id: string };
 	let targetGroup: { name: string; _id: string };
 	let threadMessage: IMessage;
+	let regularMessage: IMessage;
 	let poHomeChannel: HomeChannel;
 
 	const fillMessages = async (api: BaseTest['api']) => {
@@ -24,6 +25,11 @@ test.describe.serial('Global Search', () => {
 			await api.post('/chat.postMessage', { roomId: targetChannel._id, text: `This is thread message in channel`, tmid: parentMessage._id })
 		).json();
 		threadMessage = childMessage;
+
+		const { message: standaloneMessage } = await (
+			await api.post('/chat.postMessage', { roomId: targetChannel._id, text: 'This is regular message in channel' })
+		).json();
+		regularMessage = standaloneMessage;
 	};
 
 	test.beforeAll(async ({ api }) => {
@@ -72,7 +78,22 @@ test.describe.serial('Global Search', () => {
 		const jumpToMessageButton = message.getByRole('button', { name: 'Jump to message' });
 		await jumpToMessageButton.click();
 
-		await expect(page.locator('header').getByRole('button').filter({ hasText: targetChannel.name })).toBeVisible(); // match channel name in room header
+		await expect(poHomeChannel.content.channelHeader).toContainText(targetChannel.name);
 		await expect(page.getByText(threadMessage.msg)).toBeVisible();
+	});
+
+	test('should open the correct message when jumping from global search in group to channel message', async ({ page }) => {
+		await poHomeChannel.navbar.openChat(targetGroup.name);
+		await poHomeChannel.roomToolbar.btnSearchMessages.click();
+
+		await poHomeChannel.tabs.searchMessages.search('regular', { global: true });
+
+		const message = await poHomeChannel.tabs.searchMessages.getResultItem(regularMessage.msg);
+		await message.hover();
+		const jumpToMessageButton = message.getByRole('button', { name: 'Jump to message' });
+		await jumpToMessageButton.click();
+
+		await expect(poHomeChannel.content.channelHeader).toContainText(targetChannel.name);
+		await expect(page.getByText(regularMessage.msg)).toBeVisible();
 	});
 });

--- a/apps/meteor/tests/e2e/global-search.spec.ts
+++ b/apps/meteor/tests/e2e/global-search.spec.ts
@@ -67,33 +67,25 @@ test.describe.serial('Global Search', () => {
 		await page.goto('/home');
 	});
 
-	test('should open the correct message when jumping from global search in group to channel thread', async ({ page }) => {
+	test('should open the correct message when jumping from global search in group to channel thread', async () => {
 		await poHomeChannel.navbar.openChat(targetGroup.name);
 		await poHomeChannel.roomToolbar.btnSearchMessages.click();
 
-		await poHomeChannel.tabs.searchMessages.search(threadMessage.msg.slice(10), { global: true }); // fill partial text to match search
-
-		const message = await poHomeChannel.tabs.searchMessages.getResultItem(threadMessage.msg);
-		await message.hover();
-		const jumpToMessageButton = message.getByRole('button', { name: 'Jump to message' });
-		await jumpToMessageButton.click();
-
+		await poHomeChannel.tabs.searchMessages.search(threadMessage.msg.slice(10), { global: true }); 
+		await poHomeChannel.tabs.searchMessages.jumpToMessage(threadMessage.msg);
+		
 		await expect(poHomeChannel.content.channelHeader).toContainText(targetChannel.name);
-		await expect(page.getByText(threadMessage.msg)).toBeVisible();
+		await expect(poHomeChannel.tabs.threads.getThreadMessageByText(threadMessage.msg)).toBeVisible();
 	});
 
-	test('should open the correct message when jumping from global search in group to channel message', async ({ page }) => {
+	test('should open the correct message when jumping from global search in group to channel message', async () => {
 		await poHomeChannel.navbar.openChat(targetGroup.name);
 		await poHomeChannel.roomToolbar.btnSearchMessages.click();
 
-		await poHomeChannel.tabs.searchMessages.search('regular', { global: true });
-
-		const message = await poHomeChannel.tabs.searchMessages.getResultItem(regularMessage.msg);
-		await message.hover();
-		const jumpToMessageButton = message.getByRole('button', { name: 'Jump to message' });
-		await jumpToMessageButton.click();
+		await poHomeChannel.tabs.searchMessages.search(regularMessage.msg.slice(10), { global: true });
+		await poHomeChannel.tabs.searchMessages.jumpToMessage(regularMessage.msg);
 
 		await expect(poHomeChannel.content.channelHeader).toContainText(targetChannel.name);
-		await expect(page.getByText(regularMessage.msg)).toBeVisible();
+		await expect(poHomeChannel.content.getMessageByText(regularMessage.msg)).toBeVisible();
 	});
 });

--- a/apps/meteor/tests/e2e/page-objects/fragments/flextabs/search-messages-flextab.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/flextabs/search-messages-flextab.ts
@@ -17,4 +17,10 @@ export class SearchMessagesFlexTab extends FlexTab {
 	async getResultItem(messageText: string) {
 		return this.root.getByRole('listitem', { name: messageText });
 	}
+
+	async jumpToMessage(messageText: string) {
+		const message = (await this.getResultItem(messageText)).first();
+		await message.hover();
+		await message.getByRole('button', { name: 'Jump to message' }).click();
+	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/flextabs/threads-flextab.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/flextabs/threads-flextab.ts
@@ -14,4 +14,8 @@ export class ThreadsFlexTab extends FlexTab {
 	get lastThreadMessage(): Locator {
 		return this.listThreadMessages.locator('[data-qa-type="message"]').last().locator('[data-qa-type="message-body"]');
 	}
+
+	getThreadMessageByText(messageText: string): Locator {
+		return this.listThreadMessages.getByRole('listitem').getByText(messageText);
+	}
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

"Jump to message" does nothing when the message belongs to another room, which is the usual case for global search results.

The action only writes `?msg=<id>` onto the current room's URL. Until 8.5.0 `RoomBody` mounted `useLoadSurroundingMessages`, which called `goToRoom(message.rid)` for messages in another room. #40105 removed that call site and replaced the jump logic with `useTryToJumpToMessage`, which only looks inside the currently open room's message list, so a cross-room hit resolves to nothing.

`useTryToJumpToMessage` now calls `goToRoom(message.rid)` when the message belongs to another room. `useGoToRoom` forwards the current search parameters, so `msg` survives the navigation and the destination room's own instance of the hook finishes the jump.

Thread messages are excluded because `useTryToJumpToThreadMessage` already navigates those with the correct `tab: 'thread'` overrides.

## Issue(s)

- [SUP-1077](https://rocketchat.atlassian.net/browse/SUP-1077)

## Steps to test or reproduce

1. Enable **Admin → Settings → Search → Global Search**.
2. Post a message in channel A, then open channel B.
3. Open **⋮ → Search Messages**, turn on **Global search**, and search for the text from channel A.
4. Click **Jump to message**.

Before: stays in channel B, URL just gains `?msg=<id>`. After: navigates to channel A and highlights the message.

Also check same-room results, pinned/starred messages and thread messages still jump correctly.

## Further comments


[SUP-1077]: https://rocketchat.atlassian.net/browse/SUP-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed “Jump to message” so selecting a message from another room opens the correct room and message.
  - Preserved in-place navigation for messages in the current room.
  - Ensured thread messages continue to use the appropriate navigation behavior.
  - Improved navigation reliability when opening messages from global search.

- **Tests**
  - Added coverage for cross-room, same-room, and thread message navigation.
  - Added end-to-end coverage for jumping to messages from global search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->