### PR TITLE
test(federation): remove stray describe.only

### DIFF
--- a/apps/meteor/tests/e2e/federation/tests/messaging/threads.spec.ts
+++ b/apps/meteor/tests/e2e/federation/tests/messaging/threads.spec.ts
@@ -8,7 +8,7 @@ import { formatIntoFullMatrixUsername, formatUsernameAndDomainIntoMatrixFormat }
 import { registerUser } from '../../utils/register-user';
 import { test, expect, setupTesting, tearDownTesting } from '../../utils/test';
 
-test.describe.only('Federation - Threads', () => {
+test.describe('Federation - Threads', () => {
 	let poFederationChannelServer1: FederationChannel;
 	let poFederationChannelServer2: FederationChannel;
 	let userFromServer2UsernameOnly: string;


### PR DESCRIPTION
`apps/meteor/tests/e2e/federation/tests/messaging/threads.spec.ts` line 11 has a committed `.only`:

```ts
test.describe.only('Federation - Threads', () => {
```

Playwright's `.only` is run-wide, not file-scoped. `playwright-federation.config.ts` sets `testDir: 'tests/e2e/federation'`, so with this in place the entire federation suite collapses to that one block.

Counting `test(...)` blocks across the suite on `develop`:

| Spec | Tests |
| --- | --- |
| channel/public | 52 |
| channel/private | 49 |
| channel/dm | 33 |
| messaging/public | 59 |
| messaging/private | 59 |
| messaging/dm | 55 |
| messaging/threads | 22 |
| admin/users | 10 |
| ce-version/ce | 8 |
| admin/rooms | 6 |
| user-account/user | 7 |
| **total** | **360** |

Only the 22 in `threads.spec.ts` run. The remaining **338 federation E2E tests are silently skipped** — they report as passing-by-absence rather than failing, so nothing surfaces it.

The federation config sets no `forbidOnly`, which is why CI does not reject it. This PR only removes the modifier, since that restores the suite with the smallest possible change. If you'd like, adding `forbidOnly: !!process.env.CI` to `playwright-federation.config.ts` would stop this recurring — I checked and this is the only `.only` in the repo's test files, so enabling it would not break anything today. Happy to add it here or in a separate PR, whichever you prefer.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated federation thread tests to run as part of the full test suite instead of executing exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->