### PR TITLE
fix: anonymous spotlight search crashing when anonymous read is enabled

### DIFF
--- a/.changeset/fix-anonymous-spotlight-callers.md
+++ b/.changeset/fix-anonymous-spotlight-callers.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes room search (`spotlight`) failing for anonymous visitors when "Allow Anonymous Read" is enabled

--- a/apps/meteor/server/lib/spotlight.js
+++ b/apps/meteor/server/lib/spotlight.js
@@ -11,7 +11,7 @@ import { readSecondaryPreferred } from '../database/readSecondaryPreferred';
 
 export class Spotlight {
 	async fetchRooms(userId, rooms) {
-		if (!settings.get('Store_Last_Message') || (await hasPermissionAsync(userId, 'preview-c-room'))) {
+		if (!settings.get('Store_Last_Message') || (userId && (await hasPermissionAsync(userId, 'preview-c-room')))) {
 			return rooms;
 		}
 
@@ -191,7 +191,7 @@ export class Spotlight {
 			return users;
 		}
 
-		const canListOutsiders = await hasAllPermissionAsync(userId, ['view-outside-room', 'view-d-room']);
+		const canListOutsiders = !!userId && (await hasAllPermissionAsync(userId, ['view-outside-room', 'view-d-room']));
 		const canListInsiders = canListOutsiders || (rid && (await canAccessRoomAsync(room, { _id: userId })));
 
 		const insiderExtraQuery = [];

--- a/apps/meteor/tests/end-to-end/api/methods.ts
+++ b/apps/meteor/tests/end-to-end/api/methods.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
 
 import { retry } from './helpers/retry';
-import { api, credentials, getCredentials, methodCall, request } from '../../data/api-data';
+import { api, credentials, getCredentials, methodCall, methodCallAnon, request } from '../../data/api-data';
 import { sendMessage, sendSimpleMessage } from '../../data/chat.helper';
 import { CI_MAX_ROOMS_PER_GUEST as maxRoomsPerGuest } from '../../data/constants';
 import { closeOmnichannelRoom, createAgent, createLivechatRoom, createVisitor, makeAgentAvailable } from '../../data/livechat/rooms';
@@ -2705,6 +2705,59 @@ describe('Meteor.methods', () => {
 					expect(parsedResponse.result._id).to.equal(dmId);
 					done();
 				});
+		});
+	});
+
+	describe('[@spotlight]', () => {
+		let testChannel: IRoom;
+
+		before(async () => {
+			testChannel = (await createRoom({ type: 'c', name: `methods-spotlight-${Date.now()}` })).body.channel;
+		});
+
+		after(async () => {
+			await Promise.all([deleteRoom({ type: 'c', roomId: testChannel._id }), updateSetting('Accounts_AllowAnonymousRead', false)]);
+		});
+
+		const callAnonymousSpotlight = async (text: string) => {
+			const res = await request
+				.post(methodCallAnon('spotlight'))
+				.send({
+					message: JSON.stringify({
+						msg: 'method',
+						id: 'id',
+						method: 'spotlight',
+						params: [text],
+					}),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+
+			const parsedResponse = JSON.parse(res.body.message);
+			expect(parsedResponse).to.not.have.property('error');
+
+			return parsedResponse.result as { rooms: IRoom[]; users: IUser[] };
+		};
+
+		it('should return no rooms or users for an anonymous user when anonymous read is disabled', async () => {
+			await updateSetting('Accounts_AllowAnonymousRead', false);
+
+			// The unprefixed query also runs the user search with no user id, which used to throw.
+			const result = await callAnonymousSpotlight(testChannel.name as string);
+
+			expect(result).to.have.property('rooms').and.to.be.an('array').that.is.empty;
+			expect(result).to.have.property('users').and.to.be.an('array').that.is.empty;
+		});
+
+		it('should return public rooms but no users for an anonymous user when anonymous read is enabled', async () => {
+			await updateSetting('Accounts_AllowAnonymousRead', true);
+
+			const result = await callAnonymousSpotlight(testChannel.name as string);
+
+			expect(result.rooms.map((room) => room._id)).to.include(testChannel._id);
+			expect(result).to.have.property('users').and.to.be.an('array').that.is.empty;
 		});
 	});
 

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -538,10 +538,30 @@ describe('miscellaneous', () => {
 			after(() => updateSetting('Accounts_AllowAnonymousRead', false));
 
 			it('should return no rooms when anonymous read is disabled', async () => {
+				await updateSetting('Accounts_AllowAnonymousRead', false);
+
 				const res = await request
 					.get(api('spotlight'))
 					.query({
 						query: `#${testChannel.name}`,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('rooms').and.to.be.an('array').that.is.empty;
+				expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
+			});
+
+			// An unprefixed query keeps `type.users` enabled, so it also runs the user search with no
+			// user id - the code path that used to throw before the anonymous callers were guarded.
+			it('should return no rooms or users for an unprefixed query when anonymous read is disabled', async () => {
+				await updateSetting('Accounts_AllowAnonymousRead', false);
+
+				const res = await request
+					.get(api('spotlight'))
+					.query({
+						query: testChannel.name,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(200);
@@ -558,6 +578,22 @@ describe('miscellaneous', () => {
 					.get(api('spotlight'))
 					.query({
 						query: `#${testChannel.name}`,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body.rooms.map((r: { _id: string }) => r._id)).to.include(testChannel._id);
+				expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
+			});
+
+			it('should return public rooms but no users for an unprefixed query when anonymous read is enabled', async () => {
+				await updateSetting('Accounts_AllowAnonymousRead', true);
+
+				const res = await request
+					.get(api('spotlight'))
+					.query({
+						query: testChannel.name,
 					})
 					.expect('Content-Type', 'application/json')
 					.expect(200);

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -534,18 +534,38 @@ describe('miscellaneous', () => {
 			expect(res.body).to.have.property('users').and.to.be.an('array');
 			expect(res.body.users.map((u: { username: string }) => u.username)).to.not.include(adminUsername);
 		});
-		it('should allow anonymous (unauthenticated) requests', async () => {
-			const res = await request
-				.get(api('spotlight'))
-				.query({
-					query: `#${testChannel.name}`,
-				})
-				.expect('Content-Type', 'application/json')
-				.expect(200);
+		describe('anonymous (unauthenticated) requests', () => {
+			after(() => updateSetting('Accounts_AllowAnonymousRead', false));
 
-			expect(res.body).to.have.property('success', true);
-			expect(res.body).to.have.property('rooms').and.to.be.an('array');
-			expect(res.body).to.have.property('users').and.to.be.an('array');
+			it('should return no rooms when anonymous read is disabled', async () => {
+				const res = await request
+					.get(api('spotlight'))
+					.query({
+						query: `#${testChannel.name}`,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body).to.have.property('rooms').and.to.be.an('array').that.is.empty;
+				expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
+			});
+
+			it('should return public rooms but no users when anonymous read is enabled', async () => {
+				await updateSetting('Accounts_AllowAnonymousRead', true);
+
+				const res = await request
+					.get(api('spotlight'))
+					.query({
+						query: `#${testChannel.name}`,
+					})
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(res.body).to.have.property('success', true);
+				expect(res.body.rooms.map((r: { _id: string }) => r._id)).to.include(testChannel._id);
+				expect(res.body).to.have.property('users').and.to.be.an('array').that.is.empty;
+			});
 		});
 	});
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Since 8.7.0, an unauthenticated room search (`GET /api/v1/spotlight` and the DDP `spotlight` method) fails with `Cannot read properties of undefined (reading '_id')` whenever `Accounts_AllowAnonymousRead` is enabled — anonymous visitors can't find public channels via the navbar search.

**Root cause:** ae72939305 / #41413 (`refactor(authorization): forward only { _id, roles } from hasPermission wrappers`) introduced `toSubject` in `server/lib/authorization/hasPermission.ts`, which does `user._id` on any non-string argument. `server/lib/spotlight.js` (untyped) passes `userId = undefined` on the anonymous path in two places — `fetchRooms` and `searchUsers` — so TypeScript never flagged it. Before #41413 the wrappers passed the user straight through and the authorization service returned `false`.

**Fix:** guard those two call sites (`userId && …`) so a missing user short-circuits to "no permission", same result as before #41413. The wrappers and the `IAuthorization` contract stay strict. Alternative wrapper-level fix is in #41843; pick one.

**Tests:** `[/spotlight]` anonymous cases — no rooms/users with the setting off; public rooms (no users) with it on. The "on" case 400s on `develop`.

## Issue(s)

## Steps to test or reproduce

1. Enable `Accounts_AllowAnonymousRead`.
2. `GET /api/v1/spotlight?query=%23general` with no auth headers.
3. `develop`: 400 with the TypeError above. This branch: 200 with the public room in `rooms`, empty `users`.

## Further comments

Affects 8.7.0+, candidate for backport. Patch changeset included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

[CORE-2599](https://rocketchat.atlassian.net/browse/CORE-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[CORE-2599]: https://rocketchat.atlassian.net/browse/CORE-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed anonymous room searches when anonymous read access is enabled.
  - Anonymous visitors can now discover public rooms as configured, without triggering permission errors.
  - Anonymous user searches continue to respect access settings and return no users.
  - Search results now consistently reflect anonymous read permissions for both prefixed and unprefixed queries.
- **Tests**
  - Updated coverage for anonymous Spotlight searches across different access configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->