### PR TITLE
chore: dedupe telemetrymap types in core services

### DIFF
--- a/packages/core-services/src/types/ITelemetryEvent.ts
+++ b/packages/core-services/src/types/ITelemetryEvent.ts
@@ -1,9 +1,6 @@
-type updateCounterDataType = { settingsId: string };
-type slashCommandsDataType = { command: string };
+import type { TelemetryEvents, TelemetryMap } from '@rocket.chat/rest-typings';
 
-// TODO this is duplicated from /packages/rest-typings/src/v1/statistics.ts
-export type TelemetryMap = { slashCommandsStats: slashCommandsDataType; updateCounter: updateCounterDataType };
-export type TelemetryEvents = keyof TelemetryMap;
+export type { TelemetryEvents, TelemetryMap };
 
 export interface ITelemetryEvent {
 	register: (name: TelemetryEvents, fn: () => Promise<any> | void) => void;


### PR DESCRIPTION
fixes #39994

telemetrymap and telemetryevents were duplicated in itelemetryevent.ts. the file already had a todo pointing at rest typings. core services depends on rest typings, so i imported the types from there and re exported them.

no runtime change.