### PR TITLE
docs: add Linux and Windows options to Server Environment Setup

### DIFF
--- a/docs/developer-documentation/set-up-development-environment/server/_sidebar.md
+++ b/docs/developer-documentation/set-up-development-environment/server/_sidebar.md
@@ -1,0 +1,5 @@
+* [Server Environment Setup](index.md)
+  * [☁️ Gitpod](gitpod.md)
+  * [🍏 Mac OSX](mac-osx.md)
+  * [🐧 Linux](linux.md)
+  * [🪟 Windows (WSL)](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/gitpod.md
+++ b/docs/developer-documentation/set-up-development-environment/server/gitpod.md
@@ -1,0 +1,45 @@
+# Server Setup: Gitpod
+
+Gitpod provides an automated, cloud-based development environment for Rocket.Chat that runs directly in your browser or VS Code desktop application.
+
+---
+
+## ⚡ Quick Start
+
+Click the button below or open the URL to launch a pre-configured Gitpod workspace:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/RocketChat/Rocket.Chat)
+
+---
+
+## 🛠️ What is Pre-Configured?
+
+When you launch Rocket.Chat on Gitpod, the `.gitpod.yml` configuration automatically sets up:
+
+- **Node.js**: `v22.22.3`
+- **Yarn**: `v4.12.0`
+- **MongoDB**: Automatically started container instance (`v8.0`)
+- **Meteor**: `v3.4.1`
+- **Dependencies**: Auto-run `yarn` installation
+- **Port Forwarding**: Port `3000` is automatically exposed with a public preview link.
+
+---
+
+## 🚀 Running the App in Gitpod
+
+Once the Gitpod workspace completes initialization, run:
+
+```bash
+yarn dev
+```
+
+Gitpod will prompt you with an option to open port `3000` in a browser window or side preview.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🐧 Linux Setup Guide](linux.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/gitpod.md
+++ b/docs/developer-documentation/set-up-development-environment/server/gitpod.md
@@ -14,26 +14,28 @@ Click the button below or open the URL to launch a pre-configured Gitpod workspa
 
 ## 🛠️ What is Pre-Configured?
 
-When you launch Rocket.Chat on Gitpod, the `.gitpod.yml` configuration automatically sets up:
+When you launch Rocket.Chat on Gitpod, the `.gitpod/.gitpod.yml` configuration automatically sets up:
 
 - **Node.js**: `v22.22.3`
-- **Yarn**: `v4.12.0`
-- **MongoDB**: Automatically started container instance (`v8.0`)
-- **Meteor**: `v3.4.1`
-- **Dependencies**: Auto-run `yarn` installation
-- **Port Forwarding**: Port `3000` is automatically exposed with a public preview link.
+- **Yarn**: `v4.18.0`
+- **Meteor**: `v3.4.1` (with embedded development database)
+- **Dependencies**: Auto-run `yarn` installation during initialization
+- **Automatic Server Startup**: Automatically executes `yarn dsv` upon workspace start
+- **Port Forwarding**: Port `3000` is automatically exposed and opened in a side preview pane (`open-preview`)
 
 ---
 
 ## 🚀 Running the App in Gitpod
 
-Once the Gitpod workspace completes initialization, run:
+Once the Gitpod workspace completes initialization, the development server will launch automatically via `yarn dsv` and open a preview window on port `3000`.
+
+If you ever need to manually restart the development server, run:
 
 ```bash
-yarn dev
+yarn dsv
 ```
 
-Gitpod will prompt you with an option to open port `3000` in a browser window or side preview.
+*(You can also run `yarn dev` if you prefer the standard dev task).*
 
 ---
 

--- a/docs/developer-documentation/set-up-development-environment/server/index.md
+++ b/docs/developer-documentation/set-up-development-environment/server/index.md
@@ -1,0 +1,39 @@
+# Server Environment Setup
+
+Welcome to the Rocket.Chat server development environment setup guide. Choose your operating system or preferred setup environment below to get started.
+
+All options provide a complete development environment for building, running, and contributing to Rocket.Chat.
+
+---
+
+## 🛠️ Choose Your Development Environment
+
+All setup paths carry equal support and weight. Select the environment that matches your workflow:
+
+| Environment | Description | Setup Guide |
+| :--- | :--- | :--- |
+| ☁️ **Gitpod** | Instant, zero-config cloud development environment running directly in your browser or VS Code desktop. | [Gitpod Setup Guide](gitpod.md) |
+| 🍏 **Mac OSX** | Native local development environment for macOS using Homebrew and Xcode Command Line Tools. | [Mac OSX Setup Guide](mac-osx.md) |
+| 🐧 **Linux** | Native local development environment for Linux distributions (Ubuntu, Debian, RHEL). | [Linux Setup Guide](linux.md) |
+| 🪟 **Windows (WSL)** | Unix-based development environment on Windows using Windows Subsystem for Linux 2 (WSL2). | [Windows Setup Guide](windows.md) |
+
+---
+
+## 📋 Common Shared Prerequisites
+
+Regardless of which local platform you choose (**Mac OSX**, **Linux**, or **Windows WSL**), Rocket.Chat requires the following core software stack:
+
+- **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
+- **Package Manager**: `Yarn v4.12.0` (Corepack enabled)
+- **Framework**: `Meteor v3.4.1`
+- **Database**: `MongoDB v8.0`
+- **Version Control**: `Git`
+
+---
+
+## 🚀 Quick Navigation
+
+- [☁️ Gitpod Setup Path](gitpod.md)
+- [🍏 Mac OSX Setup Path](mac-osx.md)
+- [🐧 Linux Setup Path](linux.md)
+- [🪟 Windows (WSL) Setup Path](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/index.md
+++ b/docs/developer-documentation/set-up-development-environment/server/index.md
@@ -24,7 +24,7 @@ All setup paths carry equal support and weight. Select the environment that matc
 Regardless of which local platform you choose (**Mac OSX**, **Linux**, or **Windows WSL**), Rocket.Chat requires the following core software stack:
 
 - **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
-- **Package Manager**: `Yarn v4.12.0` (Corepack enabled)
+- **Package Manager**: `Yarn v4.18.0` (Corepack enabled)
 - **Framework**: `Meteor v3.4.1`
 - **Database**: `MongoDB v8.0`
 - **Version Control**: `Git`

--- a/docs/developer-documentation/set-up-development-environment/server/linux.md
+++ b/docs/developer-documentation/set-up-development-environment/server/linux.md
@@ -9,7 +9,7 @@ This guide walks you through setting up a native local development environment f
 Like all local setup paths, Rocket.Chat requires the following core stack on Linux:
 
 - **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
-- **Yarn**: `v4.12.0` (Corepack enabled)
+- **Yarn**: `v4.18.0` (Corepack enabled)
 - **MongoDB**: `v8.0`
 - **Meteor**: `v3.4.1` (Rocket.Chat build framework)
 - **Build Tools**: `gcc`, `g++`, `make` (`build-essential` or `Development Tools`)
@@ -50,7 +50,7 @@ corepack enable
 ```
 
 > [!NOTE]
-> If using a non-bash shell (such as zsh or fish), restart your terminal session or source your shell configuration file after installing nvm.
+> `nvm` requires a POSIX-compliant shell (such as `bash` or `zsh`). If you use **Fish shell**, `nvm` is not supported; use [`fnm`](https://github.com/Schniz/fnm) (Fast Node Manager) instead (`fnm install 22.22.3 && fnm use 22.22.3`).
 
 ---
 

--- a/docs/developer-documentation/set-up-development-environment/server/linux.md
+++ b/docs/developer-documentation/set-up-development-environment/server/linux.md
@@ -1,0 +1,155 @@
+# Server Setup: Linux
+
+This guide walks you through setting up a native local development environment for the Rocket.Chat server on Linux distributions (Ubuntu, Debian, RHEL).
+
+---
+
+## 📋 Shared Prerequisites
+
+Like all local setup paths, Rocket.Chat requires the following core stack on Linux:
+
+- **Node.js**: `v22.22.3` (Managed via `nvm` or `fnm`)
+- **Yarn**: `v4.12.0` (Corepack enabled)
+- **MongoDB**: `v8.0`
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+- **Build Tools**: `gcc`, `g++`, `make` (`build-essential` or `Development Tools`)
+- **Git**: Version control
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Install Build Tools & System Packages
+
+#### Debian / Ubuntu (`apt`):
+
+```bash
+sudo apt update
+sudo apt install -y build-essential curl git gnupg
+```
+
+#### RHEL / AlmaLinux / Rocky Linux (`dnf`):
+
+```bash
+sudo dnf groupinstall -y "Development Tools"
+sudo dnf install -y curl git
+```
+
+---
+
+### 2. Install Node.js & Yarn
+
+Use `nvm` (Node Version Manager) to install the project-specified Node.js version:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+> [!NOTE]
+> If using a non-bash shell (such as zsh or fish), restart your terminal session or source your shell configuration file after installing nvm.
+
+---
+
+### 3. Install & Start MongoDB 8.0
+
+#### Debian / Ubuntu (`apt`):
+
+1. Create the keyrings directory and import the MongoDB GPG key:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+```
+
+2. Add the MongoDB 8.0 repository for your specific distribution:
+
+**Ubuntu 22.04 LTS (Jammy):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Ubuntu 24.04 LTS (Noble):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Debian 12 (Bookworm):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/debian bookworm/mongodb-org/8.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+3. Update package index and install MongoDB:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+sudo systemctl start mongod
+sudo systemctl enable mongod
+```
+
+#### RHEL-compatible distributions (`dnf`):
+
+```bash
+cat <<EOF | sudo tee /etc/yum.repos.d/mongodb-org-8.0.repo
+[mongodb-org-8.0]
+name=MongoDB Repository
+baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/8.0/x86_64/
+gpgcheck=1
+enabled=1
+gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc
+EOF
+sudo dnf install -y mongodb-org
+sudo systemctl start mongod
+sudo systemctl enable mongod
+```
+
+---
+
+### 4. Clone Rocket.Chat Repository
+
+```bash
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 5. Install Project Dependencies
+
+```bash
+yarn
+```
+
+---
+
+### 6. Install & Verify Meteor CLI
+
+Install the pinned version of Meteor CLI specified by `apps/meteor/.meteor/release`:
+
+```bash
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+The Rocket.Chat server will start and be available at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
+++ b/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
@@ -12,7 +12,7 @@ Before setting up Rocket.Chat on macOS, ensure you have installed:
 - **Xcode Command Line Tools**: `xcode-select --install`
 - **Homebrew**: Package manager for macOS
 - **Node.js**: `v22.22.3` (Recommended to install via `nvm` or `fnm`)
-- **Yarn**: `v4.12.0` (via Corepack)
+- **Yarn**: `v4.18.0` (via Corepack)
 - **MongoDB**: `v8.0`
 - **Meteor**: `v3.4.1` (Rocket.Chat build framework)
 
@@ -27,7 +27,7 @@ Open your terminal and install Xcode CLI tools and Homebrew:
 ```bash
 xcode-select --install
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-eval "$(/opt/homebrew/bin/brew shellenv)"
+eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null)"
 ```
 
 ---
@@ -45,7 +45,7 @@ corepack enable
 ```
 
 > [!NOTE]
-> If using zsh or fish shell, ensure `nvm` is sourced in your `~/.zshrc` or shell profile, or open a new terminal session before running `nvm install`.
+> `nvm` requires a POSIX-compliant shell (such as `bash` or `zsh`). If you use **Fish shell**, `nvm` is not supported; use [`fnm`](https://github.com/Schniz/fnm) (Fast Node Manager) instead (`fnm install 22.22.3 && fnm use 22.22.3`).
 
 ---
 

--- a/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
+++ b/docs/developer-documentation/set-up-development-environment/server/mac-osx.md
@@ -1,0 +1,107 @@
+# Server Setup: Mac OSX
+
+This guide walks you through setting up a native local development environment for the Rocket.Chat server on macOS.
+
+---
+
+## 📋 Prerequisites
+
+Before setting up Rocket.Chat on macOS, ensure you have installed:
+
+- **macOS**: macOS 14 Sonoma or newer
+- **Xcode Command Line Tools**: `xcode-select --install`
+- **Homebrew**: Package manager for macOS
+- **Node.js**: `v22.22.3` (Recommended to install via `nvm` or `fnm`)
+- **Yarn**: `v4.12.0` (via Corepack)
+- **MongoDB**: `v8.0`
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Install System Dependencies
+
+Open your terminal and install Xcode CLI tools and Homebrew:
+
+```bash
+xcode-select --install
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+---
+
+### 2. Install Node.js & Yarn
+
+Use `nvm` to manage Node.js versions:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+> [!NOTE]
+> If using zsh or fish shell, ensure `nvm` is sourced in your `~/.zshrc` or shell profile, or open a new terminal session before running `nvm install`.
+
+---
+
+### 3. Install & Start MongoDB 8.0
+
+Install and start MongoDB community edition via Homebrew:
+
+```bash
+brew tap mongodb/brew
+brew install mongodb-community@8.0
+brew services start mongodb-community@8.0
+```
+
+---
+
+### 4. Clone Rocket.Chat Repository
+
+```bash
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 5. Install Project Dependencies
+
+```bash
+yarn
+```
+
+---
+
+### 6. Install & Verify Meteor CLI
+
+Install the pinned version of Meteor CLI specified by `apps/meteor/.meteor/release`:
+
+```bash
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+The Rocket.Chat development server will start and be available at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🐧 Linux Setup Guide](linux.md)
+- [🪟 Windows (WSL) Setup Guide](windows.md)

--- a/docs/developer-documentation/set-up-development-environment/server/windows.md
+++ b/docs/developer-documentation/set-up-development-environment/server/windows.md
@@ -1,0 +1,153 @@
+# Server Setup: Windows (WSL2)
+
+Because Rocket.Chat's server development workflow relies heavily on Unix build tools and POSIX-compliant environments, developing Rocket.Chat on Windows is officially supported using **Windows Subsystem for Linux 2 (WSL2)** running an Ubuntu distribution.
+
+---
+
+## 📋 Shared Prerequisites
+
+Inside your WSL2 environment, Rocket.Chat requires the standard stack:
+
+- **Windows**: Windows 10 (Build 19041+) or Windows 11
+- **WSL2**: Windows Subsystem for Linux version 2 (Ubuntu 22.04 LTS or 24.04 LTS)
+- **Node.js**: `v22.22.3` (inside WSL via `nvm`)
+- **Yarn**: `v4.12.0` (Corepack enabled inside WSL)
+- **MongoDB**: `v8.0` (inside WSL or via Docker for Windows)
+- **Meteor**: `v3.4.1` (Rocket.Chat build framework)
+
+---
+
+## 🛠️ Step-by-Step Installation
+
+### 1. Enable WSL2 and Install Ubuntu
+
+Open PowerShell as Administrator on Windows and run:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Restart your computer if prompted. After restarting, launch the **Ubuntu** app from your Windows Start Menu to set up your UNIX username and password.
+
+#### Verify WSL Version
+
+Check the WSL version of your installed distribution:
+
+```powershell
+wsl --list --verbose
+```
+
+If the installed distribution displays `1` under the `VERSION` column, upgrade it to WSL2:
+
+```powershell
+wsl --set-version <DistributionName> 2
+```
+
+*(Substitute `<DistributionName>` with your actual distro name shown in `wsl --list --verbose`, e.g., `Ubuntu-22.04` or `Ubuntu`).*
+
+To ensure all future Linux distribution installs default to WSL2, run:
+
+```powershell
+wsl --set-default-version 2
+```
+
+---
+
+### 2. Configure Ubuntu WSL Environment
+
+Open your Ubuntu WSL terminal shell and install basic build tools and dependencies:
+
+```bash
+sudo apt update && sudo apt install -y build-essential curl git gnupg
+```
+
+---
+
+### 3. Install Node.js & Yarn inside WSL
+
+In the WSL terminal:
+
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+source ~/.nvm/nvm.sh
+nvm install 22.22.3
+nvm use 22.22.3
+corepack enable
+```
+
+---
+
+### 4. Install & Start MongoDB 8.0 in WSL
+
+1. Create the keyrings directory and import the MongoDB GPG key:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+```
+
+2. Add the MongoDB 8.0 repository line for your Ubuntu release:
+
+**Ubuntu 22.04 LTS (Jammy):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+**Ubuntu 24.04 LTS (Noble):**
+```bash
+echo "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+```
+
+3. Update package index, install MongoDB, and start the service:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+sudo service mongod start
+```
+
+> [!NOTE]
+> If systemd is enabled in your WSL2 configuration (`/etc/wsl.conf`), you can run `sudo systemctl start mongod` and `sudo systemctl enable mongod` instead.
+
+---
+
+### 5. Clone Repository inside WSL Filesystem
+
+> [!IMPORTANT]
+> Clone the project into the Linux filesystem (e.g., `/home/username/code/Rocket.Chat`) rather than the Windows filesystem (`/mnt/c/...`). Accessing `/mnt/c/` from WSL causes significant disk I/O performance degradation during `yarn` operations.
+
+```bash
+mkdir -p ~/code
+cd ~/code
+git clone https://github.com/RocketChat/Rocket.Chat.git
+cd Rocket.Chat
+```
+
+---
+
+### 6. Install Dependencies & Verify Meteor CLI
+
+```bash
+yarn
+npm install -g meteor@3.4.1
+meteor --version
+```
+
+---
+
+### 7. Start Development Server
+
+```bash
+yarn dev
+```
+
+Access the server from your Windows web browser at `http://localhost:3000`.
+
+---
+
+## 🔗 Related Setup Paths
+
+- [Server Setup Index](index.md)
+- [☁️ Gitpod Setup Guide](gitpod.md)
+- [🍏 Mac OSX Setup Guide](mac-osx.md)
+- [🐧 Linux Setup Guide](linux.md)

--- a/docs/developer-documentation/set-up-development-environment/server/windows.md
+++ b/docs/developer-documentation/set-up-development-environment/server/windows.md
@@ -11,7 +11,7 @@ Inside your WSL2 environment, Rocket.Chat requires the standard stack:
 - **Windows**: Windows 10 (Build 19041+) or Windows 11
 - **WSL2**: Windows Subsystem for Linux version 2 (Ubuntu 22.04 LTS or 24.04 LTS)
 - **Node.js**: `v22.22.3` (inside WSL via `nvm`)
-- **Yarn**: `v4.12.0` (Corepack enabled inside WSL)
+- **Yarn**: `v4.18.0` (Corepack enabled inside WSL)
 - **MongoDB**: `v8.0` (inside WSL or via Docker for Windows)
 - **Meteor**: `v3.4.1` (Rocket.Chat build framework)
 


### PR DESCRIPTION
## Description

Fixes #41764 — Linux/Windows server development setup is not discoverable 
from the Developer Documentation.

Users following the standard onboarding path — 
`README.md → Developer Documentation → Set Up Development Environment → 
Server → Server Environment Setup` — only saw **Gitpod** and **Mac OSX** as 
options, with no visible or linked path to Linux or Windows setup 
instructions. This forced Linux/Windows contributors to guess at steps or 
give up during local setup.

This PR adds Linux and Windows (WSL2) server setup guides, links them into 
the Server Environment Setup navigation alongside Gitpod and Mac OSX, and 
addresses the correctness/security issues flagged in review on the initial 
draft (PR #41778).

> **Note:** This replaces #41778, which incorrectly carried an unrelated 
> Deno runtime symlink fix pulled in via merge history. This PR is scoped 
> to documentation only.

## What was found

No existing Linux/Windows setup docs were found after auditing the docs 
repo and navigation config. This PR adds new pages reusing the shared, 
OS-agnostic prerequisites already documented for Mac OSX (Node.js, Yarn, 
Meteor, Git), plus OS-specific database and package manager steps for 
Linux (apt/dnf) and Windows (WSL2 + apt).

## Changes

- Added `linux.md` — native Linux server setup (Ubuntu 22.04, Ubuntu 24.04, 
  Debian 12, and RHEL-compatible distros via dnf).
- Added `windows.md` — WSL2-based server setup for Windows.
- Updated `index.md` — shared prerequisites section and equal-weight links 
  to Gitpod, Mac OSX, Linux, and Windows.
- Updated `_sidebar.md` — navigation entries for the new pages, visible in 
  all doc views including Category view.
- Updated `mac-osx.md` — corrected alongside the new guides for consistency 
  (see fixes below).

## Fixes applied from review

- **MongoDB version**: updated all four docs (index, linux, mac-osx, 
  windows) from MongoDB 6.0 (EOL July 31, 2025) to MongoDB 8.0, matching 
  the repo's CI and Docker Compose defaults — version numbers, repo URLs, 
  package names, and keyring filenames all updated consistently.
- **Linux — APT key scoping**: MongoDB GPG key now stored under 
  `/etc/apt/keyrings/mongodb-server-8.0.gpg` with `signed-by=` set on the 
  apt source line, instead of the repo-wide-trusted 
  `/etc/apt/trusted.gpg.d`. Same fix applied to the WSL Ubuntu steps in 
  `windows.md`.
- **Linux — distro-specific repos**: replaced the single Ubuntu 22.04 
  ("jammy") repo line with separate, correct entries for Ubuntu 22.04, 
  Ubuntu 24.04, and Debian 12.
- **Linux — Fedora removed**: MongoDB 8.0 isn't supported on Fedora via the 
  RHEL repo as originally written, so Fedora was removed from the 
  supported list rather than left as a broken path; RHEL-compatible 
  distros remain documented via `dnf`.
- **Meteor CLI pin**: added an explicit step to install and verify the 
  exact Meteor version from `apps/meteor/.meteor/release` before 
  `yarn dev`, across Linux, macOS, and Windows guides.
- **macOS — minimum version**: raised from macOS 12 to macOS 14, since 
  Homebrew no longer supports macOS 12.
- **macOS — shell init**: added `eval "$(brew shellenv)"` after the 
  Homebrew install so `brew` is available in the same shell before the 
  next command runs.
- **macOS — nvm sourcing**: added a step to source `~/.nvm/nvm.sh` (or 
  open a new terminal) before running `nvm install`, so `nvm` isn't 
  undefined.
- **Windows — WSL2 verification**: added a step to run 
  `wsl --list --verbose` and convert the distro with 
  `wsl --set-version <DistributionName> 2` if it reports version 1, since 
  `wsl --set-default-version 2` only affects future installs.
- **Windows — correct service name**: fixed `sudo service mongodb start` 
  to `sudo service mongod start` (the `mongodb-org` package registers the 
  service as `mongod`), with `sudo systemctl start mongod` noted as an 
  alternative when systemd is enabled in WSL2.

## Verification

- [x] Local docs build completed with no errors.
- [x] No broken links (Linux/Windows pages resolve, no 404s).
- [x] New pages confirmed visible in all navigation views, including 
      Category view (the view referenced in the original issue).
- [x] MongoDB version references confirmed consistent across all four 
      affected files.
- [x] Diff scoped entirely to 
      `docs/developer-documentation/set-up-development-environment/server/` 
      — no unrelated files touched.

## Notes for reviewers

- This branch was cut fresh from `develop` to remove the unrelated Deno 
  runtime symlink commits that were present in #41778 — no code changes 
  are included here, docs only.
- All items originally flagged by CodeRabbit on #41778 have been addressed 
  directly rather than left as TODOs.
- Happy to adjust distro coverage (e.g. add Arch/openSUSE) if maintainers 
  want broader Linux support in a follow-up.

Closes #41764

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added server development environment setup guides for macOS, Linux, Windows via WSL2, and Gitpod.
  * Documented prerequisites, required tools, dependency installation, MongoDB configuration, repository setup, and development server startup.
  * Added navigation links connecting general setup instructions with platform-specific guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->