### PR TITLE
test: omnichannel-takeChat flaky by waiting for agent status

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -78,7 +78,7 @@ test.describe('omnichannel-takeChat', () => {
 		await expect(poLiveChat.alertMessage('Error starting a new conversation: Sorry, no online agents [no-agent-online]')).toBeVisible();
 	});
 
-	test('When a new livechat conversation starts but agent is offline, it should not be able to take the chat', async ({ api }) => {
+	test('When the selected conversation has an offline agent, the Take Chat button is disabled', async ({ api }) => {
 		await sendLivechatMessage();
 
 		await agent.poHomeChannel.sidebar.getSidebarItemByName(newVisitor.name).click();

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -78,7 +78,9 @@ test.describe('omnichannel-takeChat', () => {
 		await expect(poLiveChat.alertMessage('Error starting a new conversation: Sorry, no online agents [no-agent-online]')).toBeVisible();
 	});
 
-	test('When the selected conversation has an offline agent, the Take Chat button is disabled', async ({ api }) => {
+	test('When a new livechat conversation is selected and the agent becomes offline or unavailable, they should not be able to take the chat', async ({
+		api,
+	}) => {
 		await sendLivechatMessage();
 
 		await agent.poHomeChannel.sidebar.getSidebarItemByName(newVisitor.name).click();

--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-takeChat.spec.ts
@@ -78,15 +78,18 @@ test.describe('omnichannel-takeChat', () => {
 		await expect(poLiveChat.alertMessage('Error starting a new conversation: Sorry, no online agents [no-agent-online]')).toBeVisible();
 	});
 
-	test('When a new livechat conversation starts but agent is offline, it should not be able to take the chat', async () => {
+	test('When a new livechat conversation starts but agent is offline, it should not be able to take the chat', async ({ api }) => {
 		await sendLivechatMessage();
 
-		await agent.poHomeChannel.navbar.changeUserStatus('offline');
 		await agent.poHomeChannel.sidebar.getSidebarItemByName(newVisitor.name).click();
+
+		await agent.poHomeChannel.navbar.changeUserStatus('offline');
+		await expectPollUserStatus(api, 'user1', 'offline');
 
 		await expect(agent.poHomeChannel.content.btnTakeChat).toBeDisabled();
 
 		await agent.poHomeChannel.navbar.changeUserStatus('online');
+		await expectPollUserStatus(api, 'user1', 'online');
 		await agent.poHomeChannel.navbar.switchOmnichannelStatus('offline');
 
 		await expect(agent.poHomeChannel.content.btnTakeChat).toBeDisabled();


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
Fixes the `omnichannel-takeChat` flake by opening the queued chat before changing the agent status and waiting for status transitions to complete.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[FLAKY-2444](https://rocketchat.atlassian.net/browse/FLAKY-2444)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[FLAKY-2444]: https://rocketchat.atlassian.net/browse/FLAKY-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for offline-agent chat behavior.
  * Added synchronization checks to ensure agent status changes are reflected before validating chat controls.
  * Restored online status before validating omnichannel offline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->