### PR TITLE
fix: message list loads the entire room history while hidden

### DIFF
--- a/.changeset/message-list-history-loop-while-hidden.md
+++ b/.changeset/message-list-history-loop-while-hidden.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed the message list loading the entire room history while it is hidden behind a full-width contextual bar. On a narrow window the room layout hides the message body, and a hidden element reports its height and scroll offset as `0`, which made the load-older-messages check always true - so every page that arrived triggered the next one until the whole room was in memory, hammering the server until it rate-limited the client. On returning to the list the scroll position was far in the past, because the content had grown underneath it.

--- a/.changeset/message-list-history-loop-while-hidden.md
+++ b/.changeset/message-list-history-loop-while-hidden.md
@@ -1,5 +1,0 @@
----
-'@rocket.chat/meteor': patch
----
-
-Fixed the message list loading the entire room history while it is hidden behind a full-width contextual bar. On a narrow window the room layout hides the message body, and a hidden element reports its height and scroll offset as `0`, which made the load-older-messages check always true - so every page that arrived triggered the next one until the whole room was in memory, hammering the server until it rate-limited the client. On returning to the list the scroll position was far in the past, because the content had grown underneath it.

--- a/.changeset/soft-poems-shave.md
+++ b/.changeset/soft-poems-shave.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the message list loading a room's entire history while it is covered by a full-width contextual bar, such as a thread on a narrow window: the client kept paginating until it hit the server rate limit, and the list was left scrolled far into the past once the bar closed.

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
@@ -66,7 +66,7 @@ describe('useGetMore', () => {
 		});
 	});
 
-	it('should not call getMore while the list is hidden, even though it reports being at the top', async () => {
+	it('should not call getMore when the list is hidden', async () => {
 		const root = mockAppRoot();
 		(RoomHistoryManager.isLoading as jest.Mock).mockReturnValue(false);
 		(RoomHistoryManager.hasMore as jest.Mock).mockReturnValue(true);
@@ -74,13 +74,10 @@ describe('useGetMore', () => {
 		(RoomHistoryManager.getMore as jest.Mock).mockClear();
 
 		const Test = () => {
-			const [atBottom] = useState(false);
-			const { innerRef } = useGetMore('room-id', atBottom);
+			const { innerRef } = useGetMore('room-id', false);
 			return <div ref={innerRef as any} style={{ display: 'none' }} data-testid='scrollable-element' />;
 		};
 
-		// What a display: none element reports. Without a guard `scrollTop <= clientHeight / 3` is
-		// 0 <= 0, so every observer callback would load another page of history.
 		(getBoundingClientRect as jest.Mock).mockReturnValue({
 			scrollTop: 0,
 			clientHeight: 0,

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
@@ -66,6 +66,40 @@ describe('useGetMore', () => {
 		});
 	});
 
+	it('should not call getMore while the list is hidden, even though it reports being at the top', async () => {
+		const root = mockAppRoot();
+		(RoomHistoryManager.isLoading as jest.Mock).mockReturnValue(false);
+		(RoomHistoryManager.hasMore as jest.Mock).mockReturnValue(true);
+		(RoomHistoryManager.hasMoreNext as jest.Mock).mockReturnValue(false);
+		(RoomHistoryManager.getMore as jest.Mock).mockClear();
+
+		const Test = () => {
+			const [atBottom] = useState(false);
+			const { innerRef } = useGetMore('room-id', atBottom);
+			return <div ref={innerRef as any} style={{ display: 'none' }} data-testid='scrollable-element' />;
+		};
+
+		// What a display: none element reports. Without a guard `scrollTop <= clientHeight / 3` is
+		// 0 <= 0, so every observer callback would load another page of history.
+		(getBoundingClientRect as jest.Mock).mockReturnValue({
+			scrollTop: 0,
+			clientHeight: 0,
+			scrollHeight: 0,
+		});
+
+		render(<Test />, {
+			wrapper: root.build(),
+		});
+
+		const scrollableElement = screen.getByTestId('scrollable-element');
+		scrollableElement.dispatchEvent(new Event('wheel'));
+		scrollableElement.dispatchEvent(new Event('scroll'));
+
+		await waitFor(() => {
+			expect(RoomHistoryManager.getMore).not.toHaveBeenCalled();
+		});
+	});
+
 	it('should call getMoreNext when scrolling near bottom and hasMoreNext is true', () => {
 		const root = mockAppRoot();
 		(RoomHistoryManager.isLoading as jest.Mock).mockReturnValue(false);

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -41,6 +41,13 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 
 					const { scrollTop, clientHeight, scrollHeight } = getBoundingClientRect(element);
 
+					// RoomLayout hides the message body while a contextual bar takes the full room width,
+					// and a hidden element reports clientHeight 0. Without this guard the position check
+					// below is always true and pulls in the entire room history, one observer call at a time.
+					if (clientHeight === 0) {
+						return;
+					}
+
 					const lastScrollTopRef = scrollTop;
 					const height = clientHeight;
 					const hasMore = RoomHistoryManager.hasMore(rid);

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -41,9 +41,6 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 
 					const { scrollTop, clientHeight, scrollHeight } = getBoundingClientRect(element);
 
-					// RoomLayout hides the message body while a contextual bar takes the full room width,
-					// and a hidden element reports clientHeight 0. Without this guard the position check
-					// below is always true and pulls in the entire room history, one observer call at a time.
 					if (clientHeight === 0) {
 						return;
 					}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`RoomLayout` hides the entire message body with `display: none` once a contextual bar takes the full room width, which happens below 600px of *room* width - not viewport width, since the breakpoints come from a `ResizeObserver` on the room element:

```js
const contextualbarSize = breakpoints.includes('sm') ? (breakpoints.includes('xl') ? '38%' : '380px') : '100%';
const hideBody = aside && contextualbarSize === '100%';
```

A hidden element reports `clientHeight` and `scrollTop` as `0`, so the load-older-messages check in
`useGetMore` is permanently true:

```js
const { scrollTop, clientHeight, scrollHeight } = getBoundingClientRect(element);
...
if (hasMore === true && lastScrollTopRef <= height / 3) {   // 0 <= 0 / 3
    await RoomHistoryManager.getMore(rid);
```

The `MutationObserver` and `ResizeObserver` attached to that same element then drive the loading themselves: every page that arrives mutates the DOM, the observer fires, the next page loads.
Nothing stops it until the room has no history left. The client pulls the whole room 50 messages at a time and runs into the DDP rate limiter - the tail of the request list is `loadHistory` returning HTTP 400 `too-many-requests`.

`RoomHistoryManager.restoreScroll` cannot compensate, because it measures `scrollHeight` on the same hidden element and gets `0 - 0` as the height difference. So when the panel closes, the scroll offset is unchanged while the list is several times taller, and the user is left far in the past.

This PR bails out when the list is not rendered, and adds a unit test for it.

**Before** - one pixel narrower, thread opened, nobody scrolling: a stream of `loadHistory` calls
ending in HTTP 400, and the list is far up when the thread closes.

https://github.com/user-attachments/assets/d03691d4-60d8-482c-a35c-3b3163eeb836

**After** - same steps: 5 requests for the whole open-wait-close cycle (because scroll in thread), none of them
`loadHistory`, and the list stays where it was.

https://github.com/user-attachments/assets/a895a78d-7135-4c88-876a-06a3e1c4b522


Control at 1220px room width: list height unchanged in both cases, no jump - so the trigger is the
hidden body, not opening a panel as such.

## Issue(s)

Fixes #41132

Related to #41159, which addresses a different threshold - see *Further comments*.

## Steps to test or reproduce

Four conditions have to hold at once, and two of them are easy to destroy by accident, which is
probably why this has looked flaky:

1. `hasMore` must still be true - **reload the page first**. Once a room's history has been fully
   pulled in a session, that room is immune for the rest of the session.
2. `userInteracted` must be true - scroll the main list once with the wheel, or click in it. The
   flag is a per-mount closure variable and resets on every room switch.
3. The room area must be under 600px with a thread open, so the body is hidden.
4. The list must **not** be at the very bottom - scroll up a little first. At the bottom the
   virtualizer keeps the list anchored there and the growth stays invisible.

Then:

1. Narrow the window until the thread view takes the full chat width. With a default sidebar the
   threshold sits exactly between 880px and 879px of window width:
   | window | room area | message body |
   |---|---|---|
   | 880px | 600px | visible |
   | 879px | 599px | hidden |
2. Reload.
3. Open a room with a few thousand messages spanning a long period, so the jump is visible by date.
4. Scroll the main list up a little with the wheel.
5. Open a thread from the message list.
6. Wait 20-30 seconds with the window in the foreground, watching the network panel.
7. Close the thread.

Sanity checks that should *not* trigger it: a wide window, closing the thread again within a
second, a second attempt without reloading, or opening the thread from the Threads contextual bar
without touching the main list first.

Tested on `8.8.0-develop` at `02e633cf27` and on `8.6.1` at `bfd782302d`, in a room with 5162
messages spanning five years and a thread with 60 replies, at 580px room width.

## Further comments

The guard reads the `clientHeight` that `getBoundingClientRect` already returned rather than asking
the element again. That is the exact value the position check uses, and it keeps the hook testable:
jsdom performs no layout and reports `0` for every element, so a guard reading `element.clientHeight`
directly would make the two existing tests in `useGetMore.spec.tsx` fail.

Alternatives considered:

- Guarding inside `gatedCheck` so only observer-driven calls are skipped. That leaves the same
  always-true condition in place for any other caller, and a hidden element cannot emit a scroll
  event anyway, so the guard belongs where the value is read.
- Not observing the element at all while it is hidden. That is more code for the same effect and
  would need the layout state threaded into this hook.
- Removing `hideBody` so the situation cannot arise. That is what #41159 approaches from the layout
  side, but the `0 <= 0` fragility would remain for any other case that hides the list.

On #41159: it takes the aside out of the flex flow, which addresses a *different* threshold. Between
600px and 768px of room width the body is not hidden but squeezed - at 600px room width the message
list drops to 220px, text rewraps, cached row heights go stale, and the scroll position is off by a
noticeable amount when the panel closes. That is a separate defect with its own trigger; this change
does not touch that path and does not conflict with it, and the `hideBody` branch below 600px stays
as it is.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented hidden message lists from incorrectly loading older messages when their container has no visible height.
  * Fixed rooms from loading excessive history and leaving the message list scrolled far into the past after closing a full-width contextual bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->