### PR TITLE
fix(i18n): prevent Traditional Chinese locales from falling back to S…

### DIFF
--- a/.changeset/fix-chinese-locales-fallback.md
+++ b/.changeset/fix-chinese-locales-fallback.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/i18n': patch
+'@rocket.chat/tools': patch
+---
+
+Fix regression where Traditional Chinese (zh-TW, zh-HK) locales resolve to Simplified Chinese (zh) resources and browser language detection collapses Traditional Chinese variants into Simplified Chinese.

--- a/apps/meteor/client/providers/TranslationProvider.tsx
+++ b/apps/meteor/client/providers/TranslationProvider.tsx
@@ -6,6 +6,7 @@ import {
 	availableTranslationNamespaces,
 	defaultTranslationNamespace,
 	extractTranslationNamespaces,
+	defaultFallbackLng,
 } from '@rocket.chat/i18n';
 import languages from '@rocket.chat/i18n/dist/languages';
 import en from '@rocket.chat/i18n/dist/resources/en.i18n.json';
@@ -72,7 +73,8 @@ const useI18next = (lng: string): typeof i18next => {
 		isI18nInitialized = true;
 		i18n.init({
 			lng,
-			fallbackLng: 'en',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
 			ns: availableTranslationNamespaces,
 			defaultNS: defaultTranslationNamespace,
 			nsSeparator: '.',

--- a/apps/meteor/server/lib/i18n.ts
+++ b/apps/meteor/server/lib/i18n.ts
@@ -1,4 +1,9 @@
-import { availableTranslationNamespaces, defaultTranslationNamespace, extractTranslationNamespaces } from '@rocket.chat/i18n';
+import {
+	availableTranslationNamespaces,
+	defaultFallbackLng,
+	defaultTranslationNamespace,
+	extractTranslationNamespaces,
+} from '@rocket.chat/i18n';
 import languages from '@rocket.chat/i18n/dist/languages';
 
 import { i18n } from '../../app/utils/lib/i18n';
@@ -79,7 +84,8 @@ if (false) {
 
 void i18n.init({
 	lng: 'en',
-	fallbackLng: 'en',
+	fallbackLng: defaultFallbackLng,
+	load: 'currentOnly',
 	defaultNS: defaultTranslationNamespace,
 	ns: availableTranslationNamespaces,
 	nsSeparator: '.',

--- a/packages/i18n/src/fallbackLng.spec.ts
+++ b/packages/i18n/src/fallbackLng.spec.ts
@@ -1,0 +1,111 @@
+import i18next from 'i18next';
+
+import { defaultFallbackLng } from './index';
+
+describe('defaultFallbackLng', () => {
+	it('should resolve zh-TW to [zh-TW, zh-HK, en] without zh / Simplified Chinese', () => {
+		const i18n = i18next.createInstance();
+		i18n.init({
+			lng: 'zh-TW',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+
+		expect(i18n.languages).toEqual(['zh-TW', 'zh-HK', 'en']);
+		expect(i18n.languages).not.toContain('zh');
+		expect(i18n.languages).not.toContain('zh-CN');
+	});
+
+	it('should resolve zh-HK to [zh-HK, zh-TW, en] without zh / Simplified Chinese', () => {
+		const i18n = i18next.createInstance();
+		i18n.init({
+			lng: 'zh-HK',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+
+		expect(i18n.languages).toEqual(['zh-HK', 'zh-TW', 'en']);
+		expect(i18n.languages).not.toContain('zh');
+		expect(i18n.languages).not.toContain('zh-CN');
+	});
+
+	it('should resolve zh (Simplified Chinese) to [zh, en]', () => {
+		const i18n = i18next.createInstance();
+		i18n.init({
+			lng: 'zh',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+
+		expect(i18n.languages).toEqual(['zh', 'en']);
+	});
+
+	it('should resolve zh-CN to [zh-CN, zh, en]', () => {
+		const i18n = i18next.createInstance();
+		i18n.init({
+			lng: 'zh-CN',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+
+		expect(i18n.languages).toEqual(['zh-CN', 'zh', 'en']);
+	});
+
+	it('should resolve regional variants like pt-BR and de-AT appropriately', () => {
+		const i18nPt = i18next.createInstance();
+		i18nPt.init({
+			lng: 'pt-BR',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+		expect(i18nPt.languages).toEqual(['pt-BR', 'pt', 'en']);
+
+		const i18nDe = i18next.createInstance();
+		i18nDe.init({
+			lng: 'de-AT',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+		});
+		expect(i18nDe.languages).toEqual(['de-AT', 'de', 'en']);
+	});
+
+	it('should resolve translation keys from zh-TW and fall back to en when missing in zh-TW', () => {
+		const i18n = i18next.createInstance();
+		i18n.init({
+			lng: 'zh-TW',
+			fallbackLng: defaultFallbackLng,
+			load: 'currentOnly',
+			initImmediate: false,
+			resources: {
+				'zh-TW': {
+					translation: {
+						Users: '使用者',
+					},
+				},
+				'zh': {
+					translation: {
+						Users: '用户',
+						private: '私有',
+					},
+				},
+				'en': {
+					translation: {
+						Users: 'Users',
+						private: 'private',
+					},
+				},
+			},
+		});
+
+		// Present in zh-TW
+		expect(i18n.t('Users')).toBe('使用者');
+		// Missing in zh-TW -> should fall back to en, NOT zh (Simplified Chinese)
+		expect(i18n.t('private')).toBe('private');
+	});
+});

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -149,3 +149,20 @@ export const applyCustomTranslations = (
 		}
 	}
 };
+
+export const defaultFallbackLng = {
+	'zh-TW': ['zh-HK', 'en'],
+	'zh-HK': ['zh-TW', 'en'],
+	'zh-Hant': ['zh-TW', 'zh-HK', 'en'],
+	'zh-Hans': ['zh', 'en'],
+	'zh-CN': ['zh', 'en'],
+	'zh-SG': ['zh', 'en'],
+	'zh-MO': ['zh-HK', 'zh-TW', 'en'],
+	'pt-BR': ['pt', 'en'],
+	'de-AT': ['de', 'en'],
+	'de-IN': ['de', 'en'],
+	'bn-BD': ['bn-IN', 'en'],
+	'bn-IN': ['bn-BD', 'en'],
+	'hi-IN': ['hi', 'en'],
+	'default': ['en'],
+};

--- a/packages/tools/src/normalizeLanguage.spec.ts
+++ b/packages/tools/src/normalizeLanguage.spec.ts
@@ -1,0 +1,58 @@
+import { normalizeLanguage } from './normalizeLanguage';
+
+describe('normalizeLanguage', () => {
+	it('should return empty/falsy language as is', () => {
+		expect(normalizeLanguage('')).toBe('');
+	});
+
+	it('should normalize lowercase region codes to uppercase', () => {
+		expect(normalizeLanguage('pt-br')).toBe('pt-BR');
+		expect(normalizeLanguage('en-us')).toBe('en-US');
+		expect(normalizeLanguage('de-at')).toBe('de-AT');
+	});
+
+	it('should handle underscore delimiter', () => {
+		expect(normalizeLanguage('pt_br')).toBe('pt-BR');
+		expect(normalizeLanguage('zh_tw')).toBe('zh-TW');
+		expect(normalizeLanguage('zh_hk')).toBe('zh-HK');
+		expect(normalizeLanguage('zh_cn')).toBe('zh');
+	});
+
+	it('should resolve Traditional Chinese variants to zh-TW', () => {
+		expect(normalizeLanguage('zh-TW')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-tw')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-Hant')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-Hant-TW')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-hant-tw')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-CHT')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-cht')).toBe('zh-TW');
+	});
+
+	it('should resolve Hong Kong / Macau Traditional Chinese variants to zh-HK', () => {
+		expect(normalizeLanguage('zh-HK')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-hk')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-Hant-HK')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-hant-hk')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-MO')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-mo')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-Hant-MO')).toBe('zh-HK');
+	});
+
+	it('should resolve Simplified Chinese variants to zh', () => {
+		expect(normalizeLanguage('zh')).toBe('zh');
+		expect(normalizeLanguage('zh-CN')).toBe('zh');
+		expect(normalizeLanguage('zh-cn')).toBe('zh');
+		expect(normalizeLanguage('zh-Hans')).toBe('zh');
+		expect(normalizeLanguage('zh-Hans-CN')).toBe('zh');
+		expect(normalizeLanguage('zh-hans-cn')).toBe('zh');
+		expect(normalizeLanguage('zh-SG')).toBe('zh');
+		expect(normalizeLanguage('zh-CHS')).toBe('zh');
+	});
+
+	it('should keep other languages unchanged', () => {
+		expect(normalizeLanguage('en')).toBe('en');
+		expect(normalizeLanguage('fr')).toBe('fr');
+		expect(normalizeLanguage('de')).toBe('de');
+		expect(normalizeLanguage('ja')).toBe('ja');
+	});
+});

--- a/packages/tools/src/normalizeLanguage.spec.ts
+++ b/packages/tools/src/normalizeLanguage.spec.ts
@@ -11,17 +11,31 @@ describe('normalizeLanguage', () => {
 		expect(normalizeLanguage('de-at')).toBe('de-AT');
 	});
 
+	it('should support 3-digit UN M49 region codes', () => {
+		expect(normalizeLanguage('es-419')).toBe('es-419');
+	});
+
+	it('should normalize script subtags with title casing rather than treating them as region codes', () => {
+		expect(normalizeLanguage('sr-latn')).toBe('sr-Latn');
+		expect(normalizeLanguage('sr-Latn')).toBe('sr-Latn');
+		expect(normalizeLanguage('sr-LATN')).toBe('sr-Latn');
+		expect(normalizeLanguage('az-latn')).toBe('az-Latn');
+		expect(normalizeLanguage('uz-cyrl')).toBe('uz-Cyrl');
+	});
+
 	it('should handle underscore delimiter', () => {
 		expect(normalizeLanguage('pt_br')).toBe('pt-BR');
 		expect(normalizeLanguage('zh_tw')).toBe('zh-TW');
 		expect(normalizeLanguage('zh_hk')).toBe('zh-HK');
 		expect(normalizeLanguage('zh_cn')).toBe('zh');
+		expect(normalizeLanguage('sr_latn')).toBe('sr-Latn');
 	});
 
 	it('should resolve Traditional Chinese variants to zh-TW', () => {
 		expect(normalizeLanguage('zh-TW')).toBe('zh-TW');
 		expect(normalizeLanguage('zh-tw')).toBe('zh-TW');
 		expect(normalizeLanguage('zh-Hant')).toBe('zh-TW');
+		expect(normalizeLanguage('zh-hant')).toBe('zh-TW');
 		expect(normalizeLanguage('zh-Hant-TW')).toBe('zh-TW');
 		expect(normalizeLanguage('zh-hant-tw')).toBe('zh-TW');
 		expect(normalizeLanguage('zh-CHT')).toBe('zh-TW');
@@ -36,6 +50,7 @@ describe('normalizeLanguage', () => {
 		expect(normalizeLanguage('zh-MO')).toBe('zh-HK');
 		expect(normalizeLanguage('zh-mo')).toBe('zh-HK');
 		expect(normalizeLanguage('zh-Hant-MO')).toBe('zh-HK');
+		expect(normalizeLanguage('zh-hant-mo')).toBe('zh-HK');
 	});
 
 	it('should resolve Simplified Chinese variants to zh', () => {
@@ -43,6 +58,7 @@ describe('normalizeLanguage', () => {
 		expect(normalizeLanguage('zh-CN')).toBe('zh');
 		expect(normalizeLanguage('zh-cn')).toBe('zh');
 		expect(normalizeLanguage('zh-Hans')).toBe('zh');
+		expect(normalizeLanguage('zh-hans')).toBe('zh');
 		expect(normalizeLanguage('zh-Hans-CN')).toBe('zh');
 		expect(normalizeLanguage('zh-hans-cn')).toBe('zh');
 		expect(normalizeLanguage('zh-SG')).toBe('zh');

--- a/packages/tools/src/normalizeLanguage.ts
+++ b/packages/tools/src/normalizeLanguage.ts
@@ -1,9 +1,27 @@
 export const normalizeLanguage = (language: string): string => {
+	if (!language) {
+		return language;
+	}
+
+	const lang = language.replace(/_/g, '-');
+
+	// Traditional Chinese variants
+	if (/^zh-(hant-hk|hk|hant-mo|mo)/i.test(lang)) {
+		return 'zh-HK';
+	}
+	if (/^zh-(hant(-tw)?|cht|tw)/i.test(lang)) {
+		return 'zh-TW';
+	}
+	// Simplified Chinese variants
+	if (/^zh-(hans|cn|sg|chs)/i.test(lang) || lang.toLowerCase() === 'zh') {
+		return 'zh';
+	}
+
 	// Fix browsers having all-lowercase language settings eg. pt-br, en-us
-	const regex = /([a-z]{2,3})-([a-z]{2,4})/;
-	const matches = regex.exec(language);
+	const regex = /^([a-z]{2,3})-([a-z]{2,4})$/i;
+	const matches = regex.exec(lang);
 	if (matches) {
-		return `${matches[1]}-${matches[2].toUpperCase()}`;
+		return `${matches[1].toLowerCase()}-${matches[2].toUpperCase()}`;
 	}
 
 	return language;

--- a/packages/tools/src/normalizeLanguage.ts
+++ b/packages/tools/src/normalizeLanguage.ts
@@ -18,10 +18,20 @@ export const normalizeLanguage = (language: string): string => {
 	}
 
 	// Fix browsers having all-lowercase language settings eg. pt-br, en-us
-	const regex = /^([a-z]{2,3})-([a-z]{2,4})$/i;
+	// Region subtags are 2-letter (ISO 3166-1) or 3-digit (UN M49) codes —
+	// NOT to be confused with 4-letter script subtags (ISO 15924: Latn,
+	// Hant, Hans). Matching 2-4 letters here would incorrectly uppercase
+	// a script subtag (e.g. sr-latn -> sr-LATN instead of sr-Latn).
+	const regex = /^([a-z]{2,3})-([a-z]{2}|[0-9]{3})$/i;
 	const matches = regex.exec(lang);
 	if (matches) {
 		return `${matches[1].toLowerCase()}-${matches[2].toUpperCase()}`;
+	}
+
+	const scriptRegex = /^([a-z]{2,3})-([a-z]{4})$/i;
+	const scriptMatches = scriptRegex.exec(lang);
+	if (scriptMatches) {
+		return `${scriptMatches[1].toLowerCase()}-${scriptMatches[2][0].toUpperCase()}${scriptMatches[2].slice(1).toLowerCase()}`;
 	}
 
 	return language;

--- a/packages/tools/src/normalizeLanguage.ts
+++ b/packages/tools/src/normalizeLanguage.ts
@@ -5,23 +5,17 @@ export const normalizeLanguage = (language: string): string => {
 
 	const lang = language.replace(/_/g, '-');
 
-	// Traditional Chinese variants
 	if (/^zh-(hant-hk|hk|hant-mo|mo)/i.test(lang)) {
 		return 'zh-HK';
 	}
 	if (/^zh-(hant(-tw)?|cht|tw)/i.test(lang)) {
 		return 'zh-TW';
 	}
-	// Simplified Chinese variants
 	if (/^zh-(hans|cn|sg|chs)/i.test(lang) || lang.toLowerCase() === 'zh') {
 		return 'zh';
 	}
 
 	// Fix browsers having all-lowercase language settings eg. pt-br, en-us
-	// Region subtags are 2-letter (ISO 3166-1) or 3-digit (UN M49) codes —
-	// NOT to be confused with 4-letter script subtags (ISO 15924: Latn,
-	// Hant, Hans). Matching 2-4 letters here would incorrectly uppercase
-	// a script subtag (e.g. sr-latn -> sr-LATN instead of sr-Latn).
 	const regex = /^([a-z]{2,3})-([a-z]{2}|[0-9]{3})$/i;
 	const matches = regex.exec(lang);
 	if (matches) {


### PR DESCRIPTION
…implified Chinese (#41797)

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Traditional Chinese language detection for Taiwan, Hong Kong, and Macau.
  * Prevented Traditional Chinese locales from loading Simplified Chinese translations.
  * Missing Traditional Chinese translations now fall back to English.
  * Improved language preference normalization, including region codes, separators, and Chinese variants.

* **Improvements**
  * Added consistent fallback handling for regional Portuguese, German, Bengali, and Hindi locales.
  * Improved translation loading to use the selected language variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->