### PR TITLE
fix: message deep links leaving public rooms blank for anonymous readers

### DIFF
--- a/apps/meteor/server/meteor-methods/messages/loadSurroundingMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadSurroundingMessages.ts
@@ -7,6 +7,7 @@ import type { FindOptions } from 'mongodb';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
+import { settings } from '../../settings';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -31,13 +32,13 @@ Meteor.methods<ServerMethods>({
 		check(limit, Number);
 		check(showThreadMessages, Boolean);
 
-		if (!Meteor.userId()) {
+		const fromId = Meteor.userId() ?? undefined;
+
+		if (!fromId && settings.get('Accounts_AllowAnonymousRead') === false) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', {
 				method: 'loadSurroundingMessages',
 			});
 		}
-
-		const fromId = Meteor.userId() ?? undefined;
 
 		if (!message._id) {
 			return false;

--- a/apps/meteor/tests/unit/server/meteor-methods/messages/loadSurroundingMessages.spec.ts
+++ b/apps/meteor/tests/unit/server/meteor-methods/messages/loadSurroundingMessages.spec.ts
@@ -1,0 +1,103 @@
+import { MeteorError } from '@rocket.chat/core-services';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import p from 'proxyquire';
+import sinon from 'sinon';
+
+const checkMock = sinon.stub();
+const meteorUserIdMock = sinon.stub();
+const meteorMethodsMock = sinon.stub();
+const canAccessRoomIdMock = sinon.stub();
+const normalizeMessagesForUserMock = sinon.stub();
+const settingsGetMock = sinon.stub();
+
+// the method pushes into the array it gets back, so each call needs a fresh one
+const emptyCursor = () => ({ toArray: async () => [] });
+
+const modelsMock = {
+	Messages: {
+		findOneById: sinon.stub(),
+		findVisibleByRoomIdBeforeTimestamp: sinon.stub().callsFake(emptyCursor),
+		findVisibleByRoomIdAfterTimestamp: sinon.stub().callsFake(emptyCursor),
+	},
+};
+
+p.noCallThru().load('../../../../../server/meteor-methods/messages/loadSurroundingMessages', {
+	'meteor/meteor': {
+		Meteor: {
+			userId: meteorUserIdMock,
+			Error: MeteorError,
+			methods: meteorMethodsMock,
+		},
+	},
+	'meteor/check': {
+		check: checkMock,
+	},
+	'@rocket.chat/models': modelsMock,
+	'../../lib/authorization/canAccessRoom': {
+		canAccessRoomIdAsync: canAccessRoomIdMock,
+	},
+	'../../lib/utils/lib/normalizeMessagesForUser': {
+		normalizeMessagesForUser: normalizeMessagesForUserMock,
+	},
+	'../../settings': {
+		settings: { get: settingsGetMock },
+	},
+});
+
+const loadSurroundingMessagesMethod = meteorMethodsMock.firstCall.args[0].loadSurroundingMessages;
+
+const mainMessage = { _id: 'msg123', rid: 'room123', ts: new Date('2024-01-01T00:00:00Z') };
+
+describe('loadSurroundingMessages', () => {
+	beforeEach(() => {
+		checkMock.resetHistory();
+		meteorUserIdMock.reset();
+		canAccessRoomIdMock.reset();
+		normalizeMessagesForUserMock.reset();
+		settingsGetMock.reset();
+		modelsMock.Messages.findOneById.reset();
+	});
+
+	it('should throw for an anonymous user when anonymous read is disabled', async () => {
+		meteorUserIdMock.returns(null);
+		settingsGetMock.withArgs('Accounts_AllowAnonymousRead').returns(false);
+
+		await expect(loadSurroundingMessagesMethod({ _id: 'msg123', rid: 'room123' })).to.be.rejectedWith('Invalid user');
+	});
+
+	it('should load the surrounding messages for an anonymous user when anonymous read is enabled', async () => {
+		meteorUserIdMock.returns(null);
+		settingsGetMock.withArgs('Accounts_AllowAnonymousRead').returns(true);
+		modelsMock.Messages.findOneById.resolves(mainMessage);
+		canAccessRoomIdMock.resolves(true);
+
+		const result = await loadSurroundingMessagesMethod({ _id: 'msg123', rid: 'room123' });
+
+		expect(result).to.not.be.false;
+		expect(result.messages).to.deep.equal([mainMessage]);
+		expect(canAccessRoomIdMock.calledOnceWith('room123', undefined)).to.be.true;
+		expect(normalizeMessagesForUserMock.called).to.be.false;
+	});
+
+	it('should not load the surrounding messages when the room is out of reach', async () => {
+		meteorUserIdMock.returns(null);
+		settingsGetMock.withArgs('Accounts_AllowAnonymousRead').returns(true);
+		modelsMock.Messages.findOneById.resolves(mainMessage);
+		canAccessRoomIdMock.resolves(false);
+
+		expect(await loadSurroundingMessagesMethod({ _id: 'msg123', rid: 'room123' })).to.be.false;
+	});
+
+	it('should normalize the messages for a logged in user', async () => {
+		meteorUserIdMock.returns('user123');
+		modelsMock.Messages.findOneById.resolves(mainMessage);
+		canAccessRoomIdMock.resolves(true);
+		normalizeMessagesForUserMock.resolves([mainMessage]);
+
+		await loadSurroundingMessagesMethod({ _id: 'msg123', rid: 'room123' });
+
+		expect(settingsGetMock.called).to.be.false;
+		expect(normalizeMessagesForUserMock.calledOnceWith([mainMessage], 'user123')).to.be.true;
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

With **Allow Anonymous Read** enabled, an anonymous visitor can open a public channel, but opening that same channel through a message link (`?msg=<message-id>`) leaves the message list blank with an `error-invalid-user`.

The two methods that load messages disagree on who may call them:

| method | used when | anonymous user |
| --- | --- | --- |
| `loadHistory` | opening a room normally | allowed while `Accounts_AllowAnonymousRead` is on |
| `loadSurroundingMessages` | opening a room through `?msg=` | rejected, always |

`loadSurroundingMessages` has rejected every request without a user since 2016 (`249d99e8b`). `loadHistory` was later given an anonymous exemption; this one never was. This PR applies the same guard, so both paths answer to the same setting.

Room access is unchanged — `canAccessRoomIdAsync` still decides what an anonymous visitor may read — and messages are still normalized only for a logged in user.

## Issue(s)

- [CORE-2566](https://rocketchat.atlassian.net/browse/CORE-2566)

## Steps to test or reproduce

1. Enable **Allow Anonymous Read** in **Administration → Workspace → Settings → Accounts**.
2. Send a message in `general` and copy its link (`.../channel/general?msg=<message-id>`).
3. In an incognito window, open `.../channel/general` — the history is readable without signing in.
4. In the same window, open the copied link.

**Before:** blank or endlessly loading, with an "Invalid user" error.
**After:** the channel opens positioned on the linked message.

Also worth confirming: with the setting disabled the link is still refused, and signed in nothing changes.

## Further comments

[CORE-2566]: https://rocketchat.atlassian.net/browse/CORE-2566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous readers can now open links to messages in public channels when anonymous reading is enabled.
  * Linked-message loading no longer shows an “Invalid user” error.
  * Anonymous access remains blocked when the setting is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->