### PR TITLE
fix: address team channel pagination gap in #41698

### DIFF
--- a/.changeset/team-channel-search-whitespace.md
+++ b/.changeset/team-channel-search-whitespace.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes team channel searches with surrounding whitespace while preserving filters and pagination.

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -522,6 +522,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		const { getAllRooms, allowPrivateTeam, name, isDefault } = filter;
+		const normalizedName = name?.trim() || undefined;
 
 		const isMember = await TeamMember.findOneByUserIdAndTeamId(uid, teamId);
 		if (team.type === TeamType.PRIVATE && !allowPrivateTeam && !isMember) {
@@ -529,7 +530,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		}
 
 		if (getAllRooms) {
-			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, name, isDefault, undefined, {
+			const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, normalizedName, isDefault, undefined, {
 				skip,
 				limit,
 			});
@@ -545,7 +546,10 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 		});
 		const userRooms = user?.__rooms;
 
-		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, name, isDefault, userRooms, { skip, limit });
+		const { cursor, totalCount } = Rooms.findPaginatedByTeamIdContainingNameAndDefault(teamId, normalizedName, isDefault, userRooms, {
+			skip,
+			limit,
+		});
 
 		const [records, total] = await Promise.all([cursor.toArray(), totalCount]);
 

--- a/apps/meteor/tests/unit/server/services/team/service.tests.ts
+++ b/apps/meteor/tests/unit/server/services/team/service.tests.ts
@@ -5,10 +5,20 @@ import sinon from 'sinon';
 
 const Rooms = {
 	findDefaultRoomsForTeam: sinon.stub(),
+	findPaginatedByTeamIdContainingNameAndDefault: sinon.stub(),
 };
 
 const Users = {
 	findActiveByIds: sinon.stub(),
+	findOneById: sinon.stub(),
+};
+
+const Team = {
+	findOneById: sinon.stub(),
+};
+
+const TeamMember = {
+	findOneByUserIdAndTeamId: sinon.stub(),
 };
 
 const addUserToRoom = sinon.stub();
@@ -21,12 +31,15 @@ const { TeamService } = proxyquire.noCallThru().load('../../../../../server/serv
 		ServiceClassInternal: class {},
 		api: {},
 	},
+	'@rocket.chat/core-typings': {
+		TeamType: { PUBLIC: 0, PRIVATE: 1 },
+	},
 	'@rocket.chat/models': {
-		Team: {},
+		Team,
 		Rooms,
 		Subscriptions: {},
 		Users,
-		TeamMember: {},
+		TeamMember,
 	},
 	'@rocket.chat/string-helpers': {
 		escapeRegExp: (value: string) => value,
@@ -64,7 +77,58 @@ describe('Team service', () => {
 	beforeEach(() => {
 		addUserToRoom.reset();
 		Rooms.findDefaultRoomsForTeam.reset();
+		Rooms.findPaginatedByTeamIdContainingNameAndDefault.reset();
+		Team.findOneById.reset();
+		TeamMember.findOneByUserIdAndTeamId.reset();
 		Users.findActiveByIds.reset();
+		Users.findOneById.reset();
+	});
+
+	it('should trim the room name without shifting member filters or pagination', async () => {
+		Team.findOneById.resolves({ _id: 'team-id', type: 0 });
+		TeamMember.findOneByUserIdAndTeamId.resolves(undefined);
+		Users.findOneById.resolves({ __rooms: ['room-id'] });
+		Rooms.findPaginatedByTeamIdContainingNameAndDefault.returns({
+			cursor: { toArray: sinon.stub().resolves([]) },
+			totalCount: Promise.resolve(0),
+		});
+
+		await service.listRooms(
+			'user-id',
+			'team-id',
+			{ name: '  general  ', isDefault: false, getAllRooms: false, allowPrivateTeam: false },
+			{ offset: 5, count: 10 },
+		);
+
+		expect(
+			Rooms.findPaginatedByTeamIdContainingNameAndDefault.calledOnceWithExactly('team-id', 'general', false, ['room-id'], {
+				skip: 5,
+				limit: 10,
+			}),
+		).to.equal(true);
+	});
+
+	it('should trim the room name without shifting all-room filters or pagination', async () => {
+		Team.findOneById.resolves({ _id: 'team-id', type: 0 });
+		TeamMember.findOneByUserIdAndTeamId.resolves(undefined);
+		Rooms.findPaginatedByTeamIdContainingNameAndDefault.returns({
+			cursor: { toArray: sinon.stub().resolves([]) },
+			totalCount: Promise.resolve(0),
+		});
+
+		await service.listRooms(
+			'user-id',
+			'team-id',
+			{ name: '  general  ', isDefault: true, getAllRooms: true, allowPrivateTeam: false },
+			{ offset: 15, count: 20 },
+		);
+
+		expect(
+			Rooms.findPaginatedByTeamIdContainingNameAndDefault.calledOnceWithExactly('team-id', 'general', true, undefined, {
+				skip: 15,
+				limit: 20,
+			}),
+		).to.equal(true);
 	});
 
 	it('should wait for default room membership operations to finish', async function () {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

- Trims surrounding whitespace from Team Channels search terms before querying rooms.
- Preserves the existing five-argument model contract, including default-room filtering, member room IDs, and pagination.
- Adds regression coverage for both all-room and member-scoped listing paths.
- Adds a patch changeset for `@rocket.chat/meteor`.

This independently addresses the unresolved argument-shift gap in #41698.

## Issue(s)

Related to #41697.
Addresses #41698.

## Steps to test or reproduce

From `apps/meteor`, run:

```sh
corepack yarn exec mocha --config .mocharc.base.json tests/unit/server/services/team/service.tests.ts
```

Result: 4 passing.

Additional verification:

- ESLint passed for `tests/unit/server/services/team/service.tests.ts`.
- Prettier check passed for both changed TypeScript files and the changeset.
- Changeset status recognized a patch release.
- Independent code review found no issues.

The full suite was not run. Workspace typecheck and production-file ESLint were blocked by missing generated workspace package artifacts, including `@rocket.chat/core-typings`, `@rocket.chat/core-services`, and `@rocket.chat/models`.

## Further comments

PR #41698 passes six positional arguments to a five-argument model method. That shifts `isDefault` and room IDs, while dropping pagination options. This PR replaces only the existing name argument with its normalized value at both call sites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team-channel searches now ignore surrounding whitespace in room names.
  * Existing member filters and pagination continue to work correctly for restricted and all-room searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
