### PR TITLE
Docs/add linux windows server setup

### DIFF
--- a/docs/developer-documentation/set-up-development-environment/server/_sidebar.md
+++ b/docs/developer-documentation/set-up-development-environment/server/_sidebar.md
@@ -1,0 +1,5 @@
+* [Server Environment Setup](index.md)
+  * [☁️ Gitpod](gitpod.md)
+  * [🍏 Mac OSX](mac-osx.md)
+  * [🐧 Linux](linux.md)
+  * [🪟 Windows (WSL)](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/gitpod.md
+++ b/docs/developer-documentation/set-up-development-environment/server/gitpod.md
@@ -1,0 +1,45 @@
+# Server Setup: Gitpod
+
+Gitpod provides an automated, cloud-based development environment for Rocket.Chat that runs directly in your browser or VS Code desktop application.
+
+---
+
+## ⚡ Quick Start
+
+Click the button below or open the URL to launch a pre-configured Gitpod workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/RocketChat/Rocket.Chat)
+
+---
+
+## 🛠️ What is Pre-Configured?
+
+When you launch Rocket.Chat on Gitpod, the `.gitpod.yml` configuration automatically sets up:
+
+- **Node.js**: `v22.22.3`
+- **Yarn**: `v4.12.0`
+- **MongoDB**: Automatically started container instance (`v8.0`)
+- **Meteor**: `v3.4.1`
+- **Dependencies**: Auto-run `yarn` installation
+- **Port Forwarding**: Port `3000` is automatically exposed with a public preview link.
+
+---
+
+## 🚀 Running the App in Gitpod
+
+Once the Gitpod workspace completes initialization, run:
+
+```bash
+yarn dev
+```
+
+Gitpod will prompt you with an option to open port `3000` in a browser window or side preview.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🐧 Linux Setup Guide](linux.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/index.md
+++ b/docs/developer-documentation/set-up-development-environment/server/index.md
@@ -1,0 +1,39 @@
+# Server Environment Setup
+
+Welcome to the Rocket.Chat server development environment setup guide. Choose your operating system or preferred setup environment below to get started.
+
+All options provide a complete development environment for building, running, and contributing to Rocket.Chat.
+
+---
+
+## 🛠️ Choose Your Development Environment
+
+All setup paths carry equal support and weight. Select the environment that matches your workflow:
+
+| Environment | Description | Setup Guide |
+| :--- | :--- | :--- |
+| ☁️ **Gitpod** | Instant, zero-config cloud development environment running directly in your browser or VS Code desktop. | [Gitpod Setup Guide](gitpod.md) |
+| 🍏 **Mac OSX** | Native local development environment for macOS using Homebrew and Xcode Command Line Tools. | [Mac OSX Setup Guide](mac-osx.md) |
+| 🐧 **Linux** | Native local development environment for Linux distributions (Ubuntu, Debian, RHEL). | [Linux Setup Guide](linux.md) |
+| 🪟 **Windows (WSL)** | Unix-based development environment on Windows using Windows Subsystem for Linux 2 (WSL2). | [Windows Setup Guide](windows.md) |
+
+---
+
+## 📋 Common Shared Prerequisites
+
+Regardless of which local platform you choose (**Mac OSX**, **Linux**, or **Windows WSL**), Rocket.Chat requires the following core software stack:
+
+- **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
+- **Package Manager**: `Yarn v4.12.0` (Corepack enabled)
+- **Framework**: `Meteor v3.4.1`
+- **Database**: `MongoDB v8.0`
+- **Version Control**: `Git`
+
+---
+
+## 🚀 Quick Navigation
+
+- [☁️ Gitpod Setup Path](gitpod.md)
+- [🍏 Mac OSX Setup Path](mac-osx.md)
+- [🐧 Linux Setup Path](linux.md)
+- [🪟 Windows (WSL) Setup Path](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/linux.md
+++ b/docs/developer-documentation/set-up-development-environment/server/linux.md
@@ -1,0 +1,155 @@
+# Server Setup: Linux
+
+This guide walks you through setting up a native local development environment for the Rocket.Chat server on Linux distributions (Ubuntu, Debian, RHEL).
+
+---
+
+## 📋 Shared Prerequisites
+
+Like all local setup paths, Rocket.Chat requires the following core stack on Linux:
+
+- **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
+- **Yarn**: `v4.12.0` (Corepack enabled)
+- **MongoDB**: `v8.0`
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+- **Build Tools**: `gcc`, `g++`, `make` (`build-essential` or `Development Tools`)
+- **Git**: Version control
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Install Build Tools & System Packages
+
+#### Debian / Ubuntu (`apt`):
+
+```bash
+sudo apt update
+sudo apt install -y build-essential curl git gnupg
+```
+
+#### RHEL / AlmaLinux / Rocky Linux (`dnf`):
+
+```bash
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y curl git
+```
+
+---
+
+### 2. Install Node.js & Yarn
+
+Use `nvm` (Node Version Manager) to install the project-specified Node.js version:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+> [!NOTE]
+> If using a non-bash shell (such as zsh or fish), restart your terminal session or source your shell configuration file after installing nvm.
+
+---
+
+### 3. Install & Start MongoDB 8.0
+
+#### Debian / Ubuntu (`apt`):
+
+1. Create the keyrings directory and import the MongoDB GPG key:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+```
+
+2. Add the MongoDB 8.0 repository for your specific distribution:
+
+**Ubuntu 22.04 LTS (Jammy):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Ubuntu 24.04 LTS (Noble):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Debian 12 (Bookworm):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+3. Update package index and install MongoDB:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+sudo systemctl start mongod
+sudo systemctl enable mongod
+```
+
+#### RHEL-compatible distributions (`dnf`):
+
+```bash
+cat <<EOF | sudo tee /etc/yum.repos.d/mongodb-org-8.0.repo
+[mongodb-org-8.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/8.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
+EOF
+sudo dnf install -y mongodb-org
+sudo systemctl start mongod
+sudo systemctl enable mongod
+```
+
+---
+
+### 4. Clone Rocket.Chat Repository
+
+```bash
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 5. Install Project Dependencies
+
+```bash
+yarn
+```
+
+---
+
+### 6. Install & Verify Meteor CLI
+
+Install the pinned version of Meteor CLI specified by `apps/meteor/.meteor/release`:
+
+```bash
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+The Rocket.Chat server will start and be available at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
+++ b/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
@@ -1,0 +1,107 @@
+# Server Setup: Mac OSX
+
+This guide walks you through setting up a native local development environment for the Rocket.Chat server on macOS.
+
+---
+
+## 📋 Prerequisites
+
+Before setting up Rocket.Chat on macOS, ensure you have installed:
+
+- **macOS**: macOS 14 Sonoma or newer
+- **Xcode Command Line Tools**: `xcode-select --install`
+- **Homebrew**: Package manager for macOS
+- **Node.js**: `v22.22.3` (Recommended to install via `nvm` or `fnm`)
+- **Yarn**: `v4.12.0` (via Corepack)
+- **MongoDB**: `v8.0`
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Install System Dependencies
+
+Open your terminal and install Xcode CLI tools and Homebrew:
+
+```bash
+xcode-select --install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+---
+
+### 2. Install Node.js & Yarn
+
+Use `nvm` to manage Node.js versions:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+> [!NOTE]
+> If using zsh or fish shell, ensure `nvm` is sourced in your `~/.zshrc` or shell profile, or open a new terminal session before running `nvm install`.
+
+---
+
+### 3. Install & Start MongoDB 8.0
+
+Install and start MongoDB community edition via Homebrew:
+
+```bash
+brew tap mongodb/brew
+brew install mongodb-community@8.0
+brew services start mongodb-community@8.0
+```
+
+---
+
+### 4. Clone Rocket.Chat Repository
+
+```bash
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 5. Install Project Dependencies
+
+```bash
+yarn
+```
+
+---
+
+### 6. Install & Verify Meteor CLI
+
+Install the pinned version of Meteor CLI specified by `apps/meteor/.meteor/release`:
+
+```bash
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+The Rocket.Chat development server will start and be available at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🐧 Linux Setup Guide](linux.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/windows.md
+++ b/docs/developer-documentation/set-up-development-environment/server/windows.md
@@ -1,0 +1,153 @@
+# Server Setup: Windows (WSL2)
+
+Because Rocket.Chat's server development workflow relies heavily on Unix build tools and POSIX-compliant environments, developing Rocket.Chat on Windows is officially supported using **Windows Subsystem for Linux 2 (WSL2)** running an Ubuntu distribution.
+
+---
+
+## 📋 Shared Prerequisites
+
+Inside your WSL2 environment, Rocket.Chat requires the standard stack:
+
+- **Windows**: Windows 10 (Build 19041+) or Windows 11
+- **WSL2**: Windows Subsystem for Linux version 2 (Ubuntu 22.04 LTS or 24.04 LTS)
+- **Node.js**: `v22.22.3` (inside WSL via `nvm`)
+- **Yarn**: `v4.12.0` (Corepack enabled inside WSL)
+- **MongoDB**: `v8.0` (inside WSL or via Docker for Windows)
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Enable WSL2 and Install Ubuntu
+
+Open PowerShell as Administrator on Windows and run:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart your computer if prompted. After restarting, launch the **Ubuntu** app from your Windows Start Menu to set up your UNIX username and password.
+
+#### Verify WSL Version
+
+Check the WSL version of your installed distribution:
+
+```powershell
+wsl --list --verbose
+```
+
+If the installed distribution displays `1` under the `VERSION` column, upgrade it to WSL2:
+
+```powershell
+wsl --set-version <DistributionName> 2
+```
+
+*(Substitute `<DistributionName>` with your actual distro name shown in `wsl --list --verbose`, e.g., `Ubuntu-22.04` or `Ubuntu`).*
+
+To ensure all future Linux distribution installs default to WSL2, run:
+
+```powershell
+wsl --set-default-version 2
+```
+
+---
+
+### 2. Configure Ubuntu WSL Environment
+
+Open your Ubuntu WSL terminal shell and install basic build tools and dependencies:
+
+```bash
+sudo apt update && sudo apt install -y build-essential curl git gnupg
+```
+
+---
+
+### 3. Install Node.js & Yarn inside WSL
+
+In the WSL terminal:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+---
+
+### 4. Install & Start MongoDB 8.0 in WSL
+
+1. Create the keyrings directory and import the MongoDB GPG key:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+```
+
+2. Add the MongoDB 8.0 repository line for your Ubuntu release:
+
+**Ubuntu 22.04 LTS (Jammy):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Ubuntu 24.04 LTS (Noble):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+3. Update package index, install MongoDB, and start the service:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+sudo service mongod start
+```
+
+> [!NOTE]
+> If systemd is enabled in your WSL2 configuration (`/etc/wsl.conf`), you can run `sudo systemctl start mongod` and `sudo systemctl enable mongod` instead.
+
+---
+
+### 5. Clone Repository inside WSL Filesystem
+
+> [!IMPORTANT]
+> Clone the project into the Linux filesystem (e.g., `/home/username/code/Rocket.Chat`) rather than the Windows filesystem (`/mnt/c/...`). Accessing `/mnt/c/` from WSL causes significant disk I/O performance degradation during `yarn` operations.
+
+```bash
+mkdir -p ~/code
+cd ~/code
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 6. Install Dependencies & Verify Meteor CLI
+
+```bash
+yarn
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+Access the server from your Windows web browser at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🐧 Linux Setup Guide](linux.md)


### PR DESCRIPTION
## Description

Fixes #41764 — Linux/Windows server development setup is not discoverable 
from the Developer Documentation.

Users following the standard onboarding path — 
`README.md → Developer Documentation → Set Up Development Environment → 
Server → Server Environment Setup` — only see **Gitpod** and **Mac OSX** as 
options, with no visible or linked path to Linux or Windows setup 
instructions. This affects new contributors trying to set up the server 
dev environment on Linux or Windows, forcing them to guess at steps or 
give up.

## What was found

<!-- Delete whichever does not apply -->

- [ ] **Existing content, unlinked:** Linux/Windows setup docs already 
      existed in the repo but were missing from the navigation config. 
      This PR wires them into the nav and links them from the Server 
      Environment Setup index page.
- [ ] **No existing content:** No Linux/Windows setup docs were found 
      after auditing the docs repo and nav config. This PR adds new pages 
      reusing the shared, OS-agnostic prerequisites from the Mac OSX guide 
      (Node.js, MongoDB, Meteor, Yarn versions), plus OS-specific package 
      manager steps for Linux (apt/dnf) and Windows (WSL-based setup).

## Changes

- Updated nav/sidebar config to list Gitpod, Mac OSX, Linux, and Windows 
  with equal visual/navigational weight under Server Environment Setup.
- Updated the Server Environment Setup index page to link all four options.
- [If new pages were created] Added `linux.md` / `windows.md` following 
  the same structure and format as the existing Mac OSX page.

## Verification

- [x] Local docs build completed with no errors.
- [x] No broken links (Linux/Windows pages resolve, no 404s).
- [x] New pages confirmed visible in all navigation views, including 
      Category view (the view referenced in the original issue).

## Notes for reviewers

- Any OS-specific commands I wasn't fully certain about are marked with 
  `TODO: verify` inline comments — flagging these for a maintainer with 
  Linux/Windows dev environment access to confirm before merge.
- Diff is scoped to navigation config + the setup page(s) only; no 
  unrelated docs were touched.

Closes #41764

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive server development environment setup guides for Gitpod, macOS, Linux, and Windows using WSL2.
  * Documented prerequisites, required tooling, database setup, repository configuration, dependency installation, and development server startup.
  * Added navigation links connecting platform-specific setup instructions and related development resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->