### PR TITLE
fix: desktop notification quick replies to thread messages posted to the main room

### DIFF
--- a/.changeset/quiet-thread-replies.md
+++ b/.changeset/quiet-thread-replies.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes desktop notification quick replies to thread messages being posted to the main room instead of the thread

--- a/apps/meteor/client/hooks/notification/useNotification.spec.ts
+++ b/apps/meteor/client/hooks/notification/useNotification.spec.ts
@@ -1,0 +1,134 @@
+import type { INotificationDesktop } from '@rocket.chat/core-typings';
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useNotification } from './useNotification';
+import { useNotificationAllowed } from './useNotificationAllowed';
+import { sdk } from '../../../app/utils/client/lib/SDKClient';
+import { onClientMessageReceived } from '../../lib/onClientMessageReceived';
+
+jest.mock('./useNotificationAllowed', () => ({
+	useNotificationAllowed: jest.fn(),
+}));
+
+jest.mock('../../lib/onClientMessageReceived', () => ({
+	onClientMessageReceived: jest.fn(),
+}));
+
+jest.mock('../../../app/utils/client/lib/SDKClient', () => ({
+	sdk: {
+		rest: {
+			post: jest.fn(),
+		},
+	},
+}));
+
+jest.mock('../../../app/utils/client', () => ({
+	getUserAvatarURL: jest.fn(),
+}));
+
+type NotificationEventListener = (event: { response: string }) => void;
+
+class MockNotification {
+	static permission: NotificationPermission = 'granted';
+
+	static listenersByInstance: NotificationEventListener[] = [];
+
+	title: string;
+
+	options: NotificationOptions | undefined;
+
+	onclick: (() => void) | null = null;
+
+	constructor(title: string, options?: NotificationOptions) {
+		this.title = title;
+		this.options = options;
+	}
+
+	addEventListener(type: 'reply', listener: NotificationEventListener): void {
+		if (type === 'reply') {
+			MockNotification.listenersByInstance.push(listener);
+		}
+	}
+
+	close(): void {
+		// no-op
+	}
+}
+
+const buildPayload = (tmid?: string): INotificationDesktop => ({
+	title: 'title',
+	text: 'text',
+	payload: {
+		_id: 'msgId',
+		rid: 'roomId',
+		...(tmid && { tmid }),
+		sender: { _id: 'senderId', username: 'sender' },
+		type: 'c',
+		name: 'roomName',
+		message: { msg: 'text' },
+		audioNotificationValue: 'default',
+	},
+});
+
+describe('useNotification', () => {
+	const originalNotification = window.Notification;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		MockNotification.listenersByInstance = [];
+		(window as any).Notification = MockNotification;
+		(useNotificationAllowed as jest.MockedFunction<typeof useNotificationAllowed>).mockReturnValue(true);
+		(onClientMessageReceived as jest.MockedFunction<typeof onClientMessageReceived>).mockImplementation((message: any) =>
+			Promise.resolve(message),
+		);
+	});
+
+	afterAll(() => {
+		(window as any).Notification = originalNotification;
+	});
+
+	it('includes tmid in the sendMessage payload when the notification is for a thread message', async () => {
+		const { result } = renderHook(() => useNotification(), {
+			wrapper: mockAppRoot().build(),
+		});
+
+		await result.current(buildPayload('threadId'));
+
+		await waitFor(() => expect(MockNotification.listenersByInstance).toHaveLength(1));
+
+		MockNotification.listenersByInstance[0]({ response: 'reply text' });
+
+		expect(sdk.rest.post).toHaveBeenCalledWith(
+			'/v1/chat.sendMessage',
+			expect.objectContaining({
+				message: expect.objectContaining({
+					rid: 'roomId',
+					msg: 'reply text',
+					tmid: 'threadId',
+				}),
+			}),
+		);
+	});
+
+	it('does not include tmid in the sendMessage payload when the notification is for a room message', async () => {
+		const { result } = renderHook(() => useNotification(), {
+			wrapper: mockAppRoot().build(),
+		});
+
+		await result.current(buildPayload());
+
+		await waitFor(() => expect(MockNotification.listenersByInstance).toHaveLength(1));
+
+		MockNotification.listenersByInstance[0]({ response: 'reply text' });
+
+		expect(sdk.rest.post).toHaveBeenCalledWith(
+			'/v1/chat.sendMessage',
+			expect.objectContaining({
+				message: expect.objectContaining({ rid: 'roomId', msg: 'reply text' }),
+			}),
+		);
+		const [, body] = (sdk.rest.post as jest.Mock).mock.calls[0];
+		expect('tmid' in body.message).toBe(false);
+	});
+});

--- a/apps/meteor/client/hooks/notification/useNotification.ts
+++ b/apps/meteor/client/hooks/notification/useNotification.ts
@@ -56,6 +56,7 @@ export const useNotification = () => {
 							_id: Random.id(),
 							rid,
 							msg: response,
+							...(notification.payload.tmid && { tmid: notification.payload.tmid }),
 						},
 					}),
 			);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Replying to a desktop notification for a **thread** message posts the reply to the **main room** instead of the thread.

The server-side desktop notification payload already carries the thread id (`tmid`), but the client's `useNotification` reply handler dropped it when calling `sendMessage`. This passes it through, using the same `notification.payload.tmid` conditional the hook's `onclick` handler already uses for thread navigation. No server change needed.

Also adds the first spec coverage for `useNotification` — the regression slipped through the `sendMessage` REST migration (#40675) unnoticed because the hook had no tests:

- reply to a thread notification includes `tmid` in the sent message
- reply to a room notification sends no `tmid` key

## Issue(s)

Internal support escalation [SUP-1097] (Track B). Related Desktop-side fix: RocketChat/Rocket.Chat.Electron#3464

## Steps to test or reproduce

1. Enable desktop notifications; have another user reply to you **inside a thread** while the room is not focused.
2. Use the notification's inline reply field.
3. Before: the reply appears in the main room. After: the reply lands in the thread.

Targeted verification: `yarn jest client/hooks/notification/useNotification.spec.ts` (2/2 green), ESLint clean on changed files.

## Further comments

One-line behavioral change; `sendMessage` already accepts `tmid` (`AtLeast<IMessage, '_id' | 'rid' | 'msg'>`), so no typing changes. Changeset included (`@rocket.chat/meteor` patch).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed desktop notification quick replies so responses to threaded messages remain in the correct thread instead of posting to the main room.
  - Preserved thread context when replying directly from notifications, while keeping regular room replies unchanged.

- **Tests**
  - Added coverage for notification permissions, messaging, reply payloads, client message reception, and thread-specific behavior.
  - Verified that thread replies retain their parent message context and regular room replies continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SUP-1097]: https://rocketchat.atlassian.net/browse/SUP-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
