### PR TITLE
fix(ui-client): hide top navbar when running in desktop app

### DIFF
--- a/.changeset/window-manager-desktop-navbar.md
+++ b/.changeset/window-manager-desktop-navbar.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed an issue where the top navigation bar rendered inside the Rocket.Chat Desktop client, interfering with the native OS window manager frame

--- a/apps/meteor/client/navbar/NavBar.tsx
+++ b/apps/meteor/client/navbar/NavBar.tsx
@@ -8,6 +8,10 @@ import NavBarPagesSection from './NavBarPagesSection';
 const NavBar = () => {
 	const { navbar } = useLayout();
 
+	if (typeof window !== 'undefined' && window.RocketChatDesktop) {
+		return null;
+	}
+
 	return (
 		<NavBarComponent aria-label='header'>
 			{!navbar.searchExpanded && <NavBarPagesSection />}


### PR DESCRIPTION
Don't render the top web navigation bar when the app is running inside the Rocket.Chat Desktop client. The desktop shell manages its own top-level window controls and header, so rendering the web navbar duplicated controls and interfered with the OS window manager frame.

Fixes #41786

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Proposed changes (including videos or screenshots)

Don't render the top web navigation bar when the app is running inside the Rocket.Chat Desktop client (`window.RocketChatDesktop`). The desktop shell manages its own top-level window controls and header, so rendering the web navbar duplicated controls and interfered with the OS window manager frame.

## Issue(s)

Fixes #41786

## Steps to test or reproduce

1. Open Rocket.Chat inside the Rocket.Chat Desktop application (e.g. on Linux/Windows).
2. Observe that the top web navigation bar is omitted, leaving the native OS window manager frame/titlebar intact.
3. Open Rocket.Chat in a regular web browser and verify that the top navigation bar renders as expected.

## Further comments

Checked `window.RocketChatDesktop` safely in `apps/meteor/client/navbar/NavBar.tsx` to bypass rendering `NavBarComponent` when the desktop API bridge is present.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hid the web navigation bar when using Rocket.Chat Desktop, preventing overlap with the native window frame.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->