### PR TITLE
fix: business hours closing for one minute a day

### DIFF
--- a/.changeset/business-hour-finish-minute-inclusive.md
+++ b/.changeset/business-hour-finish-minute-inclusive.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed business hours closing for one minute a day when configured as `00:00`-`23:59`. Work hours are set at minute granularity, but the finish time was treated as exclusive, so consecutive daily windows never met and the service dropped to closed for the whole `23:59` minute — agents could not become available and the Livechat widget rendered the offline form. A work hour now stays open until the end of its finish minute.

--- a/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.spec.ts
@@ -478,3 +478,88 @@ describe('regular business hours', () => {
 		expect(bh.length).toEqual(0);
 	});
 });
+
+describe('finish time boundary', () => {
+	afterEach(() => jest.useRealTimers());
+
+	// 00:00-23:59 in Asia/Kolkata, which on a UTC server runs from Saturday 18:30 to Sunday 18:29
+	const alwaysOpenSunday = [
+		{
+			_id: '68516f256ebb4bdceda2757e',
+			name: '',
+			active: true,
+			type: LivechatBusinessHourTypes.DEFAULT,
+			ts: new Date(),
+			workHours: [
+				{
+					day: 'Sunday',
+					start: {
+						time: '00:00',
+						utc: { dayOfWeek: 'Saturday', time: '18:30' },
+						cron: { dayOfWeek: 'Saturday', time: '18:30' },
+					},
+					finish: {
+						time: '23:59',
+						utc: { dayOfWeek: 'Sunday', time: '18:29' },
+						cron: { dayOfWeek: 'Sunday', time: '18:29' },
+					},
+					open: true,
+					code: '',
+				},
+			],
+			timezone: {
+				name: 'Asia/Kolkata',
+				utc: '+05:30',
+			},
+		},
+	];
+
+	it('should keep the business hour open during its finish minute', async () => {
+		jest.useFakeTimers().setSystemTime(new Date('2025-07-27T18:29:30Z'));
+
+		expect(await filterBusinessHoursThatMustBeOpened(alwaysOpenSunday)).toHaveLength(1);
+	});
+
+	it('should close the business hour once the finish minute has elapsed', async () => {
+		jest.useFakeTimers().setSystemTime(new Date('2025-07-27T18:30:30Z'));
+
+		expect(await filterBusinessHoursThatMustBeOpened(alwaysOpenSunday)).toHaveLength(0);
+	});
+
+	it('should keep a same-day business hour open during its finish minute', async () => {
+		jest.useFakeTimers().setSystemTime(new Date('2025-07-28T20:00:30Z'));
+
+		const bh = await filterBusinessHoursThatMustBeOpened([
+			{
+				_id: '68516f256ebb4bdceda2757f',
+				name: '',
+				active: true,
+				type: LivechatBusinessHourTypes.DEFAULT,
+				ts: new Date(),
+				workHours: [
+					{
+						day: 'Monday',
+						start: {
+							time: '08:00',
+							utc: { dayOfWeek: 'Monday', time: '08:00' },
+							cron: { dayOfWeek: 'Monday', time: '08:00' },
+						},
+						finish: {
+							time: '20:00',
+							utc: { dayOfWeek: 'Monday', time: '20:00' },
+							cron: { dayOfWeek: 'Monday', time: '20:00' },
+						},
+						open: true,
+						code: '',
+					},
+				],
+				timezone: {
+					name: 'UTC',
+					utc: '+00:00',
+				},
+			},
+		]);
+
+		expect(bh).toHaveLength(1);
+	});
+});

--- a/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.ts
+++ b/apps/meteor/server/lib/omnichannel/business-hour/filterBusinessHoursThatMustBeOpened.ts
@@ -42,7 +42,13 @@ export const filterBusinessHoursThatMustBeOpened = async (
 							localTimeFinish.add(1, 'week');
 						}
 
-						return currentTime.isSameOrAfter(localTimeStart) && currentTime.isBefore(localTimeFinish);
+						// Work hours are configured at minute granularity, so a window stays open until the end of its
+						// `finish` minute. Treating `finish` as exclusive leaves consecutive daily windows disjoint:
+						// a 00:00-23:59 business hour (the only way the UI can express "always open") would close
+						// for the whole 23:59 minute, every day.
+						const afterFinishMinute = localTimeFinish.clone().add(1, 'minute');
+
+						return currentTime.isSameOrAfter(localTimeStart) && currentTime.isBefore(afterFinishMinute);
 					}),
 		)
 		.map((businessHour) => ({


### PR DESCRIPTION
[CORE-2550]

## Proposed changes

Work hours are configured at minute granularity, but `filterBusinessHoursThatMustBeOpened` compared the finish time as **exclusive**. Consecutive daily windows therefore never met: a `00:00`–`23:59` business hour — the only way the admin UI can express "always open" — leaves the service **closed for the whole `23:59` minute, every day**.

During that minute:

- agents cannot become available (`error-business-hours-are-closed` from `livechat/agent.status`)
- saving a business hour strips `openBusinessHours` from every agent
- the Livechat widget renders the offline form instead of the registration form

A work hour now stays open until the end of its finish minute:

```ts
const afterFinishMinute = localTimeFinish.clone().add(1, 'minute');
return currentTime.isSameOrAfter(localTimeStart) && currentTime.isBefore(afterFinishMinute);
```

The clone happens after the existing week-shift adjustments, so that logic is untouched.

### How this was found

CI run [31729126298](https://github.com/RocketChat/Rocket.Chat/actions/runs/31729126298) failed on `Test API Livechat (EE)` and `(FIPS)`, both on a single assertion in `19-business-hours.ts:154` (`should allow agents to be available`). The job timings pin it exactly:

| job | finished | result |
|---|---|---|
| Livechat API (CE) | 18:25:11 | :white_check_mark: |
| Livechat API (EE) | 18:29:58 | :x: |
| Livechat API (FIPS) | 18:30:06 | :x: |

That test inherits a default business hour saved as `00:00`–`23:59` in `Asia/Kolkata`, which on a UTC server runs Saturday 18:30 → Sunday 18:29. EE and FIPS ran the assertion inside the resulting 18:29:00–18:29:59 UTC hole; CE ran four minutes earlier and passed. Same commit, different wall clock.

## Reviewer notes

**This widens every business hour by one minute.** The default `08:00`–`20:00` now stays open through `20:00:59`. That is inherent to "finish is inclusive of its minute", and it is asserted explicitly by one of the new tests rather than left implicit. The alternative considered was special-casing `finish.time === '23:59'` as end-of-day — no collateral effect, but a magic constant. Happy to switch if reviewers prefer that.

**This does not fully fix the 24/7 case.** `findHoursToScheduleJobs` schedules cron jobs at exactly `start.cron.time` and `finish.cron.time`, so a `00:00`–`23:59` config still gets a close job at 18:29 and an open job at 18:30 — the cron will still strip `openBusinessHours` for that minute. This PR fixes the point-in-time check, which is what runs on business-hour save and drives `agent.status`. Making the cron skip a close that is immediately followed by an open is a separate, larger change and deserves its own issue.

**Marginal effect on an existing test.** `should not allow a user to be available if BH are closed` uses a `00:00`–`00:01` Monday window in `America/Sao_Paulo`; its open window grows from 03:00:00–03:00:59 to 03:00:00–03:01:59 UTC. Still a ~2-minutes-per-week exposure, same flake class as before.

## Testing

Three tests added to `filterBusinessHoursThatMustBeOpened.spec.ts`, using the file's existing `jest.useFakeTimers()` style:

| test | before | after |
| --- | --- | --- |
| Kolkata `00:00`–`23:59` @ Sun 18:29:30 UTC (the hole) | :x: | :white_check_mark: |
| same window @ Sun 18:30:30 UTC (past the window) | :white_check_mark: | :white_check_mark: |
| UTC `08:00`–`20:00` @ Mon 20:00:30 | :x: | :white_check_mark: |

All 6 tests in the file pass; the 3 pre-existing ones are unchanged. The two new positive tests were verified to fail against unmodified source — the middle test is the guard proving the window widens by exactly one minute and no more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Business-hour schedules now remain open throughout their configured closing minute.
  * Fixed all-day schedules, such as 00:00–23:59, incorrectly closing at 23:59.
  * Added coverage for finish-time behavior across time zones and same-day schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2550]: https://rocketchat.atlassian.net/browse/CORE-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ