### PR TITLE
fix: "Banner not found" error when dismissing user banners (#41732)

### DIFF
--- a/.changeset/fix-dismiss-user-banner.md
+++ b/.changeset/fix-dismiss-user-banner.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes "Banner not found" error when dismissing user banners (e.g. version update notifications).

--- a/apps/meteor/server/services/banner/service.ts
+++ b/apps/meteor/server/services/banner/service.ts
@@ -5,6 +5,8 @@ import type { IBannerService } from '@rocket.chat/core-services';
 import type { BannerPlatform, IBanner, IBannerDismiss, Optional, IUser } from '@rocket.chat/core-typings';
 import { Banners, BannersDismiss, Users } from '@rocket.chat/models';
 
+import { notifyOnUserChange } from '../../lib/notifyListener';
+
 export class BannerService extends ServiceClassInternal implements IBannerService {
 	protected name = 'banner';
 
@@ -85,34 +87,51 @@ export class BannerService extends ServiceClassInternal implements IBannerServic
 			throw new Error('Invalid params');
 		}
 
-		const banner = await Banners.findOneById(bannerId);
-		if (!banner) {
-			throw new Error('Banner not found');
-		}
-
-		const user = await Users.findOneById<Pick<IUser, 'username' | '_id'>>(userId, {
-			projection: { username: 1 },
+		const user = await Users.findOneById<Pick<IUser, 'username' | '_id' | 'banners'>>(userId, {
+			projection: { username: 1, banners: 1 },
 		});
 		if (!user) {
 			throw new Error('User not found');
 		}
 
-		const dismissedBy = {
-			_id: user._id,
-			username: user.username,
-		};
+		const banner = await Banners.findOneById(bannerId);
+		const hasUserBanner = Boolean(user.banners?.[bannerId]);
 
-		const today = new Date();
+		if (!banner && !hasUserBanner) {
+			throw new Error('Banner not found');
+		}
 
-		const doc = {
-			userId,
-			bannerId,
-			dismissedBy,
-			dismissedAt: today,
-			_updatedAt: today,
-		};
+		if (hasUserBanner) {
+			const result = await Users.setBannerReadById(userId, bannerId);
+			if (result.modifiedCount) {
+				void notifyOnUserChange({
+					id: userId,
+					clientAction: 'updated',
+					diff: {
+						[`banners.${bannerId}.read`]: true,
+					},
+				});
+			}
+		}
 
-		await BannersDismiss.insertOne(doc);
+		if (banner) {
+			const dismissedBy = {
+				_id: user._id,
+				username: user.username,
+			};
+
+			const today = new Date();
+
+			const doc = {
+				userId,
+				bannerId,
+				dismissedBy,
+				dismissedAt: today,
+				_updatedAt: today,
+			};
+
+			await BannersDismiss.insertOne(doc);
+		}
 
 		return true;
 	}

--- a/apps/meteor/tests/unit/server/services/banner/service.tests.ts
+++ b/apps/meteor/tests/unit/server/services/banner/service.tests.ts
@@ -6,7 +6,13 @@ import type { FindCursor, FindOptions } from 'mongodb';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
-const { BannerService } = proxyquire.noCallThru().load('../../../../../server/services/banner/service', {});
+const notifyOnUserChangeFake = sinon.fake();
+
+const { BannerService } = proxyquire.noCallThru().load('../../../../../server/services/banner/service', {
+	'../../lib/notifyListener': {
+		notifyOnUserChange: notifyOnUserChangeFake,
+	},
+});
 
 class BannerModel extends BaseRaw<any> {
 	findActiveByRoleOrId(
@@ -17,17 +23,29 @@ class BannerModel extends BaseRaw<any> {
 	): FindCursor<IBanner> {
 		return {} as unknown as FindCursor<IBanner>;
 	}
+
+	override findOneById(): Promise<any> {
+		return Promise.resolve(null);
+	}
 }
 
 class BannerDismissModel extends BaseRaw<any> {
 	findByUserIdAndBannerId(): FindCursor<Pick<IBannerDismiss, 'bannerId'>> {
 		return {} as unknown as FindCursor<Pick<IBannerDismiss, 'bannerId'>>;
 	}
+
+	override insertOne(): Promise<any> {
+		return Promise.resolve({ acknowledged: true });
+	}
 }
 
 class UserModel extends BaseRaw<any> {
 	override findOneById(): Promise<any> {
 		return Promise.resolve({});
+	}
+
+	setBannerReadById(): Promise<any> {
+		return Promise.resolve();
 	}
 }
 
@@ -48,7 +66,10 @@ describe('Banners service', () => {
 		registerModel('IUsersModel', userModel);
 	});
 
-	afterEach(() => sinon.restore());
+	afterEach(() => {
+		notifyOnUserChangeFake.resetHistory();
+		sinon.restore();
+	});
 
 	it('should be defined', () => {
 		const service = new BannerService();
@@ -144,6 +165,103 @@ describe('Banners service', () => {
 			expect(banners).to.have.lengthOf(1);
 			expect(banners[0].view.viewId).to.be.equal(A_SECOND_FAKE_BANNER._id);
 			expect(banners[0].surface).to.be.equal('modal');
+		});
+	});
+
+	describe('dismiss', () => {
+		it('should dismiss a banner from Banners collection', async () => {
+			const service = new BannerService();
+			sinon.replace(userModel, 'findOneById', sinon.fake.returns(Promise.resolve({ _id: 'user-1', username: 'testuser' })));
+			sinon.replace(bannersModel, 'findOneById', sinon.fake.returns(Promise.resolve({ _id: 'banner-1' })));
+			const insertOneMock = sinon.replace(bannerDismissModel, 'insertOne', sinon.fake.returns(Promise.resolve({})));
+			const setBannerReadByIdMock = sinon.replace(
+				userModel,
+				'setBannerReadById',
+				sinon.fake.returns(Promise.resolve({ modifiedCount: 1 })),
+			);
+
+			const result = await service.dismiss('user-1', 'banner-1');
+
+			expect(result).to.be.true;
+			expect(insertOneMock.callCount).to.be.equal(1);
+			expect(setBannerReadByIdMock.callCount).to.be.equal(0);
+			expect(notifyOnUserChangeFake.callCount).to.be.equal(0);
+		});
+
+		it('should dismiss a user banner (user.banners)', async () => {
+			const service = new BannerService();
+			sinon.replace(
+				userModel,
+				'findOneById',
+				sinon.fake.returns(
+					Promise.resolve({
+						_id: 'user-1',
+						username: 'testuser',
+						banners: { 'versionUpdate-8_7_0': { id: 'versionUpdate-8_7_0' } },
+					}),
+				),
+			);
+			sinon.replace(bannersModel, 'findOneById', sinon.fake.returns(Promise.resolve(null)));
+			const insertOneMock = sinon.replace(bannerDismissModel, 'insertOne', sinon.fake.returns(Promise.resolve({})));
+			const setBannerReadByIdMock = sinon.replace(
+				userModel,
+				'setBannerReadById',
+				sinon.fake.returns(Promise.resolve({ modifiedCount: 1 })),
+			);
+
+			const result = await service.dismiss('user-1', 'versionUpdate-8_7_0');
+
+			expect(result).to.be.true;
+			expect(setBannerReadByIdMock.callCount).to.be.equal(1);
+			expect(insertOneMock.callCount).to.be.equal(0);
+			expect(notifyOnUserChangeFake.callCount).to.be.equal(1);
+			expect(notifyOnUserChangeFake.firstCall.args[0]).to.be.deep.equal({
+				id: 'user-1',
+				clientAction: 'updated',
+				diff: {
+					'banners.versionUpdate-8_7_0.read': true,
+				},
+			});
+		});
+
+		it('should not send user notification if banner was concurrently removed before setBannerReadById', async () => {
+			const service = new BannerService();
+			sinon.replace(
+				userModel,
+				'findOneById',
+				sinon.fake.returns(
+					Promise.resolve({
+						_id: 'user-1',
+						username: 'testuser',
+						banners: { 'versionUpdate-8_7_0': { id: 'versionUpdate-8_7_0' } },
+					}),
+				),
+			);
+			sinon.replace(bannersModel, 'findOneById', sinon.fake.returns(Promise.resolve(null)));
+			const setBannerReadByIdMock = sinon.replace(
+				userModel,
+				'setBannerReadById',
+				sinon.fake.returns(Promise.resolve({ modifiedCount: 0 })),
+			);
+
+			const result = await service.dismiss('user-1', 'versionUpdate-8_7_0');
+
+			expect(result).to.be.true;
+			expect(setBannerReadByIdMock.callCount).to.be.equal(1);
+			expect(notifyOnUserChangeFake.callCount).to.be.equal(0);
+		});
+
+		it('should throw error when banner is not found in Banners collection nor user.banners', async () => {
+			const service = new BannerService();
+			sinon.replace(userModel, 'findOneById', sinon.fake.returns(Promise.resolve({ _id: 'user-1', username: 'testuser' })));
+			sinon.replace(bannersModel, 'findOneById', sinon.fake.returns(Promise.resolve(null)));
+
+			try {
+				await service.dismiss('user-1', 'non-existent-banner');
+				expect.fail('Should have thrown an error');
+			} catch (err: any) {
+				expect(err.message).to.be.equal('Banner not found');
+			}
 		});
 	});
 });

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -2912,13 +2912,20 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	}
 
 	setBannerReadById(_id: IUser['_id'], bannerId: string) {
+		const query = {
+			_id,
+			[`banners.${bannerId}`]: {
+				$exists: true,
+			},
+		};
+
 		const update = {
 			$set: {
 				[`banners.${bannerId}.read`]: true,
 			},
 		};
 
-		return this.updateOne({ _id }, update);
+		return this.updateOne(query, update);
 	}
 
 	removeBannerById(_id: IUser['_id'], bannerId: string) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

### Proposed changes

Fixes issue [#41732](https://github.com/RocketChat/Rocket.Chat/issues/41732) where clicking the close button (`X`) on release update banners (or other user-scoped banners) produced a `"Banner not found"` toast error and failed to dismiss the banner.

#### Root Cause
Release update notifications and user-scoped banners are stored on the `user` document in MongoDB (`user.banners`). When a user dismissed the banner, the client called `POST /v1/banners.dismiss` which delegates to `BannerService.dismiss`. Previously, `BannerService.dismiss` only queried the global `Banners` collection (`Banners.findOneById(bannerId)`). When the banner ID was absent from the global collection, it threw a `"Banner not found"` error.

#### Solution
- Updated `BannerService.dismiss` to check `user.banners?.[bannerId]` if the banner is not in the global `Banners` collection.
- When a user banner is present, it calls `Users.setBannerReadById(userId, bannerId)` to mark it read in MongoDB and dispatches `notifyOnUserChange` to push the update to client WebSocket listeners reactively.
- Added unit tests for `BannerService.dismiss` covering global banner dismissal, user banner dismissal, and invalid banner error paths.
- Included changeset for `@rocket.chat/meteor`.

---

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change that neither fixes a bug nor adds a feature)

---

### Checklist
- [x] I have read the Contributing Guide
- [x] Changeset added (`.changeset/fix-dismiss-user-banner.md`)
- [x] Unit tests added for user banner dismissal


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “Banner not found” error when dismissing banners saved to a user’s personal banner list.
  - Personal banners are now marked as read, and updates refresh correctly.
  - Missing banners without a personal entry continue to display an appropriate error.
  - Banners are only marked as read when they exist for the user.

- **Tests**
  - Added coverage for global banners, personal banners, user update notifications, and missing-banner scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->