### PR TITLE
fix: interpolate username in welcome messages

### DIFF
--- a/.changeset/fix-welcome-message-interpolation.md
+++ b/.changeset/fix-welcome-message-interpolation.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes welcome system messages displaying a raw placeholder instead of the username.

--- a/packages/message-types/src/MessageTypes.spec.ts
+++ b/packages/message-types/src/MessageTypes.spec.ts
@@ -59,7 +59,9 @@ it('should return false for isSystemMessage if type is not registered', () => {
 it('should pass the username as a sprintf argument in welcome messages', () => {
 	registerCommonTypes(messageTypes);
 	const welcomeMessage = messageTypes.getType({ t: 'wm' });
-	const translate = jest.fn(() => 'Welcome <em>user</em>.') as unknown as TFunction;
+	const translate = jest.fn((_key: string, options: { postProcess?: string; sprintf?: string[] }) =>
+		options.postProcess === 'sprintf' ? `Welcome <em>${options.sprintf?.[0] ?? '%s'}</em>.` : 'Welcome <em>%s</em>.',
+	) as unknown as TFunction;
 
 	expect(welcomeMessage?.text(translate, { ...baseMessage, t: 'wm' })).toBe('Welcome <em>user</em>.');
 	expect(translate).toHaveBeenCalledWith('Welcome', { postProcess: 'sprintf', sprintf: ['user'] });

--- a/packages/message-types/src/MessageTypes.spec.ts
+++ b/packages/message-types/src/MessageTypes.spec.ts
@@ -1,6 +1,8 @@
 import type { IMessage, MessageTypesValues } from '@rocket.chat/core-typings';
+import type { TFunction } from 'i18next';
 
 import { MessageTypes } from './MessageTypes';
+import registerCommonTypes from './registrations/common';
 
 let messageTypes: MessageTypes;
 const baseMessage: IMessage = {
@@ -52,4 +54,13 @@ it('should identify non-system messages', () => {
 
 it('should return false for isSystemMessage if type is not registered', () => {
 	expect(messageTypes.isSystemMessage({ ...baseMessage, t: undefined })).toBe(false);
+});
+
+it('should pass the username as a sprintf argument in welcome messages', () => {
+	registerCommonTypes(messageTypes);
+	const welcomeMessage = messageTypes.getType({ t: 'wm' });
+	const translate = jest.fn(() => 'Welcome <em>user</em>.') as unknown as TFunction;
+
+	expect(welcomeMessage?.text(translate, { ...baseMessage, t: 'wm' })).toBe('Welcome <em>user</em>.');
+	expect(translate).toHaveBeenCalledWith('Welcome', { postProcess: 'sprintf', sprintf: ['user'] });
 });

--- a/packages/message-types/src/registrations/common.ts
+++ b/packages/message-types/src/registrations/common.ts
@@ -106,7 +106,7 @@ export default (instance: MessageTypes) => {
 	instance.registerType({
 		id: 'wm',
 		system: true,
-		text: (t, message) => t('Welcome', { user: message.u.username }),
+		text: (t, message) => t('Welcome', { postProcess: 'sprintf', sprintf: [message.u.username] }),
 	});
 
 	instance.registerType({


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Welcome system messages use the legacy `%s` translation placeholder. The formatter passed a named interpolation object, causing the username to render as a raw placeholder or object value depending on the translation path.

This change passes the username through the standard i18next sprintf postprocessor and adds regression coverage for the formatter contract.

## Issue(s)

Fixes #16055

## Steps to test or reproduce

1. Log in with a workspace welcome message enabled.
2. Verify the welcome system message displays the username instead of `%s`.

Automated verification:

- `corepack yarn workspace @rocket.chat/message-types test --runInBand`: 6 passed
- `corepack yarn eslint packages/message-types/src/MessageTypes.spec.ts packages/message-types/src/registrations/common.ts`: passed
- `corepack yarn workspace @rocket.chat/message-types build`: passed
- `corepack yarn changeset status`: passed

The full Rocket.Chat test suite was not run because it is impractical for this focused monorepo change.

## Further comments

A patch changeset for `@rocket.chat/meteor` is included. Existing locale files remain unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed welcome messages displaying a raw placeholder instead of the recipient’s username.
  * Welcome messages now correctly insert the username into the translated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->