### PR TITLE
fix: direct messages addressed by username never resolve

### DIFF
--- a/.changeset/witty-beds-bow.md
+++ b/.changeset/witty-beds-bow.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes direct messages addressed by username, such as the ones opened with **Reply in direct message**, not being found on the first lookup — which made opening a conversation cost an extra request and log an avoidable `Invalid Room` error.

--- a/apps/meteor/definition/IRoomTypeConfig.ts
+++ b/apps/meteor/definition/IRoomTypeConfig.ts
@@ -108,5 +108,5 @@ export interface IRoomTypeServerDirectives {
 	getMsgSender: (message: IMessage) => Promise<IUser | null>;
 	includeInRoomSearch: () => boolean;
 	includeInDashboard: () => boolean;
-	roomFind?: (rid: string) => Promise<IRoom | undefined> | Promise<IOmnichannelRoom | null> | IRoom | undefined;
+	roomFind?: (rid: string, uid?: IUser['_id']) => Promise<IRoom | IOmnichannelRoom | null | undefined> | IRoom | undefined;
 }

--- a/apps/meteor/server/lib/rooms/findDirectRoomByIdentifier.ts
+++ b/apps/meteor/server/lib/rooms/findDirectRoomByIdentifier.ts
@@ -1,0 +1,30 @@
+import type { IRoom, IUser } from '@rocket.chat/core-typings';
+import { Rooms, Users } from '@rocket.chat/models';
+
+// direct rooms carry no `name`; the member set is what identifies them
+export const findDirectRoomByIdentifier = async (identifier: string, uid: IUser['_id']): Promise<IRoom | null> => {
+	const targets = identifier.split(',').map((username) => username.trim());
+
+	// only a single target can be a room id, since ids never contain commas.
+	if (targets.length === 1) {
+		const byId = await Rooms.findByTypeAndNameOrId('d', targets[0]);
+		if (byId) {
+			return byId;
+		}
+	}
+
+	const me = await Users.findOneById<Pick<IUser, 'username'>>(uid, { projection: { username: 1 } });
+	if (!me?.username) {
+		return null;
+	}
+
+	const usernames = [...new Set([me.username, ...targets])];
+	const members = await Users.findUsersByUsernames<Pick<IUser, '_id'>>(usernames, { projection: { _id: 1 } }).toArray();
+	if (members.length !== usernames.length) {
+		return null;
+	}
+
+	const uids = members.map(({ _id }) => _id).sort();
+
+	return Rooms.findOneDirectRoomContainingAllUserIDs(uids);
+};

--- a/apps/meteor/server/lib/rooms/roomTypes/direct.ts
+++ b/apps/meteor/server/lib/rooms/roomTypes/direct.ts
@@ -7,6 +7,7 @@ import { RoomSettingsEnum, RoomMemberActions } from '../../../../definition/IRoo
 import { getDirectMessageRoomType } from '../../../../lib/rooms/roomTypes/direct';
 import { isFederationEnabled } from '../../../services/federation/utils';
 import { settings } from '../../../settings';
+import { findDirectRoomByIdentifier } from '../findDirectRoomByIdentifier';
 import { roomCoordinator } from '../roomCoordinator';
 
 const DirectMessageRoomType = getDirectMessageRoomType(roomCoordinator);
@@ -85,6 +86,10 @@ roomCoordinator.add(DirectMessageRoomType, {
 
 	isGroupChat(room) {
 		return (room?.uids?.length || 0) > 2;
+	},
+
+	roomFind(identifier, uid) {
+		return uid ? findDirectRoomByIdentifier(identifier, uid) : undefined;
 	},
 
 	async getNotificationDetails(room, sender, notificationMessage, userId) {

--- a/apps/meteor/server/publications/room/index.ts
+++ b/apps/meteor/server/publications/room/index.ts
@@ -71,7 +71,7 @@ Meteor.methods<ServerMethods>({
 
 		const roomFind = roomCoordinator.getRoomFind(type);
 
-		const room = roomFind ? await roomFind.call(this, name) : await Rooms.findByTypeAndNameOrId(type, name);
+		const room = roomFind ? await roomFind.call(this, name, user?._id) : await Rooms.findByTypeAndNameOrId(type, name);
 
 		if (!room) {
 			throw new Meteor.Error('error-invalid-room', 'Invalid room', {

--- a/apps/meteor/tests/end-to-end/api/methods.ts
+++ b/apps/meteor/tests/end-to-end/api/methods.ts
@@ -2706,6 +2706,100 @@ describe('Meteor.methods', () => {
 					done();
 				});
 		});
+
+		it('should return the room object for a DM addressed by username', async () => {
+			const res = await request
+				.post(methodCall('getRoomByTypeAndName'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'getRoomByTypeAndName',
+						params: ['d', testUser2.username],
+						id: 'id',
+						msg: 'method',
+					}),
+				})
+				.expect(200);
+
+			const parsedResponse = JSON.parse(res.body.message);
+			expect(parsedResponse.result._id).to.equal(dmId);
+			expect(parsedResponse.result.t).to.equal('d');
+		});
+
+		it('should throw error when the DM addressed by username does not exist', async () => {
+			const stranger = await createUser();
+
+			const res = await request
+				.post(methodCall('getRoomByTypeAndName'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'getRoomByTypeAndName',
+						params: ['d', stranger.username],
+						id: 'id',
+						msg: 'method',
+					}),
+				})
+				.expect(400);
+
+			const parsedResponse = JSON.parse(res.body.message);
+			expect(parsedResponse).to.have.property('error');
+			expect(parsedResponse.error.error).to.equal('error-invalid-room');
+
+			await deleteUser(stranger);
+		});
+
+		it('should return the room object for a group DM addressed by a comma separated username list', async () => {
+			const usernames = `${testUser.username},${testUser2.username}`;
+
+			const groupDm = (await request.post(api('im.create')).set(credentials).send({ usernames }).expect(200)).body.room;
+
+			const res = await request
+				.post(methodCall('getRoomByTypeAndName'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'getRoomByTypeAndName',
+						params: ['d', usernames],
+						id: 'id',
+						msg: 'method',
+					}),
+				})
+				.expect(200);
+
+			const parsedResponse = JSON.parse(res.body.message);
+			expect(parsedResponse.result._id).to.equal(groupDm._id);
+
+			await deleteRoom({ type: 'd', roomId: groupDm._id });
+		});
+
+		it('should keep resolving a DM by username after the other member is renamed', async () => {
+			const renamedUser = await createUser();
+			const renamedDmId = (await request.post(api('im.create')).set(credentials).send({ username: renamedUser.username }).expect(200)).body
+				.room._id;
+
+			const username = `renamed.${Date.now()}`;
+			await request.post(api('users.update')).set(credentials).send({ userId: renamedUser._id, data: { username } }).expect(200);
+
+			const res = await request
+				.post(methodCall('getRoomByTypeAndName'))
+				.set(credentials)
+				.send({
+					message: JSON.stringify({
+						method: 'getRoomByTypeAndName',
+						params: ['d', username],
+						id: 'id',
+						msg: 'method',
+					}),
+				})
+				.expect(200);
+
+			const parsedResponse = JSON.parse(res.body.message);
+			expect(parsedResponse.result._id).to.equal(renamedDmId);
+
+			await deleteRoom({ type: 'd', roomId: renamedDmId });
+			await deleteUser(renamedUser);
+		});
 	});
 
 	describe('[@setUserActiveStatus]', () => {

--- a/apps/meteor/tests/unit/server/lib/rooms/findDirectRoomByIdentifier.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/rooms/findDirectRoomByIdentifier.spec.ts
@@ -1,0 +1,107 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import Sinon from 'sinon';
+
+const RoomsStub = {
+	findByTypeAndNameOrId: Sinon.stub(),
+	findOneDirectRoomContainingAllUserIDs: Sinon.stub(),
+};
+
+const UsersStub = {
+	findOneById: Sinon.stub(),
+	findUsersByUsernames: Sinon.stub(),
+};
+
+const { findDirectRoomByIdentifier } = proxyquire.noCallThru().load('../../../../../server/lib/rooms/findDirectRoomByIdentifier.ts', {
+	'@rocket.chat/models': { Rooms: RoomsStub, Users: UsersStub },
+});
+
+const cursorOf = (docs: unknown[]) => ({ toArray: async () => docs });
+
+describe('findDirectRoomByIdentifier', () => {
+	beforeEach(() => {
+		RoomsStub.findByTypeAndNameOrId.reset();
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.reset();
+		UsersStub.findOneById.reset();
+		UsersStub.findUsersByUsernames.reset();
+
+		RoomsStub.findByTypeAndNameOrId.resolves(null);
+		UsersStub.findOneById.resolves({ _id: 'me', username: 'me' });
+	});
+
+	it('should return the room when the identifier is a room id', async () => {
+		const room = { _id: 'rid1', t: 'd' };
+		RoomsStub.findByTypeAndNameOrId.resolves(room);
+
+		expect(await findDirectRoomByIdentifier('rid1', 'me')).to.equal(room);
+		expect(UsersStub.findUsersByUsernames.called).to.be.false;
+	});
+
+	it('should resolve a two-person DM by the other username, over sorted uids', async () => {
+		const room = { _id: 'rid1', t: 'd' };
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'zeta' }, { _id: 'alpha' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves(room);
+
+		expect(await findDirectRoomByIdentifier('alice', 'me')).to.equal(room);
+		expect(RoomsStub.findOneDirectRoomContainingAllUserIDs.calledWith(['alpha', 'zeta'])).to.be.true;
+	});
+
+	it('should include the caller in the member set exactly once for a self-DM', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves({ _id: 'self', t: 'd' });
+
+		await findDirectRoomByIdentifier('me', 'me');
+
+		expect(UsersStub.findUsersByUsernames.firstCall.args[0]).to.deep.equal(['me']);
+		expect(RoomsStub.findOneDirectRoomContainingAllUserIDs.calledWith(['me'])).to.be.true;
+	});
+
+	it('should resolve a group DM from a comma-separated identifier', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }, { _id: 'a' }, { _id: 'b' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves({ _id: 'group', t: 'd' });
+
+		await findDirectRoomByIdentifier('a,b', 'me');
+
+		expect(UsersStub.findUsersByUsernames.firstCall.args[0]).to.deep.equal(['me', 'a', 'b']);
+		expect(RoomsStub.findOneDirectRoomContainingAllUserIDs.calledWith(['a', 'b', 'me'])).to.be.true;
+	});
+
+	it('should not look the identifier up as a room id when it is a username list', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }, { _id: 'a' }, { _id: 'b' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves({ _id: 'group', t: 'd' });
+
+		await findDirectRoomByIdentifier('a,b', 'me');
+
+		expect(RoomsStub.findByTypeAndNameOrId.called).to.be.false;
+	});
+
+	it('should trim whitespace around each username in the list', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }, { _id: 'a' }, { _id: 'b' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves({ _id: 'group', t: 'd' });
+
+		await findDirectRoomByIdentifier('a, b', 'me');
+
+		expect(UsersStub.findUsersByUsernames.firstCall.args[0]).to.deep.equal(['me', 'a', 'b']);
+	});
+
+	it('should return null when any username does not resolve to a user', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }]));
+
+		expect(await findDirectRoomByIdentifier('ghost', 'me')).to.be.null;
+		expect(RoomsStub.findOneDirectRoomContainingAllUserIDs.called).to.be.false;
+	});
+
+	it('should return null when no direct room contains that member set', async () => {
+		UsersStub.findUsersByUsernames.returns(cursorOf([{ _id: 'me' }, { _id: 'alice' }]));
+		RoomsStub.findOneDirectRoomContainingAllUserIDs.resolves(null);
+
+		expect(await findDirectRoomByIdentifier('alice', 'me')).to.be.null;
+	});
+
+	it('should return null when the caller has no username', async () => {
+		UsersStub.findOneById.resolves({ _id: 'me' });
+
+		expect(await findDirectRoomByIdentifier('alice', 'me')).to.be.null;
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Opening a DM by username — what **Reply in direct message** always does — never found the existing conversation. A direct room has no `name`, and the resolver used `Rooms.findByTypeAndNameOrId`, which matches only `name` or `_id`. So the server answered `error-invalid-room` for a room that exists, and the client caught that error and called `im.create` — which found the DM already there and returned its id instead of creating anything. Creation was being used as a lookup, and it worked only because it answers the very question the lookup had just failed.

The fix teaches the lookup that, for a direct room, the username in the URL names a *participant*, not the room. `findDirectRoomByIdentifier` takes that username with the caller's own, resolves both to user ids, and asks for the direct room whose `uids` are exactly those.

This is one half of the escalation. The other is #41795 (SUP-1096), which stops client-safe errors from being logged as exceptions and reaching the channel configured in `Log Exceptions to Channel` — that is what the customer actually reported. This PR removes the exception being raised at all for DMs that already exist, which was the bulk of the volume.

## Issue(s)

- [SUP-1100](https://rocketchat.atlassian.net/browse/SUP-1100)

## Steps to test or reproduce

1. With a DM to user B already existing, use **Reply in direct message** on a message from B. Before: `getRoomByTypeAndName` fails, then `im.create` returns the rid. After: the first call succeeds and `im.create` is not called.
2. Confirm the DM opens with the quote and the URL still canonicalizes to `/direct/<rid>`.
3. Repeat for a DM that never existed, for `/direct/<userB>,<userC>` (with and without a space), and after renaming B.
4. Open a channel and a private group by name and by id, and a missing one, to confirm non-DM behaviour is unchanged.

[SUP-1100]: https://rocketchat.atlassian.net/browse/SUP-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct-message room lookup by username and comma-separated username lists.
  * Prevented unnecessary lookup requests and avoidable “Invalid Room” errors.
  * Added support for resolving direct and group conversations after usernames change.
  * Improved handling of missing users, self-messages, and users without usernames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->