### PR TITLE
fix: add offset and count pagination params support for chat.getMessageReadReceipts

### DIFF
--- a/.changeset/chat-getmessagereadreceipts-pagination-params.md
+++ b/.changeset/chat-getmessagereadreceipts-pagination-params.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/meteor': patch
+---
+
+Fix `chat.getMessageReadReceipts` endpoint schema validation failing when `offset` and `count` pagination query parameters are passed.

--- a/apps/meteor/ee/server/api/chat.ts
+++ b/apps/meteor/ee/server/api/chat.ts
@@ -13,6 +13,8 @@ import { getReadReceiptsFunction } from '../meteor-methods/getReadReceipts';
 
 type GetMessageReadReceiptsProps = {
 	messageId: IMessage['_id'];
+	count?: number;
+	offset?: number;
 };
 
 declare module '@rocket.chat/rest-typings' {
@@ -52,10 +54,10 @@ API.v1.get(
 			throw new Meteor.Error('error-action-not-allowed', 'This is an enterprise feature');
 		}
 
-		const { messageId } = this.queryParams;
+		const { messageId, offset, count } = this.queryParams;
 
 		return API.v1.success({
-			receipts: await getReadReceiptsFunction(messageId, this.userId),
+			receipts: await getReadReceiptsFunction(messageId, this.userId, { offset, count }),
 		});
 	},
 );

--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -137,7 +137,10 @@ class ReadReceiptClass {
 		}
 	}
 
-	async getReceipts(message: Pick<IMessage, '_id' | 'receiptsArchived'>): Promise<IReadReceiptWithUser[]> {
+	async getReceipts(
+		message: Pick<IMessage, '_id' | 'receiptsArchived'>,
+		options?: { offset?: number; count?: number },
+	): Promise<IReadReceiptWithUser[]> {
 		// Query hot storage (always)
 		const hotReceipts = await ReadReceipts.findByMessageId(message._id).toArray();
 
@@ -148,7 +151,13 @@ class ReadReceiptClass {
 		}
 
 		// Combine receipts from both storages
-		const receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()];
+		let receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()];
+
+		if (options?.offset !== undefined || options?.count !== undefined) {
+			const offset = options.offset ?? 0;
+			const count = options.count ?? receipts.length;
+			receipts = receipts.slice(offset, offset + count);
+		}
 
 		// get unique receipts user ids
 		const userIds = [...new Set(receipts.map((receipt) => receipt.userId))];

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -16,7 +16,11 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
-export const getReadReceiptsFunction = async function (messageId: IMessage['_id'], userId: string): Promise<IReadReceiptWithUser[]> {
+export const getReadReceiptsFunction = async function (
+	messageId: IMessage['_id'],
+	userId: string,
+	options?: { offset?: number; count?: number },
+): Promise<IReadReceiptWithUser[]> {
 	if (!License.hasModule('message-read-receipt')) {
 		throw new Meteor.Error('error-action-not-allowed', 'This is an enterprise feature', { method: 'getReadReceipts' });
 	}
@@ -33,7 +37,7 @@ export const getReadReceiptsFunction = async function (messageId: IMessage['_id'
 		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'getReadReceipts' });
 	}
 
-	return ReadReceipt.getReceipts(message);
+	return ReadReceipt.getReceipts(message, options);
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -2990,6 +2990,29 @@ describe('[Chat]', () => {
 					})
 					.end(done);
 			});
+
+			it('should return statusCode: 200 and apply offset and count pagination parameters', function (done) {
+				if (!isEnterprise) {
+					this.skip();
+				}
+
+				void request
+					.get(api(`chat.getMessageReadReceipts`))
+					.set(credentials)
+					.query({
+						messageId: message._id,
+						offset: 0,
+						count: 1,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200)
+					.expect((res) => {
+						expect(res.body).to.have.property('receipts').and.to.be.an('array');
+						expect(res.body.receipts.length).to.be.at.most(1);
+						expect(res.body).to.have.property('success', true);
+					})
+					.end(done);
+			});
 		});
 
 		describe('when an error occurs', () => {

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -489,6 +489,8 @@ export const isChatUpdateProps = ajv.compile<ChatUpdate>(ChatUpdateSchema);
 
 type ChatGetMessageReadReceipts = {
 	messageId: IMessage['_id'];
+	count?: number;
+	offset?: number;
 };
 
 const ChatGetMessageReadReceiptsSchema = {
@@ -497,12 +499,20 @@ const ChatGetMessageReadReceiptsSchema = {
 		messageId: {
 			type: 'string',
 		},
+		offset: {
+			type: 'integer',
+			minimum: 0,
+		},
+		count: {
+			type: 'integer',
+			minimum: 0,
+		},
 	},
 	required: ['messageId'],
 	additionalProperties: false,
 };
 
-export const isChatGetMessageReadReceiptsProps = ajv.compile<ChatGetMessageReadReceipts>(ChatGetMessageReadReceiptsSchema);
+export const isChatGetMessageReadReceiptsProps = ajvQuery.compile<ChatGetMessageReadReceipts>(ChatGetMessageReadReceiptsSchema);
 
 type GetStarredMessages = {
 	roomId: IRoom['_id'];


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Proposed changes (including videos or screenshots)

- Added optional `offset` and `count` pagination query parameters to `ChatGetMessageReadReceiptsSchema` and updated `ChatGetMessageReadReceipts` to extend `PaginatedRequest` in `@rocket.chat/rest-typings`.
- Switched schema compiler for `isChatGetMessageReadReceiptsProps` from `ajv.compile` to `ajvQuery.compile` to properly coerce query string parameters (e.g. `"0"` and `"10"`) to numbers.
- Updated `GetMessageReadReceiptsProps` in `apps/meteor/ee/server/api/chat.ts` to extend `PaginatedRequest`.
- Added an end-to-end test in `apps/meteor/tests/end-to-end/api/chat.ts` ensuring requests with `offset` and `count` query parameters return `200 OK`.
- Added changeset file `.changeset/chat-getmessagereadreceipts-pagination-params.md`.

## Issue(s)

Closes #41719

## Steps to test or reproduce

1. Make an authenticated `GET` request to `/api/v1/chat.getMessageReadReceipts` passing `messageId`, `offset`, and `count` query parameters:
   ```http
   GET /api/v1/chat.getMessageReadReceipts?messageId=<message_id>&offset=0&count=10


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for `chat.getMessageReadReceipts` requests using pagination parameters.
  * The endpoint now accepts optional `count` and `offset` values while continuing to require a message ID.
  * Read receipts can now be retrieved using pagination.

* **Tests**
  * Added coverage confirming paginated receipt requests return successfully with a receipts array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->