### PR TITLE
fix: message-parser timestamps overflow for dates from 2038

### DIFF
--- a/.changeset/fix-message-parser-timestamp-overflow.md
+++ b/.changeset/fix-message-parser-timestamp-overflow.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Fixes `<t:...>` timestamps with dates on or after 2038-01-19 rendering as a wrong (1903) date. The parser truncated the epoch seconds with `| 0`, which overflows the 32-bit signed range; it now uses `Math.floor`, so future dates parse correctly.

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -363,7 +363,7 @@ export const timestampFromHours = (hours: string, minutes = '00', seconds = '00'
 
 	const yearMonthDay = date.toISOString().split('T')[0];
 
-	const timestamp = (new Date(`${yearMonthDay}T${hours}:${minutes}:${seconds}${timezone}`).getTime() / 1000) | 0;
+	const timestamp = Math.floor(new Date(`${yearMonthDay}T${hours}:${minutes}:${seconds}${timezone}`).getTime() / 1000);
 
 	return timestamp.toString();
 };
@@ -387,9 +387,9 @@ export const timestampFromIsoTime = ({
 	milliseconds?: string;
 	timezone?: string;
 }) => {
-	const date =
-		(new Date(`${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds || '000'}${timezone ? `${timezone}` : ''}`).getTime() /
-			1000) |
-		0;
+	const date = Math.floor(
+		new Date(`${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds || '000'}${timezone ? `${timezone}` : ''}`).getTime() /
+			1000,
+	);
 	return date.toString();
 };

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -81,3 +81,26 @@ describe('relative hour timestamp parsing', () => {
 		expect(parse(input)).toEqual([paragraph([node])]);
 	});
 });
+
+describe('relative hour timestamp parsing beyond the 2038 boundary', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+		// The hour-only path builds its date from the current clock, so it only
+		// overflows once the machine clock is past 2038-01-19. Pin the clock to
+		// 2040 to exercise that branch (previously `| 0` wrapped it negative).
+		jest.setSystemTime(new Date('2040-01-01T00:00:00.000Z'));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	test.each([
+		['<t:10:00+00:00>', '2209024800', 't' as const],
+		['<t:10:00:05+00:00>', '2209024805', 't' as const],
+		['<t:10:00:00+00:00:R>', '2209024800', 'R' as const],
+	])('parses %p', (input, value, format) => {
+		const node = timestampNode(value, format, [0, input.length]);
+		expect(parse(input)).toEqual([paragraph([node])]);
+	});
+});

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -53,6 +53,9 @@ test.each([
 	['<t:2025-07-22T10:00:00.000+00:00:R>', '1753178400', 'R' as const],
 	['<t:2025-07-22T10:00:00+00:00:R>', '1753178400', 'R' as const],
 	['<t:2025-07-24T20:19:58.154+00:00:R>', '1753388398', 'R' as const],
+	// Beyond the 2038-01-19 32-bit boundary: must not overflow to a negative
+	// (previously `| 0` turned this into -2085978496 -> a 1903 date).
+	['<t:2040-01-01T00:00:00.000+00:00:R>', '2208988800', 'R' as const],
 ])('parses %p', (input, value, format) => {
 	const node = timestampNode(value, format, [0, input.length]);
 	expect(parse(input)).toEqual([paragraph([node])]);


### PR DESCRIPTION
## Proposed changes

`<t:...>` timestamp markup with a date on or after **2038-01-19 03:14:07 UTC** renders as a wrong date (a 1903 date) instead of the real one.

In `packages/message-parser/src/utils.ts`, both timestamp helpers coerce the epoch seconds with `| 0`:

```ts
const date = (new Date(`${year}-${month}-${day}T...`).getTime() / 1000) | 0;
```

`| 0` performs a `ToInt32` coercion, so any value past `2^31` wraps negative. For `<t:2040-01-01T00:00:00.000+00:00>` the correct epoch is `2208988800`, but `| 0` yields `-2085978496`, which the renderer (`gazzodown` `Timestamp`) turns into a 1903 date. A 4-digit year reaches this via the default `TimestampRules` chain in the grammar (`ISO8601Date` / `ISO8601DateWithoutMilliseconds`), so any message with a future `<t:YYYY-...>` is affected — deadlines, contract dates, reminders all silently render ~15 years of future dates wrong.

## Fix

Use `Math.floor` instead of `| 0` in `timestampFromIsoTime` and the sibling `timestampFromHours`. The epoch values are non-negative, so for every in-range date `Math.floor` and the old truncation produce the identical result — this only removes the 32-bit overflow.

I verified in-range parity against the existing test cases (`2025-07-22...` → `1753178400`, `2025-07-24T20:19:58.154...` → `1753388398`) — unchanged — and the new boundary case `2040-01-01...` now yields `2208988800` instead of `-2085978496`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing guidelines
- [x] I added a regression test (`packages/message-parser/tests/timestamp.test.ts`, a case past the 2038 boundary)
- [x] Added a changeset (`@rocket.chat/message-parser` patch)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed date and timestamp rendering for dates on or after January 19, 2038.
  - Prevented timestamp overflow that could produce incorrect dates for future messages.
  - Improved relative-time parsing for future timestamps while preserving second-level accuracy.

- **Tests**
  - Added coverage for absolute and relative timestamps from 2040 to verify accurate date conversion and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->