### PR TITLE
chore!: remove Troubleshoot_Disable_Statistics_Generator and Troubleshoot_Disable_Workspace_Sync settings

### DIFF
--- a/apps/meteor/server/settings/troubleshoot.ts
+++ b/apps/meteor/server/settings/troubleshoot.ts
@@ -42,23 +42,6 @@ export const createTroubleshootSettings = () =>
 			i18nDescription: 'Troubleshoot_Disable_Teams_Mention_Alert',
 		});
 
-		// TODO: remove this setting at next major (7.0.0)
-		await this.add('Troubleshoot_Disable_Statistics_Generator', false, {
-			type: 'boolean',
-			i18nDescription: 'Troubleshoot_Disable_Statistics_Generator_Alert',
-			private: true,
-			hidden: true,
-			readonly: true,
-		});
-		// TODO: remove this setting at next major (7.0.0)
-		await this.add('Troubleshoot_Disable_Workspace_Sync', false, {
-			type: 'boolean',
-			i18nDescription: 'Troubleshoot_Disable_Workspace_Sync_Alert',
-			private: true,
-			hidden: true,
-			readonly: true,
-		});
-
 		await this.add('Troubleshoot_Force_Caching_Version', '', {
 			type: 'string',
 			i18nDescription: 'Troubleshoot_Force_Caching_Version_Alert',

--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -44,5 +44,6 @@ import './v335';
 import './v336';
 import './v337';
 import './v338';
+import './v339';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v339.ts
+++ b/apps/meteor/server/startup/migrations/v339.ts
@@ -1,0 +1,11 @@
+import { Settings } from '@rocket.chat/models';
+
+import { addMigration } from '../../lib/migrations';
+
+addMigration({
+	version: 339,
+	name: 'Remove Troubleshoot_Disable_Statistics_Generator and Troubleshoot_Disable_Workspace_Sync settings',
+	async up() {
+		await Settings.deleteMany({ _id: { $in: ['Troubleshoot_Disable_Statistics_Generator', 'Troubleshoot_Disable_Workspace_Sync'] } });
+	},
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Removes the hidden `Troubleshoot_Disable_Statistics_Generator` and `Troubleshoot_Disable_Workspace_Sync` settings, both marked with a TODO for removal at 7.0.0. No code reads either setting anymore and their i18n keys were already removed; only the registrations remained.

Migration v339 deletes both settings from the database, following the same pattern as v337 (`FileUpload_S3_SignatureVersion`).

## Issue(s)
https://rocketchat.atlassian.net/browse/CORE-2588
https://rocketchat.atlassian.net/browse/CORE-2589

## Steps to test or reproduce

Start the server against a database that has either setting stored; after migration 339 runs, both documents are gone from `rocketchat_settings` and they no longer appear in the admin settings.

## Further comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete troubleshooting settings.
  * Added a migration to automatically clean up these settings for existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->