### PR TITLE
docs(apps-engine): fix dead case studies link

### DIFF
--- a/packages/apps-engine/README.md
+++ b/packages/apps-engine/README.md
@@ -119,7 +119,7 @@ To update or generate the documentation, please commit your changes first and th
 
 # Engage with us
 ## Share your story
-We’d love to hear about [your experience](https://survey.zohopublic.com/zs/e4BUFG) and potentially feature it on our [Blog](https://rocket.chat/case-studies/?utm_source=github&utm_medium=readme&utm_campaign=community).
+We’d love to hear about [your experience](https://survey.zohopublic.com/zs/e4BUFG) and potentially feature it on our [Blog](https://rocket.chat/customer-stories/?utm_source=github&utm_medium=readme&utm_campaign=community).
 
 ## Subscribe for Updates
 Once a month our marketing team releases an email update with news about product releases, company related topics, events and use cases. [Sign Up!](https://rocket.chat/newsletter/?utm_source=github&utm_medium=readme&utm_campaign=community)


### PR DESCRIPTION
`packages/apps-engine/README.md` invites contributors to share their experience and links to `https://rocket.chat/case-studies/`, which returns 404. The page is now [`/customer-stories`](https://rocket.chat/customer-stories/) (200); the utm parameters are preserved.

Scope note: two omnichannel API-reference URLs on developer.rocket.chat and an `app/oembed/client/oembedUrlWidget.html` link also 404, but all of those occur only in `HISTORY.md` / `apps/meteor/HISTORY.md`, which are generated release records, so I left them alone.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Share your story” link to point to the customer stories page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->