### PR TITLE
fix(apps): action button role filter never matching room scoped roles

### DIFF
--- a/.changeset/apps-action-button-room-scoped-roles.md
+++ b/.changeset/apps-action-button-room-scoped-roles.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed app action buttons never matching a role scoped to `Subscriptions` — `owner`, `moderator`, `leader`, or a custom one. The room was not being passed as the scope of the role check, so a button filtered by one of those roles stayed hidden even for a user who held it in the room.

--- a/apps/meteor/client/hooks/useApplyButtonFilters.spec.ts
+++ b/apps/meteor/client/hooks/useApplyButtonFilters.spec.ts
@@ -1,9 +1,24 @@
 import type { IUIActionButton } from '@rocket.chat/apps-engine/definition/ui';
 import { UIActionButtonContext } from '@rocket.chat/apps-engine/definition/ui';
+import type { IRoom } from '@rocket.chat/core-typings';
 import { mockAppRoot } from '@rocket.chat/mock-providers';
 import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 
-import { useApplyButtonAuthFilter } from './useApplyButtonFilters';
+import { useApplyButtonAuthFilter, useApplyButtonFilters } from './useApplyButtonFilters';
+import FakeRoomProvider from '../../tests/mocks/client/FakeRoomProvider';
+import { createFakeRoom } from '../../tests/mocks/data';
+
+const buttonRequiringRole = (role: string): IUIActionButton => ({
+	appId: 'test-app',
+	actionId: 'test-action',
+	labelI18n: 'test_label',
+	context: UIActionButtonContext.ROOM_ACTION,
+	when: {
+		hasOneRole: [role],
+	},
+});
 
 describe('useApplyButtonAuthFilter', () => {
 	describe('Role-based filtering', () => {
@@ -208,5 +223,65 @@ describe('useApplyButtonAuthFilter', () => {
 			});
 			expect(result3.current(button)).toBe(true);
 		});
+	});
+
+	describe('Room-scoped roles', () => {
+		// `owner`, `moderator` and `leader` are scoped to `Subscriptions`: the user holds them
+		// in one room, so the check only passes when it is given that room.
+		const room = createFakeRoom({ _id: 'room-with-role' });
+
+		it('should show button when the user holds the role in the given room', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleScoped('owner', room._id).build(),
+			});
+
+			expect(result.current(buttonRequiringRole('owner'), room)).toBe(true);
+		});
+
+		it('should filter button when no room is given', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleScoped('owner', room._id).build(),
+			});
+
+			expect(result.current(buttonRequiringRole('owner'))).toBe(false);
+		});
+
+		it('should filter button when the user holds the role in another room', () => {
+			const { result } = renderHook(() => useApplyButtonAuthFilter(), {
+				wrapper: mockAppRoot().withJohnDoe().withRoleScoped('owner', 'another-room').build(),
+			});
+
+			expect(result.current(buttonRequiringRole('owner'), room)).toBe(false);
+		});
+	});
+});
+
+describe('useApplyButtonFilters', () => {
+	const rid: IRoom['_id'] = 'room-with-role';
+
+	const withRoomContext = (children: ReactNode) => createElement(FakeRoomProvider, { roomOverrides: { _id: rid, t: 'c' } }, children);
+
+	it('should scope the role filter to the room in context', () => {
+		const { result } = renderHook(() => useApplyButtonFilters(), {
+			wrapper: mockAppRoot().withJohnDoe().withRoleScoped('owner', rid).wrap(withRoomContext).build(),
+		});
+
+		expect(result.current(buttonRequiringRole('owner'))).toBe(true);
+	});
+
+	it('should filter button when the user holds the role in another room', () => {
+		const { result } = renderHook(() => useApplyButtonFilters(), {
+			wrapper: mockAppRoot().withJohnDoe().withRoleScoped('owner', 'another-room').wrap(withRoomContext).build(),
+		});
+
+		expect(result.current(buttonRequiringRole('owner'))).toBe(false);
+	});
+
+	it('should still match a workspace-wide role in a room', () => {
+		const { result } = renderHook(() => useApplyButtonFilters(), {
+			wrapper: mockAppRoot().withJohnDoe().withRole('admin').wrap(withRoomContext).build(),
+		});
+
+		expect(result.current(buttonRequiringRole('admin'))).toBe(true);
 	});
 });

--- a/apps/meteor/client/hooks/useApplyButtonFilters.ts
+++ b/apps/meteor/client/hooks/useApplyButtonFilters.ts
@@ -49,13 +49,22 @@ export const useApplyButtonFilters = (category = 'default'): ((button: IUIAction
 	}
 	const applyAuthFilter = useApplyButtonAuthFilter();
 	return useCallback(
-		(button: IUIActionButton) =>
-			applyAuthFilter(button) && (!room || applyRoomFilter(button, room)) && applyCategoryFilter(button, category),
+		// The room is the scope of the role check: without it a role scoped to
+		// `Subscriptions` — `owner`, `moderator`, `leader`, or a custom one — can never match.
+		(button: IUIActionButton) => applyAuthFilter(button, room) && applyRoomFilter(button, room) && applyCategoryFilter(button, category),
 		[applyAuthFilter, category, room],
 	);
 };
 
-export const useApplyButtonAuthFilter = (): ((button: IUIActionButton) => boolean) => {
+/**
+ * Applies the `when` role and permission filters of an action button.
+ *
+ * `room` scopes the checks. A role scoped to `Subscriptions` is granted per room, so a
+ * check for one only passes when it carries the room the button is rendered in; pass the
+ * room on every room-bound surface. Surfaces with no room of their own — the user
+ * dropdown, for instance — can only match roles scoped to `Users`.
+ */
+export const useApplyButtonAuthFilter = (): ((button: IUIActionButton, room?: IRoom) => boolean) => {
 	const uid = useUserId();
 
 	const { queryAllPermissions, queryAtLeastOnePermission, queryRole } = useContext(AuthorizationContext);

--- a/packages/mock-providers/src/MockedAppRootBuilder.tsx
+++ b/packages/mock-providers/src/MockedAppRootBuilder.tsx
@@ -532,6 +532,32 @@ export class MockedAppRootBuilder {
 		return this;
 	}
 
+	/**
+	 * Grants a role scoped to `Subscriptions` — `owner`, `moderator`, `leader`, or a custom
+	 * one — in a single room. Unlike {@link withRole}, the grant is not workspace-wide: a
+	 * check only passes when it carries that room as its scope, which is how the real
+	 * provider resolves a subscription role. The role is deliberately kept out of the user's
+	 * `roles`, where only a `Users`-scoped grant belongs.
+	 */
+	withRoleScoped(role: string, scope: IRoom['_id']): this {
+		const innerFn = this.authorization.queryRole;
+
+		const outerFn = (
+			innerRole: string | ObjectId,
+			innerScope?: string | undefined,
+		): [subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => boolean] => {
+			if (innerRole === role && innerScope === scope) {
+				return [() => () => undefined, () => true];
+			}
+
+			return innerFn(innerRole, innerScope);
+		};
+
+		this.authorization.queryRole = outerFn;
+
+		return this;
+	}
+
 	withSetting(id: string, value: SettingValue, settingStructure?: Partial<ISetting>): this {
 		const setting = {
 			...settingStructure,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

An app action button filtered by `when.hasOneRole` / `when.hasAllRoles` never matched a role scoped to `Subscriptions` — the built-in `owner`, `moderator` and `leader`, or any custom role created with that scope.

`useApplyButtonFilters` resolves the room it is rendered in, but called the auth filter without it:

```ts
applyAuthFilter(button) && (!room || applyRoomFilter(button, room)) && ...
```

`useApplyButtonAuthFilter`'s inner callback did accept a `room`, but the hook's declared return type was `(button: IUIActionButton) => boolean`, so the parameter was invisible to callers and the compiler never flagged the omission. With no scope reaching it, `hasRole` takes the early return for a subscription-scoped role (`createAuthorizationFunctions.ts:41-44`):

```ts
case 'Subscriptions':
    if (!scope) return false;
```

So the button stayed hidden even for a user who did hold the role in that room.

This forwards the room as the scope and puts it on the auth filter's public type, so a caller can no longer drop it silently. A role scoped to `Users` ignores the scope argument, so workspace-wide filters (`admin`, `user`, custom `Users` roles) behave exactly as before — the change only makes the previously unreachable per-room grants reachable. The four room-bound surfaces (room toolbox, room header AI actions, message actions, message box) all go through `useApplyButtonFilters` and are fixed by this; the user dropdown has no room of its own and correctly keeps passing none.

`withRoleScoped(role, scope)` is added to `MockedAppRootBuilder` because `withRole` grants workspace-wide (it pushes into the user's `roles` and matches any scope) and cannot express a per-room grant.

## Issue(s)

Found while reviewing #41765, which touches the same filter but does not fix this.

## Steps to test or reproduce

1. Install an app whose action button declares `when: { hasOneRole: ['owner'] }` in a room context (`roomAction`, `messageAction`, or `messageBoxAction`).
2. Open a room you own.
3. Before: the button never appears, for anyone. After: it appears for the room owner and stays hidden for other members.

Also covered by unit tests: the auth filter with the room, without it, and with the role held in a *different* room, plus `useApplyButtonFilters` inside a room context. The room-context test fails on `develop` and passes with this change.

## Further comments

The permission half of the same filter has the same gap — `queryAllPermissions(hasAllPermissions)` and `queryAtLeastOnePermission(hasOnePermission)` are also called with no scope, so a button gated on a permission that is granted through `owner`/`moderator` (`delete-message`, say) stays hidden for a room owner too. Threading the room there is now a one-token change, but it widens what `hasAllPermissions` means for app authors from "workspace-wide" to "here", so it is left out of this fix deliberately. Happy to add it if that is the semantics we want.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed action buttons so room-scoped roles are correctly recognized within their assigned rooms.
  - Ensured buttons for owners, moderators, leaders, and custom room roles appear only when the relevant room context matches.
  - Preserved support for workspace-wide roles and roomless surfaces.

- **Tests**
  - Added coverage for matching and non-matching room-scoped roles and room-aware button filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->