### PR TITLE
chore: simplify getnodeicontype to return iconname

### DIFF
--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerGrid/WebdavFilePickerGrid.tsx
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerGrid/WebdavFilePickerGrid.tsx
@@ -32,7 +32,7 @@ const WebdavFilePickerGrid = ({ webdavNodes, onNodeClick, isLoading }: WebdavFil
 					))}
 			{!isLoading &&
 				webdavNodes.map((webdavNode, index) => {
-					const { icon } = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
+					const icon = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
 
 					return (
 						<WebdavFilePickerGridItem key={index} className={hoverStyle} onClick={(): void => onNodeClick(webdavNode)}>

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerTable.tsx
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/WebdavFilePickerTable.tsx
@@ -64,7 +64,7 @@ const WebdavFilePickerTable = ({ webdavNodes, sortBy, sortDirection, onSort, onN
 								.map((_, index) => <GenericTableLoadingRow key={index} cols={3} />)}
 						{!isLoading &&
 							webdavNodes?.map((webdavNode, index) => {
-								const { icon } = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
+								const icon = getNodeIconType(webdavNode.basename, webdavNode.type, webdavNode.mime);
 
 								return (
 									<GenericTableRow key={index} onClick={(): void => onNodeClick(webdavNode)} tabIndex={index} role='link' action>

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.spec.ts
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.spec.ts
@@ -3,11 +3,13 @@ import { faker } from '@faker-js/faker';
 import { getNodeIconType } from './getNodeIconType';
 
 it('should return clip icon if file does not have mime type', () => {
-	const result = getNodeIconType(faker.system.fileName(), faker.system.fileType(), undefined);
-	expect(result.icon).toBe('clip');
+	expect(getNodeIconType(faker.system.fileName(), faker.system.fileType(), undefined)).toBe('clip');
 });
 
 it('should return folder icon if file type is directory', () => {
-	const result = getNodeIconType(faker.system.fileName(), 'directory', undefined);
-	expect(result.icon).toBe('folder');
+	expect(getNodeIconType(faker.system.fileName(), 'directory', undefined)).toBe('folder');
+});
+
+it('should return file-pdf icon for PDF mime type', () => {
+	expect(getNodeIconType('report.pdf', 'file', 'application/pdf')).toBe('file-pdf');
 });

--- a/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
+++ b/apps/meteor/client/views/room/webdav/WebdavFilePickerModal/lib/getNodeIconType.ts
@@ -1,29 +1,19 @@
 import type { Keys as IconName } from '@rocket.chat/icons';
 
-// TODO: This function should be simplified, it only needs to return the icon name
-export const getNodeIconType = (
-	basename: string,
-	fileType: string,
-	mime?: string,
-): { icon: IconName; type: string; extension?: string } => {
-	let icon: IconName = 'clip';
-	let type = '';
-
-	let extension = basename?.split('.').pop();
-	if (extension === basename) {
-		extension = '';
+export const getNodeIconType = (basename: string, fileType: string, mime?: string): IconName => {
+	if (fileType === 'directory') {
+		return 'folder';
 	}
 
-	if (fileType === 'directory') {
-		icon = 'folder';
-		type = 'directory';
-	} else if (mime?.match(/application\/pdf/)) {
-		icon = 'file-pdf';
-		type = 'pdf';
-	} else if (mime && ['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-document';
-		type = 'document';
-	} else if (
+	if (mime?.match(/application\/pdf/)) {
+		return 'file-pdf';
+	}
+
+	if (mime && ['application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+		return 'file-document';
+	}
+
+	if (
 		mime &&
 		[
 			'application/vnd.ms-excel',
@@ -31,11 +21,12 @@ export const getNodeIconType = (
 			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 		].includes(mime)
 	) {
-		icon = 'file-sheets';
-		type = 'sheets';
-	} else if (mime && ['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
-		icon = 'file-sheets';
-		type = 'ppt';
+		return 'file-sheets';
 	}
-	return { icon, type, extension };
+
+	if (mime && ['application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.presentation'].includes(mime)) {
+		return 'file-sheets';
+	}
+
+	return 'clip';
 };


### PR DESCRIPTION
fixes #40240

getnodeicontype returned icon, type, and extension but only icon was used in webdavfilepickertable and webdavfilepickergrid. simplified the helper to return iconname directly and dropped the unused fields.

added a pdf mime case to the existing unit tests.