### PR TITLE
fix: enforce default blocked email domains list on a stock install

### DIFF
--- a/.changeset/fix-default-blocked-email-domains.md
+++ b/.changeset/fix-default-blocked-email-domains.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the default blocked email domains list (`Accounts_UseDefaultBlockedDomainsList`) being ignored during registration unless a custom `Accounts_BlockedDomainsList` was also set. The two settings are now independent, so the built-in list of disposable/throwaway domains is enforced on a stock install as intended.

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -51,6 +51,7 @@ export default {
 				'<rootDir>/server/api/v1/middlewares/*.spec.ts',
 				'<rootDir>/server/lib/cloud/version-check/**/*.spec.ts',
 				'<rootDir>/server/lib/auth-providers/apple/**.spec.ts',
+				'<rootDir>/server/lib/isEmailDomainBlocked.spec.ts',
 			],
 			coveragePathIgnorePatterns: ['/node_modules/'],
 		},

--- a/apps/meteor/server/lib/isEmailDomainBlocked.spec.ts
+++ b/apps/meteor/server/lib/isEmailDomainBlocked.spec.ts
@@ -19,4 +19,14 @@ describe('isEmailDomainBlocked', () => {
 	it('does not block a domain that is on neither list', () => {
 		expect(isEmailDomainBlocked('gmail.com', ['evil.example'], true)).toBe(false);
 	});
+
+	it('blocks a default-listed domain regardless of case', () => {
+		// A valid email can carry an upper-case domain (`user@0-MAIL.COM`); the
+		// lower-cased default entry must still match.
+		expect(isEmailDomainBlocked('0-MAIL.COM', [], true)).toBe(true);
+	});
+
+	it('matches the custom list case-insensitively', () => {
+		expect(isEmailDomainBlocked('EVIL.example', ['evil.EXAMPLE'], false)).toBe(true);
+	});
 });

--- a/apps/meteor/server/lib/isEmailDomainBlocked.spec.ts
+++ b/apps/meteor/server/lib/isEmailDomainBlocked.spec.ts
@@ -1,0 +1,22 @@
+import { isEmailDomainBlocked } from './isEmailDomainBlocked';
+
+// `0-mail.com` is present in the built-in default list; `gmail.com` is not.
+describe('isEmailDomainBlocked', () => {
+	it('blocks a default-listed domain when the default list is enabled, even with an empty custom list', () => {
+		// Regression: previously the default list was only consulted when the
+		// custom list was non-empty, so on a stock install this returned false.
+		expect(isEmailDomainBlocked('0-mail.com', [], true)).toBe(true);
+	});
+
+	it('does not block a default-listed domain when the default list is disabled', () => {
+		expect(isEmailDomainBlocked('0-mail.com', [], false)).toBe(false);
+	});
+
+	it('blocks a domain on the custom list', () => {
+		expect(isEmailDomainBlocked('evil.example', ['evil.example'], false)).toBe(true);
+	});
+
+	it('does not block a domain that is on neither list', () => {
+		expect(isEmailDomainBlocked('gmail.com', ['evil.example'], true)).toBe(false);
+	});
+});

--- a/apps/meteor/server/lib/isEmailDomainBlocked.ts
+++ b/apps/meteor/server/lib/isEmailDomainBlocked.ts
@@ -9,6 +9,15 @@ import { emailDomainDefaultBlackList } from './defaultBlockedDomainsList';
  * custom domain has been configured. Previously both checks were gated behind
  * the custom list being non-empty, so on a stock install the default list was
  * never consulted.
+ *
+ * Domains are case-insensitive, so the incoming domain is lowercased before
+ * comparison (the default list is stored lowercase); otherwise `user@0-MAIL.COM`
+ * would slip past a listed `0-mail.com`.
  */
-export const isEmailDomainBlocked = (emailDomain: string, blockList: string[], useDefaultList: boolean): boolean =>
-	(blockList.length > 0 && blockList.includes(emailDomain)) || (useDefaultList && emailDomainDefaultBlackList.includes(emailDomain));
+export const isEmailDomainBlocked = (emailDomain: string, blockList: string[], useDefaultList: boolean): boolean => {
+	const domain = emailDomain.toLowerCase();
+	return (
+		(blockList.length > 0 && blockList.some((blocked) => blocked.toLowerCase() === domain)) ||
+		(useDefaultList && emailDomainDefaultBlackList.includes(domain))
+	);
+};

--- a/apps/meteor/server/lib/isEmailDomainBlocked.ts
+++ b/apps/meteor/server/lib/isEmailDomainBlocked.ts
@@ -1,0 +1,14 @@
+import { emailDomainDefaultBlackList } from './defaultBlockedDomainsList';
+
+/**
+ * Decide whether an email domain should be blocked at registration.
+ *
+ * The admin-configured blocklist (`Accounts_BlockedDomainsList`) and the
+ * built-in default list (`Accounts_UseDefaultBlockedDomainsList`) are
+ * independent controls, so the default list must apply on its own even when no
+ * custom domain has been configured. Previously both checks were gated behind
+ * the custom list being non-empty, so on a stock install the default list was
+ * never consulted.
+ */
+export const isEmailDomainBlocked = (emailDomain: string, blockList: string[], useDefaultList: boolean): boolean =>
+	(blockList.length > 0 && blockList.includes(emailDomain)) || (useDefaultList && emailDomainDefaultBlackList.includes(emailDomain));

--- a/apps/meteor/server/lib/validateEmailDomain.js
+++ b/apps/meteor/server/lib/validateEmailDomain.js
@@ -4,7 +4,7 @@ import util from 'node:util';
 import { validateEmail } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';
 
-import { emailDomainDefaultBlackList } from './defaultBlockedDomainsList';
+import { isEmailDomainBlocked } from './isEmailDomainBlocked';
 import { settings } from '../settings';
 
 const dnsResolveMx = util.promisify(dns.resolveMx);
@@ -50,11 +50,7 @@ export const validateEmailDomain = async function (email) {
 			function: 'RocketChat.validateEmailDomain',
 		});
 	}
-	if (
-		emailDomainBlackList.length &&
-		(emailDomainBlackList.indexOf(emailDomain) !== -1 ||
-			(settings.get('Accounts_UseDefaultBlockedDomainsList') && emailDomainDefaultBlackList.indexOf(emailDomain) !== -1))
-	) {
+	if (isEmailDomainBlocked(emailDomain, emailDomainBlackList, settings.get('Accounts_UseDefaultBlockedDomainsList'))) {
 		throw new Meteor.Error('error-email-domain-blacklisted', 'The email domain is blacklisted', {
 			function: 'RocketChat.validateEmailDomain',
 		});


### PR DESCRIPTION
## Proposed changes

The built-in list of blocked (disposable/throwaway) email domains is silently ignored during registration on a default install.

In `apps/meteor/server/lib/validateEmailDomain.js`, the blocklist check was gated on the custom list being non-empty:

```js
if (
    emailDomainBlackList.length &&
    (emailDomainBlackList.indexOf(emailDomain) !== -1 ||
        (settings.get('Accounts_UseDefaultBlockedDomainsList') && emailDomainDefaultBlackList.indexOf(emailDomain) !== -1))
) { ... }
```

`emailDomainBlackList` comes from `Accounts_BlockedDomainsList`, which **defaults to empty**. `Accounts_UseDefaultBlockedDomainsList` **defaults to `true`**. Because the whole condition is behind `emailDomainBlackList.length`, the `&&` short-circuits and `emailDomainDefaultBlackList` (the built-in ~943-entry list) is **never consulted** unless the admin also adds an unrelated custom domain. The dedicated default-list toggle is effectively a no-op on a stock install — a user can register with a disposable domain the admin believes is blocked.

The two settings are meant to be independent: `Accounts_UseDefaultBlockedDomainsList` should enable the built-in list on its own.

## Fix

Extract the decision into a small pure helper, `isEmailDomainBlocked`, that evaluates the custom list and the default list independently, and call it from `validateEmailDomain`:

```ts
export const isEmailDomainBlocked = (emailDomain: string, blockList: string[], useDefaultList: boolean): boolean =>
    (blockList.length > 0 && blockList.includes(emailDomain)) || (useDefaultList && emailDomainDefaultBlackList.includes(emailDomain));
```

A custom-listed domain is still blocked exactly as before; a default-listed domain is now blocked whenever the default-list toggle is on.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the Contributing guidelines
- [x] I added a unit test (`apps/meteor/server/lib/isEmailDomainBlocked.spec.ts`, registered in `jest.config.ts`)
- [x] Added a changeset (`@rocket.chat/meteor` patch)

## Further comments

The new helper is pure, so it's covered directly by the unit test. I verified the four cases against the real 943-entry default list: a disposable domain (`0-mail.com`) is now blocked with stock defaults (empty custom list, toggle on) where it previously was not; a normal domain is unaffected; the toggle-off path stays unblocked; and custom-list blocking is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default blocked email domains are now enforced during registration even when no custom blocked domains are configured.
  * Custom and default blocked-domain lists are evaluated independently.
  * Email domain matching is now case-insensitive.
  * Domains absent from both lists continue to be allowed.

* **Tests**
  * Added coverage for default-list behavior, custom blocking, case-insensitive matching, and permitted domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->