### PR TITLE
test: assert imported users and rooms in import e2e tests

### DIFF
--- a/.changeset/accessible-room-counts.md
+++ b/.changeset/accessible-room-counts.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Added accessible labels to the Users and Msgs count cells in the admin Rooms table.

--- a/apps/meteor/client/views/admin/rooms/RoomRow.tsx
+++ b/apps/meteor/client/views/admin/rooms/RoomRow.tsx
@@ -84,8 +84,14 @@ const RoomRow = ({ room }: RoomRowProps) => {
 					{t(getRoomType(room))}
 				</Box>
 			</GenericTableCell>
-			<GenericTableCell withTruncatedText>{usersCount}</GenericTableCell>
-			{mediaQuery && <GenericTableCell withTruncatedText>{msgs}</GenericTableCell>}
+			<GenericTableCell aria-label={`${t('Users')}: ${usersCount}`} withTruncatedText>
+				{usersCount}
+			</GenericTableCell>
+			{mediaQuery && (
+				<GenericTableCell aria-label={`${t('Msgs')}: ${msgs}`} withTruncatedText>
+					{msgs}
+				</GenericTableCell>
+			)}
 			{mediaQuery && <GenericTableCell withTruncatedText>{isDefault ? t('True') : t('False')}</GenericTableCell>}
 			{mediaQuery && <GenericTableCell withTruncatedText>{featured ? t('True') : t('False')}</GenericTableCell>}
 			{mediaQuery && <GenericTableCell withTruncatedText>{ts ? formatDate(ts) : ''}</GenericTableCell>}

--- a/apps/meteor/tests/e2e/imports.spec.ts
+++ b/apps/meteor/tests/e2e/imports.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { parse } from 'csv-parse';
 
 import { Users } from './fixtures/userStates';
-import { AdminImports, AdminRooms } from './page-objects';
+import { AdminImports, AdminRooms, AdminUsers } from './page-objects';
 import { test, expect } from './utils/test';
 
 test.use({ storageState: Users.admin.state });
@@ -46,7 +46,9 @@ const usersCsvsToJson = async (): Promise<void> => {
 			.pipe(parse({ delimiter: ',' }))
 			.on('data', (rows) => {
 				rowUserName.push(rows[0]);
-				csvImportedUsernames.push(rows[0]);
+				if (rows[0] !== 'billy.billy') {
+					csvImportedUsernames.push(rows[0]);
+				}
 			})
 			.on('end', resolve),
 	);
@@ -125,13 +127,21 @@ test.describe.serial('imports', () => {
 	});
 
 	test('expect all imported users to be actually listed as users', async ({ page }) => {
+		const poAdmin = new AdminUsers(page);
 		await page.goto('/admin/users');
 
 		for await (const user of rowUserName) {
+			const searchResponse = page.waitForResponse((response) => {
+				const url = new URL(response.url());
+				return url.pathname.endsWith('/api/v1/users.listByStatus') && url.searchParams.get('searchTerm') === user && response.ok();
+			});
+			await page.getByRole('textbox', { name: 'Search Users' }).fill(user);
+			await searchResponse;
 			if (user === 'billy.billy') {
-				await expect(page.locator(`tbody tr td:first-child >> text="${user}"`)).not.toBeVisible();
+				await expect(page.getByRole('heading', { name: 'No users' })).toBeVisible();
+				await expect(poAdmin.getUserRowByUsername(user)).not.toBeVisible();
 			} else {
-				expect(page.locator(`tbody tr td:first-child >> text="${user}"`));
+				await expect(poAdmin.getUserRowByUsername(user)).toBeVisible();
 			}
 		}
 	});
@@ -143,8 +153,8 @@ test.describe.serial('imports', () => {
 		for await (const room of importedRooms) {
 			await poAdmin.inputSearchRooms.fill(room.name);
 
-			const expectedMembersCount = room.members.split(';').filter((username) => username !== room.ownerUsername).length + 1;
-			expect(page.locator(`tbody tr td:nth-child(2) >> text="${expectedMembersCount}"`));
+			const expectedMembersCount = room.members.split(';').filter((username) => username && username !== room.ownerUsername).length + 1;
+			await expect(poAdmin.getRoomRow(room.name).getByRole('cell').nth(2)).toHaveText(String(expectedMembersCount));
 		}
 	});
 
@@ -156,9 +166,11 @@ test.describe.serial('imports', () => {
 			await poAdmin.inputSearchRooms.fill(room.name);
 			await poAdmin.getRoomRow(room.name).click();
 
-			room.visibility === 'private'
-				? await expect(poAdmin.editRoom.privateInput).toBeChecked()
-				: await expect(poAdmin.editRoom.privateInput).not.toBeChecked();
+			if (room.visibility === 'private') {
+				await expect(poAdmin.editRoom.privateInput).toBeChecked();
+			} else {
+				await expect(poAdmin.editRoom.privateInput).not.toBeChecked();
+			}
 			await expect(poAdmin.editRoom.roomOwnerInput).toHaveValue(room.ownerUsername);
 		}
 	});
@@ -169,13 +181,14 @@ test.describe.serial('imports', () => {
 
 		for await (const user of csvImportedUsernames) {
 			await poAdmin.inputSearchRooms.fill(user);
-			expect(page.locator(`tbody tr td:first-child >> text="${user}"`));
+			const roomRow = poAdmin.getRoomRow(user);
+			await expect(roomRow).toBeVisible();
 
 			const expectedMembersCount = 2;
-			expect(page.locator(`tbody tr td:nth-child(2) >> text="${expectedMembersCount}"`));
+			await expect(roomRow.getByRole('cell').nth(2)).toHaveText(String(expectedMembersCount));
 
 			const expectedMessagesCount = dmMessages.length;
-			expect(page.locator(`tbody tr td:nth-child(3) >> text="${expectedMessagesCount}"`));
+			await expect(roomRow.getByRole('cell').nth(3)).toHaveText(String(expectedMessagesCount));
 		}
 	});
 });

--- a/apps/meteor/tests/e2e/imports.spec.ts
+++ b/apps/meteor/tests/e2e/imports.spec.ts
@@ -135,7 +135,7 @@ test.describe.serial('imports', () => {
 				const url = new URL(response.url());
 				return url.pathname.endsWith('/api/v1/users.listByStatus') && url.searchParams.get('searchTerm') === user && response.ok();
 			});
-			await page.getByRole('textbox', { name: 'Search Users' }).fill(user);
+			await poAdmin.fillUserSearch(user);
 			await searchResponse;
 			if (user === 'billy.billy') {
 				await expect(page.getByRole('heading', { name: 'No users' })).toBeVisible();
@@ -154,7 +154,7 @@ test.describe.serial('imports', () => {
 			await poAdmin.inputSearchRooms.fill(room.name);
 
 			const expectedMembersCount = room.members.split(';').filter((username) => username && username !== room.ownerUsername).length + 1;
-			await expect(poAdmin.getRoomRow(room.name).getByRole('cell').nth(2)).toHaveText(String(expectedMembersCount));
+			await expect(poAdmin.getRoomUsersCountCell(room.name)).toHaveText(String(expectedMembersCount));
 		}
 	});
 
@@ -185,10 +185,10 @@ test.describe.serial('imports', () => {
 			await expect(roomRow).toBeVisible();
 
 			const expectedMembersCount = 2;
-			await expect(roomRow.getByRole('cell').nth(2)).toHaveText(String(expectedMembersCount));
+			await expect(poAdmin.getRoomUsersCountCell(user)).toHaveText(String(expectedMembersCount));
 
 			const expectedMessagesCount = dmMessages.length;
-			await expect(roomRow.getByRole('cell').nth(3)).toHaveText(String(expectedMessagesCount));
+			await expect(poAdmin.getRoomMessagesCountCell(user)).toHaveText(String(expectedMessagesCount));
 		}
 	});
 });

--- a/apps/meteor/tests/e2e/imports.spec.ts
+++ b/apps/meteor/tests/e2e/imports.spec.ts
@@ -7,7 +7,7 @@ import { Users } from './fixtures/userStates';
 import { AdminImports, AdminRooms, AdminUsers } from './page-objects';
 import { test, expect } from './utils/test';
 
-test.use({ storageState: Users.admin.state });
+test.use({ storageState: Users.admin.state, viewport: { width: 1280, height: 720 } });
 
 type csvRoomSpec = {
 	name: string;
@@ -154,7 +154,7 @@ test.describe.serial('imports', () => {
 			await poAdmin.inputSearchRooms.fill(room.name);
 
 			const expectedMembersCount = room.members.split(';').filter((username) => username && username !== room.ownerUsername).length + 1;
-			await expect(poAdmin.getRoomUsersCountCell(room.name)).toHaveText(String(expectedMembersCount));
+			await expect(poAdmin.getRoomUsersCountCell(room.name, expectedMembersCount)).toHaveText(String(expectedMembersCount));
 		}
 	});
 
@@ -185,10 +185,10 @@ test.describe.serial('imports', () => {
 			await expect(roomRow).toBeVisible();
 
 			const expectedMembersCount = 2;
-			await expect(poAdmin.getRoomUsersCountCell(user)).toHaveText(String(expectedMembersCount));
+			await expect(poAdmin.getRoomUsersCountCell(user, expectedMembersCount)).toHaveText(String(expectedMembersCount));
 
 			const expectedMessagesCount = dmMessages.length;
-			await expect(poAdmin.getRoomMessagesCountCell(user)).toHaveText(String(expectedMessagesCount));
+			await expect(poAdmin.getRoomMessagesCountCell(user, expectedMessagesCount)).toHaveText(String(expectedMessagesCount));
 		}
 	});
 });

--- a/apps/meteor/tests/e2e/page-objects/admin-rooms.ts
+++ b/apps/meteor/tests/e2e/page-objects/admin-rooms.ts
@@ -23,6 +23,14 @@ export class AdminRooms extends Admin {
 		return this.adminPageContent.getByRole('link', { name });
 	}
 
+	getRoomUsersCountCell(name: string): Locator {
+		return this.getRoomRow(name).getByRole('cell').nth(2);
+	}
+
+	getRoomMessagesCountCell(name: string): Locator {
+		return this.getRoomRow(name).getByRole('cell').nth(3);
+	}
+
 	get btnEdit(): Locator {
 		return this.adminPageContent.getByRole('button', { name: 'Edit' });
 	}

--- a/apps/meteor/tests/e2e/page-objects/admin-rooms.ts
+++ b/apps/meteor/tests/e2e/page-objects/admin-rooms.ts
@@ -23,12 +23,12 @@ export class AdminRooms extends Admin {
 		return this.adminPageContent.getByRole('link', { name });
 	}
 
-	getRoomUsersCountCell(name: string): Locator {
-		return this.getRoomRow(name).getByRole('cell').nth(2);
+	getRoomUsersCountCell(name: string, count: number): Locator {
+		return this.getRoomRow(name).getByRole('cell', { name: `Users: ${count}`, exact: true });
 	}
 
-	getRoomMessagesCountCell(name: string): Locator {
-		return this.getRoomRow(name).getByRole('cell').nth(3);
+	getRoomMessagesCountCell(name: string, count: number): Locator {
+		return this.getRoomRow(name).getByRole('cell', { name: `Msgs: ${count}`, exact: true });
 	}
 
 	get btnEdit(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/admin-users.ts
+++ b/apps/meteor/tests/e2e/page-objects/admin-users.ts
@@ -64,8 +64,12 @@ export class AdminUsers extends Admin {
 		await this.userInfo.menuItemDeleteUser.click();
 	}
 
-	async searchUser(username: string): Promise<void> {
+	async fillUserSearch(username: string): Promise<void> {
 		await this.inputSearchUsers.fill(username);
+	}
+
+	async searchUser(username: string): Promise<void> {
+		await this.fillUserSearch(username);
 		await expect(this.getUserRowByUsername(username)).toHaveCount(1);
 	}
 }


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The import E2E spec currently contains five `expect(locator)` calls without matchers. Those statements do not assert anything, so the imported-user, room member-count, and direct-message checks can stay green without verifying the outcomes named by the tests.

This change replaces those statements with awaited assertions on the imported rows and values. It also aligns the checks with the current administration tables:

- register a wait for each exact `users.listByStatus` search response before filling the user search, then check the rendered result;
- verify the intentionally excluded user through the rendered empty-result state;
- scope room and direct-message counts to semantic Users/Msgs cells within their matching rows;
- add localized accessible names to those admin table cells and use them in the page object;
- pin the spec to a desktop viewport because the Msgs column is responsive;
- ignore an empty CSV member entry and exclude the intentionally deselected user from the direct-message fixture expectations.

## Issue(s)

No linked issue. This is a focused correction for five matcher-less assertions and the semantic locators needed to verify their results.

## Steps to test or reproduce

```sh
cd apps/meteor
yarn eslint ./client/views/admin/rooms/RoomRow.tsx ./tests/e2e/imports.spec.ts ./tests/e2e/page-objects/admin-rooms.ts
BASE_URL=http://localhost:3000 CI=true PLAYWRIGHT_RETRIES=0 yarn test:e2e ./tests/e2e/imports.spec.ts
```

Targeted ESLint passed for the changed E2E spec and page object. Prettier, changeset status, and `git diff --check` also passed locally.

## Further comments

The production change is limited to localized accessible names on the Users and Msgs count cells. A patch changeset is included for `@rocket.chat/meteor`.

Found while reviewing the test suite with [`e2e-skills/e2e-reviewer`](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added accessible labels to user and message counts in the administration Rooms table, improving screen-reader clarity.

* **Tests**
  * Improved automated coverage for user imports, searches, rooms, and direct messages.
  * Added validation for room user and message counts.
  * Updated membership and visibility checks.
  * Increased reliability by synchronizing checks with application responses and using consistent page interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->