### PR TITLE
fix: coerce string timespan in converttimeunit

### DIFF
--- a/apps/meteor/client/lib/convertTimeUnit.spec.ts
+++ b/apps/meteor/client/lib/convertTimeUnit.spec.ts
@@ -30,6 +30,10 @@ describe('timeUnitToMs function', () => {
 		expect(() => timeUnitToMs(TIMEUNIT.days, -Infinity)).toThrow(errorMessage);
 		expect(() => timeUnitToMs(TIMEUNIT.days, -1)).toThrow(errorMessage);
 	});
+
+	it('should coerce string timespan values', () => {
+		expect(timeUnitToMs(TIMEUNIT.days, '1')).toBe(86400000);
+	});
 });
 
 describe('msToTimeUnit function', () => {
@@ -61,5 +65,9 @@ describe('msToTimeUnit function', () => {
 		expect(() => msToTimeUnit(TIMEUNIT.days, Infinity)).toThrow(errorMessage);
 		expect(() => msToTimeUnit(TIMEUNIT.days, -Infinity)).toThrow(errorMessage);
 		expect(() => msToTimeUnit(TIMEUNIT.days, -1)).toThrow(errorMessage);
+	});
+
+	it('should coerce string millisecond values from settings', () => {
+		expect(msToTimeUnit(TIMEUNIT.days, '63072000000.0')).toBe(730);
 	});
 });

--- a/apps/meteor/client/lib/convertTimeUnit.ts
+++ b/apps/meteor/client/lib/convertTimeUnit.ts
@@ -4,54 +4,62 @@ export enum TIMEUNIT {
 	minutes = 'minutes',
 }
 
-export const isValidTimespan = (timespan: number): boolean => {
-	if (Number.isNaN(timespan)) {
+export const normalizeTimespan = (timespan: number | string): number => Number(timespan);
+
+export const isValidTimespan = (timespan: number | string): boolean => {
+	const value = normalizeTimespan(timespan);
+
+	if (Number.isNaN(value)) {
 		return false;
 	}
 
-	if (!Number.isFinite(timespan)) {
+	if (!Number.isFinite(value)) {
 		return false;
 	}
 
-	if (timespan < 0) {
+	if (value < 0) {
 		return false;
 	}
 
 	return true;
 };
 
-export const timeUnitToMs = (unit: TIMEUNIT, timespan: number) => {
-	if (!isValidTimespan(timespan)) {
+export const timeUnitToMs = (unit: TIMEUNIT, timespan: number | string) => {
+	const value = normalizeTimespan(timespan);
+
+	if (!isValidTimespan(value)) {
 		throw new Error(`timeUnitToMs - invalid timespan:${timespan}`);
 	}
 
 	switch (unit) {
 		case TIMEUNIT.days:
-			return timespan * 24 * 60 * 60 * 1000;
+			return value * 24 * 60 * 60 * 1000;
 
 		case TIMEUNIT.hours:
-			return timespan * 60 * 60 * 1000;
+			return value * 60 * 60 * 1000;
 
 		case TIMEUNIT.minutes:
-			return timespan * 60 * 1000;
+			return value * 60 * 1000;
 
 		default:
 			throw new Error('timeUnitToMs - invalid time unit');
 	}
 };
 
-export const msToTimeUnit = (unit: TIMEUNIT, timespan: number) => {
-	if (!isValidTimespan(timespan)) {
+export const msToTimeUnit = (unit: TIMEUNIT, timespan: number | string) => {
+	const value = normalizeTimespan(timespan);
+
+	if (!isValidTimespan(value)) {
 		throw new Error(`msToTimeUnit - invalid timespan:${timespan}`);
 	}
 
 	switch (unit) {
 		case TIMEUNIT.days:
-			return timespan / 24 / 60 / 60 / 1000;
+			return value / 24 / 60 / 60 / 1000;
 		case TIMEUNIT.hours:
-			return timespan / 60 / 60 / 1000;
+			return value / 60 / 60 / 1000;
 		case TIMEUNIT.minutes:
-			return timespan / 60 / 1000;
+			return value / 60 / 1000;
 		default:
 			throw new Error('msToTimeUnit - invalid time unit');
 	}


### PR DESCRIPTION
fixes #41761

editroominfo calls mstotimeunit with the retention ttl from usesetting. on some installs that value comes back as a string like 63072000000.0, which made isfinitetimespan fail and the channel settings form crash.

normalize timespan with number() before validation in converttimeunit. added a unit test for the reported string value.