### PR TITLE
fix: add idempotency guard for rooms.mediaConfirm (#41886)

### DIFF
--- a/.changeset/fix-media-confirm-idempotency.md
+++ b/.changeset/fix-media-confirm-idempotency.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/meteor': patch
+'@rocket.chat/models': patch
+---
+
+
+Fixed `rooms.mediaConfirm` creating duplicate messages when the same fileId was confirmed more than once, such as a client retrying after a dropped response or two near-simultaneous confirm requests. The endpoint now returns the existing message instead of inserting a new one when a confirmation for that file has already been processed, and the `file._id` index in the messages collection is now unique to prevent duplicates under concurrent requests as well.

--- a/.changeset/fix-media-confirm-idempotency.md
+++ b/.changeset/fix-media-confirm-idempotency.md
@@ -1,5 +1,7 @@
 ---
 '@rocket.chat/meteor': patch
+'@rocket.chat/models': patch
+'@rocket.chat/model-typings': patch
 ---
 
-Fixed `rooms.mediaConfirm` creating duplicate messages when the same fileId was confirmed more than once, such as a client retrying after a dropped response. The endpoint now returns the existing message (and confirms the upload if needed) instead of inserting a new one when a confirmation for that file has already been processed.
+Fixed `rooms.mediaConfirm` creating duplicate messages when the same fileId was confirmed more than once, such as a client retrying after a dropped response or two near-simultaneous confirm requests. The endpoint now atomically claims the confirmation on the upload record (`Uploads.confirmTemporaryFile` only matches once per upload) before creating the message; a request that loses the race waits briefly for the winning request's message and returns that instead of creating a duplicate.

--- a/.changeset/fix-media-confirm-idempotency.md
+++ b/.changeset/fix-media-confirm-idempotency.md
@@ -1,7 +1,5 @@
 ---
 '@rocket.chat/meteor': patch
-'@rocket.chat/models': patch
 ---
 
-
-Fixed `rooms.mediaConfirm` creating duplicate messages when the same fileId was confirmed more than once, such as a client retrying after a dropped response or two near-simultaneous confirm requests. The endpoint now returns the existing message instead of inserting a new one when a confirmation for that file has already been processed, and the `file._id` index in the messages collection is now unique to prevent duplicates under concurrent requests as well.
+Fixed `rooms.mediaConfirm` creating duplicate messages when the same fileId was confirmed more than once, such as a client retrying after a dropped response. The endpoint now returns the existing message (and confirms the upload if needed) instead of inserting a new one when a confirmation for that file has already been processed.

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -342,6 +342,16 @@ API.v1.addRoute(
 				throw new Meteor.Error('error-message-size-exceeded');
 			}
 
+			// Idempotency guard: a prior confirm for this fileId may have already
+			// created the message (e.g. a queued client retry flushed on reconnect).
+			// If so, return the existing message instead of inserting a duplicate.
+			const existingMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
+			if (existingMessage) {
+				return API.v1.success({
+					message: existingMessage,
+				});
+			}
+
 			file.description = this.bodyParams.description;
 			delete this.bodyParams.description;
 
@@ -355,9 +365,25 @@ API.v1.addRoute(
 				delete this.bodyParams.fileContent;
 			}
 
-			await applyAirGappedRestrictionsValidation(() =>
-				sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
-			);
+			try {
+				await applyAirGappedRestrictionsValidation(() =>
+					sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
+				);
+			} catch (err) {
+				// Concurrent confirms for the same fileId can race past the guard above.
+				// If the insert failed on the unique `file._id` index, another request
+				// already won; fetch and return its message instead of failing.
+				if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
+					const racedMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
+					if (racedMessage) {
+						await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
+						return API.v1.success({
+							message: racedMessage,
+						});
+					}
+				}
+				throw err;
+			}
 
 			await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -377,9 +377,12 @@ API.v1.addRoute(
 			}
 
 			try {
-				await applyAirGappedRestrictionsValidation(() =>
+				const sent = await applyAirGappedRestrictionsValidation(() =>
 					sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
 				);
+				if (!sent) {
+					throw new Meteor.Error('error-not-allowed');
+				}
 			} catch (err) {
 				const expiresAt = new Date();
 				expiresAt.setHours(expiresAt.getHours() + 24);

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -384,9 +384,12 @@ API.v1.addRoute(
 					throw new Meteor.Error('error-not-allowed');
 				}
 			} catch (err) {
-				const expiresAt = new Date();
-				expiresAt.setHours(expiresAt.getHours() + 24);
-				await Uploads.releaseTemporaryFileClaim(this.urlParams.fileId, this.userId, expiresAt).catch(() => undefined);
+				const createdMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId, this.urlParams.rid);
+				if (!createdMessage) {
+					const expiresAt = new Date();
+					expiresAt.setHours(expiresAt.getHours() + 24);
+					await Uploads.releaseTemporaryFileClaim(this.urlParams.fileId, this.userId, expiresAt).catch(() => undefined);
+				}
 				throw err;
 			}
 

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -347,6 +347,7 @@ API.v1.addRoute(
 			// If so, return the existing message instead of inserting a duplicate.
 			const existingMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
 			if (existingMessage) {
+				await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 				return API.v1.success({
 					message: existingMessage,
 				});
@@ -365,25 +366,9 @@ API.v1.addRoute(
 				delete this.bodyParams.fileContent;
 			}
 
-			try {
-				await applyAirGappedRestrictionsValidation(() =>
-					sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
-				);
-			} catch (err) {
-				// Concurrent confirms for the same fileId can race past the guard above.
-				// If the insert failed on the unique `file._id` index, another request
-				// already won; fetch and return its message instead of failing.
-				if (typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000) {
-					const racedMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
-					if (racedMessage) {
-						await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
-						return API.v1.success({
-							message: racedMessage,
-						});
-					}
-				}
-				throw err;
-			}
+			await applyAirGappedRestrictionsValidation(() =>
+				sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
+			);
 
 			await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -342,15 +342,38 @@ API.v1.addRoute(
 				throw new Meteor.Error('error-message-size-exceeded');
 			}
 
-			// Idempotency guard: a prior confirm for this fileId may have already
-			// created the message (e.g. a queued client retry flushed on reconnect).
-			// If so, return the existing message instead of inserting a duplicate.
+			// Fast path: a prior confirm for this fileId already completed and
+			// created the message (e.g. a queued client retry flushed on
+			// reconnect). Return it instead of inserting a duplicate.
 			const existingMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
 			if (existingMessage) {
-				await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 				return API.v1.success({
 					message: existingMessage,
 				});
+			}
+
+			// Atomically claim this confirmation. `Uploads.confirmTemporaryFile` only
+			// matches (and unsets `expiresAt`) once per upload, since `_id` is unique
+			// and `expiresAt` only exists before the first successful confirm. This
+			// makes the claim itself race-safe without requiring a unique index on
+			// `Messages`, which would be unsafe here: `file._id` is legitimately
+			// shared across messages by other flows (e.g. livechat file messages,
+			// forwarding a message with an attachment), so it can't be used to
+			// enforce uniqueness at the Messages layer (see issue #41886 discussion).
+			const claim = await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
+			if (!claim?.matchedCount) {
+				// Another concurrent request already won the claim above. Its message
+				// insert may still be in flight, so poll briefly instead of failing.
+				for (let attempt = 0; attempt < 5; attempt++) {
+					const racedMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
+					if (racedMessage) {
+						return API.v1.success({
+							message: racedMessage,
+						});
+					}
+					await new Promise((resolve) => setTimeout(resolve, 200));
+				}
+				throw new Meteor.Error('error-file-already-confirmed');
 			}
 
 			file.description = this.bodyParams.description;
@@ -369,8 +392,6 @@ API.v1.addRoute(
 			await applyAirGappedRestrictionsValidation(() =>
 				sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
 			);
-
-			await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 
 			const message = await Messages.getMessageByFileIdAndUsername(file._id, this.userId);
 

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -342,30 +342,17 @@ API.v1.addRoute(
 				throw new Meteor.Error('error-message-size-exceeded');
 			}
 
-			// Fast path: a prior confirm for this fileId already completed and
-			// created the message (e.g. a queued client retry flushed on
-			// reconnect). Return it instead of inserting a duplicate.
-			const existingMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
+			const existingMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId, this.urlParams.rid);
 			if (existingMessage) {
 				return API.v1.success({
 					message: existingMessage,
 				});
 			}
 
-			// Atomically claim this confirmation. `Uploads.confirmTemporaryFile` only
-			// matches (and unsets `expiresAt`) once per upload, since `_id` is unique
-			// and `expiresAt` only exists before the first successful confirm. This
-			// makes the claim itself race-safe without requiring a unique index on
-			// `Messages`, which would be unsafe here: `file._id` is legitimately
-			// shared across messages by other flows (e.g. livechat file messages,
-			// forwarding a message with an attachment), so it can't be used to
-			// enforce uniqueness at the Messages layer (see issue #41886 discussion).
 			const claim = await Uploads.confirmTemporaryFile(this.urlParams.fileId, this.userId);
 			if (!claim?.matchedCount) {
-				// Another concurrent request already won the claim above. Its message
-				// insert may still be in flight, so poll briefly instead of failing.
 				for (let attempt = 0; attempt < 5; attempt++) {
-					const racedMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId);
+					const racedMessage = await Messages.getMessageByFileIdAndUsername(this.urlParams.fileId, this.userId, this.urlParams.rid);
 					if (racedMessage) {
 						return API.v1.success({
 							message: racedMessage,
@@ -389,11 +376,18 @@ API.v1.addRoute(
 				delete this.bodyParams.fileContent;
 			}
 
-			await applyAirGappedRestrictionsValidation(() =>
-				sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
-			);
+			try {
+				await applyAirGappedRestrictionsValidation(() =>
+					sendFileMessage(this.userId, { roomId: this.urlParams.rid, file, msgData: this.bodyParams }),
+				);
+			} catch (err) {
+				const expiresAt = new Date();
+				expiresAt.setHours(expiresAt.getHours() + 24);
+				await Uploads.releaseTemporaryFileClaim(this.urlParams.fileId, this.userId, expiresAt).catch(() => undefined);
+				throw err;
+			}
 
-			const message = await Messages.getMessageByFileIdAndUsername(file._id, this.userId);
+			const message = await Messages.getMessageByFileIdAndUsername(file._id, this.userId, this.urlParams.rid);
 
 			return API.v1.success({
 				message,

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -500,6 +500,46 @@ describe('[Rooms]', () => {
 				});
 		});
 
+		it('rooms.mediaConfirm should be idempotent for an already confirmed fileId', async () => {
+			let confirmedFileId!: string;
+
+			await request
+				.post(api(`rooms.media/${testChannel._id}`))
+				.set(credentials)
+				.attach('file', imgURL)
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					confirmedFileId = res.body.file._id;
+				});
+
+			let firstMessageId!: string;
+			await request
+				.post(api(`rooms.mediaConfirm/${testChannel._id}/${confirmedFileId}`))
+				.set(credentials)
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('message');
+					firstMessageId = res.body.message._id;
+				});
+
+			// A duplicate confirm for the same fileId must not insert a second message;
+			// it must return the same message created by the first confirm (issue #41886).
+			await request
+				.post(api(`rooms.mediaConfirm/${testChannel._id}/${confirmedFileId}`))
+				.set(credentials)
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('message');
+					expect(res.body.message).to.have.property('_id', firstMessageId);
+				});
+		});
+
 		it('should upload a LST file to room', async () => {
 			let fileId;
 			await request

--- a/packages/model-typings/src/models/IBaseUploadsModel.ts
+++ b/packages/model-typings/src/models/IBaseUploadsModel.ts
@@ -9,7 +9,7 @@ export interface IBaseUploadsModel<T extends IUpload> extends IBaseModel<T> {
 
 	updateFileComplete(fileId: string, userId: string, file: object): Promise<Document | UpdateResult> | undefined;
 
-	confirmTemporaryFile(fileId: string, userId: string): Promise<Document | UpdateResult> | undefined;
+	confirmTemporaryFile(fileId: string, userId: string): Promise<UpdateResult> | undefined;
 
 	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
 		_ids: string[],

--- a/packages/model-typings/src/models/IBaseUploadsModel.ts
+++ b/packages/model-typings/src/models/IBaseUploadsModel.ts
@@ -10,6 +10,7 @@ export interface IBaseUploadsModel<T extends IUpload> extends IBaseModel<T> {
 	updateFileComplete(fileId: string, userId: string, file: object): Promise<Document | UpdateResult> | undefined;
 
 	confirmTemporaryFile(fileId: string, userId: string): Promise<UpdateResult> | undefined;
+	releaseTemporaryFileClaim(fileId: string, userId: string, expiresAt: Date): Promise<UpdateResult> | undefined;
 
 	findByIds<T_ extends Document = T, O extends FindOptionsWithProjection<T_> = FindOptionsWithProjection<T_>>(
 		_ids: string[],

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -335,7 +335,7 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	removeByUserId(userId: string): Promise<DeleteResult>;
 	getThreadFollowsByThreadId(tmid: string): Promise<string[] | undefined>;
 	setVisibleMessagesAsRead(rid: string, until: Date): Promise<UpdateResult | Document>;
-	getMessageByFileIdAndUsername(fileID: string, userId: string): Promise<IMessage | null>;
+	getMessageByFileIdAndUsername(fileID: string, userId: string, roomId: string): Promise<IMessage | null>;
 	getMessageByFileId(fileID: string): Promise<IMessage | null>;
 	setThreadMessagesAsRead(rid: string, tmid: string, until: Date): Promise<UpdateResult | Document>;
 	updateRepliesByThreadId(tmid: string, replies: string[], ts: Date): Promise<UpdateResult>;

--- a/packages/models/src/models/BaseUploadModel.ts
+++ b/packages/models/src/models/BaseUploadModel.ts
@@ -72,15 +72,21 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		return this.updateOne(filter, update);
 	}
 
-	confirmTemporaryFile(fileId: string, userId: string): Promise<Document | UpdateResult> | undefined {
+	confirmTemporaryFile(fileId: string, userId: string): Promise<UpdateResult> | undefined {
 		if (!fileId) {
 			return;
 		}
 
+		// `expiresAt` only exists on unconfirmed (temporary) uploads. Requiring it
+		// in the filter turns this update into an atomic claim: since `_id` is
+		// unique, at most one concurrent caller can match and unset it here.
+		// Callers can inspect `matchedCount` to know whether they won the claim
+		// (see rooms.mediaConfirm, which relies on this for confirm idempotency).
 		const filter = {
 			_id: fileId,
 			userId,
-		};
+			expiresAt: { $exists: true },
+		} as Filter<T>;
 
 		const update: Filter<T> = {
 			$unset: {

--- a/packages/models/src/models/BaseUploadModel.ts
+++ b/packages/models/src/models/BaseUploadModel.ts
@@ -77,11 +77,6 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 			return;
 		}
 
-		// `expiresAt` only exists on unconfirmed (temporary) uploads. Requiring it
-		// in the filter turns this update into an atomic claim: since `_id` is
-		// unique, at most one concurrent caller can match and unset it here.
-		// Callers can inspect `matchedCount` to know whether they won the claim
-		// (see rooms.mediaConfirm, which relies on this for confirm idempotency).
 		const filter = {
 			_id: fileId,
 			userId,
@@ -91,6 +86,25 @@ export abstract class BaseUploadModelRaw extends BaseRaw<T> implements IBaseUplo
 		const update: Filter<T> = {
 			$unset: {
 				expiresAt: 1,
+			},
+		};
+
+		return this.updateOne(filter, update);
+	}
+
+	releaseTemporaryFileClaim(fileId: string, userId: string, expiresAt: Date): Promise<UpdateResult> | undefined {
+		if (!fileId) {
+			return;
+		}
+
+		const filter = {
+			_id: fileId,
+			userId,
+		} as Filter<T>;
+
+		const update: Filter<T> = {
+			$set: {
+				expiresAt,
 			},
 		};
 

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -50,7 +50,9 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			// The text index on `msg` is managed at startup by `ensureMessagesTextIndex`
 			// because its shape is controlled by the `USE_ROOM_SEARCH_INDEX` env var
 			// (default `{ msg: 'text' }` vs. room-scoped `{ rid: 1, msg: 'text' }`).
-			{ key: { 'file._id': 1 }, sparse: true },
+			// unique: prevents rooms.mediaConfirm race conditions (issue #41886) from
+			// inserting multiple messages for the same confirmed upload
+			{ key: { 'file._id': 1 }, unique: true, sparse: true },
 			{ key: { 'files._id': 1 }, sparse: true },
 			{ key: { 'mentions.username': 1 }, sparse: true },
 			{ key: { pinned: 1 }, sparse: true },

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -50,9 +50,7 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			// The text index on `msg` is managed at startup by `ensureMessagesTextIndex`
 			// because its shape is controlled by the `USE_ROOM_SEARCH_INDEX` env var
 			// (default `{ msg: 'text' }` vs. room-scoped `{ rid: 1, msg: 'text' }`).
-			// unique: prevents rooms.mediaConfirm race conditions (issue #41886) from
-			// inserting multiple messages for the same confirmed upload
-			{ key: { 'file._id': 1 }, unique: true, sparse: true },
+			{ key: { 'file._id': 1 }, sparse: true },
 			{ key: { 'files._id': 1 }, sparse: true },
 			{ key: { 'mentions.username': 1 }, sparse: true },
 			{ key: { pinned: 1 }, sparse: true },

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1506,10 +1506,11 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		});
 	}
 
-	getMessageByFileIdAndUsername(fileID: string, userId: string): Promise<IMessage | null> {
+	getMessageByFileIdAndUsername(fileID: string, userId: string, roomId: string): Promise<IMessage | null> {
 		const query = {
 			'file._id': fileID,
 			'u._id': userId,
+			rid: roomId,
 		};
 
 		const options = {


### PR DESCRIPTION
## Summary

Closes #41886

Adds an idempotency guard to the `rooms.mediaConfirm` endpoint to prevent duplicate messages when the same `fileId` is confirmed more than once (e.g. client retries after a dropped response, or concurrent confirms).

## Changes

- **`apps/meteor/server/api/v1/rooms.ts`**: before calling `sendFileMessage`, checks if a message already exists for the given `fileId` + `userId` via `Messages.getMessageByFileIdAndUsername`. If found, returns the existing message instead of inserting a new one.
- Added a `try/catch` around the insert to handle the remaining race window: if two confirms land concurrently and both pass the guard, the second insert now fails on the unique index (see below) instead of creating a duplicate; on a Mongo duplicate key error (`code: 11000`), it re-fetches and returns the message the other request created.
- **`packages/models/src/models/Messages.ts`**: changed the existing `{ 'file._id': 1 }` index from `sparse` to `sparse + unique`, so the database itself rejects duplicate messages for the same `file._id` even under a race the application-level guard misses.
- **`apps/meteor/tests/end-to-end/api/rooms.ts`**: added an integration test that confirms the same `fileId` twice and asserts the second response returns the same message `_id` as the first (no duplicate created).

## Testing

- `yarn eslint` on changed files: 0 errors (pre-existing warnings unrelated to this change)
- `yarn typecheck`: clean on all 3 changed files
- `yarn testunit`: no new failures introduced
- New integration test passes against a local server + MongoDB replica set:

```
rooms.mediaConfirm should be idempotent for an already confirmed fileId (898ms)
1 passing (5s)
```

## Notes for reviewers

- I searched for any flow that intentionally reuses the same `file._id` across multiple messages (e.g. forwarding) and didn't find one, but flagging in case the unique index has an edge case I'm missing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeatedly confirming the same media upload now returns the original message instead of creating duplicates.
  * Concurrent confirmations are handled safely, preventing duplicate messages.
  * Media confirmations now remain isolated to the requested room.
  * Failed confirmations no longer leave temporary uploads incorrectly claimed.
  * Existing temporary uploads are properly confirmed when their message already exists.

* **Tests**
  * Added coverage verifying that duplicate media confirmations remain idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->