### PR TITLE
refactor: deprecate 'button' prop in GenericMenu to enforce semantic HTML (#39811)

### DIFF
--- a/.changeset/deprecate-genericmenu-button-prop.md
+++ b/.changeset/deprecate-genericmenu-button-prop.md
@@ -2,4 +2,4 @@
 '@rocket.chat/ui-client': patch
 ---
 
-Deprecates prop `button` on `GenericMenu` component to enforce semantic HTML and accessibility standards.
+Deprecates prop `button` on `GenericMenu` component in favor of semantic HTML and accessibility standards.

--- a/.changeset/deprecate-genericmenu-button-prop.md
+++ b/.changeset/deprecate-genericmenu-button-prop.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/ui-client': patch
+---
+
+Deprecates prop `button` on `GenericMenu` component to enforce semantic HTML and accessibility standards.

--- a/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
+++ b/packages/ui-client/src/components/GenericMenu/GenericMenu.tsx
@@ -1,5 +1,5 @@
 import { IconButton, MenuItem, MenuSection, Menu } from '@rocket.chat/fuselage';
-import { cloneElement, type ComponentProps, type ReactNode } from 'react';
+import { cloneElement, type ComponentProps, type ReactElement, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { GenericMenuItemProps } from './GenericMenuItem';
@@ -28,7 +28,14 @@ type GenericMenuConditionalProps =
 			sections?: never;
 	  };
 
-export type GenericMenuProps = GenericMenuCommonProps & GenericMenuConditionalProps & Omit<ComponentProps<typeof Menu>, 'children'>;
+export type GenericMenuProps = GenericMenuCommonProps &
+	GenericMenuConditionalProps &
+	Omit<ComponentProps<typeof Menu>, 'children' | 'button'> & {
+		/**
+		 * @deprecated Prop `button` is deprecated as custom elements passed here cannot be guaranteed to render a semantic `<button>` or preserve keyboard and screen-reader accessibility traits.
+		 */
+		button?: ReactElement;
+	};
 
 const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction, button, className, ...props }: GenericMenuProps) => {
 	const { t, i18n } = useTranslation();
@@ -49,8 +56,6 @@ const GenericMenu = ({ title, icon = 'menu', disabled, onAction, callbackAction,
 
 	if (isMenuEmpty || disabled) {
 		if (button) {
-			// FIXME: deprecate prop `button` as there's no way to ensure it is actually a button
-			// (e.g cloneElement could be passing props to a fragment)
 			return cloneElement(button, { small: true, icon, disabled, title, className } as any);
 		}
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Proposed changes (including videos or screenshots)
- Deprecated the `button` prop in `GenericMenuProps` within `packages/ui-client/src/components/GenericMenu/GenericMenu.tsx` by adding an explicit `@deprecated` JSDoc annotation explaining accessibility and semantic HTML implications.
- Omitted `button` from Fuselage `Menu` props in `GenericMenuProps` to ensure TypeScript and IDEs surface the deprecation warning to developers when custom elements are passed.
- Removed the developer `// FIXME: deprecate prop 'button' as there's no way to ensure it is actually a button` comment in favor of proper JSDoc documentation.
- Kept repository configuration files (such as `package.json`) untouched.

## Issue(s)
Closes #39811

## Steps to test or reproduce
1. Open `packages/ui-client/src/components/GenericMenu/GenericMenu.tsx` and inspect `GenericMenuProps`.
2. Verify that IDEs/TypeScript flag the `button` prop with `@deprecated`.
3. Run `GenericMenu` unit tests locally:
   ```bash
   yarn workspace @rocket.chat/ui-client test GenericMenu.spec.tsx



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Deprecations**
  - Deprecated the `button` prop on `GenericMenu`.
  - Existing usage remains temporarily supported, but new implementations should use semantic HTML and accessible button patterns.
  - Updated type guidance clarifies the expected button element and helps identify deprecated usage during development.

- **Accessibility**
  - Encouraged more accessible menu triggers by promoting semantic button elements and clearer usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->