### PR TITLE
fix: legacy custom roles missing from `findCustomRoles` and `countCustomRoles`

### DIFF
--- a/.changeset/plain-otters-listen.md
+++ b/.changeset/plain-otters-listen.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes custom roles created before the `protected` field existed being left out of the roles an app reads through the Apps-Engine and undercounted in the `totalCustomRoles` statistic. Those roles carry no `protected` field at all, so the exact `protected: false` match in `findCustomRoles` and `countCustomRoles` skipped them, while every other place in the code decides that a role is protected by reading the field for truthiness.

--- a/packages/models/src/models/Roles.spec.ts
+++ b/packages/models/src/models/Roles.spec.ts
@@ -1,0 +1,48 @@
+import type { Collection, Db, Filter } from 'mongodb';
+
+import { RolesRaw } from './Roles';
+
+// `Roles` reads `Subscriptions` and `Users` off the barrel and `BaseRaw` reads
+// `getCollectionName` off it, so loading the real one pulls in every model and cycles back
+// here.
+jest.mock('..', () => ({
+	getCollectionName: (name: string) => name,
+	UpdaterImpl: class {},
+	Subscriptions: {},
+	Users: {},
+}));
+
+const find = jest.fn();
+const countDocuments = jest.fn();
+
+const newRolesModel = (): RolesRaw => new RolesRaw({ collection: () => ({ find, countDocuments }) } as unknown as Db);
+
+const filterSentToDriver = (mock: jest.Mock): Filter<unknown> | undefined => mock.mock.calls.at(-1)?.[0];
+
+describe('custom roles', () => {
+	beforeEach(() => {
+		find.mockReset().mockReturnValue({} as unknown as Collection<any>);
+		countDocuments.mockReset().mockResolvedValue(0);
+	});
+
+	it('should treat a role without the `protected` field as custom', async () => {
+		const roles = newRolesModel();
+
+		roles.findCustomRoles();
+		await roles.countCustomRoles();
+
+		// roles that are older than the `protected` field do not carry it at all, so an
+		// exact `protected: false` match leaves them out of both the list and the count
+		expect(filterSentToDriver(find)).toEqual({ protected: { $ne: true } });
+		expect(filterSentToDriver(countDocuments)).toEqual({ protected: { $ne: true } });
+	});
+
+	it('should count custom roles with the same filter it lists them with', async () => {
+		const roles = newRolesModel();
+
+		roles.findCustomRoles();
+		await roles.countCustomRoles();
+
+		expect(filterSentToDriver(countDocuments)).toEqual(filterSentToDriver(find));
+	});
+});

--- a/packages/models/src/models/Roles.ts
+++ b/packages/models/src/models/Roles.ts
@@ -129,8 +129,9 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 	findCustomRoles<T extends Document = IRole, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>> {
+		// roles older than the `protected` field carry no value at all, so `false` would miss them
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.find<T, O>(query, options);
@@ -138,7 +139,7 @@ export class RolesRaw extends BaseRaw<IRole> implements IRolesModel {
 
 	countCustomRoles(options?: CountDocumentsOptions): Promise<number> {
 		const query: Filter<IRole> = {
-			protected: false,
+			protected: { $ne: true },
 		};
 
 		return this.countDocuments(query, options || {});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`findCustomRoles` and `countCustomRoles` in `packages/models/src/models/Roles.ts` select custom roles with an exact `protected: false` match.

`protected` was added to roles after roles already existed, so a role document older than the field does not carry `false`, it does not carry the field at all, and an exact match on `false` leaves it out. Every other place in the code decides whether a role is protected by reading the field for truthiness, for example the delete guard in `apps/meteor/server/api/v1/roles.ts`, the update guard in `apps/meteor/ee/server/lib/roles/updateRole.ts`, and the license check in `apps/meteor/ee/server/api/roles.ts`. So a missing field already means "custom" everywhere except these two queries.

Both queries now use `protected: { $ne: true }`, which lines the model up with how the rest of the code reads the field.

The issue mentions `findCustomRoles`. `countCustomRoles` carries the same filter, so the fix covers both, otherwise the count and the list would keep disagreeing.

Two callers are affected. `getCustomRoles` in the Apps-Engine roles bridge never returned those roles to apps, and `statistics.totalCustomRoles` undercounted them. Those are the only callers in the repo, so nothing relied on the exact-match behaviour.

Added `packages/models/src/models/Roles.spec.ts`, which asserts the filter handed to the driver, following the pattern already used by `BaseRaw.spec.ts`. It fails on `develop` and passes with this change.

On the pull requests already open for this issue: #40799, #40937, #41031, #41033, #41242 and #41329 all propose the same operator change, and to be straight about it, I found them after writing this. What this one adds is the unit test above, which covers both methods and needs no database. If you would rather take one of the earlier ones, I am happy to close this and offer the test to it instead, just say which.

## Issue(s)

Closes #40798

## Steps to test or reproduce

Insert a role that predates the field, which is what an upgraded workspace looks like:

    db.rocketchat_role.insertOne({ _id: 'legacy-custom', name: 'legacy-custom', description: '', scope: 'Users' })

Before this change the role is missing from the roles an app reads through `getCustomRoles`, and `totalCustomRoles` in `GET /api/v1/statistics` does not count it. After the change both include it.

Unit test: `yarn workspace @rocket.chat/models test`.

## Further comments

`$ne: true` does not cost anything here. `Roles` has no `modelIndexes()` override, so there is no index on `protected` for the operator to defeat, and the collection holds tens of documents.

One thing left out on purpose: `IRole.protected` is typed as a required `boolean` in `packages/core-typings/src/IRole.ts` while these old documents do not have it. Making the type honest, or backfilling the field in a migration, is a bigger change than this fix and I did not want to bundle it in. Happy to open a separate issue for it if that is useful.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Legacy custom roles without an explicit protection setting are now included in role listings.
  - Custom role totals now accurately include these legacy roles.
  - Role lists and reported counts now stay consistent.

- **Tests**
  - Added coverage to verify filtering and counting behavior for legacy custom roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->