### PR TITLE
fix(federation): endpoints rejecting valid requests

### DIFF
--- a/.changeset/real-zoos-cover.md
+++ b/.changeset/real-zoos-cover.md
@@ -8,3 +8,4 @@ Fixes federation endpoints rejecting valid requests, which broke:
 - room history backfill
 - image thumbnails
 - room message pagination
+- accepting an invite from another homeserver

--- a/.changeset/real-zoos-cover.md
+++ b/.changeset/real-zoos-cover.md
@@ -1,0 +1,10 @@
+---
+'@rocket.chat/federation-matrix': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes federation endpoints rejecting valid requests, which broke:
+
+- room history backfill
+- image thumbnails
+- room message pagination

--- a/ee/packages/federation-matrix/src/api/_matrix/client/media.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/media.ts
@@ -22,10 +22,12 @@ const isMediaParamsProps = ajv.compile(MediaParamsSchema);
 const ThumbnailQuerySchema = {
 	type: 'object',
 	properties: {
-		width: { oneOf: [{ type: 'number' }, { type: 'string' }] },
-		height: { oneOf: [{ type: 'number' }, { type: 'string' }] },
+		// union type lists rather than `oneOf`: ajvQuery coerces between number and string, so both
+		// `oneOf` branches would match a numeric value and fail validation
+		width: { type: ['number', 'string'] },
+		height: { type: ['number', 'string'] },
 		method: { type: 'string', enum: ['crop', 'scale'] },
-		timeout_ms: { oneOf: [{ type: 'number' }, { type: 'string' }] },
+		timeout_ms: { type: ['number', 'string'] },
 	},
 };
 

--- a/ee/packages/federation-matrix/src/api/_matrix/client/rooms-messaging.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/client/rooms-messaging.ts
@@ -57,7 +57,9 @@ const MessagesQuerySchema = {
 		from: { type: 'string' },
 		to: { type: 'string' },
 		dir: { type: 'string', enum: ['b', 'f'] },
-		limit: { oneOf: [{ type: 'number' }, { type: 'string' }] },
+		// a union type list rather than `oneOf`: ajvQuery coerces between number and string, so both
+		// `oneOf` branches would match a numeric value and fail validation
+		limit: { type: ['number', 'string'] },
 		filter: { type: 'string' },
 	},
 };

--- a/ee/packages/federation-matrix/src/api/_matrix/send-join.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/send-join.ts
@@ -1,4 +1,3 @@
-import type { EventID } from '@rocket.chat/federation-sdk';
 import { federationSDK } from '@rocket.chat/federation-sdk';
 import { Router } from '@rocket.chat/http-router';
 import { ajv } from '@rocket.chat/rest-typings/dist/v1/Ajv';
@@ -29,12 +28,6 @@ const TimestampSchema = {
 	description: 'Unix timestamp in milliseconds',
 };
 
-const DepthSchema = {
-	type: 'number',
-	minimum: 0,
-	description: 'Event depth',
-};
-
 const ServerNameSchema = {
 	type: 'string',
 	description: 'Matrix server name',
@@ -51,137 +44,42 @@ const SendJoinParamsSchema = {
 
 const isSendJoinParamsProps = ajv.compile(SendJoinParamsSchema);
 
-const EventHashSchema = {
-	type: 'object',
-	properties: {
-		sha256: {
-			type: 'string',
-			description: 'SHA256 hash of the event',
-		},
-	},
-	required: ['sha256'],
-};
-
-const EventSignatureSchema = {
-	type: 'object',
-	description: 'Event signatures by server and key ID',
-};
-
-const MembershipEventContentSchema = {
-	type: 'object',
-	properties: {
-		membership: {
-			type: 'string',
-			enum: ['join', 'leave', 'invite', 'ban', 'knock'],
-			description: 'Membership state',
-		},
-		displayname: {
-			type: 'string',
-			nullable: true,
-		},
-		avatar_url: {
-			type: 'string',
-			nullable: true,
-		},
-		join_authorised_via_users_server: {
-			type: 'string',
-			nullable: true,
-		},
-		is_direct: {
-			type: 'boolean',
-			nullable: true,
-		},
-		reason: {
-			type: 'string',
-			description: 'Reason for membership change',
-			nullable: true,
-		},
-	},
-	required: ['membership'],
-};
-
-const EventBaseSchema = {
+const SendJoinEventSchema = {
 	type: 'object',
 	properties: {
 		type: {
 			type: 'string',
-			description: 'Event type',
+			const: 'm.room.member',
 		},
-		content: {
-			type: 'object',
-			description: 'Event content',
+		state_key: {
+			...UsernameSchema,
+			description: 'Matrix user ID of the joining member',
 		},
-		sender: UsernameSchema,
-		room_id: RoomIdSchema,
-		origin_server_ts: TimestampSchema,
-		depth: DepthSchema,
-		prev_events: {
-			type: 'array',
-			items: {
-				type: 'string',
-			},
-			description: 'Previous events in the room',
-		},
-		auth_events: {
-			type: 'array',
-			items: {
-				type: 'string',
-			},
-			description: 'Authorization events',
+		sender: {
+			...UsernameSchema,
+			description: 'Matrix user ID of the joining member',
 		},
 		origin: {
-			type: 'string',
-			description: 'Origin server',
+			...ServerNameSchema,
+			description: 'The name of the joining homeserver',
 		},
-		hashes: {
-			...EventHashSchema,
-			nullable: true,
-		},
-		signatures: {
-			...EventSignatureSchema,
-			nullable: true,
-		},
-		unsigned: {
-			type: 'object',
-			description: 'Unsigned data',
-			nullable: true,
-		},
-	},
-	required: ['type', 'content', 'sender', 'room_id', 'origin_server_ts', 'depth', 'prev_events', 'auth_events', 'origin'],
-};
-
-const SendJoinEventSchema = {
-	type: 'object',
-	allOf: [
-		EventBaseSchema,
-		{
+		origin_server_ts: TimestampSchema,
+		content: {
 			type: 'object',
 			properties: {
-				type: {
+				membership: {
 					type: 'string',
-					const: 'm.room.member',
+					const: 'join',
 				},
-				content: {
-					type: 'object',
-					allOf: [
-						MembershipEventContentSchema,
-						{
-							type: 'object',
-							properties: {
-								membership: {
-									type: 'string',
-									const: 'join',
-								},
-							},
-							required: ['membership'],
-						},
-					],
+				join_authorised_via_users_server: {
+					...UsernameSchema,
+					description: 'User ID of a resident server member authorizing the join into a restricted room',
 				},
-				state_key: UsernameSchema,
 			},
-			required: ['type', 'content', 'state_key'],
+			required: ['membership'],
 		},
-	],
+	},
+	required: ['type', 'state_key', 'sender', 'origin', 'origin_server_ts', 'content'],
 };
 
 const isSendJoinEventProps = ajv.compile(SendJoinEventSchema);
@@ -235,7 +133,7 @@ export const getMatrixSendJoinRoutes = () => {
 			const { roomId, stateKey } = c.req.param();
 			const body = await c.req.json();
 
-			const response = await federationSDK.sendJoin(roomId, stateKey as EventID, body);
+			const response = await federationSDK.sendJoin(roomId, stateKey, body);
 
 			return {
 				body: response,

--- a/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
+++ b/ee/packages/federation-matrix/src/api/_matrix/transactions.ts
@@ -279,7 +279,10 @@ const BackfillQuerySchema = {
 			description: 'Maximum number of events to retrieve',
 		},
 		v: {
-			oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+			// a string branch here would be redundant: ajvQuery coerces a single `?v=` into a
+			// one-element array, and in a `oneOf` both branches would match and fail validation
+			type: 'array',
+			items: { type: 'string' },
 			description: 'Event ID(s) to backfill from',
 		},
 	},
@@ -289,7 +292,7 @@ const BackfillQuerySchema = {
 
 const isBackfillQueryProps = ajvQuery.compile<{
 	limit: number;
-	v: string | string[];
+	v: string[];
 }>(BackfillQuerySchema);
 
 const BackfillResponseSchema = {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2549]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2549]: https://rocketchat.atlassian.net/browse/CORE-2549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix federation request validation for room history backfill and message pagination.
  * Fixed valid image thumbnail requests that were previously rejected.
  * Improved acceptance of cross-homeserver room invitations.
  * Enhanced send-join request validation to support valid federation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->