### PR TITLE
fix: ignore incomplete avatars for thread subscribers

### DIFF
--- a/apps/meteor/server/routes/avatar/user.spec.ts
+++ b/apps/meteor/server/routes/avatar/user.spec.ts
@@ -109,7 +109,7 @@ describe('#userAvatarById()', () => {
 	it(`should serve avatar file if found`, async () => {
 		const request = { url: '/jon' };
 
-		const file = { uploadedAt: new Date(0), type: 'image/png', size: 100 };
+		const file = { uploadedAt: new Date(0), type: 'image/png', size: 100, complete: true };
 		mocks.avatarFindOneByUserId.returns(file);
 
 		await userAvatarById(request, response, next);

--- a/packages/models/src/models/Avatars.ts
+++ b/packages/models/src/models/Avatars.ts
@@ -18,7 +18,7 @@ export class AvatarsRaw extends BaseUploadModelRaw implements IAvatarsModel {
 	}
 
 	findOneByUserId(userId: IUser['_id'], options?: FindOptions<IAvatar>) {
-		return this.findOne({ userId }, options);
+		return this.findOne({ userId, complete: true }, options);
 	}
 
 	findOneByETag(etag: string, options?: FindOptions<IAvatar>): Promise<IAvatar | null> {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Ignore incomplete avatar uploads when resolving avatars for thread subscribers.

An avatar can exist in object storage and have a reference in the database while not being marked as complete (`complete: true`). Currently, this reference can be used when fetching thread subscribers, causing an incomplete/corrupted avatar to be displayed in the thread subscriber list.

This change ensures that incomplete avatars are ignored and the user's default avatar (the first letter of their name) is displayed instead.

## Issue(s)

Closes #41802

## Steps to test or reproduce

1. Use a user without an avatar.
2. Start uploading an avatar for the user.
3. Interrupt or cancel the upload before it completes.
4. Subscribe the user to a thread.
5. Make sure the affected user is one of the first two subscribers displayed in the thread.
6. Open the thread subscriber list.
7. Verify that the user's default avatar (the first letter of their name) is displayed instead of the incomplete avatar.

## Further comments

The fix checks whether the avatar upload has been completed before using the stored object-storage reference.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar retrieval to show only fully completed avatar files.
  * Updated avatar serving behavior to correctly handle completed avatar data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->