### PR TITLE
chore: deprecate `checkFederationConfiguration` meteor method

### DIFF
--- a/apps/meteor/server/meteor-methods/platform/checkFederationConfiguration.ts
+++ b/apps/meteor/server/meteor-methods/platform/checkFederationConfiguration.ts
@@ -3,6 +3,8 @@ import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { License } from '@rocket.chat/license';
 import { Meteor } from 'meteor/meteor';
 
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
+
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface ServerMethods {
@@ -12,6 +14,8 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async checkFederationConfiguration() {
+		methodDeprecationLogger.method('checkFederationConfiguration', '9.0.0', []);
+
 		const uid = Meteor.userId();
 
 		if (!uid) {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds a deprecation warning to the `checkFederationConfiguration` meteor method, following the standard `methodDeprecationLogger.method` pattern.

The method belongs to the old Matrix bridge federation stack and was only reachable through the hidden `Federation_Matrix_check_configuration_button` action setting, which is being removed in 9.0.0 (#41908). It has no other callers in the codebase and no replacement endpoint.

## Issue(s)

## Steps to test or reproduce

Call the `checkFederationConfiguration` meteor method — the server logs the deprecation warning and increments the deprecation metrics.

## Further comments

Removal targeted at 9.0.0 alongside the Matrix bridge settings removal (#41908).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. --> 

 Task: [CORE-2623]

[CORE-2623]: https://rocketchat.atlassian.net/browse/CORE-2623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked federation configuration checking as deprecated.
  * Existing validation and configuration checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->