### PR TITLE
feat(apps): allow action button role filter to match custom roles by name

### DIFF
--- a/.changeset/app-action-button-role-names.md
+++ b/.changeset/app-action-button-role-names.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps-engine': minor
+'@rocket.chat/meteor': minor
+---
+
+Accepts a role name in the `when.hasOneRole` and `when.hasAllRoles` filters of an app action button

--- a/apps/meteor/client/hooks/useApplyButtonFilters.spec.ts
+++ b/apps/meteor/client/hooks/useApplyButtonFilters.spec.ts
@@ -134,6 +134,73 @@ describe('useApplyButtonAuthFilter', () => {
 		});
 	});
 
+	describe('Custom role name resolution', () => {
+		// A custom role gets a random id, so an app can only know its name.
+		const customRole = { _id: 'aBcDeF1234567890x', name: 'Support Agent' };
+
+		const buttonRequiring = (role: string): IUIActionButton => ({
+			appId: 'test-app',
+			actionId: 'test-action',
+			labelI18n: 'test_label',
+			context: UIActionButtonContext.USER_DROPDOWN_ACTION,
+			when: {
+				hasOneRole: [role],
+			},
+		});
+
+		it('should show button when the user holds the role given by name', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleDefinition(customRole).withRole(customRole._id).build(),
+			});
+
+			expect(result.current(buttonRequiring(customRole.name))).toBe(true);
+		});
+
+		it('should filter button when the user does not hold the role given by name', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot()
+					.withJohnDoe({ roles: ['user'] })
+					.withRoleDefinition(customRole)
+					.build(),
+			});
+
+			expect(result.current(buttonRequiring(customRole.name))).toBe(false);
+		});
+
+		it('should still show button when the role is given by id', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleDefinition(customRole).withRole(customRole._id).build(),
+			});
+
+			expect(result.current(buttonRequiring(customRole._id))).toBe(true);
+		});
+
+		it('should filter button when the role name is unknown', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleDefinition(customRole).withRole(customRole._id).build(),
+			});
+
+			expect(result.current(buttonRequiring('No Such Role'))).toBe(false);
+		});
+
+		it('should prefer the id over a role whose name collides with it', () => {
+			// `decoy.name` equals `customRole._id`. The user holds only the decoy, so
+			// resolving by name would wrongly show the button.
+			const decoy = { _id: 'zZyYxXw9876543210', name: customRole._id };
+
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot()
+					.withJohnDoe({ roles: ['user'] })
+					.withRoleDefinition(customRole)
+					.withRoleDefinition(decoy)
+					.withRole(decoy._id)
+					.build(),
+			});
+
+			expect(result.current(buttonRequiring(customRole._id))).toBe(false);
+		});
+	});
+
 	describe('Permission-based filtering', () => {
 		it('should filter button when user does not have required permission (hasAllPermissions)', () => {
 			const button: IUIActionButton = {

--- a/apps/meteor/client/hooks/useApplyButtonFilters.ts
+++ b/apps/meteor/client/hooks/useApplyButtonFilters.ts
@@ -10,7 +10,7 @@ import {
 	isPublicDiscussion,
 	isPublicTeamRoom,
 } from '@rocket.chat/core-typings';
-import { AuthorizationContext, useUserId } from '@rocket.chat/ui-contexts';
+import { AuthorizationContext, useRoleIdResolver, useUserId } from '@rocket.chat/ui-contexts';
 import { useCallback, useContext } from 'react';
 
 import { useRoom } from '../views/room/contexts/RoomContext';
@@ -69,17 +69,21 @@ export const useApplyButtonAuthFilter = (): ((button: IUIActionButton, room?: IR
 
 	const { queryAllPermissions, queryAtLeastOnePermission, queryRole } = useContext(AuthorizationContext);
 
+	// An app knows the name of a custom role, not the random id the workspace gave it,
+	// so accept either form in the role filters.
+	const resolveRoleId = useRoleIdResolver();
+
 	return useCallback(
 		(button: IUIActionButton, room?: IRoom) => {
 			const { hasAllPermissions, hasOnePermission, hasAllRoles, hasOneRole } = button.when || {};
 
 			const hasAllPermissionsResult = hasAllPermissions ? queryAllPermissions(hasAllPermissions)[1]() : true;
 			const hasOnePermissionResult = hasOnePermission ? queryAtLeastOnePermission(hasOnePermission)[1]() : true;
-			const hasAllRolesResult = hasAllRoles ? !!uid && hasAllRoles.every((role) => queryRole(role, room?._id)[1]()) : true;
-			const hasOneRoleResult = hasOneRole ? !!uid && hasOneRole.some((role) => queryRole(role, room?._id)[1]()) : true;
+			const hasAllRolesResult = hasAllRoles ? !!uid && hasAllRoles.every((role) => queryRole(resolveRoleId(role), room?._id)[1]()) : true;
+			const hasOneRoleResult = hasOneRole ? !!uid && hasOneRole.some((role) => queryRole(resolveRoleId(role), room?._id)[1]()) : true;
 
 			return hasAllPermissionsResult && hasOnePermissionResult && hasAllRolesResult && hasOneRoleResult;
 		},
-		[queryAllPermissions, queryAtLeastOnePermission, queryRole, uid],
+		[queryAllPermissions, queryAtLeastOnePermission, queryRole, resolveRoleId, uid],
 	);
 };

--- a/packages/apps-engine/src/definition/ui/IUIActionButtonDescriptor.ts
+++ b/packages/apps-engine/src/definition/ui/IUIActionButtonDescriptor.ts
@@ -30,9 +30,10 @@ export interface IUActionButtonWhen {
 	 * Each entry is a role id or a role name. Prefer the name for a custom role,
 	 * because its id differs between workspaces.
 	 *
-	 * Only roles with the `Users` scope are matched. A role scoped to
-	 * `Subscriptions` — `owner`, `moderator` and `leader` among them — never
-	 * matches.
+	 * A role scoped to `Subscriptions` — `owner`, `moderator`, `leader`, or a custom
+	 * one — is granted per room, so it matches only on surfaces bound to a room. On a
+	 * surface with no room of its own, the user dropdown for instance, only roles
+	 * scoped to `Users` match.
 	 */
 	hasOneRole?: Array<string>;
 	/**
@@ -41,9 +42,10 @@ export interface IUActionButtonWhen {
 	 * Each entry is a role id or a role name. Prefer the name for a custom role,
 	 * because its id differs between workspaces.
 	 *
-	 * Only roles with the `Users` scope are matched. A role scoped to
-	 * `Subscriptions` — `owner`, `moderator` and `leader` among them — never
-	 * matches.
+	 * A role scoped to `Subscriptions` — `owner`, `moderator`, `leader`, or a custom
+	 * one — is granted per room, so it matches only on surfaces bound to a room. On a
+	 * surface with no room of its own, the user dropdown for instance, only roles
+	 * scoped to `Users` match.
 	 */
 	hasAllRoles?: Array<string>;
 }

--- a/packages/apps-engine/src/definition/ui/IUIActionButtonDescriptor.ts
+++ b/packages/apps-engine/src/definition/ui/IUIActionButtonDescriptor.ts
@@ -24,7 +24,27 @@ export interface IUActionButtonWhen {
 	messageActionContext?: Array<MessageActionContext>;
 	hasOnePermission?: Array<string>;
 	hasAllPermissions?: Array<string>;
+	/**
+	 * Show the button when the user holds at least one of these roles.
+	 *
+	 * Each entry is a role id or a role name. Prefer the name for a custom role,
+	 * because its id differs between workspaces.
+	 *
+	 * Only roles with the `Users` scope are matched. A role scoped to
+	 * `Subscriptions` — `owner`, `moderator` and `leader` among them — never
+	 * matches.
+	 */
 	hasOneRole?: Array<string>;
+	/**
+	 * Show the button when the user holds every one of these roles.
+	 *
+	 * Each entry is a role id or a role name. Prefer the name for a custom role,
+	 * because its id differs between workspaces.
+	 *
+	 * Only roles with the `Users` scope are matched. A role scoped to
+	 * `Subscriptions` — `owner`, `moderator` and `leader` among them — never
+	 * matches.
+	 */
 	hasAllRoles?: Array<string>;
 }
 

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -237,7 +237,7 @@ export class MockedAppRootBuilder {
 		},
 	};
 
-	// Mutated by `withCustomRole` before render, then held stable, so the identity is
+	// Mutated by `withRoleDefinition` before render, then held stable, so the identity is
 	// a safe `useSyncExternalStore` snapshot.
 	private rolesMap = new Map<IRole['_id'], IRole>();
 

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -1,6 +1,7 @@
 import type {
 	CallPreferences,
 	DirectCallData,
+	IRole,
 	IRoom,
 	ISetting,
 	IUser,
@@ -236,18 +237,18 @@ export class MockedAppRootBuilder {
 		},
 	};
 
-	private authorization: ContextType<typeof AuthorizationContext> = (() => {
-		const dummyRolesMap: ReturnType<ContextType<typeof AuthorizationContext>['getRoles']> = new Map();
+	// Mutated by `withCustomRole` before render, then held stable, so the identity is
+	// a safe `useSyncExternalStore` snapshot.
+	private rolesMap = new Map<IRole['_id'], IRole>();
 
-		return {
-			queryPermission: () => [() => () => undefined, () => false],
-			queryAtLeastOnePermission: () => [() => () => undefined, () => false],
-			queryAllPermissions: () => [() => () => undefined, () => false],
-			queryRole: () => [() => () => undefined, () => false],
-			getRoles: () => dummyRolesMap,
-			subscribeToRoles: () => () => undefined,
-		};
-	})();
+	private authorization: ContextType<typeof AuthorizationContext> = {
+		queryPermission: () => [() => () => undefined, () => false],
+		queryAtLeastOnePermission: () => [() => () => undefined, () => false],
+		queryAllPermissions: () => [() => () => undefined, () => false],
+		queryRole: () => [() => () => undefined, () => false],
+		getRoles: () => this.rolesMap,
+		subscribeToRoles: () => () => undefined,
+	};
 
 	private authServices: LoginService[] = [];
 
@@ -554,6 +555,22 @@ export class MockedAppRootBuilder {
 		};
 
 		this.authorization.queryRole = outerFn;
+
+		return this;
+	}
+
+	/**
+	 * Registers a role in the workspace roles map without granting it. A custom role
+	 * has an id that differs from its name, so pass both to exercise code that
+	 * resolves a name to an id. Chain `withRole(_id)` to grant it to the user.
+	 */
+	withRoleDefinition(role: Pick<IRole, '_id' | 'name'> & Partial<IRole>): this {
+		this.rolesMap.set(role._id, {
+			description: '',
+			protected: false,
+			scope: 'Users',
+			...role,
+		} as IRole);
 
 		return this;
 	}

--- a/packages/ui-contexts/src/hooks/useRoleIdResolver.ts
+++ b/packages/ui-contexts/src/hooks/useRoleIdResolver.ts
@@ -1,0 +1,32 @@
+import type { IRole } from '@rocket.chat/core-typings';
+import { useCallback, useContext, useMemo, useSyncExternalStore } from 'react';
+
+import { AuthorizationContext } from '../AuthorizationContext';
+
+/**
+ * Returns a function that maps a role reference to a role id.
+ *
+ * Authorization checks such as `queryRole` match on `IRole._id`. The default roles
+ * are seeded with `_id === name`, but a custom role gets a random id, so its name
+ * never matches. Use this resolver whenever the caller only knows the role name —
+ * an app that declares an action button filter, for example.
+ *
+ * A known id wins over a name, so an existing caller that already passes an id is
+ * unaffected. An unknown value passes through unchanged, which keeps the failure
+ * mode of the check it feeds.
+ */
+export const useRoleIdResolver = (): ((role: string) => IRole['_id']) => {
+	const { getRoles, subscribeToRoles } = useContext(AuthorizationContext);
+
+	const roles = useSyncExternalStore(subscribeToRoles, getRoles);
+
+	const idsByName = useMemo(() => {
+		const index = new Map<IRole['name'], IRole['_id']>();
+		for (const role of roles.values()) {
+			index.set(role.name, role._id);
+		}
+		return index;
+	}, [roles]);
+
+	return useCallback((role: string) => (roles.has(role) ? role : (idsByName.get(role) ?? role)), [idsByName, roles]);
+};

--- a/packages/ui-contexts/src/hooks/useRoleIdResolver.ts
+++ b/packages/ui-contexts/src/hooks/useRoleIdResolver.ts
@@ -23,6 +23,14 @@ export const useRoleIdResolver = (): ((role: string) => IRole['_id']) => {
 	const idsByName = useMemo(() => {
 		const index = new Map<IRole['name'], IRole['_id']>();
 		for (const role of roles.values()) {
+			// `roles.create` and `roles.update` reject a name already taken by another role, so a
+			// name maps to at most one role. Should duplicates still exist (e.g. written straight
+			// to the database), the first one iterated wins instead of the last, so adding another
+			// duplicate later does not silently repoint every check that names it.
+			if (index.has(role.name)) {
+				continue;
+			}
+
 			index.set(role.name, role._id);
 		}
 		return index;

--- a/packages/ui-contexts/src/index.ts
+++ b/packages/ui-contexts/src/index.ts
@@ -63,6 +63,7 @@ export { useModal } from './hooks/useModal';
 export { usePermission } from './hooks/usePermission';
 export { usePermissionWithScopedRoles } from './hooks/usePermissionWithScopedRoles';
 export { useRole } from './hooks/useRole';
+export { useRoleIdResolver } from './hooks/useRoleIdResolver';
 export { useRolesDescription } from './hooks/useRolesDescription';
 export { useRoomAvatarPath } from './hooks/useRoomAvatarPath';
 export { useRoomToolbox } from './hooks/useRoomToolbox';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Accepts a role name in the `when.hasOneRole` and `when.hasAllRoles` filters of an app action button. Previously only a role id matched, so an app had create a setting to configure the value or hard-code the random id a workspace assigned to a custom role. A role id keeps working, and takes precedence over a name.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - App action button role filters now support role names alongside role IDs.
  - Role names are automatically resolved to workspace roles when evaluating visibility conditions.
  - Existing role IDs take precedence, while unknown values remain compatible.
- **Documentation**
  - Clarified supported role identifiers and scope requirements for visibility conditions.
- **Tests**
  - Added coverage for custom, missing, unknown, and conflicting role identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2379]

[ARCH-2379]: https://rocketchat.atlassian.net/browse/ARCH-2379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ