### PR TITLE
fix: teams with a missing main room cannot be deleted

### DIFF
--- a/.changeset/tasty-dingos-sit.md
+++ b/.changeset/tasty-dingos-sit.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes team deletion failing when the team's main room no longer exists. Such teams were left orphaned: hidden from the admin UI, still reserving their name, and impossible to remove through any supported path. Deleting a team now completes even when its main room is already gone, so a deletion interrupted midway can be finished by simply retrying it, and the team name becomes available again.

--- a/apps/meteor/server/api/lib/eraseTeam.spec.ts
+++ b/apps/meteor/server/api/lib/eraseTeam.spec.ts
@@ -99,6 +99,7 @@ describe('eraseTeam (TypeScript) module', () => {
 			const team = { _id: 'team-id', roomId: 'team-room' };
 			const user = { _id: 'user-1', username: 'u' };
 			stubs.Team.getMatchingTeamRooms.resolves(['room-1', 'room-2', team.roomId]);
+			stubs.Rooms.findOneById.withArgs(team.roomId).resolves({ _id: team.roomId });
 
 			const erased: Array<{ rid: string; user: any }> = [];
 			const eraseRoomFn = async (rid: string, user: any) => {
@@ -114,6 +115,22 @@ describe('eraseTeam (TypeScript) module', () => {
 			sinon.assert.calledOnce(stubs.Team.removeAllMembersFromTeam);
 			sinon.assert.calledOnce(stubs.Team.deleteById);
 		});
+
+		it('skips the main room but still deletes the team when the main room no longer exists', async () => {
+			const team = { _id: 'team-id', roomId: 'team-room' };
+			const user = { _id: 'user-1', username: 'u' };
+			stubs.Team.getMatchingTeamRooms.resolves([]);
+			stubs.Rooms.findOneById.withArgs(team.roomId).resolves(null);
+
+			const eraseRoomFn = sandbox.stub().resolves();
+
+			await subject.eraseTeamShared(user, team, [], eraseRoomFn);
+
+			sinon.assert.notCalled(eraseRoomFn);
+			sinon.assert.calledOnce(stubs.Team.unsetTeamIdOfRooms);
+			sinon.assert.calledOnce(stubs.Team.removeAllMembersFromTeam);
+			sinon.assert.calledOnce(stubs.Team.deleteById);
+		});
 	});
 
 	describe('eraseTeam', () => {
@@ -121,6 +138,7 @@ describe('eraseTeam (TypeScript) module', () => {
 			const team = { _id: 't1', roomId: 't-room' };
 			const user = { _id: 'u1', username: 'u', name: 'User' };
 			stubs.Team.getMatchingTeamRooms.resolves([]);
+			stubs.Rooms.findOneById.withArgs(team.roomId).resolves({ _id: team.roomId });
 			const { eraseRoomStub } = stubs;
 			eraseRoomStub.resolves(true);
 

--- a/apps/meteor/server/api/lib/eraseTeam.ts
+++ b/apps/meteor/server/api/lib/eraseTeam.ts
@@ -31,8 +31,10 @@ export const eraseTeamShared = async <T extends AtLeast<IUser, '_id' | 'name' | 
 	// Move every other room back to the workspace
 	await Team.unsetTeamIdOfRooms(user, team);
 
-	// Remove the team's main room
-	await eraseRoomFn(team.roomId, user);
+	const room = await await Rooms.findOneById<Pick<IRoom, '_id'>>(team.roomId, { projection: { _id: 1 } });
+	if (room) {
+		await eraseRoomFn(team.roomId, user);
+	}
 
 	// Delete all team memberships
 	await Team.removeAllMembersFromTeam(team._id);

--- a/apps/meteor/server/api/lib/eraseTeam.ts
+++ b/apps/meteor/server/api/lib/eraseTeam.ts
@@ -31,7 +31,7 @@ export const eraseTeamShared = async <T extends AtLeast<IUser, '_id' | 'name' | 
 	// Move every other room back to the workspace
 	await Team.unsetTeamIdOfRooms(user, team);
 
-	const room = await await Rooms.findOneById<Pick<IRoom, '_id'>>(team.roomId, { projection: { _id: 1 } });
+	const room = await Rooms.findOneById<Pick<IRoom, '_id'>>(team.roomId, { projection: { _id: 1 } });
 	if (room) {
 		await eraseRoomFn(team.roomId, user);
 	}

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -421,17 +421,14 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 			throw new Error('invalid-team');
 		}
 
-		const room = await Rooms.findOneById<Pick<IRoom, 'name'>>(team.roomId, { projection: { name: 1 } });
-
-		if (!room) {
-			throw new Error('invalid-room');
-		}
-
 		if (!user) {
 			throw new Error('invalid-user');
 		}
 
-		await Message.saveSystemMessage('user-converted-to-channel', team.roomId, room.name || '', user);
+		const room = await Rooms.findOneById<Pick<IRoom, 'name'>>(team.roomId, { projection: { name: 1 } });
+		if (room) {
+			await Message.saveSystemMessage('user-converted-to-channel', team.roomId, room.name || '', user);
+		}
 
 		await Rooms.unsetTeamId(team._id);
 	}

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -422,17 +422,14 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 			throw new Error('invalid-team');
 		}
 
-		const room = await Rooms.findOneById<Pick<IRoom, 'name'>>(team.roomId, { projection: { name: 1 } });
-
-		if (!room) {
-			throw new Error('invalid-room');
-		}
-
 		if (!user) {
 			throw new Error('invalid-user');
 		}
 
-		await Message.saveSystemMessage('user-converted-to-channel', team.roomId, room.name || '', user);
+		const room = await Rooms.findOneById<Pick<IRoom, 'name'>>(team.roomId, { projection: { name: 1 } });
+		if (room) {
+			await Message.saveSystemMessage('user-converted-to-channel', team.roomId, room.name || '', user);
+		}
 
 		await Rooms.unsetTeamId(team._id);
 	}

--- a/apps/meteor/tests/unit/server/services/team/service.tests.ts
+++ b/apps/meteor/tests/unit/server/services/team/service.tests.ts
@@ -5,10 +5,16 @@ import sinon from 'sinon';
 
 const Rooms = {
 	findDefaultRoomsForTeam: sinon.stub(),
+	findOneById: sinon.stub(),
+	unsetTeamId: sinon.stub(),
 };
 
 const Users = {
 	findActiveByIds: sinon.stub(),
+};
+
+const Message = {
+	saveSystemMessage: sinon.stub(),
 };
 
 const addUserToRoom = sinon.stub();
@@ -17,7 +23,7 @@ const { TeamService } = proxyquire.noCallThru().load('../../../../../server/serv
 	'@rocket.chat/core-services': {
 		Room: {},
 		Authorization: {},
-		Message: {},
+		Message,
 		ServiceClassInternal: class {},
 		api: {},
 	},
@@ -64,7 +70,10 @@ describe('Team service', () => {
 	beforeEach(() => {
 		addUserToRoom.reset();
 		Rooms.findDefaultRoomsForTeam.reset();
+		Rooms.findOneById.reset();
+		Rooms.unsetTeamId.reset();
 		Users.findActiveByIds.reset();
+		Message.saveSystemMessage.reset();
 	});
 
 	it('should wait for default room membership operations to finish', async function () {
@@ -114,5 +123,28 @@ describe('Team service', () => {
 		).to.be.rejectedWith('room-add-failed');
 
 		expect(addUserToRoom.callCount).to.equal(1);
+	});
+
+	describe('unsetTeamIdOfRooms', () => {
+		const user = { _id: 'user-1', username: 'user-1', name: 'User One' };
+		const team = { _id: 'team-id', roomId: 'team-room' };
+
+		it('should announce the conversion on the main room and move the remaining rooms back to the workspace', async () => {
+			Rooms.findOneById.resolves({ _id: 'team-room', name: 'team-room-name' });
+
+			await service.unsetTeamIdOfRooms(user, team);
+
+			expect(Message.saveSystemMessage.calledOnceWith('user-converted-to-channel', 'team-room', 'team-room-name', user)).to.be.true;
+			expect(Rooms.unsetTeamId.calledOnceWith('team-id')).to.be.true;
+		});
+
+		it('should move the remaining rooms back to the workspace when the main room no longer exists', async () => {
+			Rooms.findOneById.resolves(null);
+
+			await service.unsetTeamIdOfRooms(user, team);
+
+			expect(Message.saveSystemMessage.called).to.be.false;
+			expect(Rooms.unsetTeamId.calledOnceWith('team-id')).to.be.true;
+		});
 	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`teams.delete` aborts when `team.roomId` points to a room that no longer exists, leaving an orphan team: invisible in the admin UI, still holding its name in the unique index, and unremovable through any supported path.

`unsetTeamIdOfRooms` and `eraseRoom` both read that room and throw when it is absent, so the memberships and the team document are never removed — and the first reads it only to post the `user-converted-to-channel` system message, inside a room the next step destroys anyway. Both reads are now conditional, and the `invalid-user` check moves above the room lookup so it stops being masked by `invalid-room`. Happy path unchanged.

## Issue(s)

- [SUP-1099](https://rocketchat.atlassian.net/browse/SUP-1099)

## Steps to test or reproduce

1. Create a team and add a channel to it.
2. Remove only the main room document from `rocketchat_room`, leaving team and memberships intact.
3. Confirm the team is absent from the admin Teams UI and its name cannot be reused.
4. `POST /api/v1/teams.delete` with `{ "teamName": "<name>" }` as an admin.

Expected: the call succeeds, team and memberships are gone, the channel is detached back to the workspace, and the name is reusable. `teamName` is the practical entry point, since the orphan is not listed in the UI and its `teamId` is not discoverable.

[SUP-1099]: https://rocketchat.atlassian.net/browse/SUP-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Team deletion now succeeds even when the team’s main room is missing.
  - Interrupted deletions can be retried, allowing the team name to be released.
  - Missing rooms no longer trigger errors during team cleanup.
  - Room-related notifications are only created when the room exists.
  - Team associations are still removed from rooms during cleanup, whether or not the main room is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->