### PR TITLE
fix: infinite `commands.list` requests when `API_Upper_Count_Limit` is below 50

### DIFF
--- a/.changeset/slash-commands-pagination-loop.md
+++ b/.changeset/slash-commands-pagination-loop.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an endless stream of `commands.list` requests when `API_Upper_Count_Limit` is lower than 50. The client paginated the slash command list in steps of 50 regardless of how many items the server actually returned, so the list never reached the reported total and the requests never stopped.

--- a/apps/meteor/client/hooks/useAppSlashCommands.spec.ts
+++ b/apps/meteor/client/hooks/useAppSlashCommands.spec.ts
@@ -263,6 +263,57 @@ describe('useAppSlashCommands', () => {
 		});
 	});
 
+	it('should fetch all commands when the server returns fewer items than requested', async () => {
+		const serverPageSizeLimit = 20;
+
+		const largeMockCommands: SlashCommand[] = Array.from({ length: 120 }, (_, i) => ({
+			command: `/command${i + 1}`,
+			description: `Description for command ${i + 1}`,
+			params: '',
+			clientOnly: false,
+			providesPreview: false,
+			appId: `app-${i + 1}`,
+			permission: undefined,
+		}));
+
+		mockGetSlashCommands.mockImplementation(({ offset, count }) => {
+			return Promise.resolve({
+				commands: largeMockCommands.slice(offset, offset + Math.min(count, serverPageSizeLimit)),
+				total: largeMockCommands.length,
+				appsLoaded: true,
+			});
+		});
+
+		renderHook(() => useAppSlashCommands(), {
+			wrapper: mockAppRoot().withJohnDoe().withEndpoint('GET', '/v1/commands.list', mockGetSlashCommands).build(),
+		});
+
+		await waitFor(() => {
+			expect(Object.keys(slashCommands.commands)).toHaveLength(largeMockCommands.length);
+		});
+
+		expect(mockGetSlashCommands).toHaveBeenCalledTimes(largeMockCommands.length / serverPageSizeLimit);
+	});
+
+	it('should stop paginating when a page comes back empty', async () => {
+		mockGetSlashCommands.mockResolvedValue({
+			commands: [],
+			total: 10,
+			appsLoaded: true,
+		});
+
+		renderHook(() => useAppSlashCommands(), {
+			wrapper: mockAppRoot().withJohnDoe().withEndpoint('GET', '/v1/commands.list', mockGetSlashCommands).build(),
+		});
+
+		await waitFor(() => {
+			expect(mockGetSlashCommands).toHaveBeenCalled();
+		});
+
+		expect(mockGetSlashCommands).toHaveBeenCalledTimes(1);
+		expect(Object.keys(slashCommands.commands)).toHaveLength(0);
+	});
+
 	it('should not load commands when apps are not loaded', async () => {
 		mockGetSlashCommands.mockResolvedValue({
 			commands: [],

--- a/apps/meteor/client/hooks/useAppSlashCommands.ts
+++ b/apps/meteor/client/hooks/useAppSlashCommands.ts
@@ -62,8 +62,8 @@ export const useAppSlashCommands = () => {
 
 				const newAccumulator = [...accumulator, ...commands];
 
-				if (newAccumulator.length < total) {
-					return fetchBatch(currentOffset + count, newAccumulator);
+				if (commands.length > 0 && newAccumulator.length < total) {
+					return fetchBatch(currentOffset + commands.length, newAccumulator);
 				}
 
 				return newAccumulator;

--- a/apps/meteor/server/api/v1/commands.ts
+++ b/apps/meteor/server/api/v1/commands.ts
@@ -171,15 +171,17 @@ const commandsEndpoints = API.v1
 
 			const totalCount = commands.length;
 
+			const paginatedCommands = processQueryOptionsOnResult(commands, {
+				sort: sort || { name: 1 },
+				skip: offset,
+				limit: count,
+			});
+
 			return API.v1.success({
-				commands: processQueryOptionsOnResult(commands, {
-					sort: sort || { name: 1 },
-					skip: offset,
-					limit: count,
-				}),
+				commands: paginatedCommands,
 				appsLoaded: true as const,
 				offset,
-				count: commands.length,
+				count: paginatedCommands.length,
 				total: totalCount,
 			});
 		},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

The client fetches the full slash command list on startup by paginating `commands.list` with `count=50`, and it advanced the offset by a fixed 50 on every step. The server does not have to honor that page size: `getPaginationItems` clamps `count` down to the `API_Upper_Count_Limit` setting. When that setting is below 50, each page returns fewer commands than the client assumes, the accumulated list never reaches the reported `total`, and the offset walks past the end of the list requesting empty pages forever. The query never settles, so React Query never caches a result and every open tab keeps firing requests indefinitely (I saw over 5k calls from a single session, with offsets past 900k).

The pagination now advances by the number of items actually returned and stops as soon as a page comes back empty, which makes the loop terminate for any server page size.

Introduced in #34167, released in 7.2.0. #35535 later reworked the same logic into a recursion and carried the flaw over unchanged.

## Issue(s)

## Steps to test or reproduce

1. Go to **Admin > Settings > General > REST API** and set `API_Upper_Count_Limit` to any value below 50 (I used 20).
2. Reload the client with the browser network tab open, or watch the server logs.
3. Before this change, `GET /api/v1/commands.list` repeats without end, with the offset growing by 50 on every call and the responses coming back empty. After this change, the requests stop once the whole command list has been fetched, and slash commands still autocomplete correctly in the composer.

## Further comments

Two unit tests cover the regression: one where the server returns fewer items than requested, and one where a page comes back empty while `total` is still unreached.
[CORE-2572](https://rocketchat.atlassian.net/browse/CORE-2572)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed slash-command loading to prevent endless pagination requests when fewer than 50 commands are returned per response.
  - Improved pagination to stop once all available commands have been retrieved or an empty response is received.
  - Slash-command lists now load reliably when server-imposed limits return smaller batches than requested.

- **Tests**
  - Added coverage for short responses, complete command retrieval, server-reported totals, and empty-page handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2572]: https://rocketchat.atlassian.net/browse/CORE-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
