### PR TITLE
chore!: remove FileUpload_S3_SignatureVersion setting

### DIFF
--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -42,5 +42,6 @@ import './v333';
 import './v334';
 import './v335';
 import './v336';
+import './v337';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v337.ts
+++ b/apps/meteor/server/startup/migrations/v337.ts
@@ -1,0 +1,11 @@
+import { Settings } from '@rocket.chat/models';
+
+import { addMigration } from '../../lib/migrations';
+
+addMigration({
+	version: 337,
+	name: 'Remove FileUpload_S3_SignatureVersion setting',
+	async up() {
+		await Settings.deleteOne({ _id: 'FileUpload_S3_SignatureVersion' });
+	},
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds migration v337 that deletes the leftover `FileUpload_S3_SignatureVersion` setting document from the database.

The setting itself was already removed from the settings definitions, the S3 store config, and all translations in #39244; this migration only clears the stale document that existing installations still carry.

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-1934
## Steps to test or reproduce

1. On a pre-9.0 database, confirm `db.rocketchat_settings.findOne({ _id: 'FileUpload_S3_SignatureVersion' })` returns a document.
2. Start the server on this branch and let migrations run.
3. Confirm the document is gone and `rocketchat_migrations` reports version 337.

## Further comments

No changeset: the setting has been unused since #39244, so there is no user-visible behavior change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete S3 signature version setting during application startup migration.
  * Improved upgrade compatibility for existing installations using legacy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->