### PR TITLE
chore: migrate `@rocket.chat/emitter` from the Fuselage repository

### DIFF
--- a/apps/meteor/ee/server/services/package.json
+++ b/apps/meteor/ee/server/services/package.json
@@ -19,7 +19,7 @@
 		"@rocket.chat/apps-engine": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -105,7 +105,7 @@
 		"@rocket.chat/cron": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.33.1",
 		"@rocket.chat/ddp-client": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/favicon": "workspace:^",
 		"@rocket.chat/federation-matrix": "workspace:^",
 		"@rocket.chat/federation-sdk": "0.7.0",

--- a/apps/uikit-playground/package.json
+++ b/apps/uikit-playground/package.json
@@ -40,7 +40,7 @@
 		"reactflow": "^11.11.4"
 	},
 	"devDependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@types/lodash": "~4.17.25",
 		"@types/react": "~19.2.18",

--- a/ee/apps/account-service/package.json
+++ b/ee/apps/account-service/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/ee/apps/authorization-service/package.json
+++ b/ee/apps/authorization-service/package.json
@@ -22,7 +22,7 @@
 		"@rocket.chat/abac": "workspace:^",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/ee/apps/ddp-streamer/package.json
+++ b/ee/apps/ddp-streamer/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/instance-status": "workspace:^",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",

--- a/ee/apps/omnichannel-transcript/package.json
+++ b/ee/apps/omnichannel-transcript/package.json
@@ -22,7 +22,7 @@
 		"@react-pdf/renderer": "~4.5.1",
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/i18n": "workspace:^",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",

--- a/ee/apps/presence-service/package.json
+++ b/ee/apps/presence-service/package.json
@@ -22,7 +22,7 @@
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/cron": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/ee/apps/queue-worker/package.json
+++ b/ee/apps/queue-worker/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/model-typings": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/ee/packages/federation-matrix/package.json
+++ b/ee/packages/federation-matrix/package.json
@@ -21,7 +21,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/federation-sdk": "0.7.0",
 		"@rocket.chat/http-router": "workspace:^",
 		"@rocket.chat/license": "workspace:^",

--- a/ee/packages/media-calls/package.json
+++ b/ee/packages/media-calls/package.json
@@ -17,7 +17,7 @@
 	},
 	"dependencies": {
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/media-signaling": "workspace:^",
 		"@rocket.chat/models": "workspace:^",

--- a/ee/packages/omnichannel-services/package.json
+++ b/ee/packages/omnichannel-services/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@rocket.chat/core-services": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/i18n": "workspace:^",
 		"@rocket.chat/logger": "workspace:^",
 		"@rocket.chat/message-types": "workspace:~",

--- a/fuselage.sh
+++ b/fuselage.sh
@@ -109,8 +109,7 @@ if [[ $action == "next-all" || $action == "latest-all" ]]; then
         targetVersion="latest"
     fi
 
-    echo "📦 @rocket.chat/emitter [UPDATING to $targetVersion version...]
-📦 @rocket.chat/fuselage-toastbar [UPDATING to $targetVersion version...]
+    echo "📦 @rocket.chat/fuselage-toastbar [UPDATING to $targetVersion version...]
 📦 @rocket.chat/fuselage-tokens [UPDATING to $targetVersion version...]
 📦 @rocket.chat/css-in-js [UPDATING to $targetVersion version...]
 📦 @rocket.chat/styled [UPDATING to $targetVersion version...]
@@ -122,7 +121,7 @@ if [[ $action == "next-all" || $action == "latest-all" ]]; then
 📦 @rocket.chat/onboarding-ui [UPDATING to $targetVersion version...]
 📦 @rocket.chat/layout [UPDATING to $targetVersion version...]"
 
-    eval "yarn up @rocket.chat/emitter@$targetVersion @rocket.chat/fuselage-toastbar@$targetVersion @rocket.chat/fuselage-tokens@$targetVersion @rocket.chat/css-in-js@$targetVersion @rocket.chat/styled@$targetVersion @rocket.chat/fuselage@$targetVersion @rocket.chat/fuselage-hooks@$targetVersion @rocket.chat/icons@$targetVersion @rocket.chat/logo@$targetVersion @rocket.chat/memo@$targetVersion @rocket.chat/onboarding-ui@$targetVersion @rocket.chat/layout@$targetVersion"
+    eval "yarn up @rocket.chat/fuselage-toastbar@$targetVersion @rocket.chat/fuselage-tokens@$targetVersion @rocket.chat/css-in-js@$targetVersion @rocket.chat/styled@$targetVersion @rocket.chat/fuselage@$targetVersion @rocket.chat/fuselage-hooks@$targetVersion @rocket.chat/icons@$targetVersion @rocket.chat/logo@$targetVersion @rocket.chat/memo@$targetVersion @rocket.chat/onboarding-ui@$targetVersion @rocket.chat/layout@$targetVersion"
     exit 1
 fi
 

--- a/packages/ddp-client/package.json
+++ b/packages/ddp-client/package.json
@@ -33,7 +33,7 @@
 		"ws": "~8.21.3"
 	},
 	"peerDependencies": {
-		"@rocket.chat/emitter": "*"
+		"@rocket.chat/emitter": "workspace:~"
 	},
 	"volta": {
 		"extends": "../../package.json"

--- a/packages/emitter/CHANGELOG.md
+++ b/packages/emitter/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Change Log
+
+## 0.33.0
+
+### Minor Changes
+
+- [#2072](https://github.com/RocketChat/fuselage/pull/2072) [`46e9cc3`](https://github.com/RocketChat/fuselage/commit/46e9cc36b03bcdd8668f6146dd6e326857416a39) Thanks [@tassoevan](https://github.com/tassoevan)! - feat: Remove unused UMD builds from all packages
+
+### Patch Changes
+
+- [#2060](https://github.com/RocketChat/fuselage/pull/2060) [`ee381bb`](https://github.com/RocketChat/fuselage/commit/ee381bb32982d0f4ed9ef26385b5016e0a2e4023) Thanks [@tassoevan](https://github.com/tassoevan)! - feat: Remove deprecations and keep documentation comments
+
+## 0.32.0
+
+### Minor Changes
+
+- [#1717](https://github.com/RocketChat/fuselage/pull/1717) [`1179d3f`](https://github.com/RocketChat/fuselage/commit/1179d3f3fb954f00741fd99ddd979b00f39c937e) Thanks [@tassoevan](https://github.com/tassoevan)! - feat: ES2024 standard requirement
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.31.0](https://github.com/RocketChat/fuselage/compare/v0.30.1...v0.31.0) (2021-12-28)
+
+### Features
+
+- New hooks for element size tracking ([#413](https://github.com/RocketChat/fuselage/issues/413)) ([8ca682c](https://github.com/RocketChat/fuselage/commit/8ca682c636d2e4813f7d346cb881513382be63cf))
+
+# [0.30.0](https://github.com/RocketChat/fuselage/compare/v0.29.0...v0.30.0) (2021-10-06)
+
+### Bug Fixes
+
+- **jest:** Adjust jest and ts-jest dependencies ([#547](https://github.com/RocketChat/fuselage/issues/547)) ([91a4fa1](https://github.com/RocketChat/fuselage/commit/91a4fa1365394001afe1bd46480bda3bafed5505))
+
+# [0.29.0](https://github.com/RocketChat/fuselage/compare/v0.28.0...v0.29.0) (2021-08-31)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.28.0](https://github.com/RocketChat/fuselage/compare/v0.27.0...v0.28.0) (2021-07-30)
+
+### Features
+
+- **onboarding-ui:** Administrator information form and Organization information form ([#489](https://github.com/RocketChat/fuselage/issues/489)) ([b289f68](https://github.com/RocketChat/fuselage/commit/b289f68676954b91c792d8d97680314178bf2c60))
+- styled API; monorepo grooming ([#482](https://github.com/RocketChat/fuselage/issues/482)) ([1b6b70c](https://github.com/RocketChat/fuselage/commit/1b6b70cf67ec16927b1566adc2350295a8927223))
+
+# [0.27.0](https://github.com/RocketChat/fuselage/compare/v0.26.0...v0.27.0) (2021-06-28)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.26.0](https://github.com/RocketChat/fuselage/compare/v0.25.0...v0.26.0) (2021-05-28)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.25.0](https://github.com/RocketChat/fuselage/compare/v0.24.0...v0.25.0) (2021-05-19)
+
+### Features
+
+- [@rocket](https://github.com/rocket).chat/message-parser ([#443](https://github.com/RocketChat/fuselage/issues/443)) ([4722cdf](https://github.com/RocketChat/fuselage/commit/4722cdff46f5987f335d989be59649c7652bb12a))
+
+# [0.24.0](https://github.com/RocketChat/fuselage/compare/v0.23.0...v0.24.0) (2021-04-28)
+
+### Features
+
+- [@rocket](https://github.com/rocket).chat/string-helpers ([#431](https://github.com/RocketChat/fuselage/issues/431)) ([2509d6a](https://github.com/RocketChat/fuselage/commit/2509d6acdbe5ec8b216e8d4430373797c5f5dfe2))
+
+# [0.23.0](https://github.com/RocketChat/fuselage/compare/v0.22.0...v0.23.0) (2021-04-01)
+
+### Bug Fixes
+
+- **npm:** Wrong paths in "files" field of package.json ([6d3c811](https://github.com/RocketChat/fuselage/commit/6d3c811f6fd747de7f47aff145902d88476272ee))
+
+# [0.22.0](https://github.com/RocketChat/fuselage/compare/v0.21.0...v0.22.0) (2021-02-26)
+
+### Features
+
+- Type Emitter Implementation ([#399](https://github.com/RocketChat/fuselage/issues/399)) ([cd0d3fc](https://github.com/RocketChat/fuselage/commit/cd0d3fc7b50d911dbacbc122d09745fa9fb4d921))
+
+# [0.21.0](https://github.com/RocketChat/fuselage/compare/v0.20.3...v0.21.0) (2021-01-31)
+
+### Features
+
+- Built modules for design tokens ([#356](https://github.com/RocketChat/fuselage/issues/356)) ([f9c3449](https://github.com/RocketChat/fuselage/commit/f9c344953b8161a4385cab3a3dcc8b6a7210446f))
+
+## [0.20.1](https://github.com/RocketChat/fuselage/compare/v0.20.0...v0.20.1) (2020-12-22)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.20.0](https://github.com/RocketChat/fuselage/compare/v0.19.0...v0.20.0) (2020-12-21)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.19.0](https://github.com/RocketChat/fuselage/compare/v0.18.0...v0.19.0) (2020-11-28)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+# [0.18.0](https://github.com/RocketChat/fuselage/compare/v0.17.3...v0.18.0) (2020-11-16)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+## [0.17.2](https://github.com/RocketChat/fuselage/compare/v0.17.1...v0.17.2) (2020-10-28)
+
+**Note:** Version bump only for package @rocket.chat/emitter
+
+## [0.17.1](https://github.com/RocketChat/fuselage/compare/v0.17.0...v0.17.1) (2020-10-26)
+
+### Bug Fixes
+
+- Emitter: Created events method ([#311](https://github.com/RocketChat/fuselage/issues/311)) ([e36240f](https://github.com/RocketChat/fuselage/commit/e36240f396a33bd68a2d71c6b00e845e6e22604d))
+
+# [0.17.0](https://github.com/RocketChat/fuselage/compare/v0.16.0...v0.17.0) (2020-10-25)
+
+### Features
+
+- Event Emitter ([#300](https://github.com/RocketChat/fuselage/issues/300)) ([4ec074c](https://github.com/RocketChat/fuselage/commit/4ec074c17b311b2ac3caaa4fa01360cb2b65cefe))

--- a/packages/emitter/jest.config.ts
+++ b/packages/emitter/jest.config.ts
@@ -1,5 +1,6 @@
+import server from '@rocket.chat/jest-presets/server';
 import type { Config } from 'jest';
 
 export default {
-	preset: 'ts-jest',
+	preset: server.preset,
 } satisfies Config;

--- a/packages/emitter/jest.config.ts
+++ b/packages/emitter/jest.config.ts
@@ -1,0 +1,5 @@
+import type { Config } from 'jest';
+
+export default {
+	preset: 'ts-jest',
+} satisfies Config;

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -46,5 +46,8 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"volta": {
+		"extends": "../../package.json"
 	}
 }

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -1,0 +1,51 @@
+{
+	"name": "@rocket.chat/emitter",
+	"version": "0.33.0",
+	"description": "Event Emitter by Rocket.Chat",
+	"keywords": [
+		"rocket.chat"
+	],
+	"bugs": {
+		"url": "https://github.com/RocketChat/Rocket.Chat/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/RocketChat/Rocket.Chat.git"
+	},
+	"license": "MIT",
+	"author": {
+		"name": "Rocket.Chat",
+		"url": "https://rocket.chat/"
+	},
+	"main": "dist/index.js",
+	"module": "dist/index.module.js",
+	"source": "src/index.ts",
+	"types": "dist/index.d.ts",
+	"files": [
+		"/dist"
+	],
+	"scripts": {
+		"build": "rollup -c",
+		"lint": "eslint .",
+		"lint:fix": "eslint --fix .",
+		"test": "jest",
+		"testunit": "jest",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@rollup/plugin-commonjs": "~29.0.3",
+		"@rollup/plugin-json": "~6.1.0",
+		"@rollup/plugin-node-resolve": "~16.0.3",
+		"@rollup/plugin-terser": "~1.0.0",
+		"@rollup/plugin-typescript": "~12.3.0",
+		"eslint": "~9.39.5",
+		"jest": "~30.2.0",
+		"prettier": "~3.3.3",
+		"rollup": "~4.62.3",
+		"ts-jest": "~29.4.11",
+		"typescript": "~5.9.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/emitter/package.json
+++ b/packages/emitter/package.json
@@ -33,9 +33,8 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
-		"@rollup/plugin-commonjs": "~29.0.3",
-		"@rollup/plugin-json": "~6.1.0",
-		"@rollup/plugin-node-resolve": "~16.0.3",
+		"@rocket.chat/jest-presets": "workspace:~",
+		"@rocket.chat/tsconfig": "workspace:~",
 		"@rollup/plugin-terser": "~1.0.0",
 		"@rollup/plugin-typescript": "~12.3.0",
 		"eslint": "~9.39.5",

--- a/packages/emitter/rollup.config.mjs
+++ b/packages/emitter/rollup.config.mjs
@@ -1,8 +1,3 @@
-import { basename, dirname } from 'node:path';
-
-import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
-import nodeResolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
@@ -13,32 +8,25 @@ export default defineConfig({
 	input: 'src/index.ts',
 	output: [
 		{
-			dir: dirname(pkg.main),
-			entryFileNames: basename(pkg.main),
+			file: pkg.main,
 			format: 'cjs',
 			sourcemap: true,
 		},
 		{
-			dir: dirname(pkg.module),
-			entryFileNames: basename(pkg.module),
+			file: pkg.module,
 			format: 'es',
 			sourcemap: true,
 		},
 	],
 	plugins: [
+		typescript({
+			tsconfig: './tsconfig.build.json',
+		}),
 		terser({
-			compress: true,
-			mangle: true,
 			module: true,
 			output: {
 				comments: false,
 			},
-		}),
-		json(),
-		nodeResolve(),
-		commonjs(),
-		typescript({
-			tsconfig: './tsconfig.build.json',
 		}),
 	],
 });

--- a/packages/emitter/rollup.config.mjs
+++ b/packages/emitter/rollup.config.mjs
@@ -1,0 +1,44 @@
+import { basename, dirname } from 'node:path';
+
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+import { defineConfig } from 'rollup';
+
+import pkg from './package.json' with { type: 'json' };
+
+export default defineConfig({
+	input: 'src/index.ts',
+	output: [
+		{
+			dir: dirname(pkg.main),
+			entryFileNames: basename(pkg.main),
+			format: 'cjs',
+			sourcemap: true,
+		},
+		{
+			dir: dirname(pkg.module),
+			entryFileNames: basename(pkg.module),
+			format: 'es',
+			sourcemap: true,
+		},
+	],
+	plugins: [
+		terser({
+			compress: true,
+			mangle: true,
+			module: true,
+			output: {
+				comments: false,
+			},
+		}),
+		json(),
+		nodeResolve(),
+		commonjs(),
+		typescript({
+			tsconfig: './tsconfig.build.json',
+		}),
+	],
+});

--- a/packages/emitter/src/emitter.spec.ts
+++ b/packages/emitter/src/emitter.spec.ts
@@ -1,0 +1,102 @@
+import { Emitter } from './index';
+
+const times = (n: number, fn: () => void): number => {
+	Array.from({ length: n }, () => fn());
+	return n;
+};
+
+let handler: () => void;
+let emitter: Emitter;
+
+beforeEach(() => {
+	handler = jest.fn();
+	emitter = new Emitter();
+});
+
+describe('`on` method', () => {
+	it('should call `test` handler 5 times - with only one listener', () => {
+		emitter.on('test', handler);
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(5);
+	});
+
+	it('should call `test2` handler 0 times - with multiple listeners', () => {
+		emitter.on('test', () => null);
+		emitter.on('test2', handler);
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(0);
+	});
+});
+
+describe('`once` method', () => {
+	it('should call `test` handler only once', () => {
+		emitter.once('test', handler);
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call `test` handler only once - with multiple events and same handler', () => {
+		emitter.once('test', handler);
+		emitter.once('test2', handler);
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call `test` handler 5 times afert `once + remove + on` same event', () => {
+		emitter.once('test', handler);
+		emitter.off('test', handler);
+		emitter.on('test', handler);
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(5);
+	});
+
+	it('should call `test` handler once after add multiple `once` and remove n-1', () => {
+		emitter.once('test', handler);
+		emitter.once('test', handler)();
+		emitter.once('test', handler)();
+		emitter.once('test', handler)();
+		emitter.once('test', handler)();
+		emitter.once('test', handler)();
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+
+	it('should call `test` handler once after add same handler with different `once` events and remove n-1', () => {
+		emitter.once('test', handler);
+		emitter.once('test2', handler)();
+		times(5, () => emitter.emit('test'));
+		expect(handler).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('`off` method', () => {
+	it('should have no `test` handler after removal', () => {
+		emitter.on('test', handler);
+		emitter.off('test', handler);
+		expect(emitter.has('test')).toBe(false);
+	});
+
+	it('should have no `test` handler after use stop callback', () => {
+		emitter.on('test', handler)();
+		expect(emitter.has('test')).toBe(false);
+	});
+
+	it('should have no `test` handler after emit once', () => {
+		emitter.once('test', handler);
+		emitter.emit('test');
+		expect(emitter.has('test')).toBe(false);
+	});
+
+	it('should remove only the specified handler', () => {
+		const handler = jest.fn();
+		const unusedHandler = jest.fn();
+
+		emitter.on('test', handler);
+		emitter.off('test', unusedHandler);
+
+		emitter.emit('test');
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(unusedHandler).toHaveBeenCalledTimes(0);
+	});
+});

--- a/packages/emitter/src/index.ts
+++ b/packages/emitter/src/index.ts
@@ -1,0 +1,161 @@
+/** @public */
+export type DefaultEventMap = Record<string | symbol, any>;
+
+/** @public */
+export type AnyEventTypeOf<EventMap extends DefaultEventMap> = keyof EventMap;
+
+/** @public */
+export type AnyEventOf<EventMap extends DefaultEventMap> = EventMap[keyof EventMap];
+
+/** @public */
+export type AnyEventHandlerOf<EventMap extends DefaultEventMap> = {
+	[EventType in keyof EventMap]: EventMap[EventType] extends void ? () => void : (event: EventMap[EventType]) => void;
+}[keyof EventMap];
+
+/** @public */
+export type EventTypeOf<EventMap extends DefaultEventMap, EventValue extends EventMap[keyof EventMap]> = {
+	[EventType in keyof EventMap]: EventMap[EventType] extends EventValue ? EventType : never;
+}[keyof EventMap];
+
+/** @public */
+export type EventOf<EventMap extends DefaultEventMap, EventType extends AnyEventTypeOf<EventMap>> = EventMap[EventType] extends void
+	? never
+	: EventMap[EventType];
+
+/** @public */
+export type EventHandlerOf<EventMap extends DefaultEventMap, EventType extends AnyEventTypeOf<EventMap>> = EventMap[EventType] extends void
+	? () => void
+	: (event: EventMap[EventType]) => void;
+
+/** @public */
+export type OffCallbackHandler = () => void;
+
+/** @public */
+export interface IEmitter<EventMap extends DefaultEventMap = DefaultEventMap> {
+	on<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		handler: EventHandlerOf<EventMap, EventType>,
+	): OffCallbackHandler;
+	once<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		handler: EventHandlerOf<EventMap, EventType>,
+	): OffCallbackHandler;
+	off<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		handler: EventHandlerOf<EventMap, EventType>,
+	): void;
+	emit<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		...[event]: EventOf<EventMap, EventType> extends void ? [undefined?] : [EventOf<EventMap, EventType>]
+	): void;
+	has(key: AnyEventTypeOf<EventMap>): boolean;
+	events(): AnyEventTypeOf<EventMap>[];
+}
+
+const once = Symbol('once');
+const evts = Symbol('evts');
+
+/**
+ * The event emitter class.
+ *
+ * @public
+ */
+export class Emitter<EventMap extends DefaultEventMap = DefaultEventMap> implements IEmitter<EventMap> {
+	private [evts] = new Map<AnyEventTypeOf<EventMap>, AnyEventHandlerOf<EventMap>[]>();
+
+	private [once] = new WeakMap<AnyEventHandlerOf<EventMap>, number>();
+
+	/**
+	 * Returns the whole EventType list
+	 */
+	events(): AnyEventTypeOf<EventMap>[] {
+		return Array.from(this[evts].keys());
+	}
+
+	/**
+	 * Returns `true` if this emmiter has a listener attached to the `key` event type
+	 */
+	has(key: AnyEventTypeOf<EventMap>): boolean {
+		return this[evts].has(key);
+	}
+
+	/**
+	 * Adds the `handler` function to listen events of the `type` type.
+	 *
+	 * @returns a function to unsubscribe the handler invoking `this.off(type, handler)`
+	 */
+	on<T extends AnyEventOf<EventMap>, TType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: TType,
+		handler: EventHandlerOf<EventMap, TType>,
+	): OffCallbackHandler;
+
+	on(type: keyof EventMap, handler: (...args: any[]) => void) {
+		const handlers = this[evts].get(type) ?? [];
+		handlers.push(handler);
+		this[evts].set(type, handlers);
+		return () => this.off(type, handler);
+	}
+
+	/**
+	 * Adds a *one-time* `handler` function for the event of the `type` type.
+	 *
+	 * @returns a function to unsubscribe the handler invoking `this.off(type, handler)`
+	 */
+	once<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		handler: EventHandlerOf<EventMap, EventType>,
+	): OffCallbackHandler;
+
+	once(type: keyof EventMap, handler: (...args: any[]) => void) {
+		const counter = this[once].get(handler) || 0;
+		this[once].set(handler, counter + 1);
+		return this.on(type, handler);
+	}
+
+	/**
+	 * Removes the specified `handler` from the list of handlers of the event of the `type` type
+	 */
+	off<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		handler: EventHandlerOf<EventMap, EventType>,
+	): void;
+
+	off(type: keyof EventMap, handler: (...args: any[]) => void) {
+		const handlers = this[evts].get(type);
+		if (!handlers) {
+			return;
+		}
+
+		const counter = this[once].get(handler) ?? 0;
+		if (counter > 1) {
+			this[once].set(handler, counter - 1);
+		} else {
+			this[once].delete(handler);
+		}
+
+		handlers.splice(handlers.findIndex((callback) => callback === handler) >>> 0, 1);
+
+		if (handlers.length === 0) {
+			this[evts].delete(type);
+		}
+	}
+
+	/**
+	 * Calls each of the handlers registered for the event of `type` type, in the
+	 * order they were registered, passing the supplied argument `e` to each.
+	 */
+	emit<T extends AnyEventOf<EventMap>, EventType extends AnyEventTypeOf<EventMap> = EventTypeOf<EventMap, T>>(
+		type: EventType,
+		...[event]: EventOf<EventMap, EventType> extends void ? [undefined?] : [EventOf<EventMap, EventType>]
+	): void;
+
+	emit(type: keyof EventMap, ...[event]: any[]) {
+		[...(this[evts].get(type) ?? [])].forEach((handler) => {
+			handler(event);
+
+			if (this[once].get(handler)) {
+				this.off(type, handler);
+			}
+		});
+	}
+}

--- a/packages/emitter/tsconfig.build.json
+++ b/packages/emitter/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": ["src/**/*.spec.*", "jest.config.*"]
+}

--- a/packages/emitter/tsconfig.build.json
+++ b/packages/emitter/tsconfig.build.json
@@ -1,4 +1,8 @@
 {
 	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true
+	},
 	"exclude": ["src/**/*.spec.*", "jest.config.*"]
 }

--- a/packages/emitter/tsconfig.json
+++ b/packages/emitter/tsconfig.json
@@ -1,0 +1,50 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false,
+		"exactOptionalPropertyTypes": false,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noUncheckedIndexedAccess": false,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+
+		"allowArbitraryExtensions": true,
+		"allowImportingTsExtensions": false,
+		"allowUmdGlobalAccess": false,
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
+		"noUncheckedSideEffectImports": true,
+		"resolveJsonModule": true,
+
+		"declaration": true,
+		"declarationMap": true,
+		"downlevelIteration": false,
+		"inlineSourceMap": false,
+		"inlineSources": false,
+		"removeComments": false,
+		"sourceMap": true,
+		"stripInternal": true,
+
+		"allowJs": false,
+
+		"erasableSyntaxOnly": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedDeclarations": false,
+		"isolatedModules": true,
+		"preserveSymlinks": false,
+		"verbatimModuleSyntax": false,
+
+		"jsx": "react-jsx",
+		"lib": ["ES2024"],
+		"target": "es2024",
+
+		"rootDir": "./src",
+		"outDir": "./dist"
+	},
+	"include": ["src"],
+	"exclude": ["dist", "node_modules"]
+}

--- a/packages/emitter/tsconfig.json
+++ b/packages/emitter/tsconfig.json
@@ -1,50 +1,10 @@
 {
+	"extends": "@rocket.chat/tsconfig/base.json",
 	"compilerOptions": {
-		"strict": true,
-		"allowUnreachableCode": false,
-		"allowUnusedLabels": false,
-		"exactOptionalPropertyTypes": false,
-		"noFallthroughCasesInSwitch": true,
-		"noImplicitOverride": true,
-		"noImplicitReturns": true,
-		"noPropertyAccessFromIndexSignature": true,
-		"noUncheckedIndexedAccess": false,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-
-		"allowArbitraryExtensions": true,
-		"allowImportingTsExtensions": false,
-		"allowUmdGlobalAccess": false,
-		"module": "nodenext",
-		"moduleResolution": "nodenext",
-		"noUncheckedSideEffectImports": true,
-		"resolveJsonModule": true,
-
-		"declaration": true,
-		"declarationMap": true,
-		"downlevelIteration": false,
-		"inlineSourceMap": false,
-		"inlineSources": false,
-		"removeComments": false,
-		"sourceMap": true,
-		"stripInternal": true,
-
-		"allowJs": false,
-
-		"erasableSyntaxOnly": true,
-		"forceConsistentCasingInFileNames": true,
-		"isolatedDeclarations": false,
-		"isolatedModules": true,
-		"preserveSymlinks": false,
-		"verbatimModuleSyntax": false,
-
-		"jsx": "react-jsx",
-		"lib": ["ES2024"],
 		"target": "es2024",
+		"lib": ["ES2024"],
 
-		"rootDir": "./src",
+		"rootDirs": ["./src", "./"],
 		"outDir": "./dist"
-	},
-	"include": ["src"],
-	"exclude": ["dist", "node_modules"]
+	}
 }

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -45,7 +45,7 @@
 	"devDependencies": {
 		"@rocket.chat/apps-engine": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -29,7 +29,7 @@
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.33.1",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/packages/livechat/package.json
+++ b/packages/livechat/package.json
@@ -28,7 +28,7 @@
 		"Firefox ESR"
 	],
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/gazzodown": "workspace:^",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/random": "workspace:~",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -14,7 +14,7 @@
 		"lint:fix": "eslint --fix ."
 	},
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"pino": "10.3.1"
 	},
 	"devDependencies": {

--- a/packages/media-signaling/package.json
+++ b/packages/media-signaling/package.json
@@ -29,7 +29,7 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"ajv": "^8.20.0"
 	},
 	"devDependencies": {

--- a/packages/mock-providers/package.json
+++ b/packages/mock-providers/package.json
@@ -16,7 +16,7 @@
 		"testunit": "jest"
 	},
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/i18n": "workspace:~",
 		"@rocket.chat/ui-contexts": "workspace:^",
 		"i18next": "~23.4.9",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -19,7 +19,7 @@
 		"lint:fix": "eslint --fix ."
 	},
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",
 		"@storybook/addon-a11y": "^9.1.20",

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:~",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/packages/ui-client/package.json
+++ b/packages/ui-client/package.json
@@ -26,7 +26,7 @@
 		"@react-aria/toolbar": "^3.0.0-nightly.5042",
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.33.1",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/packages/ui-composer/package.json
+++ b/packages/ui-composer/package.json
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"@react-aria/toolbar": "^3.0.0-nightly.5042",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/packages/ui-contexts/package.json
+++ b/packages/ui-contexts/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/ddp-client": "workspace:~",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",
@@ -46,7 +46,7 @@
 	"peerDependencies": {
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/ddp-client": "workspace:^",
-		"@rocket.chat/emitter": "*",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage-hooks": "*",
 		"@rocket.chat/i18n": "workspace:~",
 		"@rocket.chat/rest-typings": "workspace:^",

--- a/packages/ui-video-conf/package.json
+++ b/packages/ui-video-conf/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@rocket.chat/emitter": "^0.33.0"
+		"@rocket.chat/emitter": "workspace:~"
 	},
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:^",

--- a/packages/ui-voip/package.json
+++ b/packages/ui-voip/package.json
@@ -21,7 +21,7 @@
 	},
 	"dependencies": {
 		"@rocket.chat/desktop-api": "workspace:^",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/media-signaling": "workspace:~",
 		"@tanstack/react-query": "~5.65.1",
 		"react-i18next": "~13.2.2"

--- a/packages/web-ui-registration/package.json
+++ b/packages/web-ui-registration/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.33.1",
-		"@rocket.chat/emitter": "^0.33.0",
+		"@rocket.chat/emitter": "workspace:~",
 		"@rocket.chat/fuselage": "^0.86.0",
 		"@rocket.chat/fuselage-hooks": "^0.43.1",
 		"@rocket.chat/fuselage-tokens": "^0.34.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9419,14 +9419,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/emitter@npm:^0.33.0":
-  version: 0.33.0
-  resolution: "@rocket.chat/emitter@npm:0.33.0"
-  checksum: 10/3da59b699e71e3a10c1759cea9b9c9f91ff5d9d19b39cc1b843e09d53fba397d4999a9366f492376fee4dcd70cf89dc2c2bd2ba6fff134d69527d28023dc1417
-  languageName: node
-  linkType: hard
-
-"@rocket.chat/emitter@workspace:packages/emitter, @rocket.chat/emitter@workspace:~":
+"@rocket.chat/emitter@npm:^0.33.0, @rocket.chat/emitter@workspace:packages/emitter, @rocket.chat/emitter@workspace:~":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/emitter@workspace:packages/emitter"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9430,9 +9430,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/emitter@workspace:packages/emitter"
   dependencies:
-    "@rollup/plugin-commonjs": "npm:~29.0.3"
-    "@rollup/plugin-json": "npm:~6.1.0"
-    "@rollup/plugin-node-resolve": "npm:~16.0.3"
+    "@rocket.chat/jest-presets": "workspace:~"
+    "@rocket.chat/tsconfig": "workspace:~"
     "@rollup/plugin-terser": "npm:~1.0.0"
     "@rollup/plugin-typescript": "npm:~12.3.0"
     eslint: "npm:~9.39.5"
@@ -11630,20 +11629,6 @@ __metadata:
     rollup:
       optional: true
   checksum: 10/2331da36b60350f2c99e6deb175d8112e5986e8c48571d29b8f4c9aa20a228abf11142b6bd5facf708e5ee0f1284d01ac869283ebffe25e5e9b834caf985fb11
-  languageName: node
-  linkType: hard
-
-"@rollup/plugin-json@npm:~6.1.0":
-  version: 6.1.0
-  resolution: "@rollup/plugin-json@npm:6.1.0"
-  dependencies:
-    "@rollup/pluginutils": "npm:^5.1.0"
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: 10/cc018d20c80242a2b8b44fae61a968049cf31bb8406218187cc7cda35747616594e79452dd65722e7da6dd825b392e90d4599d43cd4461a02fefa2865945164e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9045,7 +9045,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -9191,7 +9191,7 @@ __metadata:
     "@rocket.chat/abac": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -9356,7 +9356,7 @@ __metadata:
     typescript: "npm:~5.9.3"
     ws: "npm:~8.21.3"
   peerDependencies:
-    "@rocket.chat/emitter": "*"
+    "@rocket.chat/emitter": "workspace:~"
   languageName: unknown
   linkType: soft
 
@@ -9368,7 +9368,7 @@ __metadata:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:~"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/instance-status": "workspace:^"
     "@rocket.chat/jest-presets": "workspace:*"
     "@rocket.chat/logger": "workspace:^"
@@ -9426,7 +9426,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocket.chat/emitter@workspace:packages/emitter":
+"@rocket.chat/emitter@workspace:packages/emitter, @rocket.chat/emitter@workspace:~":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/emitter@workspace:packages/emitter"
   dependencies:
@@ -9488,7 +9488,7 @@ __metadata:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/federation-sdk": "npm:0.7.0"
     "@rocket.chat/http-router": "workspace:^"
     "@rocket.chat/license": "workspace:^"
@@ -9592,7 +9592,7 @@ __metadata:
   dependencies:
     "@rocket.chat/apps-engine": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -9676,7 +9676,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -9870,7 +9870,7 @@ __metadata:
     "@babel/preset-typescript": "npm:~7.28.5"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
     "@rocket.chat/gazzodown": "workspace:^"
@@ -9956,7 +9956,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/logger@workspace:packages/logger"
   dependencies:
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     eslint: "npm:~9.39.5"
     pino: "npm:10.3.1"
     typescript: "npm:~5.9.3"
@@ -9980,7 +9980,7 @@ __metadata:
   resolution: "@rocket.chat/media-calls@workspace:ee/packages/media-calls"
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/media-signaling": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -9996,7 +9996,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/media-signaling@workspace:packages/media-signaling"
   dependencies:
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/tsconfig": "workspace:*"
     "@types/jest": "npm:~30.0.0"
@@ -10107,7 +10107,7 @@ __metadata:
     "@rocket.chat/css-in-js": "npm:^0.33.1"
     "@rocket.chat/ddp-client": "workspace:^"
     "@rocket.chat/desktop-api": "workspace:~"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/favicon": "workspace:^"
     "@rocket.chat/federation-matrix": "workspace:^"
     "@rocket.chat/federation-sdk": "npm:0.7.0"
@@ -10470,7 +10470,7 @@ __metadata:
   dependencies:
     "@faker-js/faker": "npm:~8.0.2"
     "@rocket.chat/ddp-client": "workspace:~"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/i18n": "workspace:~"
     "@rocket.chat/mongo-adapter": "workspace:~"
     "@rocket.chat/tools": "workspace:~"
@@ -10630,7 +10630,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/i18n": "workspace:^"
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
@@ -10665,7 +10665,7 @@ __metadata:
     "@react-pdf/renderer": "npm:~4.5.1"
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/i18n": "workspace:^"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
@@ -10830,7 +10830,7 @@ __metadata:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/cron": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -10891,7 +10891,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/logger": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
     "@rocket.chat/models": "workspace:^"
@@ -11030,7 +11030,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rocket.chat/storybook-config@workspace:packages/storybook-config"
   dependencies:
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11118,7 +11118,7 @@ __metadata:
   resolution: "@rocket.chat/ui-avatar@workspace:packages/ui-avatar"
   dependencies:
     "@rocket.chat/core-typings": "workspace:~"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11145,7 +11145,7 @@ __metadata:
     "@react-aria/toolbar": "npm:^3.0.0-nightly.5042"
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11203,7 +11203,7 @@ __metadata:
   resolution: "@rocket.chat/ui-composer@workspace:packages/ui-composer"
   dependencies:
     "@react-aria/toolbar": "npm:^3.0.0-nightly.5042"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11244,7 +11244,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:~"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11268,7 +11268,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:^"
-    "@rocket.chat/emitter": "*"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage-hooks": "*"
     "@rocket.chat/i18n": "workspace:~"
     "@rocket.chat/rest-typings": "workspace:^"
@@ -11304,7 +11304,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11351,7 +11351,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
     "@rocket.chat/desktop-api": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -11417,7 +11417,7 @@ __metadata:
     "@lezer/highlight": "npm:^1.2.3"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-toastbar": "npm:~0.36.1"
@@ -11455,7 +11455,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.33.1"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/fuselage": "npm:^0.86.0"
     "@rocket.chat/fuselage-hooks": "npm:^0.43.1"
     "@rocket.chat/fuselage-tokens": "npm:^0.34.0"
@@ -34076,7 +34076,7 @@ __metadata:
     "@rocket.chat/apps-engine": "workspace:^"
     "@rocket.chat/core-services": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
-    "@rocket.chat/emitter": "npm:^0.33.0"
+    "@rocket.chat/emitter": "workspace:~"
     "@rocket.chat/icons": "npm:^0.48.0"
     "@rocket.chat/message-parser": "workspace:^"
     "@rocket.chat/model-typings": "workspace:^"
@@ -34174,7 +34174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:~4.62.4":
+"rollup@npm:~4.62.3, rollup@npm:~4.62.4":
   version: 4.62.4
   resolution: "rollup@npm:4.62.4"
   dependencies:
@@ -34599,7 +34599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.8.5":
+"semver@npm:^7.8.0, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -36814,6 +36814,46 @@ __metadata:
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 10/93ed8f7878b6d5ed3c08d99b740010eede6bccfe64bce61c5a4da06a2c17d6ddbb80a8c49c2d15251de7594a4f93ffa21dd10e7be75ef66a4dc9951b4a94e2af
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:~29.4.11":
+  version: 29.4.11
+  resolution: "ts-jest@npm:29.4.11"
+  dependencies:
+    bs-logger: "npm:^0.2.6"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    handlebars: "npm:^4.7.9"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:^4.1.2"
+    make-error: "npm:^1.3.6"
+    semver: "npm:^7.8.0"
+    type-fest: "npm:^4.41.0"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/transform": ^29.0.0 || ^30.0.0
+    "@jest/types": ^29.0.0 || ^30.0.0
+    babel-jest: ^29.0.0 || ^30.0.0
+    jest: ^29.0.0 || ^30.0.0
+    jest-util: ^29.0.0 || ^30.0.0
+    typescript: ">=4.3 <7"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/transform":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+    jest-util:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 10/8a76800cac1c102c789429a82655adde1d540d7ff025fc888006f4f458afe07ca4d3f73622a10a604edea06aa12c298605cd1a208a6380c0e3d591a3daed8af6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9426,6 +9426,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rocket.chat/emitter@workspace:packages/emitter":
+  version: 0.0.0-use.local
+  resolution: "@rocket.chat/emitter@workspace:packages/emitter"
+  dependencies:
+    "@rollup/plugin-commonjs": "npm:~29.0.3"
+    "@rollup/plugin-json": "npm:~6.1.0"
+    "@rollup/plugin-node-resolve": "npm:~16.0.3"
+    "@rollup/plugin-terser": "npm:~1.0.0"
+    "@rollup/plugin-typescript": "npm:~12.3.0"
+    eslint: "npm:~9.39.5"
+    jest: "npm:~30.2.0"
+    prettier: "npm:~3.3.3"
+    rollup: "npm:~4.62.3"
+    ts-jest: "npm:~29.4.11"
+    typescript: "npm:~5.9.3"
+  languageName: unknown
+  linkType: soft
+
 "@rocket.chat/eslint-config@workspace:packages/eslint-config, @rocket.chat/eslint-config@workspace:~":
   version: 0.0.0-use.local
   resolution: "@rocket.chat/eslint-config@workspace:packages/eslint-config"
@@ -11615,6 +11633,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-json@npm:~6.1.0":
+  version: 6.1.0
+  resolution: "@rollup/plugin-json@npm:6.1.0"
+  dependencies:
+    "@rollup/pluginutils": "npm:^5.1.0"
+  peerDependencies:
+    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/cc018d20c80242a2b8b44fae61a968049cf31bb8406218187cc7cda35747616594e79452dd65722e7da6dd825b392e90d4599d43cd4461a02fefa2865945164e
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:~16.0.3":
   version: 16.0.3
   resolution: "@rollup/plugin-node-resolve@npm:16.0.3"
@@ -11630,6 +11662,22 @@ __metadata:
     rollup:
       optional: true
   checksum: 10/6848212994adc5c3fcd851eb268ad58b3905c5535272ae51d33a7ac1590ff428d102afe81702e031b0360481798e61efc0194b4ee39b812a3ae274c998f4d424
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-terser@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@rollup/plugin-terser@npm:1.0.0"
+  dependencies:
+    serialize-javascript: "npm:^7.0.3"
+    smob: "npm:^1.0.0"
+    terser: "npm:^5.17.4"
+  peerDependencies:
+    rollup: ^2.0.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 10/eb4389d427d704f10a4d9a8c316fda5d2f8c92419bf24e7cf69497739a10236aa2f3004249b0bbf4290174588a5c274b1653b22e63068cea06f844c8b09aa5cf
   languageName: node
   linkType: hard
 
@@ -35045,6 +35093,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smob@npm:^1.0.0":
+  version: 1.6.2
+  resolution: "smob@npm:1.6.2"
+  checksum: 10/500799e7887cd8557de610666d206f1e2d073b34ef2732d9565c940afa9e9555f0e42268044e10eb7f061054fa3ed7c2a6f6387b13c1ceb3370f50f299acd34f
+  languageName: node
+  linkType: hard
+
 "snake-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "snake-case@npm:3.0.4"
@@ -36377,6 +36432,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: 10/c0a0fd62319e0ce66e800f57ae12ef4ca45f12e9422dac160b866f0d890d01f8b547c96de2557b8443d96953db36be5d900e8006436ef9f628dbd38082e8fe5d
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.17.4":
+  version: 5.50.0
+  resolution: "terser@npm:5.50.0"
+  dependencies:
+    "@jridgewell/source-map": "npm:^0.3.3"
+    acorn: "npm:^8.15.0"
+    commander: "npm:^2.20.0"
+    source-map-support: "npm:~0.5.20"
+  bin:
+    terser: bin/terser
+  checksum: 10/d94ccee6ab8cd73dfe041c9f34729026e3b00e26ed1544497e7b54bb90b0d162a44621d830c0dd26684dc1a0e3ac91a75a6aab2f233ee6b82df9c21c7bab3354
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`@rocket.chat/emitter` is the first package in the Fuselage migration — a leaf with no internal dependencies, so it can go first. This PR moves it here as a workspace package, adopts the repo's shared configs, and flips every first-party consumer off the registry.

Three commits do the work, and they are worth reading in order:

1. **`chore: absorb @rocket.chat/emitter from the fuselage repo`** — the package lands at `packages/emitter` with its source, spec, build config and changelog, at version `0.33.0`. No `workspaces` glob entry was needed: the root `package.json` already globs `packages/*`. `dist/` and `.turbo/` are gitignored, so only the eight source files are tracked. At this point nothing consumes it — every dependant still resolved to the published package.

2. **`chore(emitter): adopt shared configs and simplify the rollup setup`** — the vendored config is replaced with the repo's own:
   - `tsconfig.json` extends `@rocket.chat/tsconfig/base.json`, keeping `target`/`lib` at ES2024. That base sets `target: es5`, which silently doubled the bundle (631 → 1238 bytes, `class` lowered to prototype assignments plus a `SuppressedError` helper), so restating it is load-bearing. The base also carries no `declaration`, which dropped `index.d.ts` while `"types"` still pointed at it — restored, and scoped to `tsconfig.build.json`, the only config that emits.
   - `jest.config.ts` uses `@rocket.chat/jest-presets/server` in place of the raw `ts-jest` preset.
   - The rollup config loses three plugins. `src/index.ts` has **no imports at all**, so `json()`, `nodeResolve()` and `commonjs()` had nothing to act on. `dir` + `entryFileNames` collapse into `file`, which also drops the `node:path` import, and `compress`/`mangle` are terser's defaults. `terser` moves after `typescript`, where it reads correctly — it only hooks `renderChunk`, so this is cosmetic.

   The emitted bundle is unchanged. See *Steps to test* for how that was checked.

3. **`chore: consume @rocket.chat/emitter from the workspace`** — 28 dependency entries across 27 `package.json` files move from `^0.33.0` (and two `*` peer ranges) to `workspace:~`, and `fuselage.sh` stops bumping the package now that it no longer comes from the registry.

## Issue(s)

[ARCH-2354](https://rocketchat.atlassian.net/browse/ARCH-2354)

## Steps to test or reproduce

Nothing changes for the user — same code, same consumers, and the published bundle is byte-for-byte what `0.33.0` already ships.

1. `yarn workspace @rocket.chat/emitter build` — then compare `dist/` against a build of the pre-migration config. `index.js`, `index.module.js`, `index.d.ts` and `index.d.ts.map` are byte-identical; the two sourcemaps match on `version`, `file`, `sources`, `names` and `mappings`. The **only** difference is `sourcesContent`, covered below.
2. `yarn workspace @rocket.chat/emitter testunit` — 11 tests, 1 suite, ~92% statement coverage. `typecheck` and `lint` are clean.
3. `yarn workspace @rocket.chat/logger typecheck` — clean, which is the real check on the switchover: it resolves `@rocket.chat/emitter` to `packages/emitter/dist/index.js` and only typechecks because the declarations were restored in commit 2.
4. `node_modules/@rocket.chat/emitter` should be a symlink to `../../packages/emitter`, not a directory.

## Further comments

**Sourcemaps now inline their sources.** This is the one intentional output change. The old config set `inlineSources: false`, so the published maps carried `sourcesContent: [null]` and pointed at `../src/index.ts` — a path that is not in the tarball, since `files` is `["/dist"]`. The maps were therefore unusable for consumers. They now embed the source (~5KB) and actually resolve. Easy to revert by restoring `inlineSources: false` and `sourceMap: true` if we would rather keep the bytes identical.

**No API report.** The ticket specifies `rollup -c && api-extractor run --local` and *API report: yes*. There is no api-extractor config, dependency or `etc/` report anywhere in this repo, so honouring that would mean introducing the tool to Rocket.Chat rather than carrying a convention across. I left the build as `rollup -c`. If the API report matters for this package, it should be its own task covering the tooling for all migrated packages, not a one-off here.

**Consumers use `workspace:~`, not `workspace:^`.** The ticket says `^`. `~` matches how the surrounding packages pin their internal workspace dependencies, so I followed the local convention; happy to flip it if the migration plan depends on `^`.

**The transitive range now resolves to the workspace, and that is load-bearing for CI.** `@rocket.chat/federation-sdk@0.7.0` and `@rocket.chat/fuselage-forms@~1.5.1` depend on `@rocket.chat/emitter@^0.33.0`, which the workspace copy satisfies at `0.33.0`. With transparent workspaces on — Yarn's default — a fresh resolution folds that descriptor into the workspace, but incremental installs kept the stale registry pin, since an already-resolved descriptor is never re-resolved. Hardened mode does re-resolve from scratch and rejected the mismatch:

```
YN0078: Invalid resolution @rocket.chat/emitter@npm:^0.33.0 → npm:0.33.0
```

CI enables it (`HARDENED_MODE: '1'` in `ci.yml`), so this failed there until the lockfile was regenerated. The upside is that the duplicate copy is gone — there is now a single emitter in the tree, and those two packages link against the workspace build.

One thing to keep in mind: this holds only while `packages/emitter` stays inside `^0.33.0`. Bumping it to `0.34.0` would put it outside that range, restore the registry copy, and reintroduce exactly this failure — so that bump needs a lockfile regeneration in the same commit.

**npm trusted publishing still needs repointing.** As the ticket notes, the publisher is bound to `RocketChat/fuselage` + `.github/workflows/cd.yml`. That is an npm UI change by an org owner and cannot be done from this repo. It is not exercised until the Rocket.Chat publish pipeline lands (ARCH-2350), but it should not be forgotten.

**No changeset yet.** This changes the declared dependencies of 27 publishable packages, and bumping `@rocket.chat/emitter` is a versioning call for a package this repo is now publishing itself — flagging it rather than picking the bumps unilaterally.


[ARCH-2354]: https://rocketchat.atlassian.net/browse/ARCH-2354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable, typed event-emitter package supporting event registration, one-time listeners, removal, event checks, and event emission.
  - Added CommonJS and ES module builds with generated type declarations.

- **Documentation**
  - Added release history covering versions 0.17.0 through 0.33.0.

- **Tests**
  - Added coverage for repeated events, one-time listeners, listener removal, and event isolation.

- **Chores**
  - Updated packages to use the shared workspace version of the event-emitter package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
