### PR TITLE
fix(password-policies): sanitize and validate forbidRepeatingCharactersCount before constructing RegExp

### DIFF
--- a/.changeset/fix-password-policy-regex-validation.md
+++ b/.changeset/fix-password-policy-regex-validation.md
@@ -2,4 +2,4 @@
 '@rocket.chat/password-policies': patch
 ---
 
-Fixed a crash where an invalid `forbidRepeatingCharactersCount` password policy setting (negative, non-integer, `NaN`, unsafely large, or non-numeric) could throw a `SyntaxError` when building the repeating-characters `RegExp`. Invalid values now fall back to the default of `3`. A configured value of `0` is preserved as a valid, distinct setting instead of being treated as "unset".
+Fixed the `forbidRepeatingCharactersCount` password policy silently turning itself off when configured with an invalid value. A negative, fractional, `NaN`, unsafely large or non-numeric count produced an invalid quantifier (`{-1,}`, `{1.5,}`, `{NaN,}`, `{1e+21,}`), which the regex engine reads as a literal, so passwords made entirely of repeated characters were accepted. A count of `0` had the opposite effect, rejecting every non-empty password and locking users out of setting one. Both cases now fall back to the default of `3`.

--- a/.changeset/fix-password-policy-regex-validation.md
+++ b/.changeset/fix-password-policy-regex-validation.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/password-policies': patch
+---
+
+Fixed a crash where an invalid `forbidRepeatingCharactersCount` password policy setting (negative, non-integer, `NaN`, unsafely large, or non-numeric) could throw a `SyntaxError` when building the repeating-characters `RegExp`. Invalid values now fall back to the default of `3`. A configured value of `0` is preserved as a valid, distinct setting instead of being treated as "unset".

--- a/packages/password-policies/src/PasswordPolicy.spec.ts
+++ b/packages/password-policies/src/PasswordPolicy.spec.ts
@@ -216,4 +216,31 @@ describe('Password Policy', () => {
 		// since its default value is 3
 		expect(policy.policy.length).toBe(1);
 	});
+	
+	it.each([-1, 0, 1.5, Number.NaN, 1e21, '3'])(
+	'should use the default repeating character count when configured with %p',
+	(count) => {
+		const passwordPolicy = new PasswordPolicy({
+			enabled: true,
+			forbidRepeatingCharacters: true,
+			forbidRepeatingCharactersCount: count as number,
+			throwError: false,
+		});
+
+		// Default count is 3 → "111" is allowed, "1111" is not
+		expect(passwordPolicy.validate('111')).toBe(true);
+		expect(passwordPolicy.validate('1111')).toBe(false);
+
+		expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
+			name: 'get-password-policy-forbidRepeatingCharactersCount',
+			isValid: false,
+			limit: 3,
+		});
+
+		expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
+			'get-password-policy-forbidRepeatingCharactersCount',
+			{ forbidRepeatingCharactersCount: 3 },
+		]);
+	},
+);
 });

--- a/packages/password-policies/src/PasswordPolicy.spec.ts
+++ b/packages/password-policies/src/PasswordPolicy.spec.ts
@@ -217,34 +217,31 @@ describe('Password Policy', () => {
 		expect(policy.policy.length).toBe(0);
 	});
 
-	it.each([-1, 1.5, Number.NaN, 1e21, '3'])(
-		'should use the default repeating character count when configured with %p',
-		(count) => {
-			const passwordPolicy = new PasswordPolicy({
-				enabled: true,
-				forbidRepeatingCharacters: true,
-				forbidRepeatingCharactersCount: count as number,
-				throwError: false,
-			});
+	it.each([0, -1, 1.5, Number.NaN, 1e21, '3'])('should use the default repeating character count when configured with %p', (count) => {
+		const passwordPolicy = new PasswordPolicy({
+			enabled: true,
+			forbidRepeatingCharacters: true,
+			forbidRepeatingCharactersCount: count as number,
+			throwError: false,
+		});
 
-			// Default count is 3 → "111" is allowed, "1111" is not
-			expect(passwordPolicy.validate('111')).toBe(true);
-			expect(passwordPolicy.validate('1111')).toBe(false);
+		// Default count is 3 → "111" is allowed, "1111" is not
+		expect(passwordPolicy.validate('111')).toBe(true);
+		expect(passwordPolicy.validate('1111')).toBe(false);
 
-			expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
-				name: 'get-password-policy-forbidRepeatingCharactersCount',
-				isValid: false,
-				limit: 3,
-			});
+		expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
+			name: 'get-password-policy-forbidRepeatingCharactersCount',
+			isValid: false,
+			limit: 3,
+		});
 
-			expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
-				'get-password-policy-forbidRepeatingCharactersCount',
-				{ forbidRepeatingCharactersCount: 3 },
-			]);
-		},
-	);
+		expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
+			'get-password-policy-forbidRepeatingCharactersCount',
+			{ forbidRepeatingCharactersCount: 3 },
+		]);
+	});
 
-	it('should preserve a configured count of 0 instead of falling back to the default', () => {
+	it('should not lock every password out when configured with a count of 0', () => {
 		const passwordPolicy = new PasswordPolicy({
 			enabled: true,
 			forbidRepeatingCharacters: true,
@@ -252,15 +249,20 @@ describe('Password Policy', () => {
 			throwError: false,
 		});
 
-		expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
-			'get-password-policy-forbidRepeatingCharactersCount',
-			{ forbidRepeatingCharactersCount: 0 },
-		]);
+		// `(.)\1{0,}` matches any non-empty string, so a count of 0 would reject every password
+		expect(passwordPolicy.validate('1')).toBe(true);
+		expect(passwordPolicy.validate('Passw0rd!')).toBe(true);
+	});
 
-		expect(passwordPolicy.sendValidationMessage('1')).toContainEqual({
-			name: 'get-password-policy-forbidRepeatingCharactersCount',
-			isValid: false,
-			limit: 0,
+	it('should keep enforcing the rule when configured with an unusable count', () => {
+		const passwordPolicy = new PasswordPolicy({
+			enabled: true,
+			forbidRepeatingCharacters: true,
+			forbidRepeatingCharactersCount: -1,
+			throwError: false,
 		});
+
+		// a `{-1,}` quantifier is read as a literal, which would silently disable the rule
+		expect(passwordPolicy.validate('11111111')).toBe(false);
 	});
 });

--- a/packages/password-policies/src/PasswordPolicy.spec.ts
+++ b/packages/password-policies/src/PasswordPolicy.spec.ts
@@ -212,35 +212,55 @@ describe('Password Policy', () => {
 		const policy = passwordPolicy.getPasswordPolicy();
 
 		expect(policy.enabled).toBe(true);
-		// even when no policy is specified, forbidRepeatingCharactersCount is still configured
-		// since its default value is 3
-		expect(policy.policy.length).toBe(1);
+		// forbidRepeatingCharacters is disabled by default, so the count entry
+		// (and its default of 3) is not reported as an active policy
+		expect(policy.policy.length).toBe(0);
 	});
-	
-	it.each([-1, 0, 1.5, Number.NaN, 1e21, '3'])(
-	'should use the default repeating character count when configured with %p',
-	(count) => {
+
+	it.each([-1, 1.5, Number.NaN, 1e21, '3'])(
+		'should use the default repeating character count when configured with %p',
+		(count) => {
+			const passwordPolicy = new PasswordPolicy({
+				enabled: true,
+				forbidRepeatingCharacters: true,
+				forbidRepeatingCharactersCount: count as number,
+				throwError: false,
+			});
+
+			// Default count is 3 → "111" is allowed, "1111" is not
+			expect(passwordPolicy.validate('111')).toBe(true);
+			expect(passwordPolicy.validate('1111')).toBe(false);
+
+			expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
+				name: 'get-password-policy-forbidRepeatingCharactersCount',
+				isValid: false,
+				limit: 3,
+			});
+
+			expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
+				'get-password-policy-forbidRepeatingCharactersCount',
+				{ forbidRepeatingCharactersCount: 3 },
+			]);
+		},
+	);
+
+	it('should preserve a configured count of 0 instead of falling back to the default', () => {
 		const passwordPolicy = new PasswordPolicy({
 			enabled: true,
 			forbidRepeatingCharacters: true,
-			forbidRepeatingCharactersCount: count as number,
+			forbidRepeatingCharactersCount: 0,
 			throwError: false,
-		});
-
-		// Default count is 3 → "111" is allowed, "1111" is not
-		expect(passwordPolicy.validate('111')).toBe(true);
-		expect(passwordPolicy.validate('1111')).toBe(false);
-
-		expect(passwordPolicy.sendValidationMessage('1111')).toContainEqual({
-			name: 'get-password-policy-forbidRepeatingCharactersCount',
-			isValid: false,
-			limit: 3,
 		});
 
 		expect(passwordPolicy.getPasswordPolicy().policy).toContainEqual([
 			'get-password-policy-forbidRepeatingCharactersCount',
-			{ forbidRepeatingCharactersCount: 3 },
+			{ forbidRepeatingCharactersCount: 0 },
 		]);
-	},
-);
+
+		expect(passwordPolicy.sendValidationMessage('1')).toContainEqual({
+			name: 'get-password-policy-forbidRepeatingCharactersCount',
+			isValid: false,
+			limit: 0,
+		});
+	});
 });

--- a/packages/password-policies/src/PasswordPolicy.ts
+++ b/packages/password-policies/src/PasswordPolicy.ts
@@ -16,8 +16,8 @@ type PasswordPolicyName<K extends PasswordPolicyKey> = `get-password-policy-${K}
 
 type PasswordPolicyParametersEntry = {
 	[K in PasswordPolicyKey]: PasswordPolicyMap[K] extends number
-		? [PasswordPolicyName<K>, Record<K, PasswordPolicyMap[K]>]
-		: [PasswordPolicyName<K>];
+	? [PasswordPolicyName<K>, Record<K, PasswordPolicyMap[K]>]
+	: [PasswordPolicyName<K>];
 }[PasswordPolicyKey];
 
 type PasswordPolicyType<Entry = PasswordPolicyParametersEntry> = {
@@ -34,8 +34,8 @@ export type PasswordPolicyOptions = Partial<
 
 export type PasswordPolicyValidation = {
 	[K in PasswordPolicyKey]: PasswordPolicyMap[K] extends number
-		? { name: PasswordPolicyName<K>; limit: number }
-		: { name: PasswordPolicyName<K> };
+	? { name: PasswordPolicyName<K>; limit: number }
+	: { name: PasswordPolicyName<K> };
 }[PasswordPolicyKey] & { isValid: boolean };
 
 export class PasswordPolicy {
@@ -79,11 +79,17 @@ export class PasswordPolicy {
 		mustContainAtLeastOneSpecialCharacter = false,
 		throwError = true,
 	}: PasswordPolicyOptions) {
+		const safeForbidRepeatingCharactersCount =
+			typeof forbidRepeatingCharactersCount === 'number' &&
+				Number.isSafeInteger(forbidRepeatingCharactersCount) &&
+				forbidRepeatingCharactersCount >= 1 ? forbidRepeatingCharactersCount : 3;
+
+
 		this.enabled = enabled;
 		this.minLength = minLength;
 		this.maxLength = maxLength;
 		this.forbidRepeatingCharacters = forbidRepeatingCharacters;
-		this.forbidRepeatingCharactersCount = forbidRepeatingCharactersCount;
+		this.forbidRepeatingCharactersCount = safeForbidRepeatingCharactersCount;
 		this.mustContainAtLeastOneLowercase = mustContainAtLeastOneLowercase;
 		this.mustContainAtLeastOneUppercase = mustContainAtLeastOneUppercase;
 		this.mustContainAtLeastOneNumber = mustContainAtLeastOneNumber;
@@ -91,7 +97,7 @@ export class PasswordPolicy {
 		this.throwError = throwError;
 
 		this.regex = {
-			forbiddingRepeatingCharacters: new RegExp(`(.)\\1{${forbidRepeatingCharactersCount},}`),
+			forbiddingRepeatingCharacters: new RegExp(`(.)\\1{${safeForbidRepeatingCharactersCount},}`),
 			mustContainAtLeastOneLowercase: new RegExp('[a-z]'),
 			mustContainAtLeastOneUppercase: new RegExp('[A-Z]'),
 			mustContainAtLeastOneNumber: new RegExp('[0-9]'),

--- a/packages/password-policies/src/PasswordPolicy.ts
+++ b/packages/password-policies/src/PasswordPolicy.ts
@@ -16,8 +16,8 @@ type PasswordPolicyName<K extends PasswordPolicyKey> = `get-password-policy-${K}
 
 type PasswordPolicyParametersEntry = {
 	[K in PasswordPolicyKey]: PasswordPolicyMap[K] extends number
-	? [PasswordPolicyName<K>, Record<K, PasswordPolicyMap[K]>]
-	: [PasswordPolicyName<K>];
+		? [PasswordPolicyName<K>, Record<K, PasswordPolicyMap[K]>]
+		: [PasswordPolicyName<K>];
 }[PasswordPolicyKey];
 
 type PasswordPolicyType<Entry = PasswordPolicyParametersEntry> = {
@@ -34,8 +34,8 @@ export type PasswordPolicyOptions = Partial<
 
 export type PasswordPolicyValidation = {
 	[K in PasswordPolicyKey]: PasswordPolicyMap[K] extends number
-	? { name: PasswordPolicyName<K>; limit: number }
-	: { name: PasswordPolicyName<K> };
+		? { name: PasswordPolicyName<K>; limit: number }
+		: { name: PasswordPolicyName<K> };
 }[PasswordPolicyKey] & { isValid: boolean };
 
 export class PasswordPolicy {
@@ -79,10 +79,12 @@ export class PasswordPolicy {
 		mustContainAtLeastOneSpecialCharacter = false,
 		throwError = true,
 	}: PasswordPolicyOptions) {
+		// Anything that is not a plain positive integer is interpolated into the quantifier below as
+		// `{NaN,}`, `{-1,}`, `{1.5,}` or `{1e+21,}`, none of which are valid quantifiers: the engine reads
+		// them as literals instead of throwing, and the rule silently stops matching repeated characters.
+		// A count of 0 is rejected for the opposite reason — `(.)\1{0,}` matches every non-empty password.
 		const safeForbidRepeatingCharactersCount =
-			typeof forbidRepeatingCharactersCount === 'number' &&
-				Number.isSafeInteger(forbidRepeatingCharactersCount) &&
-				forbidRepeatingCharactersCount >= 0 ? forbidRepeatingCharactersCount : 3;
+			Number.isSafeInteger(forbidRepeatingCharactersCount) && forbidRepeatingCharactersCount >= 1 ? forbidRepeatingCharactersCount : 3;
 
 		this.enabled = enabled;
 		this.minLength = minLength;

--- a/packages/password-policies/src/PasswordPolicy.ts
+++ b/packages/password-policies/src/PasswordPolicy.ts
@@ -79,10 +79,8 @@ export class PasswordPolicy {
 		mustContainAtLeastOneSpecialCharacter = false,
 		throwError = true,
 	}: PasswordPolicyOptions) {
-		// Anything that is not a plain positive integer is interpolated into the quantifier below as
-		// `{NaN,}`, `{-1,}`, `{1.5,}` or `{1e+21,}`, none of which are valid quantifiers: the engine reads
-		// them as literals instead of throwing, and the rule silently stops matching repeated characters.
-		// A count of 0 is rejected for the opposite reason — `(.)\1{0,}` matches every non-empty password.
+		// Invalid counts interpolate as literals rather than throwing, so the rule
+		// would silently stop matching; `{0,}` matches every non-empty password.
 		const safeForbidRepeatingCharactersCount =
 			Number.isSafeInteger(forbidRepeatingCharactersCount) && forbidRepeatingCharactersCount >= 1 ? forbidRepeatingCharactersCount : 3;
 

--- a/packages/password-policies/src/PasswordPolicy.ts
+++ b/packages/password-policies/src/PasswordPolicy.ts
@@ -82,8 +82,7 @@ export class PasswordPolicy {
 		const safeForbidRepeatingCharactersCount =
 			typeof forbidRepeatingCharactersCount === 'number' &&
 				Number.isSafeInteger(forbidRepeatingCharactersCount) &&
-				forbidRepeatingCharactersCount >= 1 ? forbidRepeatingCharactersCount : 3;
-
+				forbidRepeatingCharactersCount >= 0 ? forbidRepeatingCharactersCount : 3;
 
 		this.enabled = enabled;
 		this.minLength = minLength;
@@ -268,8 +267,6 @@ export class PasswordPolicy {
 			}
 			if (this.forbidRepeatingCharacters) {
 				data.policy.push(['get-password-policy-forbidRepeatingCharacters']);
-			}
-			if (this.forbidRepeatingCharactersCount) {
 				data.policy.push([
 					'get-password-policy-forbidRepeatingCharactersCount',
 					{ forbidRepeatingCharactersCount: this.forbidRepeatingCharactersCount },


### PR DESCRIPTION
## Summary

Validate `forbidRepeatingCharactersCount` before interpolating it into the repeating-characters `RegExp`, so that a misconfigured count can no longer silently disable the policy or lock every user out.

## Why

Fixes #41620.

The count is interpolated straight into a quantifier:

```ts
new RegExp(`(.)\\1{${forbidRepeatingCharactersCount},}`);
```

The original report describes this throwing a `SyntaxError`. It does not — and that turns out to make the bug worse rather than better. In non-unicode mode a malformed `{...}` is not a quantifier at all, so the engine parses it as a **literal** and constructs the regex happily:

| configured count | resulting regex | behaviour |
| --- | --- | --- |
| `-1` | `(.)\1{-1,}` | matches the literal text `{-1,}` |
| `1.5` | `(.)\1{1.5,}` | matches the literal text `{1.5,}` |
| `NaN` | `(.)\1{NaN,}` | matches the literal text `{NaN,}` |
| `1e21` | `(.)\1{1e+21,}` | matches the literal text `{1e+21,}` |
| `'3'` | `(.)\1{3,}` | works by accident |

So there is no crash to notice. Instead the repeating-character rule quietly stops enforcing anything, and a password like `aaaaaaaaaaaa` is accepted on a workspace that believes it is forbidden. A security control turning itself off without an error is the actual defect here.

A count of `0` fails in the opposite direction: `(.)\1{0,}` is a *valid* quantifier that matches any string of length 1 or more, so **every** non-empty password is rejected and nobody on that workspace can set a password at all.

## Changes

- Fall back to the default of `3` unless the count is a safe integer `>= 1`.
- Use the sanitized value for both the instance property and the `RegExp`, so `getPasswordPolicy()` and `sendValidationMessage()` report the limit that is actually enforced.
- Report `get-password-policy-forbidRepeatingCharactersCount` only when `forbidRepeatingCharacters` is on. This is required by the change above: once invalid counts default to `3`, the old `if (this.forbidRepeatingCharactersCount)` guard is always truthy and would advertise a repeating-character limit on workspaces that have the rule disabled.
- Added unit tests for every invalid input, for the `0` lockout, and for the silent-bypass case.

### A note on `isSafeInteger` vs `isInteger`

The suggested fix in #41620 uses `Number.isInteger`. This PR uses `Number.isSafeInteger` instead, because `Number.isInteger(1e21) === true` while `String(1e21) === '1e+21'` — an unsafely large count would pass an `isInteger` check and still produce the invalid quantifier `{1e+21,}`. `isSafeInteger` rejects it.

No upper cap beyond `Number.MAX_SAFE_INTEGER` is applied: V8 constructs `(.)\1{9007199254740991,}` without throwing, and a large-but-valid count is a permissive configuration rather than a malformed one.

## Testing

```bash
yarn workspace @rocket.chat/password-policies test
```

All 22 tests pass, including the new cases:

- `should use the default repeating character count when configured with 0 / -1 / 1.5 / NaN / 1e+21 / "3"`
- `should not lock every password out when configured with a count of 0`
- `should keep enforcing the rule when configured with an unusable count`
<img width="1192" height="777" alt="Screenshot From 2026-08-23 11-41-59" src="https://github.com/user-attachments/assets/730edf4d-36bf-4e47-a224-26a3b35333b4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved password policy validation for invalid repeating-character limits.
  - Zero, negative, non-integer, and excessively large values now safely fall back to a limit of 3.
  - Prevented configurations with invalid limits from unintentionally rejecting all non-empty passwords.
  - Password policy details now accurately reflect the active repeating-character setting.

- **Documentation**
  - Documented the corrected handling of invalid repeating-character configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->