### PR TITLE
fix: allow redeeming the same SAML credential token in the mobile login flow

### DIFF
--- a/.changeset/saml-mobile-credential-token-reuse.md
+++ b/.changeset/saml-mobile-credential-token-reuse.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes mobile SAML login failing with "No matching login attempt found": the SAML login handler no longer deletes the credential token on its first redemption, so the in-app webview and the native app can both redeem the same token as the mobile login flow requires. Credential tokens are still cleaned up by the existing TTL index on `expireAt`.

--- a/apps/meteor/server/lib/saml/loginHandler.ts
+++ b/apps/meteor/server/lib/saml/loginHandler.ts
@@ -1,4 +1,3 @@
-import { CredentialTokens } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 
@@ -27,7 +26,10 @@ Accounts.registerLoginHandler('saml', async (loginRequest) => {
 
 	const loginResult = await SAML.retrieveCredential(loginRequest.credentialToken);
 
-	await CredentialTokens.removeById(loginRequest.credentialToken);
+	// Do not delete the credential token on redemption: the mobile login flow makes the webview
+	// and the native app redeem the same token concurrently, so removing it after the first
+	// redemption makes the second one fail with "No matching login attempt found".
+	// The credential_tokens collection cleans these up via its TTL index on `expireAt`.
 	SAMLUtils.log({ msg: 'RESULT', loginResult });
 
 	if (!loginResult) {

--- a/apps/meteor/tests/unit/server/lib/saml/loginHandler.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/loginHandler.spec.ts
@@ -4,11 +4,17 @@ import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 const retrieveCredential = sinon.stub().resolves(null);
+const insertOrUpdateSAMLUser = sinon.stub().resolves({ userId: 'some-user-id', token: 'some-token' });
 const removeById = sinon.stub().resolves();
+const warnUnlicensedAuthService = sinon.stub();
+const mapProfileToUserObject = sinon.stub().returns({
+	identifier: { type: 'username', attribute: 'username', value: 'some-username' },
+	attributeList: new Map(),
+} as any);
 const samlUtilsMock = {
 	serviceProviders: [{ provider: 'test-saml' }] as any[],
 	log: sinon.stub(),
-	mapProfileToUserObject: sinon.stub(),
+	mapProfileToUserObject,
 	events: { emit: sinon.stub() },
 };
 
@@ -29,19 +35,22 @@ proxyquire.noCallThru().load('../../../../../server/lib/saml/loginHandler', {
 		Meteor: { Error },
 	},
 	'./lib/SAML': {
-		SAML: { retrieveCredential },
+		SAML: { retrieveCredential, insertOrUpdateSAMLUser },
 	},
 	'./lib/Utils': {
 		SAMLUtils: samlUtilsMock,
 	},
 	'../i18n': { i18n: { t: sinon.stub().returns('') } },
 	'../logger/system': { SystemLogger: { error: sinon.stub() } },
+	'../premiumAuthDeprecation': { warnUnlicensedAuthService },
 });
 
 describe('SAML loginHandler', () => {
 	beforeEach(() => {
 		retrieveCredential.reset();
 		retrieveCredential.resolves(null);
+		insertOrUpdateSAMLUser.reset();
+		insertOrUpdateSAMLUser.resolves({ userId: 'some-user-id', token: 'some-token' });
 		removeById.reset();
 		removeById.resolves();
 		samlUtilsMock.serviceProviders = [{ provider: 'test-saml' }];
@@ -65,10 +74,25 @@ describe('SAML loginHandler', () => {
 		expect(retrieveCredential.called).to.be.false;
 	});
 
-	it('should delete the credential token after retrieval', async () => {
-		await handler({ saml: true, credentialToken: 'token-to-delete' });
+	it('should not delete the credential token after retrieval so the mobile webview and the native app can both redeem it', async () => {
+		await handler({ saml: true, credentialToken: 'token-to-keep' });
 
-		expect(removeById.calledOnce).to.be.true;
-		expect(removeById.calledWith('token-to-delete')).to.be.true;
+		expect(removeById.called).to.be.false;
+	});
+
+	it('should let the same credential token be redeemed more than once (mobile login flow)', async () => {
+		const tokenStore = new Map<string, { profile: Record<string, any> }>();
+		retrieveCredential.callsFake(async (token: string) => tokenStore.get(token));
+		removeById.callsFake(async (token: string) => {
+			tokenStore.delete(token);
+		});
+		tokenStore.set('shared-token', { profile: { username: 'mobile-user', email: 'mobile@example.com' } });
+
+		const first = await handler({ saml: true, credentialToken: 'shared-token' });
+		const second = await handler({ saml: true, credentialToken: 'shared-token' });
+
+		expect(first).to.have.property('userId');
+		expect(second).to.have.property('userId');
+		expect(removeById.called).to.be.false;
 	});
 });


### PR DESCRIPTION
## Proposed changes

Fixes mobile SAML login failing with `No matching login attempt found` for the large majority of attempts.

The mobile login flow makes the in-app webview and the native app redeem the **same** credential token concurrently. The SAML login handler was deleting the token on its first redemption (`CredentialTokens.removeById`), so whichever request lost the race found no token and login failed with 401. This restores the behavior of the original fix in #7343, which this code regressed from.

The token is now left for the TTL mechanism to clean up: `credential_tokens` already has a TTL index on `expireAt` (tokens are created with a 60-second validity in `CredentialTokensRaw.create`), so no documents leak.

## Issue(s)

Closes #40605

## Steps to test or reproduce

1. Configure SAML login with any IdP (reproduced with Keycloak).
2. On a mobile device, open the Rocket.Chat React Native app.
3. Tap the SAML login button and complete authentication at the IdP.
4. The in-app webview completes the login; the native app must now also succeed with `POST /api/v1/login` instead of returning `No matching login attempt found`.

Unit-level reproduction is covered by the added regression test `tests/unit/server/lib/saml/loginHandler.spec.ts`, which simulates the two redemptions sharing one token and fails on the previous code (second redemption returns `{ type: 'saml', error: 403 }`).

## Further comments

- The deletion was removed rather than deferred because both redemptions legitimately need the same token within the flow; a grace window shorter than the token TTL would not reliably cover the native app's request.
- The TTL index on `credential_tokens.expireAt` already provides cleanup, so this does not introduce a storage leak.
- Security consideration: the token is a ~17-character random value transmitted over HTTPS and expires in at most 60 seconds, so allowing it to be redeemed twice does not meaningfully widen the replay window and matches the behavior of the original fix (#7343) and of the CAS flow's design.

---

_Automated by pr-pipeline (com.ashutosh.prpipeline)._


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SAML credential tokens can now be redeemed by both mobile webview and native app flows.
  * Tokens remain available for concurrent authentication attempts and are automatically cleaned up after expiration.
* **Tests**
  * Added coverage confirming tokens can be redeemed more than once before expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->