### PR TITLE
chore: build `@rocket.chat/ai-search` to dist instead of raw ts

### DIFF
--- a/packages/ai-search/package.json
+++ b/packages/ai-search/package.json
@@ -2,9 +2,9 @@
 	"name": "@rocket.chat/ai-search",
 	"version": "0.2.0",
 	"private": true,
-	"main": "./src/index.ts",
-	"types": "./src/index.ts",
-	"typings": "./src/index.ts",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"typings": "./dist/index.d.ts",
 	"files": [
 		"/dist"
 	],


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

`@rocket.chat/ai-search` is the only client-consumed workspace package whose entry points resolve to raw TypeScript instead of compiled output:

```
"main": "./src/index.ts",
"types": "./src/index.ts",
"typings": "./src/index.ts",
```

This came from 4b57346a59 (feat: (poc) Unified AI Search, #40890), which moved the package off the dist entry points it originally had. Every other client-consumed package (`ui-client`, `ui-contexts`, `core-typings`, …) ships from dist.

Shipping raw `.ts` means each consumer's bundler has to transpile the package itself. Meteor and Jest do; Storybook's webpack build doesn't, and it fails:

```
ERROR in ../../packages/ai-search/src/index.ts 5:7
Module parse failed: Unexpected token (5:7)
> export type * from './types';
```

Storybook only applies `swc-loader` under its detected project root, and `packages/` can fall outside that root, leaving the TypeScript untranspiled for webpack's JS parser.

Building to `dist` removes the dependency on that detection — webpack parses plain JS, exactly as it already does for every other workspace package.

Packaging only; no source or runtime changes. The `build/dev` scripts, `tsconfig.json`, and "files": ["/dist"] were already in place — only the three entry-point fields move back to the compiled output.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. `yarn build` at the repo root, so `packages/ai-search/dist` exists.
2. `cd apps/meteor && yarn storybook`
3. The preview compiles with no errors and Storybook starts.
Before this change, step 3 ends in `Failed to build the preview.`
Also verified: `build`, `typecheck`, and `test` all pass in `packages/ai-search`.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package entry points to use compiled distribution files, improving package consumption and release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[CORE-2547]

[CORE-2547]: https://rocketchat.atlassian.net/browse/CORE-2547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ