### PR TITLE
test: address voice call locator gap in #41741

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/fragments/voice-calls.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/voice-calls.ts
@@ -25,8 +25,12 @@ export class VoiceCallControls {
 		return this._controls.getByRole('button', { name: 'Accept', exact: true });
 	}
 
+	get btnReject(): Locator {
+		return this._controls.getByRole('button', { name: 'Reject', exact: true });
+	}
+
 	get hangup(): Locator {
-		return this._controls.getByRole('button', { name: /End call|Reject/, exact: true });
+		return this._controls.getByRole('button', { name: /^End call with .+$/ });
 	}
 
 	get cancel(): Locator {
@@ -152,6 +156,11 @@ export class Widget {
 
 	async endCall(): Promise<void> {
 		await this.callControls.hangup.click();
+		await expect(this.content).not.toBeVisible();
+	}
+
+	async rejectCall(): Promise<void> {
+		await this.callControls.btnReject.click();
 		await expect(this.content).not.toBeVisible();
 	}
 

--- a/apps/meteor/tests/e2e/voice-calls-ee.spec.ts
+++ b/apps/meteor/tests/e2e/voice-calls-ee.spec.ts
@@ -146,7 +146,7 @@ test.describe('Internal Voice Calls - Enterprise Edition', () => {
 		});
 
 		await test.step('user2 declines the call', async () => {
-			await user2.poHomeChannel.voiceCalls.widget.endCall();
+			await user2.poHomeChannel.voiceCalls.widget.rejectCall();
 		});
 
 		await test.step('Verify call widget disappears', async () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Split incoming call rejection from active call hangup controls in the voice call E2E page object.

PR #41741 correctly identified that the old `End call|Reject` locator could match multiple incoming controls. Its replacement uses the exact name `End call`, but active call buttons are rendered from `Voice_call__user__hangup` as `End call with {{user}}`. This follow-up uses the complete active-call label pattern and a separate exact `Reject` locator.

## Issue(s)

Follow-up to #41741.

## Steps to test or reproduce

1. Run `corepack yarn exec prettier --check tests/e2e/page-objects/fragments/voice-calls.ts tests/e2e/voice-calls-ee.spec.ts` from `apps/meteor`.
2. Run `corepack yarn eslint tests/e2e/page-objects/fragments/voice-calls.ts tests/e2e/voice-calls-ee.spec.ts` from `apps/meteor`.
3. Run `corepack yarn test:e2e tests/e2e/voice-calls-ee.spec.ts --list` from `apps/meteor`.
4. In the EE E2E environment, run `corepack yarn test:e2e tests/e2e/voice-calls-ee.spec.ts`.

## Further comments

The full EE browser suite requires the CI service stack and was not run locally. PR #41741 currently shows five failures where Playwright cannot find an exact `End call` button after accepting a call.

No changeset is included because this only updates E2E tests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved voice call end-to-end coverage by distinguishing between rejecting an incoming call and ending an active call.
  * Added verification that rejected calls are removed from the call interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->