### PR TITLE
test: sidebar-menu flaky by waiting for sidebar rendering

### DIFF
--- a/apps/meteor/tests/e2e/sidebar-menu.spec.ts
+++ b/apps/meteor/tests/e2e/sidebar-menu.spec.ts
@@ -13,7 +13,7 @@ test.describe('sidebar-menu', () => {
 		});
 
 		await page.goto('/home', { waitUntil: 'domcontentloaded' });
-		await expect(page.getByRole('button', { name: 'Create new' })).toBeVisible();
+		await page.getByRole('button', { name: 'Create new' }).waitFor();
 
 		await page.keyboard.press('Tab');
 		await page.keyboard.press('Tab');


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes the `sidebar-menu` E2E flake by waiting for the **Create new** button with Playwright’s locator timeout, giving the sidebar enough time to finish rendering on slower CI runs.

## Issue(s)

[FLAKY-2442](https://rocketchat.atlassian.net/browse/FLAKY-2442)

## Steps to test or reproduce


## Further comments

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

[FLAKY-2442]: https://rocketchat.atlassian.net/browse/FLAKY-2442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved sidebar end-to-end test stability by waiting for the “Create new” button to be available before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->