### PR TITLE
fix: federated presence is never sent

### DIFF
--- a/.changeset/federated-presence-never-sent.md
+++ b/.changeset/federated-presence-never-sent.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/federation-matrix': patch
+---
+
+Fixed federated user presence never being sent to remote workspaces

--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -103,7 +103,7 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 				if (!user.username || !user.status || user.username.includes(':')) {
 					return;
 				}
-				const localUser = await Users.findOneByUsername<Pick<IUser, '_id' | 'username' | 'federated' | 'federation'>>(user.username, {
+				const localUser = await Users.findOneByUsername(user.username, {
 					projection: { _id: 1, username: 1, federated: 1, federation: 1 },
 				});
 				if (!localUser?.username) {

--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -112,9 +112,6 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 
 				// TODO: Check if it should exclude himself from the list
 				const roomsUserIsMemberOf = await Subscriptions.findUserFederatedRoomIds(localUser._id).toArray();
-				if (!roomsUserIsMemberOf.length) {
-					return;
-				}
 				const statusMap: Record<UserStatus, PresenceState> = {
 					[UserStatus.ONLINE]: 'online',
 					[UserStatus.OFFLINE]: 'offline',
@@ -122,8 +119,6 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 					[UserStatus.BUSY]: 'unavailable',
 					[UserStatus.DISABLED]: 'offline',
 				};
-				// local users carry no federation metadata, so derive their Matrix ID the same way
-				// notifyUserTyping does instead of requiring a stored `mui`
 				const userMui = isUserNativeFederated(localUser) ? localUser.federation.mui : `@${localUser.username}:${this.serverName}`;
 
 				void federationSDK.sendPresenceUpdateToRooms(

--- a/ee/packages/federation-matrix/src/FederationMatrix.ts
+++ b/ee/packages/federation-matrix/src/FederationMatrix.ts
@@ -103,17 +103,18 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 				if (!user.username || !user.status || user.username.includes(':')) {
 					return;
 				}
-				const localUser = await Users.findOneByUsername(user.username, { projection: { _id: 1, federated: 1, federation: 1 } });
-				if (!localUser) {
-					return;
-				}
-
-				if (!isUserNativeFederated(localUser)) {
+				const localUser = await Users.findOneByUsername<Pick<IUser, '_id' | 'username' | 'federated' | 'federation'>>(user.username, {
+					projection: { _id: 1, username: 1, federated: 1, federation: 1 },
+				});
+				if (!localUser?.username) {
 					return;
 				}
 
 				// TODO: Check if it should exclude himself from the list
 				const roomsUserIsMemberOf = await Subscriptions.findUserFederatedRoomIds(localUser._id).toArray();
+				if (!roomsUserIsMemberOf.length) {
+					return;
+				}
 				const statusMap: Record<UserStatus, PresenceState> = {
 					[UserStatus.ONLINE]: 'online',
 					[UserStatus.OFFLINE]: 'offline',
@@ -121,10 +122,14 @@ export class FederationMatrix extends ServiceClass implements IFederationMatrixS
 					[UserStatus.BUSY]: 'unavailable',
 					[UserStatus.DISABLED]: 'offline',
 				};
+				// local users carry no federation metadata, so derive their Matrix ID the same way
+				// notifyUserTyping does instead of requiring a stored `mui`
+				const userMui = isUserNativeFederated(localUser) ? localUser.federation.mui : `@${localUser.username}:${this.serverName}`;
+
 				void federationSDK.sendPresenceUpdateToRooms(
 					[
 						{
-							user_id: localUser.federation.mui,
+							user_id: userMui,
 							presence: statusMap[user.status] || 'offline',
 						},
 					],

--- a/ee/packages/federation-matrix/tests/end-to-end/presence.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/presence.spec.ts
@@ -16,15 +16,6 @@ const remoteUser = federationConfig.hs1.additionalUser1;
 
 const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 
-/**
- * Presence is only federated while `Federation_Service_EDU_Process_Presence` is on, and it
- * defaults to off, so this suite owns the setting and restores it afterwards.
- *
- * The assertion deliberately reads the remote homeserver's own view of the user rather than
- * Rocket.Chat's, because the send path is what regressed: the handler used to require
- * federation metadata that is never written for local users, so no EDU was ever emitted and
- * a Rocket.Chat side check would have passed against a shadow user that never updated.
- */
 (IS_EE ? describe : describe.skip)('Federation presence', () => {
 	let rc1AdminRequestConfig: IRequestConfig;
 	let rc1UserRequestConfig: IRequestConfig;
@@ -39,7 +30,6 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 			.expect(200);
 	};
 
-	// the remote server is the source of truth here: it only knows a status if an EDU arrived
 	const expectRemotePresence = async (expected: string) =>
 		retry(
 			`waiting for ${remoteUser.username} to see ${localUser.matrixUserId} as ${expected}`,
@@ -78,8 +68,6 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 		hs1UserApp = new SynapseClient(federationConfig.hs1.url, remoteUser.username, remoteUser.password);
 		await hs1UserApp.initialize();
 
-		// presence is only sent to servers that share a federated room with the user, so the
-		// two sides need one before any status change can be observed
 		const channelName = `fed-presence-${Date.now()}`;
 		const synapseRoomId = await hs1UserApp.createRoom(channelName, Visibility.Private);
 		await hs1UserApp.inviteUserToRoom(synapseRoomId, localUser.matrixUserId);
@@ -104,7 +92,6 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 	}, 120000);
 
 	afterAll(async () => {
-		// leave the workspace as it was found: this setting is off by default
 		if (rc1AdminRequestConfig) {
 			await setPresenceSetting(false);
 		}
@@ -131,8 +118,6 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 		expect(response.body.subscription).toBeTruthy();
 	});
 
-	// `online` is the assertion that actually pins the regression: an unknown remote user reads
-	// as `offline` on Synapse, so only a non-offline state proves an EDU was received.
 	it('should reach the remote server when the local user goes online', async () => {
 		await setLocalStatus(UserStatus.ONLINE);
 
@@ -142,9 +127,6 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 	describe('with a connected client', () => {
 		let ddp: DDPListener;
 
-		// away and busy are only *effective* statuses while the user has a live connection;
-		// for a REST-only user Rocket.Chat resolves both to offline, which is indistinguishable
-		// from "no EDU arrived". A DDP session makes them real, and therefore assertable.
 		beforeAll(async () => {
 			ddp = new DDPListener(federationConfig.rc1.url, rc1UserRequestConfig);
 			await ddp.connect();
@@ -162,6 +144,9 @@ const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
 		}, 60000);
 
 		it('should reach the remote server when the local user goes busy', async () => {
+			await setLocalStatus(UserStatus.ONLINE);
+			await expectRemotePresence('online');
+
 			await setLocalStatus(UserStatus.BUSY);
 
 			await expectRemotePresence('unavailable');

--- a/ee/packages/federation-matrix/tests/end-to-end/presence.spec.ts
+++ b/ee/packages/federation-matrix/tests/end-to-end/presence.spec.ts
@@ -1,0 +1,176 @@
+import type { IRoomNativeFederated } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
+import { Visibility } from 'matrix-js-sdk';
+
+import { api } from '../../../../../apps/meteor/tests/data/api-data';
+import { acceptRoomInvite } from '../../../../../apps/meteor/tests/data/rooms.helper';
+import { type IRequestConfig, createUser, getRequestConfig, getUserByUsername } from '../../../../../apps/meteor/tests/data/users.helper';
+import { IS_EE } from '../../../../../apps/meteor/tests/e2e/config/constants';
+import { retry } from '../../../../../apps/meteor/tests/end-to-end/api/helpers/retry';
+import { federationConfig } from '../helper/config';
+import { DDPListener } from '../helper/ddp-listener';
+import { SynapseClient } from '../helper/synapse-client';
+
+const localUser = federationConfig.rc1.additionalUser1;
+const remoteUser = federationConfig.hs1.additionalUser1;
+
+const PRESENCE_SETTING = 'Federation_Service_EDU_Process_Presence';
+
+/**
+ * Presence is only federated while `Federation_Service_EDU_Process_Presence` is on, and it
+ * defaults to off, so this suite owns the setting and restores it afterwards.
+ *
+ * The assertion deliberately reads the remote homeserver's own view of the user rather than
+ * Rocket.Chat's, because the send path is what regressed: the handler used to require
+ * federation metadata that is never written for local users, so no EDU was ever emitted and
+ * a Rocket.Chat side check would have passed against a shadow user that never updated.
+ */
+(IS_EE ? describe : describe.skip)('Federation presence', () => {
+	let rc1AdminRequestConfig: IRequestConfig;
+	let rc1UserRequestConfig: IRequestConfig;
+	let hs1UserApp: SynapseClient;
+	let federatedRoomId: string;
+
+	const setPresenceSetting = async (value: boolean) => {
+		await rc1AdminRequestConfig.request
+			.post(api(`settings/${PRESENCE_SETTING}`))
+			.set(rc1AdminRequestConfig.credentials)
+			.send({ value })
+			.expect(200);
+	};
+
+	// the remote server is the source of truth here: it only knows a status if an EDU arrived
+	const expectRemotePresence = async (expected: string) =>
+		retry(
+			`waiting for ${remoteUser.username} to see ${localUser.matrixUserId} as ${expected}`,
+			async () => {
+				const status = await hs1UserApp.matrixClient.getPresence(localUser.matrixUserId);
+
+				expect(status.presence).toBe(expected);
+			},
+			{ retries: 10, delayMs: 2000 },
+		);
+
+	beforeAll(async () => {
+		rc1AdminRequestConfig = await getRequestConfig(
+			federationConfig.rc1.url,
+			federationConfig.rc1.adminUser,
+			federationConfig.rc1.adminPassword,
+		);
+
+		const existingLocalUser = await getUserByUsername(localUser.username, rc1AdminRequestConfig);
+		if (!existingLocalUser?._id) {
+			await createUser(
+				{
+					username: localUser.username,
+					password: localUser.password,
+					email: `${localUser.username}@rocket.chat`,
+					name: localUser.username,
+				},
+				rc1AdminRequestConfig,
+			);
+		}
+
+		rc1UserRequestConfig = await getRequestConfig(federationConfig.rc1.url, localUser.username, localUser.password);
+
+		await setPresenceSetting(true);
+
+		hs1UserApp = new SynapseClient(federationConfig.hs1.url, remoteUser.username, remoteUser.password);
+		await hs1UserApp.initialize();
+
+		// presence is only sent to servers that share a federated room with the user, so the
+		// two sides need one before any status change can be observed
+		const channelName = `fed-presence-${Date.now()}`;
+		const synapseRoomId = await hs1UserApp.createRoom(channelName, Visibility.Private);
+		await hs1UserApp.inviteUserToRoom(synapseRoomId, localUser.matrixUserId);
+
+		await retry(
+			'waiting for the federated room to reach RC',
+			async () => {
+				const response = await rc1UserRequestConfig.request.get(api('rooms.get')).set(rc1UserRequestConfig.credentials).expect(200);
+
+				const rcRoom = response.body.update.find(
+					(room: IRoomNativeFederated) => room.federation?.mrid === synapseRoomId,
+				) as IRoomNativeFederated | null;
+
+				expect(rcRoom).toBeTruthy();
+				federatedRoomId = rcRoom!._id;
+			},
+			{ retries: 10, delayMs: 2000 },
+		);
+
+		const accepted = await acceptRoomInvite(federatedRoomId, rc1UserRequestConfig);
+		expect(accepted).toHaveProperty('success', true);
+	}, 120000);
+
+	afterAll(async () => {
+		// leave the workspace as it was found: this setting is off by default
+		if (rc1AdminRequestConfig) {
+			await setPresenceSetting(false);
+		}
+		await hs1UserApp?.close();
+	});
+
+	const setLocalStatus = async (status: UserStatus) => {
+		const response = await rc1UserRequestConfig.request
+			.post(api('users.setStatus'))
+			.set(rc1UserRequestConfig.credentials)
+			.send({ status, message: '' })
+			.expect(200);
+
+		expect(response.body).toHaveProperty('success', true);
+	};
+
+	it('should share a federated room with the remote user', async () => {
+		const response = await rc1UserRequestConfig.request
+			.get(api('subscriptions.getOne'))
+			.set(rc1UserRequestConfig.credentials)
+			.query({ roomId: federatedRoomId })
+			.expect(200);
+
+		expect(response.body.subscription).toBeTruthy();
+	});
+
+	// `online` is the assertion that actually pins the regression: an unknown remote user reads
+	// as `offline` on Synapse, so only a non-offline state proves an EDU was received.
+	it('should reach the remote server when the local user goes online', async () => {
+		await setLocalStatus(UserStatus.ONLINE);
+
+		await expectRemotePresence('online');
+	}, 60000);
+
+	describe('with a connected client', () => {
+		let ddp: DDPListener;
+
+		// away and busy are only *effective* statuses while the user has a live connection;
+		// for a REST-only user Rocket.Chat resolves both to offline, which is indistinguishable
+		// from "no EDU arrived". A DDP session makes them real, and therefore assertable.
+		beforeAll(async () => {
+			ddp = new DDPListener(federationConfig.rc1.url, rc1UserRequestConfig);
+			await ddp.connect();
+		}, 60000);
+
+		afterAll(() => {
+			ddp?.disconnect();
+		});
+
+		// away and busy both collapse to the Matrix `unavailable` state
+		it('should reach the remote server when the local user goes away', async () => {
+			await setLocalStatus(UserStatus.AWAY);
+
+			await expectRemotePresence('unavailable');
+		}, 60000);
+
+		it('should reach the remote server when the local user goes busy', async () => {
+			await setLocalStatus(UserStatus.BUSY);
+
+			await expectRemotePresence('unavailable');
+		}, 60000);
+
+		it('should reach the remote server when the local user comes back online', async () => {
+			await setLocalStatus(UserStatus.ONLINE);
+
+			await expectRemotePresence('online');
+		}, 60000);
+	});
+});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[CORE-2554](https://rocketchat.atlassian.net/browse/CORE-2554)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2554]: https://rocketchat.atlassian.net/browse/CORE-2554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed federated presence updates not being sent reliably to remote workspaces.
  * Improved presence handling for local users, including those who are not natively federated.
  * Local users now receive correctly derived Matrix identities when participating in federated rooms.
  * Improved synchronization of online, away, busy, and returning-online presence states with remote homeservers.
  * Presence updates now continue working even when users have no federated rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->