### PR TITLE
chore: migrate `@rocket.chat/memo` from Fuselage

### DIFF
--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -127,7 +127,7 @@
 		"@rocket.chat/logo": "^0.33.2",
 		"@rocket.chat/media-calls": "workspace:^",
 		"@rocket.chat/media-signaling": "workspace:^",
-		"@rocket.chat/memo": "~0.31.25",
+		"@rocket.chat/memo": "workspace:~",
 		"@rocket.chat/message-parser": "workspace:^",
 		"@rocket.chat/message-types": "workspace:~",
 		"@rocket.chat/model-typings": "workspace:^",

--- a/fuselage.sh
+++ b/fuselage.sh
@@ -117,11 +117,10 @@ if [[ $action == "next-all" || $action == "latest-all" ]]; then
 📦 @rocket.chat/fuselage-hooks [UPDATING to $targetVersion version...]
 📦 @rocket.chat/icons [UPDATING to $targetVersion version...]
 📦 @rocket.chat/logo [UPDATING to $targetVersion version...]
-📦 @rocket.chat/memo [UPDATING to $targetVersion version...]
 📦 @rocket.chat/onboarding-ui [UPDATING to $targetVersion version...]
 📦 @rocket.chat/layout [UPDATING to $targetVersion version...]"
 
-    eval "yarn up @rocket.chat/fuselage-toastbar@$targetVersion @rocket.chat/fuselage-tokens@$targetVersion @rocket.chat/css-in-js@$targetVersion @rocket.chat/styled@$targetVersion @rocket.chat/fuselage@$targetVersion @rocket.chat/fuselage-hooks@$targetVersion @rocket.chat/icons@$targetVersion @rocket.chat/logo@$targetVersion @rocket.chat/memo@$targetVersion @rocket.chat/onboarding-ui@$targetVersion @rocket.chat/layout@$targetVersion"
+    eval "yarn up @rocket.chat/fuselage-toastbar@$targetVersion @rocket.chat/fuselage-tokens@$targetVersion @rocket.chat/css-in-js@$targetVersion @rocket.chat/styled@$targetVersion @rocket.chat/fuselage@$targetVersion @rocket.chat/fuselage-hooks@$targetVersion @rocket.chat/icons@$targetVersion @rocket.chat/logo@$targetVersion @rocket.chat/onboarding-ui@$targetVersion @rocket.chat/layout@$targetVersion"
     exit 1
 fi
 

--- a/packages/memo/jest.config.ts
+++ b/packages/memo/jest.config.ts
@@ -1,0 +1,6 @@
+import server from '@rocket.chat/jest-presets/server';
+import type { Config } from 'jest';
+
+export default {
+	preset: server.preset,
+} satisfies Config;

--- a/packages/memo/package.json
+++ b/packages/memo/package.json
@@ -5,13 +5,12 @@
 	"keywords": [
 		"memoize"
 	],
-	"homepage": "https://github.com/RocketChat/fuselage#readme",
 	"bugs": {
-		"url": "https://github.com/RocketChat/fuselage/issues"
+		"url": "https://github.com/RocketChat/Rocket.Chat/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/RocketChat/fuselage.git",
+		"url": "git+https://github.com/RocketChat/Rocket.Chat.git",
 		"directory": "packages/memo"
 	},
 	"license": "MIT",
@@ -26,10 +25,7 @@
 		"/dist"
 	],
 	"scripts": {
-		".:build:cjs": "tsc -p tsconfig.cjs.json",
-		".:build:esm": "tsc -p tsconfig.esm.json",
-		"build": "run .:build:esm && run .:build:cjs",
-		"clean": "rm -rf dist",
+		"build": "rm -rf dist && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
 		"lint": "eslint .",
 		"lint:fix": "eslint --fix .",
 		"test": "jest",
@@ -44,6 +40,9 @@
 		"prettier": "~3.3.3",
 		"ts-jest": "~29.4.11",
 		"typescript": "~5.9.3"
+	},
+	"volta": {
+		"extends": "../../package.json"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/memo/package.json
+++ b/packages/memo/package.json
@@ -1,0 +1,51 @@
+{
+	"name": "@rocket.chat/memo",
+	"version": "0.31.25",
+	"description": "Memoization utilities",
+	"keywords": [
+		"memoize"
+	],
+	"homepage": "https://github.com/RocketChat/fuselage#readme",
+	"bugs": {
+		"url": "https://github.com/RocketChat/fuselage/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/RocketChat/fuselage.git",
+		"directory": "packages/memo"
+	},
+	"license": "MIT",
+	"author": {
+		"name": "Rocket.Chat",
+		"url": "https://rocket.chat/"
+	},
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"types": "dist/esm/index.d.ts",
+	"files": [
+		"/dist"
+	],
+	"scripts": {
+		".:build:cjs": "tsc -p tsconfig.cjs.json",
+		".:build:esm": "tsc -p tsconfig.esm.json",
+		"build": "run .:build:esm && run .:build:cjs",
+		"clean": "rm -rf dist",
+		"lint": "eslint .",
+		"lint:fix": "eslint --fix .",
+		"test": "jest",
+		"testunit": "jest",
+		"typecheck": "tsc --noEmit"
+	},
+	"devDependencies": {
+		"@rocket.chat/jest-presets": "workspace:~",
+		"@rocket.chat/tsconfig": "workspace:~",
+		"eslint": "~9.39.5",
+		"jest": "~30.2.0",
+		"prettier": "~3.3.3",
+		"ts-jest": "~29.4.11",
+		"typescript": "~5.9.3"
+	},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/memo/src/index.ts
+++ b/packages/memo/src/index.ts
@@ -1,0 +1,1 @@
+export { memoize, clear, type MemoizableFunction, type MemoizedFunction, type Options } from './memoize';

--- a/packages/memo/src/memoize.spec.ts
+++ b/packages/memo/src/memoize.spec.ts
@@ -1,0 +1,105 @@
+import { memoize, clear } from './memoize';
+
+it('should memoize a function that takes no parameter', () => {
+	const fn = jest.fn(() => 'foo');
+	const memoized = jest.fn(memoize(fn));
+
+	memoized(undefined);
+	memoized(undefined);
+
+	expect(memoized).toHaveBeenCalledTimes(2);
+	expect(fn).toHaveBeenCalledTimes(1);
+
+	expect(fn).toHaveReturnedWith('foo');
+	expect(memoized).toHaveReturnedWith('foo');
+});
+
+it('should memoize a function that takes one parameter', () => {
+	const fn = jest.fn((i: number) => i + 1);
+	const memoized = jest.fn(memoize(fn));
+
+	memoized(5);
+	memoized(5);
+	memoized(2);
+
+	expect(memoized).toHaveBeenCalledTimes(3);
+	expect(fn).toHaveBeenCalledTimes(2);
+
+	expect(fn).toHaveNthReturnedWith(1, 6);
+	expect(fn).toHaveNthReturnedWith(2, 3);
+
+	expect(memoized).toHaveNthReturnedWith(1, 6);
+	expect(memoized).toHaveNthReturnedWith(2, 6);
+	expect(memoized).toHaveNthReturnedWith(3, 3);
+});
+
+describe('clear', () => {
+	it('should discard cached values of a memoized function', () => {
+		const fn = jest.fn(() => 'foo');
+		const memoized = memoize(fn);
+		const spiedMemoized = jest.fn(memoized);
+
+		spiedMemoized(undefined);
+		spiedMemoized(undefined);
+		clear(memoized);
+		spiedMemoized(undefined);
+
+		expect(spiedMemoized).toHaveBeenCalledTimes(3);
+		expect(fn).toHaveBeenCalledTimes(2);
+
+		expect(fn).toHaveReturnedWith('foo');
+		expect(spiedMemoized).toHaveReturnedWith('foo');
+	});
+
+	it('should do nothing when a non-memoized function is passed', () => {
+		const fn = jest.fn(() => 'foo');
+
+		expect(() => clear(fn)).not.toThrow();
+	});
+});
+
+describe('timeout', () => {
+	it('should memoize a function that takes one parameter and clear after x ms', () => {
+		jest.useFakeTimers();
+
+		const fn = jest.fn((i: number) => i + 1);
+		const memoized = jest.fn(memoize(fn, { maxAge: 3000 }));
+
+		memoized(5);
+		jest.advanceTimersByTime(2000);
+		memoized(5);
+		jest.advanceTimersByTime(2000);
+		memoized(5);
+		jest.advanceTimersByTime(3000);
+		memoized(5);
+
+		expect(fn).toHaveBeenCalledTimes(2);
+
+		expect(memoized).toHaveNthReturnedWith(1, 6);
+		expect(memoized).toHaveNthReturnedWith(2, 6);
+		expect(memoized).toHaveNthReturnedWith(3, 6);
+		expect(memoized).toHaveNthReturnedWith(4, 6);
+	});
+
+	it('should memoize a function caching for two parameters and clearing both after x ms each one', () => {
+		jest.useFakeTimers();
+
+		const fn = jest.fn((i: number) => i + 1);
+		const memoized = jest.fn(memoize(fn, { maxAge: 3000 }));
+
+		memoized(5);
+		jest.advanceTimersByTime(2000);
+		memoized(6);
+		jest.advanceTimersByTime(2000);
+
+		memoized(6);
+		memoized(5);
+
+		expect(fn).toHaveBeenCalledTimes(3);
+
+		expect(memoized).toHaveNthReturnedWith(1, 6);
+		expect(memoized).toHaveNthReturnedWith(2, 7);
+		expect(memoized).toHaveNthReturnedWith(3, 7);
+		expect(memoized).toHaveNthReturnedWith(4, 6);
+	});
+});

--- a/packages/memo/src/memoize.ts
+++ b/packages/memo/src/memoize.ts
@@ -1,0 +1,59 @@
+export type MemoizableFunction<T, A, R> = (this: T, arg: A) => R;
+export type MemoizedFunction<T, A, R> = (this: T, arg: A) => R;
+
+export type Options = {
+	maxAge: number;
+};
+
+const store = new WeakMap<MemoizableFunction<unknown, unknown, unknown>, Map<unknown, unknown>>();
+
+const isCachedValue = <A, R>(cachedValue: R | undefined, arg: A, cache: Map<A, R>): cachedValue is R =>
+	cache.has(arg) && cache.get(arg) === cachedValue;
+
+export const memoize = <T, A, R>(fn: MemoizableFunction<T, A, R>, _options?: Options): MemoizedFunction<T, A, R> => {
+	const cache = new Map<A, R>();
+	const cacheTimers = new Map<A, ReturnType<typeof setTimeout>>();
+
+	const memoized: MemoizedFunction<T, A, R> = function (this, arg) {
+		const cleanUp = (): void => {
+			cache.delete(arg);
+			cacheTimers.delete(arg);
+		};
+
+		const cachedValue = cache.get(arg);
+
+		if (isCachedValue(cachedValue, arg, cache)) {
+			const oldTimer = cacheTimers.get(arg);
+			if (oldTimer) {
+				clearTimeout(oldTimer);
+			}
+
+			if (_options) {
+				const timer = setTimeout(cleanUp, _options.maxAge);
+				cacheTimers.set(arg, timer);
+			}
+
+			return cachedValue;
+		}
+
+		const result = fn.call(this, arg);
+
+		cache.set(arg, result);
+
+		if (_options) {
+			const timer = setTimeout(cleanUp, _options.maxAge);
+			cacheTimers.set(arg, timer);
+		}
+
+		return result;
+	};
+
+	store.set(memoized as MemoizableFunction<unknown, unknown, unknown>, cache);
+
+	return memoized;
+};
+
+export const clear = (fn: MemoizedFunction<unknown, unknown, unknown>): void => {
+	const cache = store.get(fn);
+	cache?.clear();
+};

--- a/packages/memo/tsconfig.cjs.json
+++ b/packages/memo/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"outDir": "./dist/cjs"
+	},
+	"exclude": ["**/*.spec.*", "jest.config.*"]
+}

--- a/packages/memo/tsconfig.cjs.json
+++ b/packages/memo/tsconfig.cjs.json
@@ -3,6 +3,9 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"moduleResolution": "node",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
 		"outDir": "./dist/cjs"
 	},
 	"exclude": ["**/*.spec.*", "jest.config.*"]

--- a/packages/memo/tsconfig.esm.json
+++ b/packages/memo/tsconfig.esm.json
@@ -1,6 +1,11 @@
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {
+		"module": "esnext",
+		"moduleResolution": "node",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
 		"outDir": "./dist/esm"
 	},
 	"exclude": ["**/*.spec.*", "jest.config.*"]

--- a/packages/memo/tsconfig.esm.json
+++ b/packages/memo/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "./dist/esm"
+	},
+	"exclude": ["**/*.spec.*", "jest.config.*"]
+}

--- a/packages/memo/tsconfig.json
+++ b/packages/memo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "@rocket.chat/tsconfig/base.json",
+	"include": ["src/**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10000,12 +10000,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/memo@npm:^0.31.25, @rocket.chat/memo@npm:~0.31.25":
-  version: 0.31.25
-  resolution: "@rocket.chat/memo@npm:0.31.25"
-  checksum: 10/92d595c68d76a5258fb37ed4639e2709ba290c5d240df1272d81a2ab6b4be28ee2dd5b721dad940fe2638a89e8d14e684a970c59890003a06ce6088c655b7c0e
-  languageName: node
-  linkType: hard
+"@rocket.chat/memo@npm:^0.31.25, @rocket.chat/memo@workspace:packages/memo, @rocket.chat/memo@workspace:~":
+  version: 0.0.0-use.local
+  resolution: "@rocket.chat/memo@workspace:packages/memo"
+  dependencies:
+    "@rocket.chat/jest-presets": "workspace:~"
+    "@rocket.chat/tsconfig": "workspace:~"
+    eslint: "npm:~9.39.5"
+    jest: "npm:~30.2.0"
+    prettier: "npm:~3.3.3"
+    ts-jest: "npm:~29.4.11"
+    typescript: "npm:~5.9.3"
+  languageName: unknown
+  linkType: soft
 
 "@rocket.chat/message-parser@workspace:^, @rocket.chat/message-parser@workspace:packages/message-parser, @rocket.chat/message-parser@workspace:~":
   version: 0.0.0-use.local
@@ -10124,7 +10131,7 @@ __metadata:
     "@rocket.chat/logo": "npm:^0.33.2"
     "@rocket.chat/media-calls": "workspace:^"
     "@rocket.chat/media-signaling": "workspace:^"
-    "@rocket.chat/memo": "npm:~0.31.25"
+    "@rocket.chat/memo": "workspace:~"
     "@rocket.chat/message-parser": "workspace:^"
     "@rocket.chat/message-types": "workspace:~"
     "@rocket.chat/mock-providers": "workspace:^"


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This code was migrated from the [Fuselage repository](https://github.com/RocketChat/fuselage), where `@rocket.chat/memo` lived until now. The package is a tiny memoization helper — a `memoize(fn, { maxAge })` wrapper backed by a `Map`, plus a `clear(fn)` to drop a memoized function's cache. Two source files, ~60 lines total.

Fuselage is a design system repository; a generic memoization utility has nothing to do with a design system, and keeping it there meant every change required a release cycle across two repos before it could reach the product. This follows the same move made for `@rocket.chat/mp3-encoder` in #41745.

Worth noting who actually consumes this: nothing in the product imports `@rocket.chat/memo` directly. It is a transitive dependency of the published Fuselage packages — `@rocket.chat/fuselage`, `@rocket.chat/css-in-js` and `@rocket.chat/css-supports` all declare `^0.31.25`. The workspace package keeps version `0.31.25`, so that range now resolves to this local copy for all of them, and the single `yarn.lock` entry collapses `npm:^0.31.25` and `workspace:~` onto one resolution. `apps/meteor` moves from `~0.31.25` to `workspace:~`.

`@rocket.chat/memo` is also dropped from the `next-all`/`latest-all` bump list in `fuselage.sh`, since it is no longer released from the Fuselage repo.

The package keeps its name, its `0.31.25` version and its `publishConfig.access: public`, so nothing changes for external consumers.

No changeset: this does not change behavior for end users.

### A build fix on top of the migration

The migrated build configuration was broken in two ways, both fixed in `fix(memo): emit real ESM and type declarations`:

- `tsconfig.esm.json` only overrode `outDir`, so the ESM build inherited `module: commonjs` from `@rocket.chat/tsconfig/base.json` and `dist/esm/index.js` came out **byte-identical to the CJS build** — the `module` entry point was serving CommonJS.
- Neither build enabled `declaration`, so `dist/esm/index.d.ts` — the package's `types` entry point — **did not exist at all**.

Since the published Fuselage packages above resolve onto this workspace copy, shipping it as-is would have handed the whole Fuselage stack an untyped `memo` with a fake ESM build. The fix sets `module: esnext` for the ESM build and enables `declaration`, `declarationMap` and `sourceMap` for both, matching what the published `0.31.25` tarball actually shipped.

Output was verified against that tarball (`npm pack @rocket.chat/memo@0.31.25`):

- `dist/{esm,cjs}/index.js` — byte-identical.
- `dist/{esm,cjs}/memoize.js` — identical ignoring whitespace; the only differences are line wrapping from this repo's Prettier width. Same `es5` target as the published build.
- `dist/{esm,cjs}/*.d.ts` — one intentional, additive difference: `index.d.ts` now re-exports `MemoizableFunction`, `MemoizedFunction` and `Options`, which the published build kept internal. `Options` is emitted as a type alias rather than an `interface`; the shape is unchanged.

### Metadata and tooling cleanup

`chore(memo): update package metadata and simplify build script` finishes the move:

- `repository` and `bugs` now point at Rocket.Chat rather than Fuselage, and the stale `homepage` pointing at the Fuselage README is gone.
- The `.:build:esm` / `.:build:cjs` / `clean` script trio is collapsed into a single `build`: `rm -rf dist && tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json`. The original inherited Fuselage's `run .:build:esm && run .:build:cjs`; that does work here (Yarn 4 puts a `run` shim on `PATH` during script execution, so `run x` is `yarn run x`), but `packages/memo` was the only package in the repo written that way, and the inlined form matches every other workspace package. `clean` is not referenced by `turbo.json`, so dropping it is safe.
- Adds the usual `volta.extends` pointer to the root `package.json`.

## Issue(s)

[ARCH-2357](https://rocketchat.atlassian.net/browse/ARCH-2357)

## Steps to test or reproduce

Behavior should be identical to `develop` — the point of the migration is that nothing changes for the user.

1. `yarn install` and confirm `node_modules/@rocket.chat/memo` is a symlink into `packages/memo` rather than an unpacked tarball.
2. `yarn workspace @rocket.chat/memo build`, then check that `dist/esm/index.js` starts with `export { memoize, clear } from './memoize';` and that `dist/esm/index.d.ts` exists.
3. `yarn workspace @rocket.chat/memo test` — 1 suite, 6 tests, 100% statement/branch/function/line coverage of `memoize.ts`.
4. `yarn workspace @rocket.chat/memo typecheck` and `... lint` — both clean.
5. Run the app and exercise anything Fuselage-heavy (the admin area, message list, any styled component); `css-in-js`, `css-supports` and `fuselage` all call `memoize` when resolving styles, so a broken build here would surface as missing or unstyled UI.

## Further comments

The `dist` output is not committed; it is produced by the package's `build` script.

The published `0.31.25` tarball also shipped compiled `memoize.spec.js`/`.d.ts` files. Those are excluded here via `exclude` in both build tsconfigs, so the published artifact from this repo would be slightly smaller. That is deliberate and matches how other packages in this monorepo are built.

The `maxAge` option is implemented with a `setTimeout` per cached key, and the timer is reset on every cache *hit* — so a key that keeps being read never expires. That is the behavior of the published package and it is preserved verbatim here; changing it belongs in a separate PR, not in a migration.

The corresponding package in Fuselage should be deprecated once this lands.


[ARCH-2357]: https://rocketchat.atlassian.net/browse/ARCH-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable memoization utility for caching function results.
  * Supports argument-based caching, optional expiration, and manual cache clearing.
  * Available with CommonJS, ESM, and TypeScript support.

* **Tests**
  * Added coverage for caching behavior, expiration, cache clearing, and non-memoized inputs.

* **Chores**
  * Updated workspace package usage and streamlined dependency update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->