### PR TITLE
fix(omnichannel): transfer comment text wrapping

### DIFF
--- a/apps/meteor/client/components/message/variants/SystemMessage.tsx
+++ b/apps/meteor/client/components/message/variants/SystemMessage.tsx
@@ -102,7 +102,11 @@ const SystemMessage = ({ message, showUserAvatar, ...props }: SystemMessageProps
 						)}
 					</MessageNameContainer>
 					{messageType && (
-						<MessageSystemBody role='document' aria-roledescription={t('system_message_body')}>
+						<MessageSystemBody
+							role='document'
+							aria-roledescription={t('system_message_body')}
+							style={{ overflowWrap: 'break-word', wordWrap: 'break-word' }}
+						>
 							{messageType.text(t, message)}
 						</MessageSystemBody>
 					)}


### PR DESCRIPTION
Fixes #26723

## Problem
When transferring an omnichannel conversation to another agent with a comment, the comment text was not wrapping to new lines and was being truncated with '...' (ellipsis).

## Solution
Added overflow-wrap: break-word and word-wrap: break-word styles to the MessageSystemBody component in the SystemMessage variant to allow long text to wrap properly.

## Testing
- Verified that the fix allows long transfer comments to wrap to multiple lines
- The fix is minimal and only affects system message rendering

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long system messages now wrap correctly instead of overflowing the message area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->