### PR TITLE
Release 8.7.1

### DIFF
--- a/.changeset/bump-patch-1787062423707.md
+++ b/.changeset/bump-patch-1787062423707.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Bump @rocket.chat/meteor version.

--- a/.changeset/fuzzy-ends-refuse.md
+++ b/.changeset/fuzzy-ends-refuse.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Adds per-client rate limiting to the unauthenticated sendForgotPasswordEmail method, matching the REST users.forgotPassword endpoint

--- a/.changeset/lovely-bats-buy.md
+++ b/.changeset/lovely-bats-buy.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

--- a/.changeset/ninety-buses-create.md
+++ b/.changeset/ninety-buses-create.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue where a `MultiSelect` option checkbox remained checked after the option was deselected

--- a/.changeset/pink-dolls-flash.md
+++ b/.changeset/pink-dolls-flash.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Replace http with serverFetch in downloadPublicImportFile to add SSRF protection

--- a/.changeset/shy-actors-jump.md
+++ b/.changeset/shy-actors-jump.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes special characters not being escaped in the visitor name shown in the Omnichannel queue side panel's message preview

--- a/.github/workflows/ci-test-e2e.yml
+++ b/.github/workflows/ci-test-e2e.yml
@@ -191,9 +191,14 @@ jobs:
           # the deprecation logger log without throwing. Other suites use the
           # docker-compose default of TEST_MODE='true'.
           TEST_MODE: ${{ startsWith(inputs.type, 'api') && 'api' || 'true' }}
+          TEST_TYPE: ${{ inputs.type }}
         run: |
-          # when we are testing CE, we only need to start the rocketchat container
-          DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d rocketchat --wait
+          # when we are testing CE, we only need to start the rocketchat container (plus mock-server for the api suite)
+          services=(rocketchat)
+          if [ "$TEST_TYPE" == "api" ]; then
+            services+=(mock-server)
+          fi
+          DEBUG_LOG_LEVEL=${DEBUG_LOG_LEVEL:-0} docker compose -f docker-compose-ci.yml up -d "${services[@]}" --wait
 
       - name: Start containers for EE
         if: inputs.release == 'ee'

--- a/apps/meteor/client/views/navigation/sidepanel/omnichannel/InquireSidePanelItem.tsx
+++ b/apps/meteor/client/views/navigation/sidepanel/omnichannel/InquireSidePanelItem.tsx
@@ -1,5 +1,6 @@
 import { isOmnichannelRoom } from '@rocket.chat/core-typings';
 import { SidebarV2ItemIcon as SidebarItemIcon } from '@rocket.chat/fuselage';
+import { escapeHTML } from '@rocket.chat/string-helpers';
 import { RoomAvatar } from '@rocket.chat/ui-avatar';
 import { useUserId } from '@rocket.chat/ui-contexts';
 import { memo } from 'react';
@@ -29,7 +30,8 @@ const InquireSidePanelItem = ({ room, openedRoom, ...props }: InquireSidePanelIt
 
 	const time = 'lastMessage' in room ? room.lastMessage?.ts : undefined;
 	const message =
-		room.lastMessage && `${room.lastMessage.u.name || room.lastMessage.u.username}: ${normalizeMessagePreview(room.lastMessage, t)}`;
+		room.lastMessage &&
+		`${escapeHTML(room.lastMessage.u.name || room.lastMessage.u.username)}: ${normalizeMessagePreview(room.lastMessage, t)}`;
 	const title = roomCoordinator.getRoomName(room.t, room) || '';
 	const href = roomCoordinator.getRouteLink(room.t, room) || '';
 

--- a/apps/meteor/package.json
+++ b/apps/meteor/package.json
@@ -109,7 +109,7 @@
 		"@rocket.chat/favicon": "workspace:^",
 		"@rocket.chat/federation-matrix": "workspace:^",
 		"@rocket.chat/federation-sdk": "0.7.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-forms": "~1.5.0",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-toastbar": "~0.36.1",

--- a/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
+++ b/apps/meteor/server/meteor-methods/auth/sendForgotPasswordEmail.ts
@@ -2,6 +2,7 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Users } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
+import { DDPRateLimiter } from 'meteor/ddp-rate-limiter';
 import { Meteor } from 'meteor/meteor';
 
 import { SystemLogger } from '../../lib/logger/system';
@@ -44,3 +45,15 @@ Meteor.methods<ServerMethods>({
 		return sendForgotPasswordEmail(to);
 	},
 });
+
+DDPRateLimiter.addRule(
+	{
+		type: 'method',
+		name: 'sendForgotPasswordEmail',
+		clientAddress() {
+			return true;
+		},
+	},
+	10,
+	60000,
+);

--- a/apps/meteor/server/meteor-methods/import/downloadPublicImportFile.ts
+++ b/apps/meteor/server/meteor-methods/import/downloadPublicImportFile.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs';
-import http from 'node:http';
-import https from 'node:https';
+import type { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import { Import } from '@rocket.chat/core-services';
 import type { IUser } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';
+import { serverFetch as fetch } from '@rocket.chat/server-fetch';
 import { Meteor } from 'meteor/meteor';
 
 import { ProgressStep } from '../../../app/importer/lib/ImporterProgressStep';
@@ -12,12 +13,22 @@ import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { Importers } from '../../lib/import';
 import { RocketChatImportFileInstance } from '../../lib/import/startup/store';
+import { SystemLogger } from '../../lib/logger/system';
+import { settings } from '../../settings';
 
-function downloadHttpFile(fileUrl: string, writeStream: fs.WriteStream): void {
-	const protocol = fileUrl.startsWith('https') ? https : http;
-	protocol.get(fileUrl, (response) => {
-		response.pipe(writeStream);
+async function getHttpFileStream(fileUrl: string): Promise<Readable> {
+	const response = await fetch(fileUrl, {
+		ignoreSsrfValidation: false,
+		allowList: settings.get<string>('SSRF_Allowlist'),
 	});
+
+	const body = response.body as Readable;
+	if (!response.ok) {
+		body.resume();
+		throw new Error(`Unexpected response status ${response.status}`);
+	}
+
+	return body;
 }
 
 function copyLocalFile(filePath: fs.PathLike, writeStream: fs.WriteStream): void {
@@ -53,27 +64,46 @@ export const executeDownloadPublicImportFile = async (userId: IUser['_id'], file
 	await instance.updateProgress(ProgressStep.DOWNLOADING_FILE);
 
 	const writeStream = RocketChatImportFileInstance.createWriteStream(newFileName);
+	let errorProgressUpdate: Promise<unknown> | undefined;
+	const markImportAsFailed = (): Promise<unknown> => {
+		errorProgressUpdate ??= instance.updateProgress(ProgressStep.ERROR).catch((error) => {
+			SystemLogger.error({ msg: 'Failed to update import progress to ERROR', err: error });
+		});
+		return errorProgressUpdate;
+	};
 
 	writeStream.on('error', () => {
-		void instance.updateProgress(ProgressStep.ERROR);
+		void markImportAsFailed();
 	});
 
-	writeStream.on('end', () => {
+	let readStream: Readable | undefined;
+	if (isUrl) {
+		try {
+			readStream = await getHttpFileStream(fileUrl);
+		} catch (error) {
+			writeStream.destroy();
+			await markImportAsFailed();
+			throw error;
+		}
+	}
+
+	writeStream.on('finish', () => {
 		void instance.updateProgress(ProgressStep.FILE_LOADED);
 	});
 
-	if (isUrl) {
-		downloadHttpFile(fileUrl, writeStream);
-	} else {
-		// If the url is actually a folder path on the current machine, skip moving it to the file store
-		if (fs.statSync(fileUrl).isDirectory()) {
-			await instance.updateRecord({ file: fileUrl });
-			await instance.updateProgress(ProgressStep.FILE_LOADED);
-			return;
-		}
-
-		copyLocalFile(fileUrl, writeStream);
+	if (readStream) {
+		void pipeline(readStream, writeStream).catch(() => markImportAsFailed());
+		return;
 	}
+
+	// If the url is actually a folder path on the current machine, skip moving it to the file store
+	if (fs.statSync(fileUrl).isDirectory()) {
+		await instance.updateRecord({ file: fileUrl });
+		await instance.updateProgress(ProgressStep.FILE_LOADED);
+		return;
+	}
+
+	copyLocalFile(fileUrl, writeStream);
 };
 
 declare module '@rocket.chat/ddp-client' {

--- a/apps/meteor/server/meteor-methods/messages/getThreadMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getThreadMessages.ts
@@ -31,6 +31,10 @@ Meteor.methods<ServerMethods>({
 			});
 		}
 
+		if (typeof tmid !== 'string') {
+			throw new Meteor.Error('error-invalid-message', 'Invalid message', { method: 'getThreadMessages' });
+		}
+
 		const thread = await Messages.findOneById(tmid);
 		if (!thread) {
 			return [];
@@ -48,9 +52,9 @@ Meteor.methods<ServerMethods>({
 		}
 
 		await callbacks.run('beforeReadMessages', thread.rid, user._id);
-		await readThread({ user: user as IUser, room, tmid });
+		await readThread({ user: user as IUser, room, tmid: thread._id });
 
-		const result = await Messages.findVisibleThreadByThreadId(tmid, {
+		const result = await Messages.findVisibleThreadByThreadId(thread._id, {
 			...(skip && { skip }),
 			...(limit && { limit }),
 			sort: { ts: -1 },

--- a/apps/meteor/server/meteor-methods/messages/getThreadsList.ts
+++ b/apps/meteor/server/meteor-methods/messages/getThreadsList.ts
@@ -29,6 +29,10 @@ Meteor.methods<ServerMethods>({
 			throw new Meteor.Error('error-not-allowed', 'Threads Disabled', { method: 'getThreadsList' });
 		}
 
+		if (typeof rid !== 'string') {
+			throw new Meteor.Error('error-invalid-room', 'Invalid room', { method: 'getThreadsList' });
+		}
+
 		const user = await Meteor.userAsync();
 		const room = await Rooms.findOneById(rid);
 
@@ -36,6 +40,6 @@ Meteor.methods<ServerMethods>({
 			throw new Meteor.Error('error-not-allowed', 'Not Allowed', { method: 'getThreadsList' });
 		}
 
-		return Messages.findThreadsByRoomId(rid, skip, limit).toArray();
+		return Messages.findThreadsByRoomId(room._id, skip, limit).toArray();
 	},
 });

--- a/apps/meteor/server/modules/notifications/notifications.module.ts
+++ b/apps/meteor/server/modules/notifications/notifications.module.ts
@@ -250,7 +250,11 @@ export class NotificationsModule {
 			...args: [{ action: string; params: { callId: string; uid: string; rid: string } }] | [IUserDataEvent]
 		) {
 			const [roomId, e] = eventName.split('/') as [string, 'video-conference' | 'userData'];
-			if (this.userId && (await Subscriptions.countByRoomIdAndUserId(roomId, this.userId)) > 0) {
+			if (
+				this.userId &&
+				['video-conference', 'userData'].includes(e) &&
+				(await Subscriptions.countByRoomIdAndUserId(roomId, this.userId)) > 0
+			) {
 				const subscriptions: ISubscription[] = await Subscriptions.findByRoomIdAndNotUserId(roomId, this.userId, {
 					projection: { 'u._id': 1, '_id': 0 },
 				}).toArray();

--- a/apps/meteor/tests/end-to-end/api/import.spec.ts
+++ b/apps/meteor/tests/end-to-end/api/import.spec.ts
@@ -2,9 +2,15 @@ import { expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
 import type { Response } from 'supertest';
 
+import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials } from '../../data/api-data';
+import { mockServerHealthy, mockServerReset, mockServerSet } from '../../data/mock-server.helper';
+import { getSettingValueById, updateSetting } from '../../data/permissions.helper';
 import { password } from '../../data/user';
 import { createUser, login, deleteUser } from '../../data/users.helper';
+import { withTimeout } from '../../data/utils';
+
+const IMPORT_MOCK_SERVER_URL = process.env.IMPORT_MOCK_SERVER_URL ?? 'http://mock-server.dev:8080';
 
 describe('Imports', () => {
 	before((done) => getCredentials(done));
@@ -109,6 +115,70 @@ describe('Imports', () => {
 					expect(res.body.channels).to.be.an('array');
 					expect(res.body.message_count).to.greaterThanOrEqual(0);
 				});
+		});
+	});
+
+	describe('[/downloadPublicImportFile]', () => {
+		let previousSsrfAllowlist: Awaited<ReturnType<typeof getSettingValueById>>;
+
+		const waitForImportStep = (expectedStep: string): Promise<string> =>
+			withTimeout(async (signal) => {
+				let step = '';
+				while (!signal.aborted) {
+					const res = await request.get(api('getImportProgress')).set(credentials).expect(200);
+					step = res.body.step;
+					if (step === expectedStep || step === 'importer_import_failed') {
+						return step;
+					}
+					await sleep(100);
+				}
+				return step;
+			}, 10_000);
+
+		before(async () => {
+			expect(await mockServerHealthy(), 'mock-server is not reachable — ensure it is running').to.be.true;
+			previousSsrfAllowlist = await getSettingValueById('SSRF_Allowlist');
+			await Promise.all([mockServerReset(), updateSetting('SSRF_Allowlist', '')]);
+		});
+
+		after(async () => {
+			await Promise.all([
+				mockServerReset(),
+				previousSsrfAllowlist !== undefined ? updateSetting('SSRF_Allowlist', previousSsrfAllowlist) : Promise.resolve(),
+			]);
+		});
+
+		it('should reject a private target that is not on the SSRF allowlist and mark the operation as failed', async () => {
+			await request
+				.post(api('downloadPublicImportFile'))
+				.set(credentials)
+				.send({ fileUrl: 'http://127.0.0.1:3000/api/v1/info', importerKey: 'slack-users' })
+				.expect(400)
+				.expect((res: Response) => {
+					expect(res.body.success).to.be.false;
+					expect(res.body.error).to.equal('error-ssrf-validation-failed');
+				});
+
+			const progress = await request.get(api('getImportProgress')).set(credentials).expect(200);
+			expect(progress.body.step).to.equal('importer_import_failed');
+		});
+
+		it('should download a file from an allowlisted private target', async () => {
+			await Promise.all([
+				mockServerSet('GET', '/import-test.zip', { marker: 'downloaded-by-server-fetch' }),
+				updateSetting('SSRF_Allowlist', new URL(IMPORT_MOCK_SERVER_URL).host),
+			]);
+
+			await request
+				.post(api('downloadPublicImportFile'))
+				.set(credentials)
+				.send({ fileUrl: `${IMPORT_MOCK_SERVER_URL}/import-test.zip`, importerKey: 'csv' })
+				.expect(200)
+				.expect((res: Response) => {
+					expect(res.body.success).to.be.true;
+				});
+
+			expect(await waitForImportStep('importer_file_loaded')).to.equal('importer_file_loaded');
 		});
 	});
 

--- a/apps/meteor/tests/unit/server/meteor-methods/import/downloadPublicImportFile.spec.ts
+++ b/apps/meteor/tests/unit/server/meteor-methods/import/downloadPublicImportFile.spec.ts
@@ -1,0 +1,144 @@
+import { PassThrough } from 'node:stream';
+
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+const progressStep = {
+	DOWNLOADING_FILE: 'importer_downloading_file',
+	FILE_LOADED: 'importer_file_loaded',
+	ERROR: 'importer_import_failed',
+};
+
+const stubs = {
+	newOperation: sinon.stub(),
+	serverFetch: sinon.stub(),
+	importersGet: sinon.stub(),
+	createWriteStream: sinon.stub(),
+	startFileUpload: sinon.stub(),
+	updateProgress: sinon.stub(),
+	updateRecord: sinon.stub(),
+	systemLoggerError: sinon.stub(),
+};
+
+class MockImporter {
+	startFileUpload = stubs.startFileUpload;
+
+	updateProgress = stubs.updateProgress;
+
+	updateRecord = stubs.updateRecord;
+}
+
+const { executeDownloadPublicImportFile } = proxyquire
+	.noCallThru()
+	.load('../../../../../server/meteor-methods/import/downloadPublicImportFile.ts', {
+		'@rocket.chat/core-services': { Import: { newOperation: stubs.newOperation } },
+		'@rocket.chat/server-fetch': { serverFetch: stubs.serverFetch },
+		'meteor/meteor': { Meteor: { methods: sinon.stub() } },
+		'../../lib/authorization/hasPermission': { hasPermissionAsync: sinon.stub() },
+		'../../lib/deprecationWarningLogger': { methodDeprecationLogger: { method: sinon.stub() } },
+		'../../lib/import': { Importers: { get: stubs.importersGet } },
+		'../../lib/import/startup/store': { RocketChatImportFileInstance: { createWriteStream: stubs.createWriteStream } },
+		'../../lib/logger/system': { SystemLogger: { error: stubs.systemLoggerError } },
+		'../../settings': { settings: { get: sinon.stub().returns('') } },
+		'../../../app/importer/lib/ImporterProgressStep': { ProgressStep: progressStep },
+	});
+
+describe('executeDownloadPublicImportFile', () => {
+	let writeStream: PassThrough;
+
+	beforeEach(() => {
+		Object.values(stubs).forEach((stub) => stub.reset());
+
+		writeStream = new PassThrough();
+		stubs.newOperation.resolves({ _id: 'operation-id' });
+		stubs.importersGet.returns({ key: 'csv', name: 'CSV', importer: MockImporter });
+		stubs.createWriteStream.returns(writeStream);
+		stubs.startFileUpload.resolves();
+		stubs.updateProgress.resolves();
+		stubs.updateRecord.resolves();
+	});
+
+	it('rejects an unsuccessful HTTP response and drains its body', async () => {
+		const responseBody = new PassThrough();
+		const resume = sinon.spy(responseBody, 'resume');
+		stubs.serverFetch.resolves({ ok: false, status: 404, body: responseBody });
+
+		await expect(executeDownloadPublicImportFile('user-id', 'https://example.com/import.zip', 'csv')).to.be.rejectedWith(
+			'Unexpected response status 404',
+		);
+
+		expect(resume.calledOnce).to.be.true;
+		expect(writeStream.destroyed).to.be.true;
+		expect(stubs.updateProgress.calledWith(progressStep.ERROR)).to.be.true;
+	});
+
+	it('marks the import as failed and destroys the writable when the HTTP stream fails', async () => {
+		const responseBody = new PassThrough();
+		stubs.serverFetch.resolves({ ok: true, status: 200, body: responseBody });
+
+		await executeDownloadPublicImportFile('user-id', 'https://example.com/import.zip', 'csv');
+		const writeStreamClosed = new Promise<void>((resolve) => writeStream.once('close', resolve));
+		responseBody.destroy(new Error('stream failed'));
+		await writeStreamClosed;
+
+		expect(writeStream.destroyed).to.be.true;
+		expect(stubs.updateProgress.withArgs(progressStep.ERROR).calledOnce).to.be.true;
+		expect(stubs.updateProgress.calledWith(progressStep.FILE_LOADED)).to.be.false;
+	});
+
+	it('marks the import as failed and destroys the HTTP stream when the writable fails', async () => {
+		const responseBody = new PassThrough();
+		stubs.serverFetch.resolves({ ok: true, status: 200, body: responseBody });
+
+		await executeDownloadPublicImportFile('user-id', 'https://example.com/import.zip', 'csv');
+		const responseBodyClosed = new Promise<void>((resolve) => responseBody.once('close', resolve));
+		writeStream.destroy(new Error('stream failed'));
+		await responseBodyClosed;
+
+		expect(responseBody.destroyed).to.be.true;
+		expect(stubs.updateProgress.withArgs(progressStep.ERROR).calledOnce).to.be.true;
+		expect(stubs.updateProgress.calledWith(progressStep.FILE_LOADED)).to.be.false;
+	});
+
+	it('handles a rejected error progress update when the writable fails', async () => {
+		const responseBody = new PassThrough();
+		const unhandledRejection = sinon.spy();
+		const progressUpdateError = new Error('progress update failed');
+		stubs.serverFetch.resolves({ ok: true, status: 200, body: responseBody });
+		stubs.updateProgress.withArgs(progressStep.ERROR).rejects(progressUpdateError);
+		process.on('unhandledRejection', unhandledRejection);
+
+		try {
+			await executeDownloadPublicImportFile('user-id', 'https://example.com/import.zip', 'csv');
+			const responseBodyClosed = new Promise<void>((resolve) => responseBody.once('close', resolve));
+			writeStream.destroy(new Error('stream failed'));
+			await responseBodyClosed;
+			await new Promise<void>((resolve) => setImmediate(resolve));
+
+			expect(unhandledRejection.called).to.be.false;
+			expect(stubs.updateProgress.withArgs(progressStep.ERROR).calledOnce).to.be.true;
+			sinon.assert.calledOnceWithExactly(stubs.systemLoggerError, {
+				msg: 'Failed to update import progress to ERROR',
+				err: progressUpdateError,
+			});
+		} finally {
+			process.off('unhandledRejection', unhandledRejection);
+		}
+	});
+
+	it('marks the file as loaded when the writable finishes', async () => {
+		const responseBody = new PassThrough();
+		stubs.serverFetch.resolves({ ok: true, status: 200, body: responseBody });
+
+		await executeDownloadPublicImportFile('user-id', 'https://example.com/import.zip', 'csv');
+		expect(stubs.updateProgress.calledWith(progressStep.FILE_LOADED)).to.be.false;
+
+		const finished = new Promise<void>((resolve) => writeStream.once('finish', resolve));
+		responseBody.end('file contents');
+		await finished;
+
+		expect(stubs.updateProgress.calledWith(progressStep.FILE_LOADED)).to.be.true;
+	});
+});

--- a/apps/meteor/tests/unit/server/modules/notifications/notifications.module.spec.ts
+++ b/apps/meteor/tests/unit/server/modules/notifications/notifications.module.spec.ts
@@ -19,61 +19,135 @@ class TestStreamer extends Streamer<any> {
 }
 const validateActionStub = sinon.stub();
 const processSerializedSignalStub = sinon.stub();
+const countByRoomIdAndUserIdStub = sinon.stub();
+const findSubscriptionsExcludingUserStub = sinon.stub();
 
 const { NotificationsModule } = proxyquire.noCallThru().load('../../../../../server/modules/notifications/notifications.module', {
 	'@rocket.chat/core-services': {
 		VideoConf: { validateAction: validateActionStub },
 		MediaCall: { processSerializedSignal: processSerializedSignalStub },
 	},
+	'@rocket.chat/models': {
+		Subscriptions: {
+			countByRoomIdAndUserId: countByRoomIdAndUserIdStub,
+			findByRoomIdAndNotUserId: findSubscriptionsExcludingUserStub,
+		},
+		Rooms: {},
+		Users: {},
+	},
 });
 
-describe('NotificationsModule notify-user allowWrite', () => {
+describe('NotificationsModule', () => {
 	let notifications: any;
 
-	// `isWriteAllowed` is public on the concrete Streamer class but not on the IStreamer
-	// interface that `streamUser` is typed as, so cast to reach it.
-	const writeAllowed = (eventName: string, ...args: unknown[]) =>
-		(notifications.streamUser as unknown as Streamer<'notify-user'>).isWriteAllowed({ userId: 'userId' } as any, eventName, args);
-
 	beforeEach(() => {
-		validateActionStub.reset();
-		validateActionStub.resolves(true);
-		processSerializedSignalStub.reset();
-		processSerializedSignalStub.resolves(undefined);
-
 		notifications = new NotificationsModule(TestStreamer as any);
 		notifications.configure();
 	});
 
-	afterEach(() => {
-		Object.keys(StreamerCentral.instances).forEach((name) => delete StreamerCentral.instances[name]);
-	});
+	describe('notify-user allowWrite', () => {
+		// `isWriteAllowed` is public on the concrete Streamer class but not on the IStreamer
+		// interface that `streamUser` is typed as, so cast to reach it.
+		const writeAllowed = (eventName: string, ...args: unknown[]) =>
+			(notifications.streamUser as unknown as Streamer<'notify-user'>).isWriteAllowed({ userId: 'userId' } as any, eventName, args);
 
-	['force_logout', 'notification', 'message', 'uiInteraction', 'subscriptions-changed', 'webdav', 'banners'].forEach((event) => {
-		it(`should deny a logged-in client writing "${event}" to another user's stream`, async () => {
-			expect(await writeAllowed(`victim/${event}`, { foo: 'bar' })).to.equal(false);
+		beforeEach(() => {
+			validateActionStub.reset();
+			validateActionStub.resolves(true);
+			processSerializedSignalStub.reset();
+			processSerializedSignalStub.resolves(undefined);
+			countByRoomIdAndUserIdStub.reset();
+			findSubscriptionsExcludingUserStub.reset();
+		});
+
+		afterEach(() => {
+			Object.keys(StreamerCentral.instances).forEach((name) => delete StreamerCentral.instances[name]);
+		});
+
+		['force_logout', 'notification', 'message', 'uiInteraction', 'subscriptions-changed', 'webdav', 'banners'].forEach((event) => {
+			it(`should deny a logged-in client writing "${event}" to another user's stream`, async () => {
+				expect(await writeAllowed(`victim/${event}`, { foo: 'bar' })).to.equal(false);
+			});
+		});
+
+		it("should deny writes even to the client's own stream", async () => {
+			expect(await writeAllowed(`userId/force_logout`, undefined)).to.equal(false);
+		});
+
+		it('should accept "video-conference" and delegate authorization to VideoConf.validateAction', async () => {
+			const result = await writeAllowed(`userId/video-conference`, {
+				action: 'call-start',
+				params: { callId: '123', uid: '456', rid: '789' },
+			});
+
+			expect(result).to.be.true;
+			expect(validateActionStub.calledOnceWith('call-start', 'userId', { callId: '123', uid: '456', rid: '789' })).to.be.true;
+		});
+
+		it('should process "media-calls" signals server-side and never broadcast them', async () => {
+			const signal = '{"type":"offer"}';
+			const result = await writeAllowed(`userId/media-calls`, signal);
+
+			expect(result).to.equal(false);
+			expect(processSerializedSignalStub.calledOnceWith('userId', signal)).to.be.true;
 		});
 	});
 
-	it("should deny writes even to the client's own stream", async () => {
-		expect(await writeAllowed(`userId/force_logout`, undefined)).to.equal(false);
-	});
+	describe('notify-room-users allowWrite', () => {
+		const writeAllowed = (eventName: string, ...args: unknown[]) =>
+			(notifications.streamRoomUsers as unknown as Streamer<'notify-room-users'>).isWriteAllowed(
+				{ userId: 'attacker' } as any,
+				eventName,
+				args,
+			);
 
-	it('should accept "video-conference" and delegate authorization to VideoConf.validateAction', async () => {
-		const result = await writeAllowed(`userId/video-conference`, {
-			action: 'call-start',
-			params: { callId: '123', uid: '456', rid: '789' },
+		beforeEach(() => {
+			countByRoomIdAndUserIdStub.reset();
+			countByRoomIdAndUserIdStub.resolves(1); // attacker is subscribed to the room
+			findSubscriptionsExcludingUserStub.reset();
+			findSubscriptionsExcludingUserStub.returns({ toArray: async () => [{ u: { _id: 'victim' } }] });
 		});
 
-		expect(result).to.be.true;
-		expect(validateActionStub.calledOnceWith('call-start', 'userId', { callId: '123', uid: '456', rid: '789' })).to.be.true;
-	});
+		afterEach(() => {
+			Object.keys(StreamerCentral.instances).forEach((name) => delete StreamerCentral.instances[name]);
+		});
 
-	it('should process "media-calls" signals server-side and never broadcast them', async () => {
-		const signal = '{"type":"offer"}';
-		const result = await writeAllowed(`userId/media-calls`, signal);
+		['force_logout', 'notification', 'message', 'uiInteraction', 'subscriptions-changed', 'webdav', 'banners'].forEach((event) => {
+			it(`should deny and not relay an arbitrary "${event}" event to other room members`, async () => {
+				const emitSpy = sinon.spy(notifications.streamUser, 'emit');
 
-		expect(result).to.equal(false);
-		expect(processSerializedSignalStub.calledOnceWith('userId', signal)).to.be.true;
+				const result = await writeAllowed(`room1/${event}`, { foo: 'bar' });
+
+				expect(result).to.equal(false);
+				expect(findSubscriptionsExcludingUserStub.called).to.equal(false);
+				expect(emitSpy.called).to.equal(false);
+			});
+		});
+
+		it('should not relay anything for a user not subscribed to the room', async () => {
+			countByRoomIdAndUserIdStub.resolves(0);
+			const emitSpy = sinon.spy(notifications.streamUser, 'emit');
+
+			const result = await writeAllowed('room1/video-conference', {
+				action: 'call-start',
+				params: { callId: '123', uid: 'victim', rid: 'room1' },
+			});
+
+			expect(result).to.equal(false);
+			expect(findSubscriptionsExcludingUserStub.called).to.equal(false);
+			expect(emitSpy.called).to.equal(false);
+		});
+
+		['video-conference', 'userData'].forEach((event) => {
+			it(`should relay "${event}" event to other room members`, async () => {
+				const emitSpy = sinon.spy(notifications.streamUser, 'emit');
+
+				const result = await writeAllowed(`room1/${event}`, { foo: 'bar' });
+
+				expect(result).to.equal(false);
+				expect(findSubscriptionsExcludingUserStub.called).to.equal(true);
+				expect(emitSpy.called).to.equal(true);
+			});
+		});
 	});
 });

--- a/apps/uikit-playground/package.json
+++ b/apps/uikit-playground/package.json
@@ -18,7 +18,7 @@
 		"@lezer/highlight": "^1.2.3",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-toastbar": "~0.36.1",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -227,6 +227,12 @@ services:
       - api
     ports:
       - 4000:8080
+    networks:
+      default:
+        # single-label hostnames fail server-fetch SSRF domain validation and message-parser only links TLDs
+        # from its whitelist (.local/.test/.internal are not in it), so tests reach it through this alias
+        aliases:
+          - mock-server.dev
     healthcheck:
       test: ['CMD', '/mock-server', '-healthcheck']
       interval: 2s

--- a/packages/fuselage-ui-kit/package.json
+++ b/packages/fuselage-ui-kit/package.json
@@ -46,7 +46,7 @@
 		"@rocket.chat/apps-engine": "workspace:^",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/gazzodown/package.json
+++ b/packages/gazzodown/package.json
@@ -30,7 +30,7 @@
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.33.0",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/storybook-config/package.json
+++ b/packages/storybook-config/package.json
@@ -33,7 +33,7 @@
 		"webpack": "~5.104.1"
 	},
 	"devDependencies": {
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/icons": "^0.48.0",
 		"@rocket.chat/tsconfig": "workspace:*",
 		"@storybook/react": "^9.1.13",

--- a/packages/ui-avatar/package.json
+++ b/packages/ui-avatar/package.json
@@ -17,7 +17,7 @@
 	"devDependencies": {
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-client/package.json
+++ b/packages/ui-client/package.json
@@ -26,7 +26,7 @@
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.33.0",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-composer/package.json
+++ b/packages/ui-composer/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@react-aria/toolbar": "^3.0.0-nightly.5042",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-contexts/package.json
+++ b/packages/ui-contexts/package.json
@@ -23,7 +23,7 @@
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/ddp-client": "workspace:~",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/i18n": "workspace:~",

--- a/packages/ui-video-conf/package.json
+++ b/packages/ui-video-conf/package.json
@@ -22,7 +22,7 @@
 	},
 	"devDependencies": {
 		"@rocket.chat/css-in-js": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/icons": "^0.48.0",

--- a/packages/ui-voip/package.json
+++ b/packages/ui-voip/package.json
@@ -31,7 +31,7 @@
 		"@react-spectrum/test-utils": "~1.0.0-alpha.8",
 		"@rocket.chat/core-typings": "workspace:^",
 		"@rocket.chat/css-in-js": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/fuselage-ui-kit": "workspace:^",

--- a/packages/web-ui-registration/package.json
+++ b/packages/web-ui-registration/package.json
@@ -23,7 +23,7 @@
 		"@rocket.chat/core-typings": "workspace:~",
 		"@rocket.chat/css-in-js": "^0.33.0",
 		"@rocket.chat/emitter": "^0.33.0",
-		"@rocket.chat/fuselage": "^0.83.0",
+		"@rocket.chat/fuselage": "0.83.1",
 		"@rocket.chat/fuselage-hooks": "~0.43.0",
 		"@rocket.chat/fuselage-tokens": "~0.33.2",
 		"@rocket.chat/i18n": "workspace:~",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9308,7 +9308,7 @@ __metadata:
     "@rocket.chat/apps-engine": "workspace:^"
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/gazzodown": "workspace:^"
@@ -9363,9 +9363,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rocket.chat/fuselage@npm:^0.83.0":
-  version: 0.83.0
-  resolution: "@rocket.chat/fuselage@npm:0.83.0"
+"@rocket.chat/fuselage@npm:0.83.1":
+  version: 0.83.1
+  resolution: "@rocket.chat/fuselage@npm:0.83.1"
   dependencies:
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/css-supports": "npm:^0.31.25"
@@ -9382,7 +9382,7 @@ __metadata:
     react: "*"
     react-dom: "*"
     react-virtuoso: "*"
-  checksum: 10/b4224929fb7fd193028ec478eb79db696aef4cd0da54a9b2532e39aadf8d83299c965cac2950dfc2b92634baa1dfef3487c674dc038dca2bbe7f533864b2625d
+  checksum: 10/ec69bc3d9f53b832b7e128e09dab9b4085344c7f2e87636bd478f005181952bca028d0f9001ea94de6718fb46f8ccadbc0cdc05703173f507b6cb5cad327fb62
   languageName: node
   linkType: hard
 
@@ -9393,7 +9393,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -9826,7 +9826,7 @@ __metadata:
     "@rocket.chat/favicon": "workspace:^"
     "@rocket.chat/federation-matrix": "workspace:^"
     "@rocket.chat/federation-sdk": "npm:0.7.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-forms": "npm:~1.5.0"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-toastbar": "npm:~0.36.1"
@@ -10735,7 +10735,7 @@ __metadata:
   resolution: "@rocket.chat/storybook-config@workspace:packages/storybook-config"
   dependencies:
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10830,7 +10830,7 @@ __metadata:
   dependencies:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10857,7 +10857,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10914,7 +10914,7 @@ __metadata:
   dependencies:
     "@react-aria/toolbar": "npm:^3.0.0-nightly.5042"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -10954,7 +10954,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/ddp-client": "workspace:~"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/i18n": "workspace:~"
@@ -11013,7 +11013,7 @@ __metadata:
   dependencies:
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/icons": "npm:^0.48.0"
@@ -11060,7 +11060,7 @@ __metadata:
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/desktop-api": "workspace:^"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/fuselage-ui-kit": "workspace:^"
@@ -11126,7 +11126,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:^"
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-toastbar": "npm:~0.36.1"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
@@ -11164,7 +11164,7 @@ __metadata:
     "@rocket.chat/core-typings": "workspace:~"
     "@rocket.chat/css-in-js": "npm:^0.33.0"
     "@rocket.chat/emitter": "npm:^0.33.0"
-    "@rocket.chat/fuselage": "npm:^0.83.0"
+    "@rocket.chat/fuselage": "npm:0.83.1"
     "@rocket.chat/fuselage-hooks": "npm:~0.43.0"
     "@rocket.chat/fuselage-tokens": "npm:~0.33.2"
     "@rocket.chat/i18n": "workspace:~"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9436,7 +9436,7 @@ __metadata:
     "@rocket.chat/css-in-js": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/fuselage-tokens": "*"
-    "@rocket.chat/message-parser": 0.32.0-rc.0
+    "@rocket.chat/message-parser": 0.32.0
     "@rocket.chat/styled": "*"
     "@rocket.chat/ui-client": "workspace:^"
     "@rocket.chat/ui-contexts": "workspace:^"
@@ -10941,7 +10941,7 @@ __metadata:
     "@react-aria/toolbar": "*"
     "@rocket.chat/fuselage": "*"
     "@rocket.chat/icons": "*"
-    "@rocket.chat/ui-client": 33.0.0-rc.0
+    "@rocket.chat/ui-client": 33.0.0
     react: "*"
     react-dom: "*"
   languageName: unknown
@@ -11195,7 +11195,7 @@ __metadata:
   peerDependencies:
     "@rocket.chat/layout": "*"
     "@rocket.chat/tools": 0.3.0
-    "@rocket.chat/ui-contexts": 33.0.0-rc.0
+    "@rocket.chat/ui-contexts": 33.0.0
     "@tanstack/react-query": "*"
     react: "*"
     react-hook-form: "*"


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected visitor names containing special characters in Omnichannel queue message previews.
  * Improved validation when loading thread messages and thread lists.
  * Fixed MultiSelect checkboxes remaining selected after deselection.
  * Improved reliability when downloading public import files.

* **Security**
  * Added rate limiting to unauthenticated password-reset email requests.
  * Strengthened notification access controls for room and video-conference events.
  * Added SSRF protection for public import-file downloads.

* **Chores**
  * Prepared a patch release for the application package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- release-notes-start -->
<!-- This content is automatically generated. Changing this will not reflect on the final release log -->

_You can see below a preview of the release change log:_

# 8.7.1

### Engine versions

- Node: `22.22.3`
- Deno: `2.3.1`
- MongoDB: `8.0`
- Apps-Engine: `1.65.1`

### Patch Changes

*   Bump @rocket.chat/meteor version.

*   ([#41818](https://github.com/RocketChat/Rocket.Chat/pull/41818) by [@dionisio-bot](https://github.com/dionisio-bot)) Adds per-client rate limiting to the unauthenticated sendForgotPasswordEmail method, matching the REST users.forgotPassword endpoint

*   ([#41820](https://github.com/RocketChat/Rocket.Chat/pull/41820) by [@dionisio-bot](https://github.com/dionisio-bot)) Security Hotfix (https://docs.rocket.chat/docs/security-fixes-and-updates)

*   ([#41846](https://github.com/RocketChat/Rocket.Chat/pull/41846)) Fixes an issue where a `MultiSelect` option checkbox remained checked after the option was deselected

*   ([#41819](https://github.com/RocketChat/Rocket.Chat/pull/41819) by [@dionisio-bot](https://github.com/dionisio-bot)) Replace http with serverFetch in downloadPublicImportFile to add SSRF protection

*   ([#41817](https://github.com/RocketChat/Rocket.Chat/pull/41817) by [@dionisio-bot](https://github.com/dionisio-bot)) Fixes special characters not being escaped in the visitor name shown in the Omnichannel queue side panel's message preview

*   <details><summary>Updated dependencies []:</summary>

    *   @rocket.chat/core-typings@8.7.1
    *   @rocket.chat/rest-typings@8.7.1

    </details>

<!-- release-notes-end -->