### PR TITLE
fix: correct channel names in directory

### DIFF
--- a/apps/meteor/client/views/directory/tabs/channels/ChannelsTable/ChannelsTableRow.tsx
+++ b/apps/meteor/client/views/directory/tabs/channels/ChannelsTable/ChannelsTableRow.tsx
@@ -17,19 +17,20 @@ export type ChannelsTableRowProps = {
 
 const ChannelsTableRow = ({ onClick, room, mediaQuery }: ChannelsTableRowProps) => {
 	const formatDate = useFormatDate();
-	const { _id, ts, t, name, fname, usersCount, lastMessage, topic, belongsTo } = room;
+	const { _id, ts, t, name, usersCount, lastMessage, topic, belongsTo } = room;
+	const roomName = roomCoordinator.getRoomName(t, room);
 	const avatarUrl = roomCoordinator.getRoomDirectives(t).getAvatarPath(room);
 
 	return (
 		<GenericTableRow key={_id} onKeyDown={onClick(name, t)} onClick={onClick(name, t)} tabIndex={0} role='link' action>
 			<GenericTableCell>
 				<Box display='flex'>
-					<Box flexGrow={0}>{avatarUrl && <Avatar size='x40' title={fname || name} url={avatarUrl} />}</Box>
+					<Box flexGrow={0}>{avatarUrl && <Avatar size='x40' title={roomName} url={avatarUrl} />}</Box>
 					<Box flexGrow={1} marginInline={8} withTruncatedText>
 						<Box display='flex' alignItems='center'>
 							<RoomIcon room={room} />
 							<Box fontScale='p2m' marginInline={4}>
-								{fname || name}
+								{roomName}
 							</Box>
 							<RoomTags room={room} />
 						</Box>


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fix channel names in the directory by using `roomCoordinator.getRoomName(t, room)` instead of directly using `fname || name`.

This ensures the channel name displayed in the directory is resolved consistently based on the room type.

## Issue(s)

Closes #10995

## Steps to test or reproduce

1. Open the Rocket.Chat directory.
2. Go to the Channels tab.
3. Verify that channel names are displayed correctly.
4. Verify the channel avatar title also uses the resolved room name.

## Further comments

Small UI fix limited to the Channels Directory row component.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel names in the directory now consistently use the resolved display name.
  * Avatars and channel labels show matching, accurate names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->