### PR TITLE
feat: add fromTs param to chat.syncMessages

### DIFF
--- a/.changeset/sync-messages-from-ts.md
+++ b/.changeset/sync-messages-from-ts.md
@@ -1,8 +1,6 @@
 ---
-'@rocket.chat/meteor': patch
-'@rocket.chat/rest-typings': patch
-'@rocket.chat/model-typings': patch
-'@rocket.chat/models': patch
+'@rocket.chat/meteor': minor
+'@rocket.chat/rest-typings': minor
 ---
 
 Adds an optional `fromTs` query parameter to `chat.syncMessages`, so it can be used as a replacement for the deprecated `loadMissedMessages` DDP method.

--- a/.changeset/sync-messages-from-ts.md
+++ b/.changeset/sync-messages-from-ts.md
@@ -3,4 +3,4 @@
 '@rocket.chat/rest-typings': minor
 ---
 
-Adds an optional `fromTs` query parameter to `chat.syncMessages`, so it can be used as a replacement for the deprecated `loadMissedMessages` DDP method.
+Adds an optional `fromTs` query parameter to `chat.syncMessages`, so it can be used as a replacement for the deprecated `loadMissedMessages` DDP method. It bounds the sync window and must be used together with `lastUpdate`; sending it with cursor pagination is rejected instead of being ignored.

--- a/.changeset/sync-messages-from-ts.md
+++ b/.changeset/sync-messages-from-ts.md
@@ -1,0 +1,8 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+---
+
+Adds an optional `fromTs` query parameter to `chat.syncMessages`, so it can be used as a replacement for the deprecated `loadMissedMessages` DDP method.

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -26,7 +26,7 @@ jest.mock('../../../../app/utils/client/lib/SDKClient', () => ({
 
 const rid = 'room-id';
 
-const createMessage = (_id: string, ts: Date, extra: Partial<IMessage> = {}): IMessage =>
+const createMessage = (_id: string, ts: Date, extra: Partial<IMessage & { temp: boolean }> = {}): IMessage =>
 	({
 		_id,
 		rid,
@@ -85,6 +85,59 @@ describe('useLoadMissedMessages', () => {
 				fromTs: oldest.toISOString(),
 			}),
 		);
+	});
+
+	it('should leave hidden and temp messages out of the sync window', async () => {
+		const oldest = new Date(2_000);
+		const newest = new Date(3_000);
+		Messages.state.storeMany([
+			createMessage('hidden', new Date(1_000), { _hidden: true }),
+			createMessage('oldest', oldest),
+			createMessage('newest', newest),
+			createMessage('temp', new Date(4_000), { temp: true }),
+		]);
+
+		renderReconnection();
+
+		await waitFor(() =>
+			expect(sdk.rest.get).toHaveBeenCalledWith('/v1/chat.syncMessages', {
+				roomId: rid,
+				lastUpdate: newest.toISOString(),
+				fromTs: oldest.toISOString(),
+			}),
+		);
+	});
+
+	it('should leave messages from other rooms out of the sync window', async () => {
+		const oldest = new Date(2_000);
+		const newest = new Date(3_000);
+		Messages.state.storeMany([
+			createMessage('other-older', new Date(1_000), { rid: 'other-room-id' }),
+			createMessage('oldest', oldest),
+			createMessage('newest', newest),
+			createMessage('other-newer', new Date(4_000), { rid: 'other-room-id' }),
+		]);
+
+		renderReconnection();
+
+		await waitFor(() =>
+			expect(sdk.rest.get).toHaveBeenCalledWith('/v1/chat.syncMessages', {
+				roomId: rid,
+				lastUpdate: newest.toISOString(),
+				fromTs: oldest.toISOString(),
+			}),
+		);
+	});
+
+	it('should not sync a room holding only hidden and temp messages', async () => {
+		Messages.state.storeMany([
+			createMessage('hidden', new Date(1_000), { _hidden: true }),
+			createMessage('temp', new Date(2_000), { temp: true }),
+		]);
+
+		renderReconnection();
+
+		await waitFor(() => expect(sdk.rest.get).not.toHaveBeenCalled());
 	});
 
 	it('should not sync while the connection stays online', async () => {

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -1,0 +1,118 @@
+import type { IMessage } from '@rocket.chat/core-typings';
+import { useConnectionStatus } from '@rocket.chat/ui-contexts';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useLoadMissedMessages } from './useLoadMissedMessages';
+import { sdk } from '../../../../app/utils/client/lib/SDKClient';
+import { Messages } from '../../../stores/Messages';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useConnectionStatus: jest.fn(),
+}));
+
+jest.mock('../../../../app/ui-utils/client/lib/LegacyRoomManager', () => ({
+	LegacyRoomManager: { openedRooms: { 'room-id': { rid: 'room-id' } } },
+}));
+
+jest.mock('../../../../app/ui-utils/client/lib/RoomHistoryManager', () => ({
+	upsertMessageBulk: jest.fn(),
+}));
+
+jest.mock('../../../../app/utils/client/lib/SDKClient', () => ({
+	sdk: { rest: { get: jest.fn() } },
+}));
+
+const rid = 'room-id';
+
+const createMessage = (_id: string, ts: Date, extra: Partial<IMessage> = {}): IMessage =>
+	({
+		_id,
+		rid,
+		msg: _id,
+		ts,
+		_updatedAt: ts,
+		u: { _id: 'user-id', username: 'user' },
+		...extra,
+	}) as IMessage;
+
+const mockSyncResponse = ({ updated = [], deleted = [] }: { updated?: unknown[]; deleted?: { _id: string }[] } = {}) => {
+	(sdk.rest.get as jest.Mock).mockResolvedValue({ result: { updated, deleted } });
+};
+
+/** Renders the hook while offline, then flips the connection back on — the only transition that triggers a sync. */
+const renderReconnection = () => {
+	(useConnectionStatus as jest.Mock).mockReturnValue({ connected: false });
+	const { rerender } = renderHook(() => useLoadMissedMessages());
+
+	(useConnectionStatus as jest.Mock).mockReturnValue({ connected: true });
+	rerender();
+};
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	Messages.state.replaceAll([]);
+	mockSyncResponse();
+});
+
+describe('useLoadMissedMessages', () => {
+	it('should bound the sync window by the oldest and newest loaded messages', async () => {
+		const oldest = new Date(1_000);
+		const newest = new Date(3_000);
+		Messages.state.storeMany([createMessage('oldest', oldest), createMessage('newest', newest)]);
+
+		renderReconnection();
+
+		await waitFor(() =>
+			expect(sdk.rest.get).toHaveBeenCalledWith('/v1/chat.syncMessages', {
+				roomId: rid,
+				lastUpdate: newest.toISOString(),
+				fromTs: oldest.toISOString(),
+			}),
+		);
+	});
+
+	it('should not sync while the connection stays online', async () => {
+		Messages.state.store(createMessage('message', new Date(1_000)));
+
+		(useConnectionStatus as jest.Mock).mockReturnValue({ connected: true });
+		const { rerender } = renderHook(() => useLoadMissedMessages());
+		rerender();
+
+		await waitFor(() => expect(sdk.rest.get).not.toHaveBeenCalled());
+	});
+
+	it('should remove the messages reported as deleted', async () => {
+		Messages.state.storeMany([createMessage('kept', new Date(1_000)), createMessage('dropped', new Date(2_000))]);
+		mockSyncResponse({ deleted: [{ _id: 'dropped' }] });
+
+		renderReconnection();
+
+		await waitFor(() => expect(Messages.state.get('dropped')).toBeUndefined());
+		expect(Messages.state.get('kept')).toBeDefined();
+	});
+
+	it('should clear "tmid" from replies whose thread parent was deleted', async () => {
+		Messages.state.storeMany([createMessage('parent', new Date(1_000)), createMessage('reply', new Date(2_000), { tmid: 'parent' })]);
+		mockSyncResponse({ deleted: [{ _id: 'parent' }] });
+
+		renderReconnection();
+
+		await waitFor(() => expect(Messages.state.get('parent')).toBeUndefined());
+		expect(Messages.state.get('reply')).toBeDefined();
+		expect(Messages.state.get('reply')).not.toHaveProperty('tmid');
+	});
+
+	it('should keep "tmid" on replies whose thread parent survived', async () => {
+		Messages.state.storeMany([
+			createMessage('parent', new Date(1_000)),
+			createMessage('reply', new Date(2_000), { tmid: 'parent' }),
+			createMessage('dropped', new Date(3_000)),
+		]);
+		mockSyncResponse({ deleted: [{ _id: 'dropped' }] });
+
+		renderReconnection();
+
+		await waitFor(() => expect(Messages.state.get('dropped')).toBeUndefined());
+		expect(Messages.state.get('reply')).toHaveProperty('tmid', 'parent');
+	});
+});

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.spec.ts
@@ -3,8 +3,10 @@ import { useConnectionStatus } from '@rocket.chat/ui-contexts';
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { useLoadMissedMessages } from './useLoadMissedMessages';
+import { upsertMessageBulk } from '../../../../app/ui-utils/client/lib/RoomHistoryManager';
 import { sdk } from '../../../../app/utils/client/lib/SDKClient';
 import { Messages } from '../../../stores/Messages';
+import { Subscriptions } from '../../../stores/Subscriptions';
 
 jest.mock('@rocket.chat/ui-contexts', () => ({
 	useConnectionStatus: jest.fn(),
@@ -35,6 +37,17 @@ const createMessage = (_id: string, ts: Date, extra: Partial<IMessage> = {}): IM
 		...extra,
 	}) as IMessage;
 
+/** Mimics what the API returns: the same shape as `createMessage`, but with dates serialized. */
+const createSerializedMessage = (_id: string, ts: Date, extra: Record<string, unknown> = {}) => ({
+	_id,
+	rid,
+	msg: _id,
+	ts: ts.toISOString(),
+	_updatedAt: ts.toISOString(),
+	u: { _id: 'user-id', username: 'user' },
+	...extra,
+});
+
 const mockSyncResponse = ({ updated = [], deleted = [] }: { updated?: unknown[]; deleted?: { _id: string }[] } = {}) => {
 	(sdk.rest.get as jest.Mock).mockResolvedValue({ result: { updated, deleted } });
 };
@@ -51,7 +64,10 @@ const renderReconnection = () => {
 beforeEach(() => {
 	jest.clearAllMocks();
 	Messages.state.replaceAll([]);
+	Subscriptions.state.replaceAll([]);
 	mockSyncResponse();
+	// stand-in for the real bulk upsert, which only stores the messages it is handed
+	(upsertMessageBulk as jest.Mock).mockImplementation(async ({ msgs }: { msgs: IMessage[] }) => Messages.state.storeMany(msgs));
 });
 
 describe('useLoadMissedMessages', () => {
@@ -79,6 +95,53 @@ describe('useLoadMissedMessages', () => {
 		rerender();
 
 		await waitFor(() => expect(sdk.rest.get).not.toHaveBeenCalled());
+	});
+
+	it('should merge the messages reported as updated into the store', async () => {
+		const ts = new Date(1_000);
+		const editedAt = new Date(2_000);
+		Messages.state.storeMany([createMessage('edited', ts), createMessage('untouched', ts)]);
+		mockSyncResponse({
+			updated: [
+				createSerializedMessage('edited', ts, { msg: 'edited text', editedAt: editedAt.toISOString() }),
+				createSerializedMessage('added', editedAt),
+			],
+		});
+
+		renderReconnection();
+
+		await waitFor(() => expect(Messages.state.get('edited')).toHaveProperty('msg', 'edited text'));
+		expect(Messages.state.get('edited')).toHaveProperty('editedAt', editedAt);
+		expect(Messages.state.get('added')).toHaveProperty('ts', editedAt);
+		expect(Messages.state.get('untouched')).toHaveProperty('msg', 'untouched');
+	});
+
+	it('should deserialize the dates of the messages reported as updated', async () => {
+		const ts = new Date(1_000);
+		const editedAt = new Date(2_000);
+		Messages.state.store(createMessage('edited', ts));
+		mockSyncResponse({ updated: [createSerializedMessage('edited', ts, { editedAt: editedAt.toISOString() })] });
+
+		renderReconnection();
+
+		await waitFor(() => expect(upsertMessageBulk).toHaveBeenCalled());
+		expect(upsertMessageBulk).toHaveBeenCalledWith(
+			expect.objectContaining({
+				msgs: [expect.objectContaining({ _id: 'edited', ts, _updatedAt: ts, editedAt })],
+			}),
+		);
+	});
+
+	it('should pass the room subscription along with the updated messages', async () => {
+		const ts = new Date(1_000);
+		const subscription = { _id: 'subscription-id', rid } as Parameters<typeof Subscriptions.state.store>[0];
+		Messages.state.store(createMessage('edited', ts));
+		Subscriptions.state.storeMany([subscription, { _id: 'other-subscription-id', rid: 'other-room-id' } as typeof subscription]);
+		mockSyncResponse({ updated: [createSerializedMessage('edited', ts)] });
+
+		renderReconnection();
+
+		await waitFor(() => expect(upsertMessageBulk).toHaveBeenCalledWith(expect.objectContaining({ subscription })));
 	});
 
 	it('should remove the messages reported as deleted', async () => {

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
@@ -1,34 +1,48 @@
-import type { IRoom } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom } from '@rocket.chat/core-typings';
 import { useConnectionStatus } from '@rocket.chat/ui-contexts';
 import { useEffect, useRef } from 'react';
 
-import { LegacyRoomManager, upsertMessage } from '../../../../app/ui-utils/client';
-import { callWithErrorHandling } from '../../../lib/utils/callWithErrorHandling';
-import { Messages, Subscriptions } from '../../../stores';
+import { LegacyRoomManager } from '../../../../app/ui-utils/client/lib/LegacyRoomManager';
+import { upsertMessageBulk } from '../../../../app/ui-utils/client/lib/RoomHistoryManager';
+import { sdk } from '../../../../app/utils/client/lib/SDKClient';
+import { mapMessageFromApi } from '../../../lib/utils/mapMessageFromApi';
+import { Messages } from '../../../stores/Messages';
+import { Subscriptions } from '../../../stores/Subscriptions';
 
 /**
- * Loads missed messages for a room
+ * Reconciles a room with the server after the connection drops.
+ *
+ * `lastUpdate` is the newest loaded message's timestamp, so anything created or edited since then comes
+ * back. `fromTs` is the oldest loaded one, which bounds the query to the window the client actually holds
+ * — without it the server has no usable index bounds and scans every message in the room. The trade-off
+ * is that edits to messages older than `fromTs` go unreported, which is fine here: those messages are not
+ * loaded, so they are fetched fresh if the user scrolls back to them.
+ *
  * @param rid - Room ID
  */
 const loadMissedMessages = async (rid: IRoom['_id']): Promise<void> => {
-	const lastMessage = Messages.state.findFirst(
-		(record) => record.rid === rid && record._hidden !== true && !record.temp,
-		(a, b) => b.ts.getTime() - a.ts.getTime(),
-	);
+	const isLoaded = (record: IMessage & { temp?: boolean }) => record.rid === rid && record._hidden !== true && !record.temp;
 
-	if (!lastMessage) {
+	const newestLoaded = Messages.state.findFirst(isLoaded, (a, b) => b.ts.getTime() - a.ts.getTime());
+	const oldestLoaded = Messages.state.findFirst(isLoaded, (a, b) => a.ts.getTime() - b.ts.getTime());
+
+	if (!newestLoaded || !oldestLoaded) {
 		return;
 	}
 
 	try {
-		// TODO(ddp-removal): this should move to `/v1/chat.syncMessages` so reconnect
-		// also reconciles edits/deletions made while offline, but that endpoint queries
-		// by `_updatedAt` (+ trash collection) and is currently too slow for this path.
-		// Evaluate/optimize the query before migrating; for now keep the DDP method.
-		const result = await callWithErrorHandling('loadMissedMessages', rid, lastMessage.ts);
-		if (result) {
-			const subscription = Subscriptions.state.find((record) => record.rid === rid);
-			await Promise.all(Array.from(result).map((msg) => upsertMessage({ msg, subscription })));
+		const { result } = await sdk.rest.get('/v1/chat.syncMessages', {
+			roomId: rid,
+			lastUpdate: newestLoaded.ts.toISOString(),
+			fromTs: oldestLoaded.ts.toISOString(),
+		});
+
+		const subscription = Subscriptions.state.find((record) => record.rid === rid);
+
+		await upsertMessageBulk({ msgs: result.updated.map((msg) => mapMessageFromApi(msg)), subscription });
+
+		for (const { _id } of result.deleted) {
+			Messages.state.delete(_id);
 		}
 	} catch (error) {
 		console.error('Error loading missed messages:', error);

--- a/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
+++ b/apps/meteor/client/views/root/hooks/useLoadMissedMessages.ts
@@ -41,8 +41,19 @@ const loadMissedMessages = async (rid: IRoom['_id']): Promise<void> => {
 
 		await upsertMessageBulk({ msgs: result.updated.map((msg) => mapMessageFromApi(msg)), subscription });
 
+		const deletedIds = new Set<IMessage['_id']>();
+
 		for (const { _id } of result.deleted) {
 			Messages.state.delete(_id);
+			deletedIds.add(_id);
+		}
+
+		if (deletedIds.size > 0) {
+			// remove thread reference from deleted messages
+			Messages.state.update(
+				(record) => record.tmid !== undefined && deletedIds.has(record.tmid),
+				({ tmid: _, ...record }) => record,
+			);
 		}
 	} catch (error) {
 		console.error('Error loading missed messages:', error);

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -709,7 +709,7 @@ const chatEndpoints = API.v1
 			},
 		},
 		async function action() {
-			const { roomId, lastUpdate, count, next, previous, type } = this.queryParams;
+			const { roomId, lastUpdate, fromTs, count, next, previous, type } = this.queryParams;
 
 			if (!roomId) {
 				throw new Meteor.Error('error-param-required', 'The required "roomId" query param is missing');
@@ -723,8 +723,13 @@ const chatEndpoints = API.v1
 				throw new Meteor.Error('error-lastUpdate-param-invalid', 'The "lastUpdate" query parameter must be a valid date');
 			}
 
+			if (fromTs && isNaN(Date.parse(fromTs))) {
+				throw new Meteor.Error('error-fromTs-param-invalid', 'The "fromTs" query parameter must be a valid date');
+			}
+
 			const getMessagesQuery = {
 				...(lastUpdate && { lastUpdate: new Date(lastUpdate) }),
+				...(fromTs && { fromTs: new Date(fromTs) }),
 				...(next && { next }),
 				...(previous && { previous }),
 				...(count && { count }),

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -723,10 +723,6 @@ const chatEndpoints = API.v1
 				throw new Meteor.Error('error-lastUpdate-param-invalid', 'The "lastUpdate" query parameter must be a valid date');
 			}
 
-			if (fromTs && isNaN(Date.parse(fromTs))) {
-				throw new Meteor.Error('error-fromTs-param-invalid', 'The "fromTs" query parameter must be a valid date');
-			}
-
 			const getMessagesQuery = {
 				...(lastUpdate && { lastUpdate: new Date(lastUpdate) }),
 				...(fromTs && { fromTs: new Date(fromTs) }),

--- a/apps/meteor/server/meteor-methods/messages/loadMissedMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadMissedMessages.ts
@@ -5,6 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -15,6 +16,7 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async loadMissedMessages(rid, start) {
+		methodDeprecationLogger.method('loadMissedMessages', '9.0.0', '/v1/chat.syncMessages');
 		check(rid, String);
 		check(start, Date);
 

--- a/apps/meteor/server/publications/messages.ts
+++ b/apps/meteor/server/publications/messages.ts
@@ -260,6 +260,12 @@ export const getMessageHistory = async (
 		);
 	}
 
+	// `fromTs` only bounds the query on the `lastUpdate` path; neither cursor pagination nor the channel
+	// history fallback honors it, so accepting it there would silently widen the result set.
+	if (fromTs && !lastUpdate) {
+		throw new Meteor.Error('error-fromTs-requires-lastUpdate', 'The "fromTs" parameter can only be used together with "lastUpdate"');
+	}
+
 	const hasCursorPagination = !!((next || previous) && count !== null && type);
 
 	if (!hasCursorPagination && !lastUpdate) {

--- a/apps/meteor/server/publications/messages.ts
+++ b/apps/meteor/server/publications/messages.ts
@@ -140,13 +140,16 @@ export function mountPreviousCursor(
 	return mountCursorFromMessage(messages[0], type);
 }
 
-export async function handleWithoutPagination(rid: IRoom['_id'], lastUpdate: Date) {
-	const query = { $gt: lastUpdate };
+export async function handleWithoutPagination(rid: IRoom['_id'], lastUpdate: Date, fromTs?: Date) {
 	const options: FindOptions<IMessage> = { sort: { ts: -1 } };
 
 	const [updatedMessages, deletedMessages] = await Promise.all([
-		Messages.findForUpdates(rid, query, options).toArray(),
-		Messages.trashFindDeletedAfter(lastUpdate, { rid }, { projection: { _id: 1, _deletedAt: 1 }, ...options }).toArray(),
+		Messages.findForUpdates(rid, { updatedAt: { $gt: lastUpdate }, minTs: fromTs }, options).toArray(),
+		Messages.trashFindDeletedAfter(
+			lastUpdate,
+			{ rid, ...(fromTs && { ts: { $gte: fromTs } }) },
+			{ projection: { _id: 1, _deletedAt: 1 }, ...options },
+		).toArray(),
 	]);
 
 	return {
@@ -173,7 +176,7 @@ export async function handleCursorPagination(
 
 	const response =
 		type === 'UPDATED'
-			? await Messages.findForUpdates(rid, query, options).toArray()
+			? await Messages.findForUpdates(rid, { updatedAt: query }, options).toArray()
 			: ((await Messages.trashFind(
 					{ rid, _deletedAt: query },
 					{ projection: { _id: 1, _deletedAt: 1 }, ...options },
@@ -200,6 +203,7 @@ export const getMessageHistory = async (
 	fromId: string,
 	{
 		lastUpdate,
+		fromTs,
 		latestDate = new Date(),
 		oldestDate,
 		inclusive = false,
@@ -210,6 +214,7 @@ export const getMessageHistory = async (
 		type,
 	}: {
 		lastUpdate?: Date;
+		fromTs?: Date;
 		latestDate?: Date;
 		oldestDate?: Date;
 		inclusive?: boolean;
@@ -262,7 +267,7 @@ export const getMessageHistory = async (
 	}
 
 	if (lastUpdate) {
-		return handleWithoutPagination(rid, lastUpdate);
+		return handleWithoutPagination(rid, lastUpdate, fromTs);
 	}
 
 	if (!type) {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -3990,8 +3990,7 @@ describe('[Chat]', () => {
 				.expect(400);
 
 			expect(res.body).to.have.property('success', false);
-			expect(res.body.errorType).to.be.equal('invalid-params');
-			expect(res.body.error).to.include('must match format "iso-date-time"');
+			expect(res.body.errorType).to.be.equal('error-invalid-params');
 		});
 
 		describe('"fromTs" parameter', () => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -3990,8 +3990,8 @@ describe('[Chat]', () => {
 				.expect(400);
 
 			expect(res.body).to.have.property('success', false);
-			expect(res.body.errorType).to.be.equal('error-fromTs-param-invalid');
-			expect(res.body.error).to.include('The "fromTs" query parameter must be a valid date');
+			expect(res.body.errorType).to.be.equal('invalid-params');
+			expect(res.body.error).to.include('must match format "iso-date-time"');
 		});
 
 		describe('"fromTs" parameter', () => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -3999,9 +3999,20 @@ describe('[Chat]', () => {
 			let newerMessage: IMessage;
 			let lastUpdate: string;
 
+			// the server filters with `ts: { $gte: fromTs }`, so a boundary taken from the newer message only
+			// excludes the older one when the two land on distinct milliseconds
+			const sendBoundaryMessages = async (olderText: string, newerText: string): Promise<[IMessage, IMessage]> => {
+				const older: IMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: olderText })).body.message;
+				await sleep(5);
+				const newer: IMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: newerText })).body.message;
+
+				expect(new Date(newer.ts).getTime()).to.be.greaterThan(new Date(older.ts).getTime());
+
+				return [older, newer];
+			};
+
 			before(async () => {
-				olderMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Older Message' })).body.message;
-				newerMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Newer Message' })).body.message;
+				[olderMessage, newerMessage] = await sendBoundaryMessages('Older Message', 'Newer Message');
 
 				// every edit below happens after this point, so both messages are candidates on `_updatedAt`
 				lastUpdate = new Date().toISOString();
@@ -4041,8 +4052,7 @@ describe('[Chat]', () => {
 			});
 
 			it('should omit deletions of messages older than "fromTs"', async () => {
-				const droppedMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'To Be Deleted' })).body.message;
-				const windowStart = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Window Start' })).body.message;
+				const [droppedMessage, windowStart] = await sendBoundaryMessages('To Be Deleted', 'Window Start');
 
 				const deletionLastUpdate = new Date().toISOString();
 				await deleteMessage({ roomId: testChannel._id, msgId: droppedMessage._id });

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -8,7 +8,7 @@ import type { Response } from 'supertest';
 import { retry } from './helpers/retry';
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
-import { followMessage, sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
+import { followMessage, sendSimpleMessage, deleteMessage, updateMessage } from '../../data/chat.helper';
 import { imgURL } from '../../data/interactions';
 import { mockServerHealthy, mockServerReset, mockServerSet } from '../../data/mock-server.helper';
 import { updatePermission, updateSetting } from '../../data/permissions.helper';
@@ -3979,6 +3979,93 @@ describe('[Chat]', () => {
 			expect(responseAfterDelete.body.result.deleted[0]._id).to.be.equal(firstMessage.body.message._id);
 
 			await deleteMessage({ roomId: testChannel._id, msgId: secondMessage.body.message._id });
+		});
+
+		it('should return an error when the "fromTs" parameter is invalid', async () => {
+			const res = await request
+				.get(api('chat.syncMessages'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, lastUpdate: new Date().toISOString(), fromTs: 'invalid-date' })
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-fromTs-param-invalid');
+			expect(res.body.error).to.include('The "fromTs" query parameter must be a valid date');
+		});
+
+		describe('"fromTs" parameter', () => {
+			let olderMessage: IMessage;
+			let newerMessage: IMessage;
+			let lastUpdate: string;
+
+			before(async () => {
+				olderMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Older Message' })).body.message;
+				newerMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Newer Message' })).body.message;
+
+				// every edit below happens after this point, so both messages are candidates on `_updatedAt`
+				lastUpdate = new Date().toISOString();
+
+				await updateMessage({ roomId: testChannel._id, msgId: olderMessage._id, updatedMessage: 'Older Message edited' });
+				await updateMessage({ roomId: testChannel._id, msgId: newerMessage._id, updatedMessage: 'Newer Message edited' });
+			});
+
+			after(() =>
+				Promise.all([
+					deleteMessage({ roomId: testChannel._id, msgId: olderMessage._id }),
+					deleteMessage({ roomId: testChannel._id, msgId: newerMessage._id }),
+				]),
+			);
+
+			it('should return every edited message when "fromTs" is not provided', async () => {
+				const response = await request
+					.get(api('chat.syncMessages'))
+					.set(credentials)
+					.query({ roomId: testChannel._id, lastUpdate })
+					.expect(200);
+
+				expect(response.body.result.updated).to.have.lengthOf(2);
+				expect(response.body.result.updated.map((msg: IMessage) => msg._id)).to.have.members([olderMessage._id, newerMessage._id]);
+			});
+
+			it('should omit messages older than "fromTs" while still returning the ones inside the window', async () => {
+				const response = await request
+					.get(api('chat.syncMessages'))
+					.set(credentials)
+					.query({ roomId: testChannel._id, lastUpdate, fromTs: newerMessage.ts })
+					.expect(200);
+
+				expect(response.body.result.updated).to.have.lengthOf(1);
+				expect(response.body.result.updated[0]._id).to.be.equal(newerMessage._id);
+				expect(response.body.result.updated[0].msg).to.be.equal('Newer Message edited');
+			});
+
+			it('should omit deletions of messages older than "fromTs"', async () => {
+				const droppedMessage = (await sendSimpleMessage({ roomId: testChannel._id, text: 'To Be Deleted' })).body.message;
+				const windowStart = (await sendSimpleMessage({ roomId: testChannel._id, text: 'Window Start' })).body.message;
+
+				const deletionLastUpdate = new Date().toISOString();
+				await deleteMessage({ roomId: testChannel._id, msgId: droppedMessage._id });
+
+				const scoped = await request
+					.get(api('chat.syncMessages'))
+					.set(credentials)
+					.query({ roomId: testChannel._id, lastUpdate: deletionLastUpdate, fromTs: windowStart.ts })
+					.expect(200);
+
+				expect(scoped.body.result.deleted).to.have.lengthOf(0);
+
+				const unscoped = await request
+					.get(api('chat.syncMessages'))
+					.set(credentials)
+					.query({ roomId: testChannel._id, lastUpdate: deletionLastUpdate })
+					.expect(200);
+
+				expect(unscoped.body.result.deleted).to.have.lengthOf(1);
+				expect(unscoped.body.result.deleted[0]._id).to.be.equal(droppedMessage._id);
+
+				await deleteMessage({ roomId: testChannel._id, msgId: windowStart._id });
+			});
 		});
 
 		it('should return all updated messages with a cursor when "type" parameter is "UPDATED"', async () => {

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -3993,6 +3993,31 @@ describe('[Chat]', () => {
 			expect(res.body.errorType).to.be.equal('error-invalid-params');
 		});
 
+		it('should return an error when "fromTs" is sent along with cursor pagination', async () => {
+			const res = await request
+				.get(api('chat.syncMessages'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, type: 'UPDATED', next: `${Date.now()}`, fromTs: new Date().toISOString() })
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-fromTs-requires-lastUpdate');
+			expect(res.body.error).to.include('The "fromTs" parameter can only be used together with "lastUpdate"');
+		});
+
+		it('should return an error when "fromTs" is sent without "lastUpdate"', async () => {
+			const res = await request
+				.get(api('chat.syncMessages'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, type: 'UPDATED', fromTs: new Date().toISOString() })
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			expect(res.body).to.have.property('success', false);
+			expect(res.body.errorType).to.be.equal('error-fromTs-requires-lastUpdate');
+		});
+
 		describe('"fromTs" parameter', () => {
 			let olderMessage: IMessage;
 			let newerMessage: IMessage;

--- a/apps/meteor/tests/unit/server/publications/messages.spec.ts
+++ b/apps/meteor/tests/unit/server/publications/messages.spec.ts
@@ -21,6 +21,9 @@ const messagesMock = {
 	trashFind: sinon.stub(),
 };
 
+const canAccessRoomIdAsyncStub = sinon.stub().resolves(true);
+const getChannelHistoryStub = sinon.stub();
+
 const {
 	extractTimestampFromCursor,
 	mountCursorQuery,
@@ -29,12 +32,16 @@ const {
 	mountPreviousCursor,
 	handleWithoutPagination,
 	handleCursorPagination,
+	getMessageHistory,
 } = proxyquire.noCallThru().load('../../../../server/publications/messages', {
 	'meteor/check': {
 		check: sinon.stub(),
 	},
+	'../lib/authorization/canAccessRoom': {
+		canAccessRoomIdAsync: canAccessRoomIdAsyncStub,
+	},
 	'../meteor-methods/messages/getChannelHistory': {
-		getChannelHistory: sinon.stub(),
+		getChannelHistory: getChannelHistoryStub,
 	},
 	'meteor/meteor': {
 		'Meteor': {
@@ -295,5 +302,53 @@ describe('handleCursorPagination', () => {
 
 		expect(result.updated).to.deep.equal([]);
 		expect(result.cursor).to.deep.equal({ next: null, previous: null });
+	});
+});
+
+describe('getMessageHistory', () => {
+	const rid = 'roomId';
+	const fromId = 'userId';
+
+	const catchError = async (promise: Promise<unknown>): Promise<any> => {
+		try {
+			await promise;
+		} catch (error) {
+			return error;
+		}
+
+		throw new Error('expected the call to be rejected');
+	};
+
+	beforeEach(() => {
+		messagesMock.findForUpdates.reset();
+		messagesMock.trashFindDeletedAfter.reset();
+		messagesMock.trashFind.reset();
+		getChannelHistoryStub.reset();
+	});
+
+	it('should reject "fromTs" when combined with cursor pagination', async () => {
+		const error = await catchError(getMessageHistory(rid, fromId, { fromTs: new Date(), type: 'UPDATED', next: '1704067200000' }));
+
+		expect(error).to.have.property('error', 'error-fromTs-requires-lastUpdate');
+		sinon.assert.notCalled(messagesMock.findForUpdates);
+	});
+
+	it('should reject "fromTs" when it would fall through to the channel history', async () => {
+		const error = await catchError(getMessageHistory(rid, fromId, { fromTs: new Date() }));
+
+		expect(error).to.have.property('error', 'error-fromTs-requires-lastUpdate');
+		sinon.assert.notCalled(getChannelHistoryStub);
+	});
+
+	it('should bound the query by "fromTs" when "lastUpdate" is provided', async () => {
+		const lastUpdate = new Date('2024-01-02T00:00:00.000Z');
+		const fromTs = new Date('2024-01-01T00:00:00.000Z');
+
+		messagesMock.findForUpdates.returns({ toArray: sinon.stub().resolves([]) });
+		messagesMock.trashFindDeletedAfter.returns({ toArray: sinon.stub().resolves([]) });
+
+		await getMessageHistory(rid, fromId, { lastUpdate, fromTs });
+
+		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { updatedAt: { $gt: lastUpdate }, minTs: fromTs }, { sort: { ts: -1 } });
 	});
 });

--- a/apps/meteor/tests/unit/server/publications/messages.spec.ts
+++ b/apps/meteor/tests/unit/server/publications/messages.spec.ts
@@ -213,11 +213,30 @@ describe('handleWithoutPagination', () => {
 			deleted: deletedMessages,
 		});
 
-		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { $gt: lastUpdate }, { sort: { ts: -1 } });
+		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { updatedAt: { $gt: lastUpdate }, minTs: undefined }, { sort: { ts: -1 } });
 		sinon.assert.calledWith(
 			messagesMock.trashFindDeletedAfter,
 			lastUpdate,
 			{ rid },
+			{ projection: { _id: 1, _deletedAt: 1 }, sort: { ts: -1 } },
+		);
+	});
+
+	it('should bound both queries by `ts` when fromTs is provided', async () => {
+		const rid = 'roomId';
+		const lastUpdate = new Date('2024-01-02T00:00:00.000Z');
+		const fromTs = new Date('2024-01-01T00:00:00.000Z');
+
+		messagesMock.findForUpdates.returns({ toArray: sinon.stub().resolves([]) });
+		messagesMock.trashFindDeletedAfter.returns({ toArray: sinon.stub().resolves([]) });
+
+		await handleWithoutPagination(rid, lastUpdate, fromTs);
+
+		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { updatedAt: { $gt: lastUpdate }, minTs: fromTs }, { sort: { ts: -1 } });
+		sinon.assert.calledWith(
+			messagesMock.trashFindDeletedAfter,
+			lastUpdate,
+			{ rid, ts: { $gte: fromTs } },
 			{ projection: { _id: 1, _deletedAt: 1 }, sort: { ts: -1 } },
 		);
 	});
@@ -248,6 +267,8 @@ describe('handleCursorPagination', () => {
 		const result = await handleCursorPagination('UPDATED', rid, count);
 
 		expect(messagesMock.findForUpdates.calledOnce).to.be.true;
+		// the cursor path has no `ts` bound to apply — it paginates on `_updatedAt` alone
+		sinon.assert.calledWith(messagesMock.findForUpdates, rid, { updatedAt: { $gt: new Date(0) } }, { sort: { _updatedAt: 1 } });
 		expect(result.updated).to.deep.equal(messages);
 		expect(result.cursor).to.have.keys(['next', 'previous']);
 	});

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -198,7 +198,11 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	getLastTimestamp(options?: FindOptions<IMessage>): Promise<Date | undefined>;
 	findOneBySlackBotIdAndSlackTs(slackBotId: string, slackTs: Date): Promise<IMessage | null>;
 	findByRoomIdAndMessageIds(rid: string, messageIds: string[], options?: FindOptions<IMessage>): FindCursor<IMessage>;
-	findForUpdates(roomId: IMessage['rid'], timestamp: { $lt: Date } | { $gt: Date }, options?: FindOptions<IMessage>): FindCursor<IMessage>;
+	findForUpdates(
+		roomId: IMessage['rid'],
+		{ updatedAt, minTs }: { updatedAt: { $lt: Date } | { $gt: Date }; minTs?: Date },
+		options?: FindOptions<IMessage>,
+	): FindCursor<IMessage>;
 	updateUsernameOfEditByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 	updateAllUsernamesByUserId(userId: string, username: string): Promise<UpdateResult | Document>;
 

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -791,11 +791,16 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.find(query, options);
 	}
 
-	findForUpdates(roomId: IMessage['rid'], timestamp: { $lt: Date } | { $gt: Date }, options?: FindOptions<IMessage>): FindCursor<IMessage> {
+	findForUpdates(
+		roomId: IMessage['rid'],
+		{ updatedAt, minTs }: { updatedAt: { $lt: Date } | { $gt: Date }; minTs?: Date },
+		options?: FindOptions<IMessage>,
+	): FindCursor<IMessage> {
 		const query = {
 			rid: roomId,
 			_hidden: { $ne: true },
-			_updatedAt: timestamp,
+			_updatedAt: updatedAt,
+			...(minTs && { ts: { $gte: minTs } }),
 		};
 
 		return this.find(query, options);

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -606,6 +606,7 @@ export const isChatGetMentionedMessagesProps = ajvQuery.compile<GetMentionedMess
 type ChatSyncMessages = {
 	roomId: IRoom['_id'];
 	lastUpdate?: string;
+	fromTs?: string;
 	count?: number;
 	next?: string;
 	previous?: string;
@@ -619,6 +620,10 @@ const ChatSyncMessagesSchema = {
 			type: 'string',
 		},
 		lastUpdate: {
+			type: 'string',
+			nullable: true,
+		},
+		fromTs: {
 			type: 'string',
 			nullable: true,
 		},

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -625,7 +625,7 @@ const ChatSyncMessagesSchema = {
 		},
 		fromTs: {
 			type: 'string',
-			nullable: true,
+			format: 'iso-date-time',
 		},
 		count: {
 			type: 'number',


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[ARCH-2182]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[ARCH-2182]: https://rocketchat.atlassian.net/browse/ARCH-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message synchronization after reconnection by reconciling updated and deleted messages within the currently loaded time range.
  * Prevented hidden and temporary messages from being incorrectly synchronized.
  * Preserved valid thread references when messages are updated or deleted.
  * Added optional timestamp filtering for more accurate message history updates.

* **Deprecation**
  * The legacy missed-message loading method is deprecated in favor of the `chat.syncMessages` endpoint.
  * The endpoint supports optional timestamp filtering for targeted synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->