### PR TITLE
refactor(ui-client): use some with optional chaining for dontAskAgain

### DIFF
--- a/packages/ui-client/src/hooks/useDontAskAgain.spec.ts
+++ b/packages/ui-client/src/hooks/useDontAskAgain.spec.ts
@@ -1,0 +1,32 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook } from '@testing-library/react';
+
+import { useDontAskAgain } from './useDontAskAgain';
+
+it('should return true if action exists in dontAskAgainList', () => {
+	const { result } = renderHook(() => useDontAskAgain('delete'), {
+		wrapper: mockAppRoot()
+			.withUserPreference('dontAskAgainList', [{ action: 'delete', label: 'Delete message' }])
+			.build(),
+	});
+
+	expect(result.current).toBe(true);
+});
+
+it('should return false if action does not exist in dontAskAgainList', () => {
+	const { result } = renderHook(() => useDontAskAgain('edit'), {
+		wrapper: mockAppRoot()
+			.withUserPreference('dontAskAgainList', [{ action: 'delete', label: 'Delete message' }])
+			.build(),
+	});
+
+	expect(result.current).toBe(false);
+});
+
+it('should return false if dontAskAgainList is undefined', () => {
+	const { result } = renderHook(() => useDontAskAgain('delete'), {
+		wrapper: mockAppRoot().build(),
+	});
+
+	expect(result.current).toBe(false);
+});

--- a/packages/ui-client/src/hooks/useDontAskAgain.ts
+++ b/packages/ui-client/src/hooks/useDontAskAgain.ts
@@ -4,7 +4,7 @@ export type DontAskAgainList = Array<{ action: string; label: string }>;
 
 export const useDontAskAgain = (action: string): boolean => {
 	const dontAskAgainList = useUserPreference<DontAskAgainList>('dontAskAgainList');
-	const shouldNotAskAgain = dontAskAgainList?.some(({ action: currentAction }) => action === currentAction)??false;
+	const shouldNotAskAgain = dontAskAgainList?.some(({ action: currentAction }) => action === currentAction) ?? false;
 
 	return shouldNotAskAgain;
 };

--- a/packages/ui-client/src/hooks/useDontAskAgain.ts
+++ b/packages/ui-client/src/hooks/useDontAskAgain.ts
@@ -4,7 +4,7 @@ export type DontAskAgainList = Array<{ action: string; label: string }>;
 
 export const useDontAskAgain = (action: string): boolean => {
 	const dontAskAgainList = useUserPreference<DontAskAgainList>('dontAskAgainList');
-	const shouldNotAskAgain = !!dontAskAgainList?.filter(({ action: currentAction }) => action === currentAction).length;
+	const shouldNotAskAgain = dontAskAgainList?.some(({ action: currentAction }) => action === currentAction)??false;
 
 	return shouldNotAskAgain;
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes

This PR replaces the use of `filter().length` with `some()` when checking for the presence of an action in `dontAskAgainList` within the `useDontAskAgain` hook.

The change improves readability and better expresses the intent of performing an existence check, while preserving the existing behavior.

Optional chaining with `?? false` also ensures the hook safely returns `false` when `dontAskAgainList` is undefined.


## Steps to test or reproduce

1. Run the application normally.
2. Trigger any flow that relies on the `useDontAskAgain` hook.
3. Verify that the behavior remains unchanged when the corresponding action exists or does not exist in the user's preferences.

## Further comments

This is a small internal refactor with no intended functional behavior changes. It avoids unnecessary array creation and uses the idiomatic `some()` method for existence checks.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Don’t ask again” action check to reliably handle missing actions and return the correct result.
* **Tests**
  * Added coverage for matching actions, non-matching actions, and missing “Don’t ask again” settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->