### PR TITLE
fix: address read receipt pagination gaps in #41720

### DIFF
--- a/.changeset/read-receipts-pagination-gap.md
+++ b/.changeset/read-receipts-pagination-gap.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/rest-typings': patch
+---
+
+Support validated offset and count pagination for message read receipts.

--- a/apps/meteor/ee/server/api/chat.ts
+++ b/apps/meteor/ee/server/api/chat.ts
@@ -9,10 +9,13 @@ import {
 import { Meteor } from 'meteor/meteor';
 
 import { API } from '../../../server/api/api';
+import { getPaginationItems } from '../../../server/api/lib/getPaginationItems';
 import { getReadReceiptsFunction } from '../meteor-methods/getReadReceipts';
 
 type GetMessageReadReceiptsProps = {
 	messageId: IMessage['_id'];
+	count?: number;
+	offset?: number;
 };
 
 declare module '@rocket.chat/rest-typings' {
@@ -52,10 +55,11 @@ API.v1.get(
 			throw new Meteor.Error('error-action-not-allowed', 'This is an enterprise feature');
 		}
 
-		const { messageId } = this.queryParams;
+		const { messageId, offset, count } = this.queryParams;
+		const pagination = offset === undefined && count === undefined ? undefined : await getPaginationItems({ offset, count });
 
 		return API.v1.success({
-			receipts: await getReadReceiptsFunction(messageId, this.userId),
+			receipts: await getReadReceiptsFunction(messageId, this.userId, pagination),
 		});
 	},
 );

--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -137,7 +137,10 @@ class ReadReceiptClass {
 		}
 	}
 
-	async getReceipts(message: Pick<IMessage, '_id' | 'receiptsArchived'>): Promise<IReadReceiptWithUser[]> {
+	async getReceipts(
+		message: Pick<IMessage, '_id' | 'receiptsArchived'>,
+		options?: { offset?: number; count?: number },
+	): Promise<IReadReceiptWithUser[]> {
 		// Query hot storage (always)
 		const hotReceipts = await ReadReceipts.findByMessageId(message._id).toArray();
 
@@ -148,7 +151,13 @@ class ReadReceiptClass {
 		}
 
 		// Combine receipts from both storages
-		const receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()];
+		let receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()];
+
+		if (options) {
+			const offset = options.offset ?? 0;
+			const count = options.count ?? receipts.length;
+			receipts = receipts.slice(offset, count === 0 ? undefined : offset + count);
+		}
 
 		// get unique receipts user ids
 		const userIds = [...new Set(receipts.map((receipt) => receipt.userId))];

--- a/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
+++ b/apps/meteor/ee/server/lib/message-read-receipt/ReadReceipt.ts
@@ -151,7 +151,9 @@ class ReadReceiptClass {
 		}
 
 		// Combine receipts from both storages
-		let receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()];
+		let receipts = [...new Map([...hotReceipts, ...coldReceipts].map((receipt) => [receipt._id, receipt])).values()].sort((a, b) =>
+			a._id.localeCompare(b._id),
+		);
 
 		if (options) {
 			const offset = options.offset ?? 0;

--- a/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
+++ b/apps/meteor/ee/server/meteor-methods/getReadReceipts.ts
@@ -16,7 +16,11 @@ declare module '@rocket.chat/ddp-client' {
 	}
 }
 
-export const getReadReceiptsFunction = async function (messageId: IMessage['_id'], userId: string): Promise<IReadReceiptWithUser[]> {
+export const getReadReceiptsFunction = async function (
+	messageId: IMessage['_id'],
+	userId: string,
+	options?: { offset?: number; count?: number },
+): Promise<IReadReceiptWithUser[]> {
 	if (!License.hasModule('message-read-receipt')) {
 		throw new Meteor.Error('error-action-not-allowed', 'This is an enterprise feature', { method: 'getReadReceipts' });
 	}
@@ -33,7 +37,7 @@ export const getReadReceiptsFunction = async function (messageId: IMessage['_id'
 		throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'getReadReceipts' });
 	}
 
-	return ReadReceipt.getReceipts(message);
+	return ReadReceipt.getReceipts(message, options);
 };
 
 Meteor.methods<ServerMethods>({

--- a/apps/meteor/ee/tests/unit/server/lib/message-read-receipt/ReadReceipt.spec.ts
+++ b/apps/meteor/ee/tests/unit/server/lib/message-read-receipt/ReadReceipt.spec.ts
@@ -36,9 +36,9 @@ describe('ReadReceipt.getReceipts', () => {
 
 		modelsMock.ReadReceipts.findByMessageId.returns({
 			toArray: sinon.stub().resolves([
+				{ _id: 'receipt-3', messageId: 'message-id', roomId: 'room-id', userId: 'user-3', ts: new Date('2026-01-03') },
 				{ _id: 'receipt-1', messageId: 'message-id', roomId: 'room-id', userId: 'user-1', ts: new Date('2026-01-01') },
 				{ _id: 'receipt-2', messageId: 'message-id', roomId: 'room-id', userId: 'user-2', ts: new Date('2026-01-02') },
-				{ _id: 'receipt-3', messageId: 'message-id', roomId: 'room-id', userId: 'user-3', ts: new Date('2026-01-03') },
 			]),
 		});
 		modelsMock.Users.findByIds.returns({

--- a/apps/meteor/ee/tests/unit/server/lib/message-read-receipt/ReadReceipt.spec.ts
+++ b/apps/meteor/ee/tests/unit/server/lib/message-read-receipt/ReadReceipt.spec.ts
@@ -1,0 +1,69 @@
+import type { IMessage, IReadReceiptWithUser } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const modelsMock = {
+	LivechatVisitors: { findByIds: sinon.stub() },
+	Messages: {},
+	ReadReceipts: { findByMessageId: sinon.stub() },
+	ReadReceiptsArchive: { findByMessageId: sinon.stub() },
+	Rooms: {},
+	Subscriptions: {},
+	Users: { findByIds: sinon.stub() },
+};
+
+const { ReadReceipt } = proxyquire.noCallThru().load('../../../../../server/lib/message-read-receipt/ReadReceipt', {
+	'@rocket.chat/core-services': { api: { broadcast: sinon.stub() } },
+	'@rocket.chat/models': modelsMock,
+	'../../../../server/lib/logger/system': { SystemLogger: { error: sinon.stub() } },
+	'../../../../server/lib/notifyListener': { notifyOnMessageChange: sinon.stub(), notifyOnRoomChangedById: sinon.stub() },
+	'../../../../server/settings': { settings: { get: sinon.stub() } },
+});
+
+type GetReceipts = (
+	message: Pick<IMessage, '_id' | 'receiptsArchived'>,
+	options?: { offset?: number; count?: number },
+) => Promise<IReadReceiptWithUser[]>;
+
+describe('ReadReceipt.getReceipts', () => {
+	beforeEach(() => {
+		modelsMock.ReadReceipts.findByMessageId.reset();
+		modelsMock.ReadReceiptsArchive.findByMessageId.reset();
+		modelsMock.LivechatVisitors.findByIds.reset();
+		modelsMock.Users.findByIds.reset();
+
+		modelsMock.ReadReceipts.findByMessageId.returns({
+			toArray: sinon.stub().resolves([
+				{ _id: 'receipt-1', messageId: 'message-id', roomId: 'room-id', userId: 'user-1', ts: new Date('2026-01-01') },
+				{ _id: 'receipt-2', messageId: 'message-id', roomId: 'room-id', userId: 'user-2', ts: new Date('2026-01-02') },
+				{ _id: 'receipt-3', messageId: 'message-id', roomId: 'room-id', userId: 'user-3', ts: new Date('2026-01-03') },
+			]),
+		});
+		modelsMock.Users.findByIds.returns({
+			toArray: sinon.stub().resolves([
+				{ _id: 'user-1', username: 'user-1' },
+				{ _id: 'user-2', username: 'user-2' },
+				{ _id: 'user-3', username: 'user-3' },
+			]),
+		});
+	});
+
+	it('applies offset and count before resolving receipt users', async () => {
+		const getReceipts = ReadReceipt.getReceipts as GetReceipts;
+
+		const receipts = await getReceipts.call(ReadReceipt, { _id: 'message-id' }, { offset: 1, count: 1 });
+
+		expect(receipts.map(({ _id }) => _id)).to.deep.equal(['receipt-2']);
+		expect(modelsMock.Users.findByIds.calledOnceWithExactly(['user-2'], { projection: { username: 1, name: 1 } })).to.equal(true);
+	});
+
+	it('treats count zero as unlimited after applying the offset', async () => {
+		const getReceipts = ReadReceipt.getReceipts as GetReceipts;
+
+		const receipts = await getReceipts.call(ReadReceipt, { _id: 'message-id' }, { offset: 1, count: 0 });
+
+		expect(receipts.map(({ _id }) => _id)).to.deep.equal(['receipt-2', 'receipt-3']);
+	});
+});

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -489,6 +489,8 @@ export const isChatUpdateProps = ajv.compile<ChatUpdate>(ChatUpdateSchema);
 
 type ChatGetMessageReadReceipts = {
 	messageId: IMessage['_id'];
+	count?: number;
+	offset?: number;
 };
 
 const ChatGetMessageReadReceiptsSchema = {
@@ -497,12 +499,20 @@ const ChatGetMessageReadReceiptsSchema = {
 		messageId: {
 			type: 'string',
 		},
+		offset: {
+			type: 'integer',
+			minimum: 0,
+		},
+		count: {
+			type: 'integer',
+			minimum: 0,
+		},
 	},
 	required: ['messageId'],
 	additionalProperties: false,
 };
 
-export const isChatGetMessageReadReceiptsProps = ajv.compile<ChatGetMessageReadReceipts>(ChatGetMessageReadReceiptsSchema);
+export const isChatGetMessageReadReceiptsProps = ajvQuery.compile<ChatGetMessageReadReceipts>(ChatGetMessageReadReceiptsSchema);
 
 type GetStarredMessages = {
 	roomId: IRoom['_id'];


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This is an independent follow-up to #41720 for its unresolved pagination coverage gap.

- Accept validated non-negative integer `offset` and `count` query parameters.
- Forward pagination through the REST handler and read receipt retrieval path.
- Apply Rocket.Chat's standard default count, upper limit, and infinite count policy when pagination is requested.
- Paginate after hot and archived receipts are deduplicated, before resolving users.
- Preserve the existing unpaginated response when neither parameter is supplied.
- Add focused regression coverage for offset, count, user resolution, and unlimited `count=0` behavior.

## Issue(s)

Related to #41719.
Follow-up to #41720.

## Steps to test or reproduce

1. Call `GET /api/v1/chat.getMessageReadReceipts` with a valid `messageId`, `offset`, and `count`.
2. Confirm `offset` shifts the receipt window and `count` limits it.
3. Confirm negative or fractional pagination values are rejected.
4. Confirm calls without pagination parameters still return the existing full receipt list.

Verified locally with:

- `corepack yarn exec mocha --config .mocharc.base.json ee/tests/unit/server/lib/message-read-receipt/ReadReceipt.spec.ts`: 2 passing.
- ESLint on all changed TypeScript files: passed.
- `corepack yarn workspace @rocket.chat/rest-typings typecheck`: passed.
- Focused schema smoke test: numeric query strings coerced; negative and fractional values rejected.
- Prettier check on all changed files: passed.
- `git diff --check`: passed.

The full Rocket.Chat unit, API, and end-to-end suites were not run.

## Further comments

The regression was developed test-first. Before the implementation, the offset/count test returned all three receipts. A second red-green cycle caught the standard `count=0` unlimited case.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `offset` and `count` pagination parameters to message read-receipt requests.
  - Retrieve specific receipt ranges while preserving existing behavior when pagination is omitted.
  - A `count` of `0` returns all receipts from the requested offset onward.

- **Bug Fixes**
  - Added validation to ensure pagination values are non-negative integers.

- **Tests**
  - Added coverage for offset and count pagination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->