### PR TITLE
chore: apps converters golden spec breaking unit tests

### DIFF
--- a/apps/meteor/tests/unit/app/apps/server/converters.golden.spec.ts
+++ b/apps/meteor/tests/unit/app/apps/server/converters.golden.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
 
 import { AppContactsConverter } from '../../../../../app/apps/server/converters/contacts';
 import { AppDepartmentsConverter } from '../../../../../app/apps/server/converters/departments';
@@ -8,7 +9,6 @@ import { AppRolesConverter } from '../../../../../app/apps/server/converters/rol
 import { AppRoomsConverter } from '../../../../../app/apps/server/converters/rooms';
 import { AppSettingsConverter } from '../../../../../app/apps/server/converters/settings';
 import { AppThreadsConverter } from '../../../../../app/apps/server/converters/threads';
-import { AppUploadsConverter } from '../../../../../app/apps/server/converters/uploads';
 import { AppUsersConverter } from '../../../../../app/apps/server/converters/users';
 import { AppVideoConferencesConverter } from '../../../../../app/apps/server/converters/videoConferences';
 import { AppVisitorsConverter } from '../../../../../app/apps/server/converters/visitors';
@@ -478,6 +478,14 @@ describe('apps converters — golden snapshots (pre-codec behaviour)', () => {
 	});
 
 	describe('AppUploadsConverter', () => {
+		// The uploads codec derives `url` via the server-side `getURL`, which transitively imports
+		// `server/settings` — a module with a top-level await that esbuild cannot emit as CJS. `@global`
+		// reaches it through the codec; its key resolves from the converter's directory, hence one level
+		// less than the codec's own import path.
+		const { AppUploadsConverter } = proxyquire.noCallThru().load('../../../../../app/apps/server/converters/uploads', {
+			'../../../../server/lib/utils/getURL': { 'getURL': (path: string) => `http://siteurl.test${path}`, '@global': true },
+		});
+
 		const converter = new AppUploadsConverter(stubOrch);
 
 		it('convertToApp maps an upload and resolves room/user/visitor via converters', async () => {
@@ -515,9 +523,9 @@ describe('apps converters — golden snapshots (pre-codec behaviour)', () => {
 				extension: 'png',
 				progress: 1,
 				etag: 'etag-1',
-				path: '/path',
+				path: '/file-upload/up-1/file.png',
 				token: 'up-tok',
-				url: 'http://example/file.png',
+				url: 'http://siteurl.test/file-upload/up-1/file.png',
 				updatedAt: '2024-02-02T00:00:00.000Z',
 				uploadedAt: '2024-01-01T00:00:00.000Z',
 				room: { __converted: 'rooms', id: 'room-1' },


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Unit tests have been failing on `release-9.0.0` since the develop merge on 21 Jul.

**Problem.** A spec from develop imports the apps uploads converter → codec → `getURL` → `server/settings`, which ends in a top-level await that mocha can't transpile to CJS. Mocha resolves every spec before running any, so this aborts the whole stage: all 2159 tests go dark rather than red.

**Why CI was green on both sides.** Neither half breaks alone. #41054 (into `release-9.0.0`, 30 Jun) added the `getURL` import to the codec, before the spec existed. #41400 (into `develop`, 17 Jul) added the spec, and develop has no `/ufs` removal so its codec has no `getURL` import. They first met in the 21 Jul merge, and since they don't overlap textually there was no conflict to report. The top-level await itself predates all of this by years — it was just never reachable from a mocha spec.

**Fix.** Load the converter through `proxyquire` with `getURL` stubbed, and update the uploads expectations, which still asserted the `url`/`path` pass-through that #41054 intentionally removed.

Test-only, no production code touched.

## Issue(s)

Regression from the interaction of #41054 and #41400. No tracking issue.
- [RC9-3](https://rocketchat.atlassian.net/browse/RC9-3)

## Steps to test or reproduce

Run `yarn testunit` from `apps/meteor` — passes on this branch, fails on `release-9.0.0`.

## Further comments

The top-level await stays, so any future unit test importing into `server/settings` breaks the stage the same way — aborting the run rather than reporting a failure. Worth a follow-up on `develop`.

No changeset: this PR changes no behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated upload conversion tests to use a stubbed URL provider.
  * Revised snapshots to reflect the generated upload path and site URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RC9-3]: https://rocketchat.atlassian.net/browse/RC9-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ