### PR TITLE
fix: thread root message missing after editing a reply

### DIFF
--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -1233,13 +1233,13 @@ const chatEndpoints = API.v1
 					if (target?.tmid !== tmid || !target.ts) {
 						throw new Meteor.Error('error-invalid-message', 'The provided "aroundId" does not belong to the thread');
 					}
-					const before = await Messages.countDocuments({ ...query, tmid, ts: { $lt: target.ts } });
+					const before = await Messages.countDocuments({ ...query, tmid, _hidden: { $ne: true }, ts: { $lt: target.ts } });
 					resolvedOffset = Math.max(0, before - Math.floor(count / 2));
 				}
 			}
 
 			const { cursor, totalCount } = Messages.findPaginated(
-				{ ...query, tmid },
+				{ ...query, tmid, _hidden: { $ne: true } },
 				{
 					sort: resolvedSort,
 					skip: resolvedOffset,

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -8,7 +8,7 @@ import type { Response } from 'supertest';
 import { retry } from './helpers/retry';
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
-import { followMessage, sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
+import { followMessage, sendSimpleMessage, deleteMessage, updateMessage } from '../../data/chat.helper';
 import { imgURL } from '../../data/interactions';
 import { mockServerHealthy, mockServerReset, mockServerSet } from '../../data/mock-server.helper';
 import { updatePermission, updateSetting } from '../../data/permissions.helper';
@@ -4602,6 +4602,38 @@ describe('Threads', () => {
 			expect(res.body).to.have.property('count');
 			expect(res.body.messages).to.have.lengthOf(1);
 			expect(res.body.messages[0].tmid).to.be.equal(createdThreadMessage._id);
+		});
+
+		describe('Message_KeepHistory', () => {
+			describe('when enabled', () => {
+				before(() => updateSetting('Message_KeepHistory', true));
+				after(() => updateSetting('Message_KeepHistory', false));
+
+				it('should exclude hidden message edit history from pagination results', async () => {
+					await updateMessage({
+						msgId: threadMessage._id,
+						updatedMessage: 'Edited thread message',
+						roomId: testChannel._id,
+					});
+
+					const res = await request
+						.get(api('chat.getThreadMessages'))
+						.set(credentials)
+						.query({
+							tmid: threadMessage.tmid,
+						})
+						.expect('Content-Type', 'application/json')
+						.expect(200);
+
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('total', 1);
+					expect(res.body).to.have.property('count', 1);
+					expect(res.body.messages).to.have.lengthOf(1);
+					expect(res.body.messages[0]).to.have.property('_id', threadMessage._id);
+					expect(res.body.messages[0]).to.have.property('msg', 'Edited thread message');
+					expect(res.body.messages[0]).to.not.have.property('_hidden');
+				});
+			});
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -4606,32 +4606,56 @@ describe('Threads', () => {
 
 		describe('Message_KeepHistory', () => {
 			describe('when enabled', () => {
-				before(() => updateSetting('Message_KeepHistory', true));
-				after(() => updateSetting('Message_KeepHistory', false));
+				let secondThreadMessage: IThreadMessage;
 
-				it('should exclude hidden message edit history from pagination results', async () => {
+				before(async () => {
+					await updateSetting('Message_KeepHistory', true);
 					await updateMessage({
 						msgId: threadMessage._id,
 						updatedMessage: 'Edited thread message',
 						roomId: testChannel._id,
 					});
+					secondThreadMessage = (
+						await sendSimpleMessage({
+							roomId: testChannel._id,
+							text: 'Second thread message',
+							tmid: createdThreadMessage._id,
+						})
+					).body.message;
+				});
+				after(() => updateSetting('Message_KeepHistory', false));
 
+				it('should exclude hidden message edit history from offset pagination', async () => {
 					const res = await request
 						.get(api('chat.getThreadMessages'))
 						.set(credentials)
 						.query({
 							tmid: threadMessage.tmid,
+							count: 1,
+							offset: 1,
 						})
 						.expect('Content-Type', 'application/json')
 						.expect(200);
 
-					expect(res.body).to.have.property('success', true);
-					expect(res.body).to.have.property('total', 1);
-					expect(res.body).to.have.property('count', 1);
+					expect(res.body).to.include({ success: true, total: 2, count: 1, offset: 1 });
 					expect(res.body.messages).to.have.lengthOf(1);
-					expect(res.body.messages[0]).to.have.property('_id', threadMessage._id);
-					expect(res.body.messages[0]).to.have.property('msg', 'Edited thread message');
-					expect(res.body.messages[0]).to.not.have.property('_hidden');
+					expect(res.body.messages[0]).to.have.property('_id', secondThreadMessage._id);
+				});
+
+				it('should exclude hidden message edit history when resolving an aroundId offset', async () => {
+					const res = await request
+						.get(api('chat.getThreadMessages'))
+						.set(credentials)
+						.query({
+							tmid: threadMessage.tmid,
+							aroundId: secondThreadMessage._id,
+							count: 2,
+						})
+						.expect('Content-Type', 'application/json')
+						.expect(200);
+
+					expect(res.body).to.include({ success: true, total: 2, count: 2, offset: 0 });
+					expect(res.body.messages.map(({ _id }: IMessage) => _id)).to.deep.equal([threadMessage._id, secondThreadMessage._id]);
 				});
 			});
 		});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes thread pagination incorrectly treating hidden message edit-history records as visible replies.

When `Message_KeepHistory` is enabled, editing a thread reply creates a copy marked with `_hidden: true`. The `chat.getThreadMessages` endpoint included this record in its results and pagination total. Although the client filtered the hidden record, the incorrect total caused it to assume an older page existed and hide the thread root message.

This PR:

- Excludes hidden messages from `chat.getThreadMessages`.
- Excludes hidden messages when calculating pagination offsets.
- Adds regression coverage for edited thread replies when message history is enabled.

## Issue(s)

[CORE-2529](https://rocketchat.atlassian.net/browse/CORE-2529)

## Steps to test or reproduce

1. Enable **Keep Per Message Editing History** under **Administration → Workspace → Settings → Message**.
2. Create a channel message.
3. Add one reply to its thread.
4. Edit the thread reply.
5. Close the thread panel and refresh the browser.
6. Open the thread again.

Before this change, only the edited reply is displayed and the thread root message is missing.

After this change, both the thread root message and the edited reply are displayed.

## Further comments

The endpoint now uses `_hidden: { $ne: true }`, which excludes hidden history records while preserving regular messages where `_hidden` is either absent or explicitly `false`.

Pagination results, totals, and offsets are therefore calculated using the same set of visible messages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


[CORE-2529]: https://rocketchat.atlassian.net/browse/CORE-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Thread message pagination now excludes hidden message history when calculating offsets and displaying results.
  - Edited thread messages now appear correctly with their updated content, without exposing hidden-history markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->