### PR TITLE
fix: Message list scroll position lost after switching channels and returning

### DIFF
--- a/.changeset/jolly-poets-tan.md
+++ b/.changeset/jolly-poets-tan.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the issue where the message list keep jumping to the latest messages instead of restoring the previous
+position when leaving a channel scrolled mid-history and coming back.

--- a/.changeset/jolly-poets-tan.md
+++ b/.changeset/jolly-poets-tan.md
@@ -2,5 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes the issue where the message list keep jumping to the latest messages instead of restoring the previous
-position when leaving a channel scrolled mid-history and coming back.
+Fixes the issue where the message list kept jumping to the latest messages instead of restoring the previous position when switching channels.

--- a/apps/meteor/client/views/room/MessageList/hooks/useKeepAtBottom.spec.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useKeepAtBottom.spec.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+
+import { useKeepAtBottom } from './useKeepAtBottom';
+
+let resizeCallbacks: ResizeObserverCallback[] = [];
+
+class MockResizeObserver {
+	constructor(cb: ResizeObserverCallback) {
+		resizeCallbacks.push(cb);
+	}
+
+	observe = jest.fn();
+
+	unobserve = jest.fn();
+
+	disconnect = jest.fn();
+}
+
+// Rows are measured asynchronously after the list remounts (avatars, images, reactions),
+// so the observer fires repeatedly while the restored position is being applied.
+const settleList = (times: number) => {
+	for (let i = 0; i < times; i++) {
+		resizeCallbacks.forEach((cb) => cb([], {} as ResizeObserver));
+	}
+};
+
+const mountList = (isAtBottom: { current: boolean }) => {
+	const { result } = renderHook(() => useKeepAtBottom(isAtBottom));
+
+	const node = document.createElement('div');
+	node.appendChild(document.createElement('div'));
+	result.current.keepAtBottomRef(node);
+
+	const scrollToEnd = jest.fn();
+	result.current.setKeepAtBottom(scrollToEnd);
+
+	return scrollToEnd;
+};
+
+describe('useKeepAtBottom', () => {
+	beforeEach(() => {
+		resizeCallbacks = [];
+		(global as any).ResizeObserver = MockResizeObserver;
+	});
+
+	it('does not pull the list to the latest messages when the room was left mid-history', () => {
+		const scrollToEnd = mountList({ current: false });
+
+		settleList(3);
+
+		expect(scrollToEnd).not.toHaveBeenCalled();
+	});
+
+	it('keeps the list at the bottom when the room was left at the bottom', () => {
+		const scrollToEnd = mountList({ current: true });
+
+		settleList(3);
+
+		expect(scrollToEnd).toHaveBeenCalledTimes(3);
+	});
+});

--- a/apps/meteor/client/views/room/body/RoomBody.tsx
+++ b/apps/meteor/client/views/room/body/RoomBody.tsx
@@ -3,7 +3,7 @@ import { isTruthy } from '@rocket.chat/tools';
 import { CustomVirtuaScrollbars, useEmbeddedLayout } from '@rocket.chat/ui-client';
 import { usePermission, useRole, useSetting, useTranslation, useUser, useUserPreference, useRoomToolbox } from '@rocket.chat/ui-contexts';
 import type { MouseEvent } from 'react';
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useMergedRefsV2 } from '../../../hooks/useMergedRefsV2';
 import { BubbleDate } from '../BubbleDate';
@@ -17,6 +17,7 @@ import UploadProgressIndicator from './UploadProgress';
 import ComposerContainer from '../composer/ComposerContainer';
 import { useFileUpload } from './hooks/useFileUpload';
 import { useGoToHomeOnRemoved } from './hooks/useGoToHomeOnRemoved';
+import { useIsAtBottomRef } from './hooks/useIsAtBottomRef';
 import { useQuoteMessageByUrl } from './hooks/useQuoteMessageByUrl';
 import { useReadMessageWindowEvents } from './hooks/useReadMessageWindowEvents';
 import RoomComposer from '../composer/RoomComposer/RoomComposer';
@@ -48,7 +49,7 @@ const RoomBody = () => {
 	const subscription = useRoomSubscription();
 
 	const [shouldJumpToBottom, setShouldJumpToBottom] = useState<boolean>(false);
-	const isAtBottom = useRef<boolean>(true);
+	const isAtBottom = useIsAtBottomRef(room._id);
 	const [isJumpingToMessage, setIsJumpingToMessage] = useState<boolean>(false);
 
 	const retentionPolicy = useRetentionPolicy(room);

--- a/apps/meteor/client/views/room/body/hooks/useIsAtBottomRef.spec.ts
+++ b/apps/meteor/client/views/room/body/hooks/useIsAtBottomRef.spec.ts
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react';
+
+import { useIsAtBottomRef } from './useIsAtBottomRef';
+import { RoomManager } from '../../../../lib/RoomManager';
+
+jest.mock('../../../../lib/RoomManager', () => ({
+	RoomManager: { getStore: jest.fn() },
+}));
+
+const mockStore = (store: { atBottom: boolean } | undefined) => (RoomManager.getStore as jest.Mock).mockReturnValue(store);
+
+describe('useIsAtBottomRef', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('starts at the bottom when the room has no stored position yet', () => {
+		mockStore(undefined);
+
+		const { result } = renderHook(() => useIsAtBottomRef('rid'));
+
+		expect(result.current.current).toBe(true);
+	});
+
+	it('starts away from the bottom when the room was left scrolled mid-history', () => {
+		mockStore({ atBottom: false });
+
+		const { result } = renderHook(() => useIsAtBottomRef('rid'));
+
+		expect(result.current.current).toBe(false);
+	});
+
+	it('starts at the bottom when the room was left at the bottom', () => {
+		mockStore({ atBottom: true });
+
+		const { result } = renderHook(() => useIsAtBottomRef('rid'));
+
+		expect(result.current.current).toBe(true);
+	});
+});

--- a/apps/meteor/client/views/room/body/hooks/useIsAtBottomRef.ts
+++ b/apps/meteor/client/views/room/body/hooks/useIsAtBottomRef.ts
@@ -1,0 +1,9 @@
+import type { RefObject } from 'react';
+import { useRef } from 'react';
+
+import { RoomManager } from '../../../../lib/RoomManager';
+
+/** Starting from `true` makes `useKeepAtBottom` pull a restored mid-history position down to the latest messages, so seed it from the position persisted for the room being opened. */
+export const useIsAtBottomRef = (rid: string): RefObject<boolean> => {
+	return useRef<boolean>(RoomManager.getStore(rid)?.atBottom ?? true);
+};


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
`RoomBody` initialized `isAtBottom` to a hardcoded `true`, so a room always started out believing it was pinned to the bottom — even when reopening one the user had left scrolled mid-history.

That matters because `useKeepAtBottom` observes the message list with a `ResizeObserver` and scrolls to the end on every resize while `isAtBottom.current` is true. Message rows resize repeatedly as they are measured after the list remounts, so the restored mid-history position was dragged down to the latest messages.

`isAtBottom` is now seeded from the `atBottom` value already persisted per room in `RoomManager`'s store, falling back to `true` when there is no store yet (first visit).

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Open a channel with 100+ messages and scroll up so mid-history is in view.
2. Switch to another channel, then return.
3. The viewport should stay in the same region instead of sliding to the latest messages.

Note: with more than 5 rooms open, `closeOlderRooms()` evicts the room's stored position and messages, which masks the behavior — test with a small number of open rooms.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[SUP-1098]

[SUP-1098]: https://rocketchat.atlassian.net/browse/SUP-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message-list position restoration when returning to a channel.
  * Preserved the previous scroll position for channels left mid-history.
  * Continued scrolling to the latest messages for channels previously left at the bottom.

* **Tests**
  * Added coverage for repeated list resizing and scroll-position restoration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->