### PR TITLE
fix: address hour-only timestamp overflow gap in #41752

### DIFF
--- a/.changeset/fuzzy-clocks-flow.md
+++ b/.changeset/fuzzy-clocks-flow.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/message-parser': patch
+---
+
+Fix hour-only timestamps overflowing after the signed 32-bit Unix timestamp boundary.

--- a/packages/message-parser/src/utils.ts
+++ b/packages/message-parser/src/utils.ts
@@ -363,7 +363,7 @@ export const timestampFromHours = (hours: string, minutes = '00', seconds = '00'
 
 	const yearMonthDay = date.toISOString().split('T')[0];
 
-	const timestamp = (new Date(`${yearMonthDay}T${hours}:${minutes}:${seconds}${timezone}`).getTime() / 1000) | 0;
+	const timestamp = Math.floor(new Date(`${yearMonthDay}T${hours}:${minutes}:${seconds}${timezone}`).getTime() / 1000);
 
 	return timestamp.toString();
 };

--- a/packages/message-parser/tests/timestamp.test.ts
+++ b/packages/message-parser/tests/timestamp.test.ts
@@ -78,3 +78,21 @@ describe('relative hour timestamp parsing', () => {
 		expect(parse(input)).toEqual([paragraph([node])]);
 	});
 });
+
+describe('relative hour timestamp parsing after the signed 32-bit boundary', () => {
+	beforeAll(() => {
+		jest.useFakeTimers();
+		jest.setSystemTime(new Date('2040-01-01T00:00:00.000Z'));
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
+	it('does not overflow an hour-only timestamp', () => {
+		const input = '<t:00:00+00:00:R>';
+		const node = timestampNode('2208988800', 'R', [0, input.length]);
+
+		expect(parse(input)).toEqual([paragraph([node])]);
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Hour-only timestamp markup derives its date from the current day.
The parser coerced the resulting Unix seconds with `| 0`, which wraps values after the signed 32-bit boundary into negative timestamps.

Replace that coercion in `timestampFromHours` with `Math.floor`.
Add a parser regression that fixes the clock at 2040 and verifies `<t:00:00+00:00:R>` produces `2208988800`.
Add the required patch changeset for `@rocket.chat/message-parser`.

This addresses the unresolved hour-only grammar coverage gap identified in #41752 without duplicating that PR's ISO timestamp change.

## Issue(s)

Related to #41752.

## Steps to test or reproduce

1. Fix the system clock at `2040-01-01T00:00:00.000Z`.
2. Parse `<t:00:00+00:00:R>`.
3. Confirm the timestamp value is `2208988800`, not `-2085978496`.

Verification performed with Node 22.22.3 and Yarn 4.17.1:

- Regression before the fix: 1 failed, 15 passed, with `-2085978496` received.
- Targeted timestamp suite after the fix: 16 passed.
- Complete `@rocket.chat/message-parser` suite: 36 suites passed, 719 tests passed.
- Package typecheck: passed.
- Package lint: passed with 0 errors and 6 existing warnings.
- Changed-file lint: passed with 0 errors and 2 existing warnings outside the changed lines.
- `git diff --check`: passed.

## Further comments

The full Rocket.Chat monorepo suite was not run because it is impractical for this focused package change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hour-only timestamps in messages so they remain accurate for dates beyond the signed 32-bit Unix timestamp limit.
  * Improved timestamp handling for future dates, including dates after 2038.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->