### PR TITLE
fix(agenda): settle Job.run() when the initial save fails

### DIFF
--- a/.changeset/agenda-run-initial-save.md
+++ b/.changeset/agenda-run-initial-save.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/agenda': patch
+---
+
+Fixed `Job.run()` hanging forever when the initial job save fails. The pre-run bookkeeping (`lastRunAt`, `computeNextRunAt`, the first `save()`) ran outside the error handling inside a promise executor, so a database failure there left the returned promise pending and surfaced as an unhandled rejection, stranding the worker with the job still locked. Those steps now run inside the same error path as the job function itself, so the failure marks the job failed and settles `run()`.

--- a/packages/agenda/src/Job.ts
+++ b/packages/agenda/src/Job.ts
@@ -189,11 +189,6 @@ export class Job {
 		const definition = this.agenda.getDefinition(this.attrs.name);
 
 		return new Promise(async (resolve, reject) => {
-			this.attrs.lastRunAt = new Date();
-			debug('[%s:%s] setting lastRunAt to: %s', this.attrs.name, this.attrs._id, this.attrs.lastRunAt.toISOString());
-			this.computeNextRunAt();
-			await this.save();
-
 			let finished = false;
 			const jobCallback = async (err?: Error): Promise<void> => {
 				// We don't want to complete the job multiple times
@@ -236,6 +231,14 @@ export class Job {
 			};
 
 			try {
+				this.attrs.lastRunAt = new Date();
+				debug('[%s:%s] setting lastRunAt to: %s', this.attrs.name, this.attrs._id, this.attrs.lastRunAt.toISOString());
+				this.computeNextRunAt();
+				// An unguarded rejection here would leave the returned promise
+				// pending forever and surface as an unhandledRejection, since a
+				// promise executor ignores the async function's own promise.
+				await this.save();
+
 				this.agenda.emit('start', this);
 				this.agenda.emit(`start:${this.attrs.name}`, this);
 				debug('[%s:%s] starting job', this.attrs.name, this.attrs._id);


### PR DESCRIPTION
`Job.run()` builds its result with an async promise executor, and the pre-run bookkeeping sat outside the `try`:

```ts
return new Promise(async (resolve, reject) => {
  this.attrs.lastRunAt = new Date();
  this.computeNextRunAt();
  await this.save();        // outside any handler

  let finished = false;
  const jobCallback = ...;
  try { ... } catch (error) { await jobCallback(error); }
});
```

A promise executor ignores the async function's own promise, so if that first `save()` rejects (database hiccup at exactly the wrong moment), nothing catches it: the async executor's rejection becomes a process-level `unhandledRejection`, and the promise `run()` returned never settles. The worker `await`ing `job.run()` is stranded permanently, with the job still locked (`lockedAt` set), so the job neither fails nor retries until lock expiry, and the worker slot is gone.

Minimal semantics demo of the two shapes:

```text
before-shape run(): PENDING   + unhandledRejection observed
after-shape  run(): settled
```

The fix moves `lastRunAt`/`computeNextRunAt`/the initial `save()` inside the existing `try`, so a failure there flows through `jobCallback(error)` exactly like a failure in the job function: the job is marked failed, `fail`/`complete` are emitted, and `run()` settles.

No behavior change on the happy path: the same statements run in the same order before the `start` events. `tsc` on the package is clean and the edit is a pure move plus one comment. Changeset included (patch, `@rocket.chat/agenda`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved job execution reliability when the initial save fails.
  - Failed jobs are now marked accordingly, and pending operations settle with an error instead of remaining unresolved.
  - Scheduling and save errors are handled consistently during job execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->