### PR TITLE
regression: unresolved `@rocket.chat/string-helpers` import breaks Omnichannel queue side panel

### DIFF
--- a/apps/meteor/client/views/navigation/sidepanel/omnichannel/InquireSidePanelItem.tsx
+++ b/apps/meteor/client/views/navigation/sidepanel/omnichannel/InquireSidePanelItem.tsx
@@ -1,6 +1,6 @@
 import { isOmnichannelRoom } from '@rocket.chat/core-typings';
 import { SidebarV2ItemIcon as SidebarItemIcon } from '@rocket.chat/fuselage';
-import { escapeHTML } from '@rocket.chat/string-helpers';
+import { escapeHTML } from '@rocket.chat/tools';
 import { RoomAvatar } from '@rocket.chat/ui-avatar';
 import { useUserId } from '@rocket.chat/ui-contexts';
 import { memo } from 'react';


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

`InquireSidePanelItem` imports `escapeHTML` from `@rocket.chat/string-helpers`, a package that no longer exists in the monorepo and is not a dependency of `apps/meteor`. This points the import at nothing, so the Omnichannel queue side panel items break at runtime.

Two PRs combined to produce this:

- #41763 (`742009a091`) dropped the `@rocket.chat/string-helpers` package in favor of `@rocket.chat/tools`, which is where `escapeHTML` lives now.
- #41595 (`b2c16d5842`) added the `escapeHTML` import while still pointing at `@rocket.chat/string-helpers`. The import was valid when that branch was written, but #41763 landed first and #41595 merged without picking it up, so `develop` ended up importing a deleted package.

The Meteor bundler surfaces it as an unresolved module during the build:

```
Unable to resolve some modules:

  "@rocket.chat/string-helpers" in
  apps/meteor/client/views/navigation/sidepanel/omnichannel/InquireSidePanelItem.tsx
  (web.browser)
```

This PR repoints the import to `@rocket.chat/tools`, which is already a workspace dependency of `apps/meteor` and exports the same `escapeHTML` (`packages/tools/src/escapeHTML.ts`). It is the module every other `escapeHTML` call site in the repo uses, so this only aligns the one straggler. No behavior change beyond restoring the escaping that #41595 intended.

No changeset: the breakage exists only on `develop` and was never released, so there is nothing to tell end users about.

## Issue(s)

Regression from #41595, caused by the package removal in #41763.

## Steps to test or reproduce

1. Check out `develop` at `b2c16d5842` or later and build the Meteor app. Note the `Unable to resolve some modules: "@rocket.chat/string-helpers"` warning.
2. Enable Omnichannel and turn on the side panel / queue view, then have an incoming inquiry whose last message contains special characters, for example `<b>bold</b> & "quoted"`.
3. Open the Omnichannel queue side panel and look at the inquiry item's message preview.
4. Expected result: the side panel renders without errors and the preview shows the literal text `<b>bold</b> & "quoted"` rather than crashing or rendering markup.

## Further comments

`escapeHTML` moved in #41763; the dangling import arrived in #41595.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal HTML escaping utility usage without changing visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->