### PR TITLE
fix: `canAccessRoom` throwing when the user's `_id` is undefined

### DIFF
--- a/.changeset/lazy-ends-drive.md
+++ b/.changeset/lazy-ends-drive.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes `canAccessRoom` throwing when the user's `_id` is undefined

--- a/apps/meteor/server/services/authorization/canAccessRoom.ts
+++ b/apps/meteor/server/services/authorization/canAccessRoom.ts
@@ -106,7 +106,7 @@ const roomAccessValidators: RoomAccessValidatorConverted[] = [
 ];
 
 export const isPartialUser = (user: IUser | Pick<IUser, '_id'> | undefined): user is Pick<IUser, '_id'> => {
-	return Boolean(user && Object.keys(user).length === 1 && '_id' in user);
+	return Boolean(user && Object.keys(user).length === 1 && user._id);
 };
 
 export const canAccessRoom: RoomAccessValidator = async (room, user, extraData): Promise<boolean> => {

--- a/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
+++ b/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
@@ -97,20 +97,20 @@ describe('canAccessRoom', () => {
 			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
 		});
 
-		it('should not hydrate a user whose _id is empty, and treat it as anonymous instead of throwing when anonymous read is on', async () => {
+		it('should not hydrate a user whose _id is undefined, and treat it as anonymous instead of throwing when anonymous read is on', async () => {
 			coreServicesMock.Settings.get.resolves(true);
 
-			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: '' });
+			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: undefined });
 
 			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
 			expect(coreServicesMock.Settings.get.calledWith('Accounts_AllowAnonymousRead')).to.be.true;
 			expect(result).to.be.true;
 		});
 
-		it('should deny access to a user whose _id is empty when anonymous read is off', async () => {
+		it('should deny access to a user whose _id is undefined when anonymous read is off', async () => {
 			coreServicesMock.Settings.get.resolves(false);
 
-			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: '' });
+			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: undefined });
 
 			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
 			expect(result).to.be.false;

--- a/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
+++ b/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
@@ -1,0 +1,119 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import p from 'proxyquire';
+import sinon from 'sinon';
+
+const modelsMock = {
+	Subscriptions: {
+		findOneBannedSubscription: sinon.stub(),
+		countByRoomIdAndUserId: sinon.stub(),
+	},
+	Rooms: {
+		findOneById: sinon.stub(),
+	},
+	TeamMember: {
+		findOneByUserIdAndTeamId: sinon.stub(),
+	},
+	Team: {
+		findOneById: sinon.stub(),
+	},
+	Users: {
+		findOneById: sinon.stub(),
+	},
+};
+
+const coreServicesMock = {
+	Authorization: {
+		hasPermission: sinon.stub(),
+		canAccessRoom: sinon.stub(),
+	},
+	License: {
+		hasModule: sinon.stub(),
+	},
+	Abac: {
+		canAccessObject: sinon.stub(),
+	},
+	Settings: {
+		get: sinon.stub(),
+	},
+};
+
+const canAccessRoomLivechatMock = sinon.stub();
+
+const { canAccessRoom } = p.noCallThru().load('../../../../../server/services/authorization/canAccessRoom.ts', {
+	'@rocket.chat/models': modelsMock,
+	'@rocket.chat/core-services': coreServicesMock,
+	'./canAccessRoomLivechat': { canAccessRoomLivechat: canAccessRoomLivechatMock },
+});
+
+describe('canAccessRoom', () => {
+	beforeEach(() => {
+		sinon.reset();
+
+		// sane defaults: everything denies access unless a test says otherwise
+		modelsMock.Subscriptions.findOneBannedSubscription.resolves(null);
+		modelsMock.Subscriptions.countByRoomIdAndUserId.resolves(0);
+		modelsMock.Rooms.findOneById.resolves(null);
+		modelsMock.TeamMember.findOneByUserIdAndTeamId.resolves(null);
+		modelsMock.Team.findOneById.resolves(null);
+		modelsMock.Users.findOneById.resolves(null);
+		coreServicesMock.Authorization.hasPermission.resolves(false);
+		coreServicesMock.Authorization.canAccessRoom.resolves(false);
+		coreServicesMock.License.hasModule.resolves(false);
+		coreServicesMock.Abac.canAccessObject.resolves(false);
+		coreServicesMock.Settings.get.resolves(false);
+		canAccessRoomLivechatMock.resolves(false);
+	});
+
+	describe('user hydration', () => {
+		it('should hydrate a partial user before running the validators', async () => {
+			const fullUser = { _id: 'user-id', username: 'john.doe', roles: ['user'] };
+			modelsMock.Users.findOneById.resolves(fullUser);
+			coreServicesMock.Authorization.hasPermission.resolves(true);
+
+			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: 'user-id' });
+
+			expect(result).to.be.true;
+			expect(modelsMock.Users.findOneById.calledOnceWith('user-id')).to.be.true;
+			expect(coreServicesMock.Authorization.hasPermission.calledWith(fullUser, 'view-c-room')).to.be.true;
+		});
+
+		it('should throw when the partial user cannot be found', async () => {
+			modelsMock.Users.findOneById.resolves(null);
+
+			await expect(canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: 'user-id' })).to.be.rejectedWith('User not found');
+		});
+
+		it('should not hydrate a full user', async () => {
+			await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: 'user-id', username: 'john.doe' } as IUser);
+
+			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
+		});
+
+		it('should not hydrate an undefined user', async () => {
+			await canAccessRoom({ _id: 'room-id', t: 'c' }, undefined);
+
+			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
+		});
+
+		it('should not hydrate a user whose _id is empty, and treat it as anonymous instead of throwing when anonymous read is on', async () => {
+			coreServicesMock.Settings.get.resolves(true);
+
+			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: '' });
+
+			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
+			expect(coreServicesMock.Settings.get.calledWith('Accounts_AllowAnonymousRead')).to.be.true;
+			expect(result).to.be.true;
+		});
+
+		it('should deny access to a user whose _id is empty when anonymous read is off', async () => {
+			coreServicesMock.Settings.get.resolves(false);
+
+			const result = await canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: '' });
+
+			expect(modelsMock.Users.findOneById.notCalled).to.be.true;
+			expect(result).to.be.false;
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
+++ b/apps/meteor/tests/unit/server/services/authorization/canAccessRoom.spec.ts
@@ -4,42 +4,44 @@ import { beforeEach, describe, it } from 'mocha';
 import p from 'proxyquire';
 import sinon from 'sinon';
 
+const sandbox = sinon.createSandbox();
+
 const modelsMock = {
 	Subscriptions: {
-		findOneBannedSubscription: sinon.stub(),
-		countByRoomIdAndUserId: sinon.stub(),
+		findOneBannedSubscription: sandbox.stub(),
+		countByRoomIdAndUserId: sandbox.stub(),
 	},
 	Rooms: {
-		findOneById: sinon.stub(),
+		findOneById: sandbox.stub(),
 	},
 	TeamMember: {
-		findOneByUserIdAndTeamId: sinon.stub(),
+		findOneByUserIdAndTeamId: sandbox.stub(),
 	},
 	Team: {
-		findOneById: sinon.stub(),
+		findOneById: sandbox.stub(),
 	},
 	Users: {
-		findOneById: sinon.stub(),
+		findOneById: sandbox.stub(),
 	},
 };
 
 const coreServicesMock = {
 	Authorization: {
-		hasPermission: sinon.stub(),
-		canAccessRoom: sinon.stub(),
+		hasPermission: sandbox.stub(),
+		canAccessRoom: sandbox.stub(),
 	},
 	License: {
-		hasModule: sinon.stub(),
+		hasModule: sandbox.stub(),
 	},
 	Abac: {
-		canAccessObject: sinon.stub(),
+		canAccessObject: sandbox.stub(),
 	},
 	Settings: {
-		get: sinon.stub(),
+		get: sandbox.stub(),
 	},
 };
 
-const canAccessRoomLivechatMock = sinon.stub();
+const canAccessRoomLivechatMock = sandbox.stub();
 
 const { canAccessRoom } = p.noCallThru().load('../../../../../server/services/authorization/canAccessRoom.ts', {
 	'@rocket.chat/models': modelsMock,
@@ -49,7 +51,7 @@ const { canAccessRoom } = p.noCallThru().load('../../../../../server/services/au
 
 describe('canAccessRoom', () => {
 	beforeEach(() => {
-		sinon.reset();
+		sandbox.reset();
 
 		// sane defaults: everything denies access unless a test says otherwise
 		modelsMock.Subscriptions.findOneBannedSubscription.resolves(null);
@@ -80,8 +82,6 @@ describe('canAccessRoom', () => {
 		});
 
 		it('should throw when the partial user cannot be found', async () => {
-			modelsMock.Users.findOneById.resolves(null);
-
 			await expect(canAccessRoom({ _id: 'room-id', t: 'c' }, { _id: 'user-id' })).to.be.rejectedWith('User not found');
 		});
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
In https://github.com/RocketChat/Rocket.Chat/pull/38622 we added a method name `isPartialUser`, which checks for the existence of the `_id` property in the user object rather than checking it's truthy. That implementation returned `true` every time the user `_id` came as `undefined`, getting into the conditional that hydrates the object querying to the user's collection by `_id`, and hence, throwing 'User not found' error.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[SUP-1093 Regression in 8.3.0: loadMissedMessages throws User not found for unauthenticated callers, reachable from an unauthenticated public endpoint](https://rocketchat.atlassian.net/browse/SUP-1093)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
Precondition: You need to have a room with the `GENERAL` _id, or tweak the body based on your needs.

This can be tested via API, use the POST method against `http://localhost:3000/api/v1/method.callAnon/loadMissedMessages`, no headers.

Body template:
```
{"message":"{\"msg\":\"method\",\"id\":\"42\",\"method\":\"loadMissedMessages\",\"params\":[\"GENERAL\",{\"$date\":1700000000000}]}"
```

Expected result: You shouldn't get an 'User not found' error in console. The response should contain `success: true`.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed an authorization error that could occur when a user ID was undefined.
- Improved handling of incomplete user information during room access checks.
- Preserved correct anonymous-access decisions when user IDs are empty.

## Tests
- Added coverage for user hydration, missing users, incomplete users, and anonymous access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->