### PR TITLE
fix: message list not scrolling to bottom when sending a message

### DIFF
--- a/.changeset/lucky-boxes-shave.md
+++ b/.changeset/lucky-boxes-shave.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixes the message list often not scrolling to the bottom after you send a message. The scroll was triggered by the server's echo of the message, which is skipped whenever the response to the send is processed first — the message is then no longer recognised as new and nothing tells the list to move. It now scrolls as soon as the message is appended locally, so it no longer waits for the round-trip.

--- a/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
@@ -210,9 +210,35 @@ describe('MessageList scroll position', () => {
 
 		const otherUserMessage = {
 			...createMessage('message-3'),
+			temp: true,
 			u: { _id: 'other-user-id', username: 'other' },
 		} as IMessage;
 		(useMessages as jest.Mock).mockReturnValue([createMessage('message-1'), createMessage('message-2'), otherUserMessage]);
+		rerender(<MessageList {...defaultProps} />);
+
+		expect(defaultProps.setShouldJumpToBottom).not.toHaveBeenCalledWith(true);
+	});
+
+	it('should not jump to bottom when older messages are prepended', () => {
+		const store = {
+			scroll: 123,
+			atBottom: false,
+			update: jest.fn(),
+		};
+		(RoomManager.getStore as jest.Mock).mockReturnValue(store);
+
+		const ownOptimisticMessage = { ...createMessage('message-3'), temp: true } as IMessage;
+		(useMessages as jest.Mock).mockReturnValue([createMessage('message-1'), createMessage('message-2'), ownOptimisticMessage]);
+
+		const { rerender } = render(<MessageList {...defaultProps} />, { wrapper: root.build() });
+		defaultProps.setShouldJumpToBottom.mockClear();
+
+		(useMessages as jest.Mock).mockReturnValue([
+			createMessage('message-0'),
+			createMessage('message-1'),
+			createMessage('message-2'),
+			ownOptimisticMessage,
+		]);
 		rerender(<MessageList {...defaultProps} />);
 
 		expect(defaultProps.setShouldJumpToBottom).not.toHaveBeenCalledWith(true);

--- a/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.spec.tsx
@@ -125,6 +125,7 @@ describe('MessageList scroll position', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		defaultProps.isAtBottom.current = false;
 		mockVirtualizerHandle.scrollToIndex.mockClear();
 		mockVirtualizerHandle.scrollTo.mockClear();
 		mockVirtualizerHandle.findItemIndex.mockImplementation((offset: number) => offset);
@@ -176,6 +177,45 @@ describe('MessageList scroll position', () => {
 		render(<MessageList {...defaultProps} shouldJumpToBottom={true} />, { wrapper: root.build() });
 
 		expect(defaultProps.setShouldJumpToBottom).toHaveBeenCalledWith(true);
+	});
+
+	it("should jump to bottom when the current user's optimistic message is appended", () => {
+		const store = {
+			scroll: 123,
+			atBottom: false,
+			update: jest.fn(),
+		};
+		(RoomManager.getStore as jest.Mock).mockReturnValue(store);
+
+		const { rerender } = render(<MessageList {...defaultProps} />, { wrapper: root.build() });
+		defaultProps.setShouldJumpToBottom.mockClear();
+
+		const ownOptimisticMessage = { ...createMessage('message-3'), temp: true } as IMessage;
+		(useMessages as jest.Mock).mockReturnValue([createMessage('message-1'), createMessage('message-2'), ownOptimisticMessage]);
+		rerender(<MessageList {...defaultProps} />);
+
+		expect(defaultProps.setShouldJumpToBottom).toHaveBeenCalledWith(true);
+	});
+
+	it('should not jump to bottom when someone else sends a message', () => {
+		const store = {
+			scroll: 123,
+			atBottom: false,
+			update: jest.fn(),
+		};
+		(RoomManager.getStore as jest.Mock).mockReturnValue(store);
+
+		const { rerender } = render(<MessageList {...defaultProps} />, { wrapper: root.build() });
+		defaultProps.setShouldJumpToBottom.mockClear();
+
+		const otherUserMessage = {
+			...createMessage('message-3'),
+			u: { _id: 'other-user-id', username: 'other' },
+		} as IMessage;
+		(useMessages as jest.Mock).mockReturnValue([createMessage('message-1'), createMessage('message-2'), otherUserMessage]);
+		rerender(<MessageList {...defaultProps} />);
+
+		expect(defaultProps.setShouldJumpToBottom).not.toHaveBeenCalledWith(true);
 	});
 
 	it('should do nothing if no previous scroll position is stored', () => {

--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -82,7 +82,7 @@ export const MessageList = function MessageList({
 
 	const virtualizerRef = useRef<VirtualizerHandle | null>(null);
 	const lastScrollSizeRef = useRef(0);
-	const prevMessagesLengthRef = useRef(0);
+	const prevLastMessageIdRef = useRef<IMessage['_id'] | undefined>(undefined);
 	const ownUserId = user?._id;
 
 	const messages = useMessages({ rid });
@@ -143,6 +143,12 @@ export const MessageList = function MessageList({
 
 	// Scroll to bottom
 	useEffect(() => {
+		// Tracked by id, not by length, so loading older messages does not look like a new
+		// send. Updated before the early returns below, otherwise it stays unset on mount.
+		const lastMessage = messages.at(-1);
+		const prevLastMessageId = prevLastMessageIdRef.current;
+		prevLastMessageIdRef.current = lastMessage?._id;
+
 		if (isJumpingToMessage || messageJumpParam) {
 			if (!isRoomInitialized.current) {
 				// Jump to message will have to load messages, thus removing the need to initialize the room here
@@ -183,13 +189,8 @@ export const MessageList = function MessageList({
 
 		// Scroll to bottom when the user's own temp message is appended, so the list does not
 		// depend on streamNewMessage, which may not run for a message the client already added.
-		const prevMessagesLength = prevMessagesLengthRef.current;
-		prevMessagesLengthRef.current = messages.length;
-		if (messages.length > prevMessagesLength && ownUserId) {
-			const lastMessage = messages.at(-1);
-			if (lastMessage?.temp && lastMessage.u._id === ownUserId) {
-				setShouldJumpToBottom(true);
-			}
+		if (lastMessage?._id !== prevLastMessageId && lastMessage?.temp && lastMessage.u._id === ownUserId) {
+			setShouldJumpToBottom(true);
 		}
 
 		if (shouldJumpToBottom === true && handle) {

--- a/apps/meteor/client/views/room/MessageList/MessageList.tsx
+++ b/apps/meteor/client/views/room/MessageList/MessageList.tsx
@@ -82,6 +82,8 @@ export const MessageList = function MessageList({
 
 	const virtualizerRef = useRef<VirtualizerHandle | null>(null);
 	const lastScrollSizeRef = useRef(0);
+	const prevMessagesLengthRef = useRef(0);
+	const ownUserId = user?._id;
 
 	const messages = useMessages({ rid });
 
@@ -178,10 +180,25 @@ export const MessageList = function MessageList({
 
 		const handle = virtualizerRef.current;
 		const lastItemIndex = messages.length - 1;
-		if (shouldJumpToBottom === true) {
+
+		// Scroll to bottom when the user's own temp message is appended, so the list does not
+		// depend on streamNewMessage, which may not run for a message the client already added.
+		const prevMessagesLength = prevMessagesLengthRef.current;
+		prevMessagesLengthRef.current = messages.length;
+		if (messages.length > prevMessagesLength && ownUserId) {
+			const lastMessage = messages.at(-1);
+			if (lastMessage?.temp && lastMessage.u._id === ownUserId) {
+				setShouldJumpToBottom(true);
+			}
+		}
+
+		if (shouldJumpToBottom === true && handle) {
+			// Mark as at-bottom before the scroll runs, so useKeepAtBottom re-scrolls if the
+			// content grows in between. Only with a handle, otherwise nothing would scroll.
+			isAtBottom.current = true;
 			// When new messages arrive, this effect is triggered, but the latest message is not on the index, so it scrolls to the previous index
 			// TODO: Find if there is a better way to scroll to the latest message
-			handle?.scrollToIndex(lastItemIndex + 1, {
+			handle.scrollToIndex(lastItemIndex + 1, {
 				align: 'center',
 			});
 		}
@@ -202,6 +219,7 @@ export const MessageList = function MessageList({
 		rid,
 		firstUnreadMessageId,
 		setShouldJumpToBottom,
+		ownUserId,
 	]);
 
 	const storeScrollPosition = useStoreScrollPosition({ rid, isAtBottom, virtualizerRef });


### PR DESCRIPTION

## Proposed changes (including videos or screenshots)

The message list often does not scroll to the bottom after you send a message.

Your message is added to the list right away and marked `temp`. The scroll is triggered by `streamNewMessage`, which only runs if `LegacyRoomManager` still sees the incoming echo as new. When the response to `sendMessage` is processed before the echo arrives, `temp` is already gone, the echo counts as known, and no scroll happens. Nothing corrects it later, because `streamNewMessage` is the only trigger left. `handleComposerResize` looks like a second one, but `RoomBody.tsx` passes `onResize` down and nothing ever calls it.

So it depends on which of the two the client handles first, not on how far apart they arrive. In one run a send scrolled fine with the echo landing 327 ms after the response, in another it failed at 278 ms.

This PR scrolls when your own message shows up in the list, without waiting for anything from the server. Same approach #40956 already uses for the thread panel.

### Verification

The bug is timing dependent, so simply retrying is not comparable between runs. To get a stable test I delayed the `stream-room-messages` echo in the client, which makes the response win on purpose. A rare failure becomes one you can measure.

Local build, 20 sends per cell, list scrolled up before each send. Numbers are sends that never reached the bottom:

| echo delayed by | unpatched | patched |
|---|---|---|
| nothing | 0/20 | 0/20 |
| 1 ms | 19/20 | 0/20 |
| 120 ms | 20/20 | 0/20 |

1 ms is already enough, because it pushes the echo behind the response. 8.6.1 behaves the same as develop.

The patched build scrolls on every send even though `streamNewMessage` still never runs in those cases. It also stops waiting for the network: on develop the list was at the bottom after 182 ms while the server response took 344 ms.

## Issue(s)

Fixes #41746

## Steps to test or reproduce

In a room with enough history:

1. Scroll up a few hundred pixels.
2. Send a message.
3. The list should jump down and show it.

Unpatched this fails now and then, so try it 15 to 20 times. On a real deployment it happens far more often than on localhost.

To see it every time, delay the echo: intercept the DDP WebSocket before the app connects and re-dispatch any frame containing `stream-room-messages` from a `setTimeout` instead of the socket event. 1 ms is enough. I used a Tampermonkey script for that and can share it.

Only the main message list is affected. Threads were already fixed in #40956.

## Further comments

Why scroll on the local message instead of making `streamNewMessage` reliable: keeping `temp` until the echo has been handled ties two independent async paths together and needs extra care around failed sends and retries. Reacting to the local message avoids the race and matches what the thread panel does.

`isAtBottom.current` is set before `scrollToIndex` so the `ResizeObserver` in `useKeepAtBottom` can still correct the position if content grows before Virtua runs the scroll. It is only set when a virtualizer handle exists, otherwise it would claim a scroll that never happened and break the existing `should do nothing if no previous scroll position is stored` test.

`align: 'center'` is left alone, since #41410 is about changing it.

Tests: one for your own optimistic message, one making sure someone else's message does not trigger the jump. Reverting only `MessageList.tsx` makes the first fail and leaves the rest passing. `defaultProps.isAtBottom` is now reset in `beforeEach`, it is a shared ref and leaked state from one test into the next.

### Discovered issues (out of scope)

- `refactor`: `handleComposerResize` is dead code. `RoomBody.tsx` passes `onResize` down but nothing calls it. It looks like a second scroll trigger and cost me time while tracing this.
- `bug`: `isAtBottom` is still not derived reliably. The existing `FIXME` stays valid, and this PR adds one more place that writes the ref directly.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sent messages now immediately scroll the message list to the bottom, without waiting for the server response.
  * Messages sent by other users no longer trigger an unnecessary scroll.
* **Tests**
  * Added coverage for automatic scrolling behavior when sending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->