### PR TITLE
fix: user-specific banners failing with `Banner not found` error when dismissing it

### DIFF
--- a/.changeset/some-banks-spend.md
+++ b/.changeset/some-banks-spend.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes `POST /v1/banners.dismiss` failing with `Banner not found` for banners stored in the user's record (such as the version update ones), which were never marked as read. The endpoint now marks them as read as the deprecated `banner/dismiss` method did, and only fails when the banner does not exist in the banners collection nor in the user's record.

--- a/apps/meteor/server/services/banner/service.ts
+++ b/apps/meteor/server/services/banner/service.ts
@@ -5,6 +5,8 @@ import type { IBannerService } from '@rocket.chat/core-services';
 import type { BannerPlatform, IBanner, IBannerDismiss, Optional, IUser } from '@rocket.chat/core-typings';
 import { Banners, BannersDismiss, Users } from '@rocket.chat/models';
 
+import { notifyOnUserChange } from '../../lib/notifyListener';
+
 export class BannerService extends ServiceClassInternal implements IBannerService {
 	protected name = 'banner';
 
@@ -87,7 +89,21 @@ export class BannerService extends ServiceClassInternal implements IBannerServic
 
 		const banner = await Banners.findOneById(bannerId);
 		if (!banner) {
-			throw new Error('Banner not found');
+			const { matchedCount } = await Users.setBannerReadById(userId, bannerId);
+
+			if (!matchedCount) {
+				throw new Error('Banner not found');
+			}
+
+			void notifyOnUserChange({
+				id: userId,
+				clientAction: 'updated',
+				diff: {
+					[`banners.${bannerId}.read`]: true,
+				},
+			});
+
+			return true;
 		}
 
 		const user = await Users.findOneById<Pick<IUser, 'username' | '_id'>>(userId, {

--- a/apps/meteor/tests/end-to-end/api/banners.ts
+++ b/apps/meteor/tests/end-to-end/api/banners.ts
@@ -86,6 +86,15 @@ describe('banners', () => {
 			});
 
 			after(async () => {
+				await connection
+					.db()
+					.collection<IUser>('users')
+					.updateOne(
+						{ _id: 'rocketchat.internal.admin.test' },
+						{
+							$unset: { banners: 1 },
+						},
+					);
 				await connection.close();
 			});
 

--- a/apps/meteor/tests/end-to-end/api/banners.ts
+++ b/apps/meteor/tests/end-to-end/api/banners.ts
@@ -1,7 +1,11 @@
+import type { IUser } from '@rocket.chat/core-typings';
 import { expect } from 'chai';
-import { before, describe, it } from 'mocha';
+import { after, before, describe, it } from 'mocha';
+import { MongoClient } from 'mongodb';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
+import { getMe } from '../../data/users.helper';
+import { URL_MONGODB } from '../../e2e/config/constants';
 
 describe('banners', () => {
 	before((done) => getCredentials(done));
@@ -48,6 +52,90 @@ describe('banners', () => {
 				.expect(400);
 
 			expect(res.body).to.have.property('success', false);
+		});
+
+		describe('banners stored in the user record', () => {
+			let connection: MongoClient;
+
+			const bannerId = 'alert-user-banner-test';
+
+			const getUserBanners = async () => (await getMe<IUser>(credentials)).banners;
+
+			before(async () => {
+				connection = await MongoClient.connect(URL_MONGODB);
+
+				await connection
+					.db()
+					.collection<IUser>('users')
+					.updateOne(
+						{ _id: 'rocketchat.internal.admin.test' },
+						{
+							$set: {
+								[`banners.${bannerId}`]: {
+									id: bannerId,
+									priority: 10,
+									title: 'Banner_Title',
+									text: 'Banner_Text',
+									textArguments: [],
+									modifiers: [],
+									link: 'https://rocket.chat',
+								},
+							},
+						},
+					);
+			});
+
+			after(async () => {
+				await connection.close();
+			});
+
+			it('should mark the banner as read on the user record', async () => {
+				const res = await request
+					.post(api('banners.dismiss'))
+					.set(credentials)
+					.send({
+						bannerId,
+					})
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+
+				const banners = await getUserBanners();
+
+				expect(banners).to.have.nested.property(`${bannerId}.read`, true);
+			});
+
+			it('should succeed if the banner was already dismissed', async () => {
+				const res = await request
+					.post(api('banners.dismiss'))
+					.set(credentials)
+					.send({
+						bannerId,
+					})
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+
+				const banners = await getUserBanners();
+
+				expect(banners).to.have.nested.property(`${bannerId}.read`, true);
+			});
+
+			it('should not add an unknown banner to the user record', async () => {
+				const res = await request
+					.post(api('banners.dismiss'))
+					.set(credentials)
+					.send({
+						bannerId: 'an-unknown-banner-id',
+					})
+					.expect(400);
+
+				expect(res.body).to.have.property('success', false);
+
+				const banners = await getUserBanners();
+
+				expect(banners).to.not.have.property('an-unknown-banner-id');
+			});
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/banners.ts
+++ b/apps/meteor/tests/end-to-end/api/banners.ts
@@ -92,7 +92,7 @@ describe('banners', () => {
 					.updateOne(
 						{ _id: 'rocketchat.internal.admin.test' },
 						{
-							$unset: { banners: 1 },
+							$unset: { [`banners.${bannerId}`]: 1 },
 						},
 					);
 				await connection.close();

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -2912,13 +2912,19 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 	}
 
 	setBannerReadById(_id: IUser['_id'], bannerId: string) {
+		const query = {
+			_id,
+			[`banners.${bannerId}`]: {
+				$exists: true,
+			},
+		};
 		const update = {
 			$set: {
 				[`banners.${bannerId}.read`]: true,
 			},
 		};
 
-		return this.updateOne({ _id }, update);
+		return this.updateOne(query, update);
 	}
 
 	removeBannerById(_id: IUser['_id'], bannerId: string) {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
When migrating some Meteor methods to REST endpoints in https://github.com/RocketChat/Rocket.Chat/pull/40704 we overlooked that `banners.dismiss` do not cover user-specific banners (banners within the user record in a `banners` array). 

To fix this: 
- I modified the `dismiss` method from the `BannerService` to try to mark user-specific banners as read as fallback if there is none matching the `rocketchat_banner` collection. I did this following the `banner/dismiss` Meteor method current logic (the one used before). 
- The `setBannerReadById` User model method was modified to avoid the user from arbitrarily setting a banner in their record.
-  API tests were added covering this new behavior.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[SUP-1095 "Update your Rocket.Chat" banner cannot be dismissed on 8.6.0 and later](https://rocketchat.atlassian.net/browse/SUP-1095)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->


1. Login as an admin user
2. Run the following MongoDB shell command, replacing with the proper user’s username:
(the version number must be higher than the current one you’re using to test for the banner to show up)
```
db.users.updateOne(
  { username: "rocketchat.internal.admin.test" },
  { $set: { "banners.versionUpdate-8_9_0": {
      id: "versionUpdate-8_9_0",
      priority: 10,
      title: "Update_your_RocketChat",
      text: "New_version_available_(s)",
      textArguments: ["8.9.0"],
      link: "https://github.com/RocketChat/Rocket.Chat/releases/tag/8.9.0",
      modifiers: []
  } } }
)
```
3. Click on the cross icon to dismiss the banner.

Expected result: Banner should be dismissed without errors and if you refresh the page it shouldn’t come back.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Dismissing a banner stored on a user record now marks it as read.
  - Repeated dismissal of an already-read banner succeeds safely.
  - Unknown banners now return an error without creating or modifying banner records.
  - Banner updates are skipped when no matching banner exists.
  - Banner changes are reflected promptly in the user’s session.
  - Banner dismissal behavior is now consistent across stored and standard banners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->