### PR TITLE
fix(message-parser): keep URL underscores from closing link-text emphasis

### DIFF
--- a/.changeset/calm-links-render.md
+++ b/.changeset/calm-links-render.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Fixes Markdown links when both the label and URL contain underscores.

--- a/packages/message-parser/src/grammar.pegjs
+++ b/packages/message-parser/src/grammar.pegjs
@@ -390,7 +390,8 @@ References
 
 // Fast-path: bulk consume chars that can't start ]( or ] [ and aren't emphasis markers
 LinkTitle
-  = (Whitespace / Emphasis)
+  = "_" &((!("_" / "](") .)* "](") { return plain('_'); }
+  / (Whitespace / Emphasis)
   / anyTitle:$[^\]()*_~ \t\r\n]+ { return plain(anyTitle) }
   / anyTitle:$(!("](" .) !("] [" [^\]]* "](") .) { return plain(anyTitle) }
 

--- a/packages/message-parser/tests/link.test.ts
+++ b/packages/message-parser/tests/link.test.ts
@@ -26,6 +26,10 @@ test.each([
 	['[title](https://rocket.chat)', [paragraph([link('https://rocket.chat', [plain('title')])])]],
 	['[title](http://localhost)', [paragraph([link('http://localhost', [plain('title')])])]],
 	['[title](http://localhost?testing=true)', [paragraph([link('http://localhost?testing=true', [plain('title')])])]],
+	[
+		'[test-with-a-text-containing-an_here](http://example.com?param=my_value)',
+		[paragraph([link('http://example.com?param=my_value', [plain('test-with-a-text-containing-an_here')])])],
+	],
 	['[**title**](https://rocket.chat)', [paragraph([link('https://rocket.chat', [bold([plain('title')])])])]],
 	['[~~title~~](https://rocket.chat)', [paragraph([link('https://rocket.chat', [strike([plain('title')])])])]],
 	['[__title__](https://rocket.chat)', [paragraph([link('https://rocket.chat', [italic([plain('title')])])])]],


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Prevents an unmatched underscore in Markdown link text from treating an underscore in the URL as its emphasis closer.

Adds the exact reported regression case and a patch changeset for `@rocket.chat/message-parser`.

Keeps the change scoped to the message parser.

## Issue(s)

Fixes #41725

Related to #41727

## Steps to test or reproduce

1. Post `[test-with-a-text-containing-an_here](http://example.com?param=my_value)` in a channel.
2. Confirm only `test-with-a-text-containing-an_here` is displayed and the whole label links to `http://example.com?param=my_value`.
3. Run `corepack yarn workspace @rocket.chat/message-parser test --runInBand` with Node 22.22.3.

## Further comments

Local verification:

- Message parser tests: 36 suites passed, 719 tests passed.
- Message parser lint: passed with 0 errors and 6 existing warnings.
- Message parser typecheck: passed.
- Message parser build: passed.

The full Rocket.Chat monorepo test suite was not run because it is impractical for this focused parser change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Markdown links so labels and URLs containing underscores are parsed and displayed correctly.

* **Tests**
  * Added coverage for links containing hyphens and underscores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
