### PR TITLE
test: cover anonymous read API paths

### DIFF
--- a/apps/meteor/tests/end-to-end/api/methods.ts
+++ b/apps/meteor/tests/end-to-end/api/methods.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
 
 import { retry } from './helpers/retry';
-import { api, credentials, getCredentials, methodCall, request } from '../../data/api-data';
+import { api, credentials, getCredentials, methodCall, methodCallAnon, request } from '../../data/api-data';
 import { sendMessage, sendSimpleMessage } from '../../data/chat.helper';
 import { CI_MAX_ROOMS_PER_GUEST as maxRoomsPerGuest } from '../../data/constants';
 import { closeOmnichannelRoom, createAgent, createLivechatRoom, createVisitor, makeAgentAvailable } from '../../data/livechat/rooms';
@@ -857,7 +857,75 @@ describe('Meteor.methods', () => {
 				.end(done);
 		});
 
-		after(() => deleteRoom({ type: 'p', roomId: rid }));
+		let publicRid: IRoom['_id'];
+		let publicMessageId: IMessage['_id'];
+
+		before('create public channel with a message', async () => {
+			publicRid = (await createRoom({ type: 'c', name: `methods-test-public-${Date.now()}` })).body.channel._id;
+			publicMessageId = (await sendMessage({ message: { rid: publicRid, msg: 'public message' } })).body.message._id;
+		});
+
+		after(() => Promise.all([deleteRoom({ type: 'p', roomId: rid }), deleteRoom({ type: 'c', roomId: publicRid })]));
+
+		describe('anonymous read', () => {
+			before(() => updateSetting('Accounts_AllowAnonymousRead', true));
+			after(() => updateSetting('Accounts_AllowAnonymousRead', false));
+
+			it('should return public channel messages to an anonymous caller when anonymous read is enabled', async () => {
+				const res = await request
+					.post(methodCallAnon('loadHistory'))
+					.send({
+						message: JSON.stringify({
+							id: 'id',
+							msg: 'method',
+							method: 'loadHistory',
+							params: [publicRid],
+						}),
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				const data = JSON.parse(res.body.message);
+				expect(data.result).to.have.a.property('messages').that.is.an('array');
+				expect(data.result.messages.map((m: IMessage) => m._id)).to.include(publicMessageId);
+			});
+
+			it('should not return private group messages to an anonymous caller even when anonymous read is enabled', async () => {
+				const res = await request
+					.post(methodCallAnon('loadHistory'))
+					.send({
+						message: JSON.stringify({
+							id: 'id',
+							msg: 'method',
+							method: 'loadHistory',
+							params: [rid],
+						}),
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				const data = JSON.parse(res.body.message);
+				expect(data.result).to.equal(false);
+			});
+		});
+
+		it('should fail for an anonymous caller when anonymous read is disabled', async () => {
+			const res = await request
+				.post(methodCallAnon('loadHistory'))
+				.send({
+					message: JSON.stringify({
+						id: 'id',
+						msg: 'method',
+						method: 'loadHistory',
+						params: [publicRid],
+					}),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400);
+
+			const data = JSON.parse(res.body.message);
+			expect(data.error).to.have.property('error', 'error-invalid-user');
+		});
 
 		it('should fail if not logged in', async () => {
 			const res = await request
@@ -2539,7 +2607,7 @@ describe('Meteor.methods', () => {
 				}),
 			};
 
-			const res = await request.post('/api/v1/method.callAnon/getRoomByTypeAndName').set('Content-Type', 'application/json').send(payload);
+			const res = await request.post(methodCallAnon('getRoomByTypeAndName')).send(payload);
 
 			expect(res.body).to.have.property('message');
 			const parsedMessage = JSON.parse(res.body.message);
@@ -2668,17 +2736,14 @@ describe('Meteor.methods', () => {
 		it('should return the room object for a Public Channel if anonymous read is enabled', async () => {
 			await updateSetting('Accounts_AllowAnonymousRead', true);
 
-			const res = await request
-				.post(methodCall('getRoomByTypeAndName'))
-				.set(credentials)
-				.send({
-					message: JSON.stringify({
-						method: 'getRoomByTypeAndName',
-						params: ['c', room._id],
-						id: 'id',
-						msg: 'method',
-					}),
-				});
+			const res = await request.post(methodCallAnon('getRoomByTypeAndName')).send({
+				message: JSON.stringify({
+					method: 'getRoomByTypeAndName',
+					params: ['c', room._id],
+					id: 'id',
+					msg: 'method',
+				}),
+			});
 
 			expect(res.body.success).to.equal(true);
 			const parsedResponse = JSON.parse(res.body.message);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Anonymous read (`Accounts_AllowAnonymousRead`) had almost no API coverage for the DDP paths gated by it.

- `[@loadHistory]`: anonymous caller gets public channel messages when the setting is on, `false` for a private group, and `error-invalid-user` when the setting is off
- `[@getRoomByTypeAndName]`: the existing "anonymous read enabled" case was sending admin credentials — it now calls `method.callAnon` so it is actually anonymous

Anonymous `spotlight` coverage and its fix live in #41876 (the anonymous "on" case crashes on `develop`, so it can't land here first).

Not covered on purpose: `getRoomRoles` (no anonymous entry point — DDP method is not registered and `rooms.roles` is `authRequired`) and `browseChannels` (returns early without a user).

## Issue(s)

## Steps to test or reproduce

`yarn testapi` — new cases in `tests/end-to-end/api/methods.ts`.

## Further comments

Test-only, no changeset. 

 Task: [CORE-2601]

[CORE-2601]: https://rocketchat.atlassian.net/browse/CORE-2601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ