### PR TITLE
test: address review feedback on #41795

### DIFF
--- a/.changeset/client-safe-errors-not-exceptions.md
+++ b/.changeset/client-safe-errors-not-exceptions.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes client-safe errors being reported as exceptions to the channel configured in `Log Exceptions to Channel` when `Log_Level` is set to `2`.

--- a/apps/meteor/server/api/lib/logMethodCallError.spec.ts
+++ b/apps/meteor/server/api/lib/logMethodCallError.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import { describe, it, before, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const debugMock = sinon.stub();
+const errorMock = sinon.stub();
+const meteorDebugMock = sinon.stub();
+const settingsGetMock = sinon.stub();
+
+describe('logMethodCallError', () => {
+	let logMethodCallError: (method: string, err: unknown) => void;
+
+	before(() => {
+		({ logMethodCallError } = proxyquire.noCallThru().load('./logMethodCallError', {
+			'meteor/meteor': {
+				Meteor: { _debug: meteorDebugMock },
+			},
+			'../../lib/logger/system': {
+				SystemLogger: { debug: debugMock, error: errorMock },
+			},
+			'../../settings': {
+				settings: { get: settingsGetMock },
+			},
+		}));
+	});
+
+	beforeEach(() => {
+		debugMock.reset();
+		errorMock.reset();
+		meteorDebugMock.reset();
+		settingsGetMock.reset();
+		settingsGetMock.withArgs('Log_Level').returns('2');
+	});
+
+	it('should not report client-safe errors as exceptions', () => {
+		logMethodCallError('loadHistory', { isClientSafe: true, error: 'error-invalid-user' });
+
+		expect(meteorDebugMock.called).to.be.false;
+		expect(errorMock.called).to.be.false;
+		expect(debugMock.calledOnce).to.be.true;
+	});
+
+	it('should not report meteor errors as exceptions', () => {
+		logMethodCallError('login', { meteorError: { error: 'totp-required' } });
+
+		expect(meteorDebugMock.called).to.be.false;
+		expect(errorMock.called).to.be.false;
+		expect(debugMock.calledOnce).to.be.true;
+	});
+
+	it('should report unexpected errors as exceptions when Log_Level is 2', () => {
+		const err = new Error('Match error: Expected string, got number');
+
+		logMethodCallError('loadHistory', err);
+
+		expect(errorMock.calledOnce).to.be.true;
+		expect(meteorDebugMock.calledOnce).to.be.true;
+		expect(meteorDebugMock.calledWith('Exception while invoking method loadHistory', err)).to.be.true;
+	});
+
+	it('should report unexpected errors without notifying the exceptions channel when Log_Level is not 2', () => {
+		settingsGetMock.withArgs('Log_Level').returns('0');
+
+		logMethodCallError('loadHistory', new Error('Match error: Expected string, got number'));
+
+		expect(errorMock.calledOnce).to.be.true;
+		expect(meteorDebugMock.called).to.be.false;
+	});
+});

--- a/apps/meteor/server/api/lib/logMethodCallError.spec.ts
+++ b/apps/meteor/server/api/lib/logMethodCallError.spec.ts
@@ -34,19 +34,25 @@ describe('logMethodCallError', () => {
 	});
 
 	it('should not report client-safe errors as exceptions', () => {
-		logMethodCallError('loadHistory', { isClientSafe: true, error: 'error-invalid-user' });
+		const err = { isClientSafe: true, error: 'error-invalid-user' };
+
+		logMethodCallError('loadHistory', err);
 
 		expect(meteorDebugMock.called).to.be.false;
 		expect(errorMock.called).to.be.false;
 		expect(debugMock.calledOnce).to.be.true;
+		expect(debugMock.calledWith({ msg: 'Expected error while invoking method', err, method: 'loadHistory' })).to.be.true;
 	});
 
 	it('should not report meteor errors as exceptions', () => {
-		logMethodCallError('login', { meteorError: { error: 'totp-required' } });
+		const err = { meteorError: { error: 'totp-required' } };
+
+		logMethodCallError('login', err);
 
 		expect(meteorDebugMock.called).to.be.false;
 		expect(errorMock.called).to.be.false;
 		expect(debugMock.calledOnce).to.be.true;
+		expect(debugMock.calledWith({ msg: 'Expected error while invoking method', err, method: 'login' })).to.be.true;
 	});
 
 	it('should report unexpected errors as exceptions when Log_Level is 2', () => {
@@ -55,6 +61,7 @@ describe('logMethodCallError', () => {
 		logMethodCallError('loadHistory', err);
 
 		expect(errorMock.calledOnce).to.be.true;
+		expect(errorMock.calledWith({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
 		expect(meteorDebugMock.calledOnce).to.be.true;
 		expect(meteorDebugMock.calledWith('Exception while invoking method loadHistory', err)).to.be.true;
 	});
@@ -62,9 +69,12 @@ describe('logMethodCallError', () => {
 	it('should report unexpected errors without notifying the exceptions channel when Log_Level is not 2', () => {
 		settingsGetMock.withArgs('Log_Level').returns('0');
 
-		logMethodCallError('loadHistory', new Error('Match error: Expected string, got number'));
+		const err = new Error('Match error: Expected string, got number');
+
+		logMethodCallError('loadHistory', err);
 
 		expect(errorMock.calledOnce).to.be.true;
+		expect(errorMock.calledWith({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
 		expect(meteorDebugMock.called).to.be.false;
 	});
 });

--- a/apps/meteor/server/api/lib/logMethodCallError.spec.ts
+++ b/apps/meteor/server/api/lib/logMethodCallError.spec.ts
@@ -40,8 +40,7 @@ describe('logMethodCallError', () => {
 
 		expect(meteorDebugMock.called).to.be.false;
 		expect(errorMock.called).to.be.false;
-		expect(debugMock.calledOnce).to.be.true;
-		expect(debugMock.calledWith({ msg: 'Expected error while invoking method', err, method: 'loadHistory' })).to.be.true;
+		expect(debugMock.calledOnceWithExactly({ msg: 'Expected error while invoking method', err, method: 'loadHistory' })).to.be.true;
 	});
 
 	it('should not report meteor errors as exceptions', () => {
@@ -51,8 +50,7 @@ describe('logMethodCallError', () => {
 
 		expect(meteorDebugMock.called).to.be.false;
 		expect(errorMock.called).to.be.false;
-		expect(debugMock.calledOnce).to.be.true;
-		expect(debugMock.calledWith({ msg: 'Expected error while invoking method', err, method: 'login' })).to.be.true;
+		expect(debugMock.calledOnceWithExactly({ msg: 'Expected error while invoking method', err, method: 'login' })).to.be.true;
 	});
 
 	it('should report unexpected errors as exceptions when Log_Level is 2', () => {
@@ -60,10 +58,9 @@ describe('logMethodCallError', () => {
 
 		logMethodCallError('loadHistory', err);
 
-		expect(errorMock.calledOnce).to.be.true;
-		expect(errorMock.calledWith({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
-		expect(meteorDebugMock.calledOnce).to.be.true;
-		expect(meteorDebugMock.calledWith('Exception while invoking method loadHistory', err)).to.be.true;
+		expect(debugMock.called).to.be.false;
+		expect(errorMock.calledOnceWithExactly({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
+		expect(meteorDebugMock.calledOnceWithExactly('Exception while invoking method loadHistory', err)).to.be.true;
 	});
 
 	it('should report unexpected errors without notifying the exceptions channel when Log_Level is not 2', () => {
@@ -73,8 +70,8 @@ describe('logMethodCallError', () => {
 
 		logMethodCallError('loadHistory', err);
 
-		expect(errorMock.calledOnce).to.be.true;
-		expect(errorMock.calledWith({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
+		expect(debugMock.called).to.be.false;
+		expect(errorMock.calledOnceWithExactly({ msg: 'Exception while invoking method', err, method: 'loadHistory' })).to.be.true;
 		expect(meteorDebugMock.called).to.be.false;
 	});
 });

--- a/apps/meteor/server/api/lib/logMethodCallError.ts
+++ b/apps/meteor/server/api/lib/logMethodCallError.ts
@@ -1,0 +1,17 @@
+import { Meteor } from 'meteor/meteor';
+
+import { SystemLogger } from '../../lib/logger/system';
+import { settings } from '../../settings';
+
+export function logMethodCallError(method: string, err: unknown): void {
+	if ((err as any)?.isClientSafe || (err as any)?.meteorError) {
+		SystemLogger.debug({ msg: 'Expected error while invoking method', err, method });
+		return;
+	}
+
+	SystemLogger.error({ msg: 'Exception while invoking method', err, method });
+
+	if (settings.get('Log_Level') === '2') {
+		Meteor._debug(`Exception while invoking method ${method}`, err);
+	}
+}

--- a/apps/meteor/server/api/v1/misc.ts
+++ b/apps/meteor/server/api/v1/misc.ts
@@ -25,7 +25,6 @@ import { Meteor } from 'meteor/meteor';
 
 import { passwordPolicy } from '../../lib/auth/passwordPolicy';
 import { i18n } from '../../lib/i18n';
-import { SystemLogger } from '../../lib/logger/system';
 import { notifyOnSettingChangedById } from '../../lib/notifyListener';
 import { getBaseUserFields } from '../../lib/utils/functions/getBaseUserFields';
 import { isSMTPConfigured } from '../../lib/utils/functions/isSMTPConfigured';
@@ -38,6 +37,7 @@ import { API } from '../api';
 import { getPaginationItems } from '../lib/getPaginationItems';
 import { getUserFromParams } from '../lib/getUserFromParams';
 import { getUserInfo } from '../lib/getUserInfo';
+import { logMethodCallError } from '../lib/logMethodCallError';
 
 /**
  * @openapi
@@ -670,13 +670,7 @@ API.v1.post(
 
 			return API.v1.success(mountResult({ id, result: await Meteor.callAsync(method, ...params) }));
 		} catch (err) {
-			if (!(err as any).isClientSafe && !(err as any).meteorError) {
-				SystemLogger.error({ msg: 'Exception while invoking method', err, method });
-			}
-
-			if (settings.get('Log_Level') === '2') {
-				Meteor._debug(`Exception while invoking method ${method}`, err);
-			}
+			logMethodCallError(method, err);
 
 			return API.v1.failure(mountResult({ id, error: err }));
 		}
@@ -732,12 +726,8 @@ API.v1.post(
 
 			return API.v1.success(mountResult({ id, result: await Meteor.callAsync(method, ...params) }));
 		} catch (err) {
-			if (!(err as any).isClientSafe && !(err as any).meteorError) {
-				SystemLogger.error({ msg: 'Exception while invoking method', err, method });
-			}
-			if (settings.get('Log_Level') === '2') {
-				Meteor._debug(`Exception while invoking method ${method}`, err);
-			}
+			logMethodCallError(method, err);
+
 			return API.v1.failure(mountResult({ id, error: err }));
 		}
 	},


### PR DESCRIPTION
## Proposed changes

This is a follow-up to #41795. It strengthens the unit tests for the new `logMethodCallError` helper so that every call to `SystemLogger.debug`, `SystemLogger.error`, and `Meteor._debug` is validated with its full payload (message, error object, and method name).

This addresses the unresolved CodeRabbit / cubic review comments on the original PR, which asked for complete payload assertions instead of only call counts.

No production code is changed.

## Issue(s)

Follow-up to #41795.

## Steps to test or reproduce

Run the targeted unit tests:

```
./node_modules/.bin/mocha --no-config --require tsx --require ./tests/setup/chaiPlugins.ts ./server/api/lib/logMethodCallError.spec.ts
```

All four tests should pass.

## Further comments

The original PR already passed CI; this change only improves test coverage quality and should not affect runtime behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed client-safe errors being incorrectly reported as exceptions when `Log_Level` is set to `2`.
  * Improved error handling for authenticated and anonymous API method calls.
  * Expected errors are now logged without unnecessary exception notifications.
  * Unexpected errors continue to be reported according to the configured log level.

* **Tests**
  * Added coverage for expected and unexpected error logging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->