### PR TITLE
regression: stale pagination offset skips thread replies after a live insert

### DIFF
--- a/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
@@ -70,6 +70,19 @@ describe('mutateThreadMessagesInfiniteData', () => {
 		expect(data?.pageParams).toEqual([0]);
 	});
 
+	it('shifts pageParams when the inserted message ties the newest cached timestamp', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			messages.push(createMessage('reply-200', 124));
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(201);
+		expect(data?.pageParams).toEqual([76]);
+	});
+
 	it('shifts every page pageParam, not just the last one, when a newer message arrives', () => {
 		const cache: ThreadMessagesInfiniteData = {
 			pages: [

--- a/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
@@ -51,6 +51,25 @@ describe('mutateThreadMessagesInfiniteData', () => {
 		expect(data?.pageParams).toEqual([76]);
 	});
 
+	it('keeps a pageParam of 0 unshifted when a newer message is inserted and user is at the newest message', () => {
+		const cache: ThreadMessagesInfiniteData = {
+			pages: [{ items: [createMessage('reply-150', 150), createMessage('reply-199', 199)], itemCount: 200 }],
+			pageParams: [0],
+		};
+		queryClient.setQueryData(queryKey, cache);
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			messages.push(createMessage('reply-200', 1000));
+			messages.sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(201);
+		expect(data?.pages[0].items.map((m) => m._id)).toContain('reply-200');
+		expect(data?.pageParams).toEqual([0]);
+	});
+
 	it('shifts every page pageParam, not just the last one, when a newer message arrives', () => {
 		const cache: ThreadMessagesInfiniteData = {
 			pages: [

--- a/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
@@ -1,0 +1,166 @@
+import type { IThreadMessage } from '@rocket.chat/core-typings';
+import { QueryClient } from '@tanstack/react-query';
+
+import { mutateThreadMessagesInfiniteData, upsertThreadMessageInCache, type ThreadMessagesInfiniteData } from './threadMessageUtils';
+
+const rid = 'room1';
+const tmid = 'thread1';
+const queryKey = ['rooms', rid, 'threads', tmid, 'messages'] as const;
+
+const createMessage = (id: string, ts: number): IThreadMessage =>
+	({
+		_id: id,
+		rid,
+		tmid,
+		msg: id,
+		ts: new Date(ts).toISOString() as any,
+		u: { _id: 'user1', username: 'user1' },
+		_updatedAt: new Date(ts).toISOString() as any,
+	}) as IThreadMessage;
+
+// A thread with 200 replies, one cached page holding reply-075..reply-124.
+const createAnchoredCache = (): ThreadMessagesInfiniteData => ({
+	pages: [
+		{
+			items: Array.from({ length: 50 }, (_, i) => createMessage(`reply-${String(i + 75).padStart(3, '0')}`, i + 75)),
+			itemCount: 200,
+		},
+	],
+	pageParams: [75],
+});
+
+describe('mutateThreadMessagesInfiniteData', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient();
+	});
+
+	it('shifts every stored pageParam forward when a message newer than everything cached is inserted', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			messages.push(createMessage('reply-200', 1000));
+			messages.sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(201);
+		expect(data?.pages[0].items.map((m) => m._id)).toContain('reply-200');
+		expect(data?.pageParams).toEqual([76]);
+	});
+
+	it('shifts every page pageParam, not just the last one, when a newer message arrives', () => {
+		const cache: ThreadMessagesInfiniteData = {
+			pages: [
+				{ items: [createMessage('reply-025', 25), createMessage('reply-026', 26)], itemCount: 200 },
+				{ items: [createMessage('reply-075', 75), createMessage('reply-076', 76)], itemCount: 200 },
+			],
+			pageParams: [25, 75],
+		};
+		queryClient.setQueryData(queryKey, cache);
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			messages.push(createMessage('reply-200', 1000));
+			messages.sort((a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime());
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pageParams).toEqual([26, 76]);
+	});
+
+	it('does not shift pageParams when the inserted message is older than what is already cached', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			messages.unshift(createMessage('reply-010', 10));
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(201);
+		expect(data?.pageParams).toEqual([75]);
+	});
+
+	it('does not shift pageParams when a cached message is deleted', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			const index = messages.findIndex((m) => m._id === 'reply-100');
+			messages.splice(index, 1);
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].items.map((m) => m._id)).not.toContain('reply-100');
+		expect(data?.pages[0].itemCount).toBe(199);
+		expect(data?.pageParams).toEqual([75]);
+	});
+
+	it('does not shift pageParams when an existing message is edited in place', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			const index = messages.findIndex((m) => m._id === 'reply-100');
+			messages[index] = { ...messages[index], msg: 'edited' };
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(200);
+		expect(data?.pageParams).toEqual([75]);
+	});
+});
+
+describe('upsertThreadMessageInCache', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient();
+	});
+
+	it('seeds the cache with pageParams [0] when nothing was cached yet', () => {
+		upsertThreadMessageInCache(createMessage('reply-000', 0), rid, tmid, queryClient);
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+
+		expect(data?.pages[0].itemCount).toBe(1);
+		expect(data?.pageParams).toEqual([0]);
+	});
+
+	it('keeps the next-page fetch offset aligned with the real data after a live reply arrives, so no message is skipped', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		upsertThreadMessageInCache(createMessage('reply-200', 1000), rid, tmid, queryClient);
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+		const [pageParam] = data?.pageParams ?? [];
+
+		expect(data?.pages[0].itemCount).toBe(201);
+		expect(pageParam).toBe(76);
+
+		// Mirrors getNextPageParam in useThreadMessagesQuery: offset = pageParam - count.
+		const count = 50;
+		const nextOffset = pageParam > 0 ? Math.max(0, pageParam - count) : undefined;
+
+		// offset 26 fetches reply-125..reply-174, including reply-125.
+		// A stale pageParam of 75 would produce offset 25, fetching reply-126..reply-175 instead.
+		expect(nextOffset).toBe(26);
+	});
+
+	it('updates an existing message in place without shifting pageParams', () => {
+		queryClient.setQueryData(queryKey, createAnchoredCache());
+
+		const edited = { ...createMessage('reply-100', 100), msg: 'edited' };
+		upsertThreadMessageInCache(edited, rid, tmid, queryClient);
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+		const updated = data?.pages[0].items.find((m) => m._id === 'reply-100');
+
+		expect(updated?.msg).toBe('edited');
+		expect(data?.pages[0].itemCount).toBe(200);
+		expect(data?.pageParams).toEqual([75]);
+	});
+});

--- a/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
@@ -171,15 +171,9 @@ describe('upsertThreadMessageInCache', () => {
 		const [pageParam] = data?.pageParams ?? [];
 
 		expect(data?.pages[0].itemCount).toBe(201);
+		// useThreadMessagesQuery's getNextPageParam computes offset = pageParam - count (50),
+		// so 76 (not the stale 75) produces offset 26, which includes reply-125.
 		expect(pageParam).toBe(76);
-
-		// Mirrors getNextPageParam in useThreadMessagesQuery: offset = pageParam - count.
-		const count = 50;
-		const nextOffset = pageParam > 0 ? Math.max(0, pageParam - count) : undefined;
-
-		// offset 26 fetches reply-125..reply-174, including reply-125.
-		// A stale pageParam of 75 would produce offset 25, fetching reply-126..reply-175 instead.
-		expect(nextOffset).toBe(26);
 	});
 
 	it('updates an existing message in place without shifting pageParams', () => {

--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -67,6 +67,8 @@ export const mutateThreadMessagesInfiniteData = (
 		const items = old.pages.flatMap((page) => page.items);
 		const originalPageLengths = old.pages.map((page) => page.items.length);
 		const oldTotal = old.pages.at(-1)?.itemCount ?? 0;
+		const oldIds = new Set(items.map((message) => message._id));
+		const oldMaxTs = items.reduce((max, message) => Math.max(max, new Date(message.ts).getTime()), -Infinity);
 
 		const beforeMutationItemsLength = items.length;
 		mutation(items);
@@ -74,6 +76,8 @@ export const mutateThreadMessagesInfiniteData = (
 
 		const itemCountDelta = beforeMutationItemsLength - afterMutationItemsLength;
 		const newTotal = Math.max(0, oldTotal - itemCountDelta);
+
+		const newerInsertedCount = items.filter((message) => !oldIds.has(message._id) && new Date(message.ts).getTime() > oldMaxTs).length;
 
 		const pages: ThreadMessagesPage[] = [];
 		let cursor = 0;
@@ -87,7 +91,7 @@ export const mutateThreadMessagesInfiniteData = (
 
 		return {
 			pages,
-			pageParams: old.pageParams,
+			pageParams: newerInsertedCount > 0 ? old.pageParams.map((pageParam) => pageParam + newerInsertedCount) : old.pageParams,
 		};
 	});
 };

--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -77,7 +77,7 @@ export const mutateThreadMessagesInfiniteData = (
 		const itemCountDelta = beforeMutationItemsLength - afterMutationItemsLength;
 		const newTotal = Math.max(0, oldTotal - itemCountDelta);
 
-		const newerInsertedCount = items.filter((message) => !oldIds.has(message._id) && new Date(message.ts).getTime() > oldMaxTs).length;
+		const newerInsertedCount = items.filter((message) => !oldIds.has(message._id) && new Date(message.ts).getTime() >= oldMaxTs).length;
 
 		const pages: ThreadMessagesPage[] = [];
 		let cursor = 0;

--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -91,7 +91,10 @@ export const mutateThreadMessagesInfiniteData = (
 
 		return {
 			pages,
-			pageParams: newerInsertedCount > 0 ? old.pageParams.map((pageParam) => pageParam + newerInsertedCount) : old.pageParams,
+			pageParams:
+				newerInsertedCount > 0
+					? old.pageParams.map((pageParam) => (pageParam > 0 ? pageParam + newerInsertedCount : pageParam))
+					: old.pageParams,
 		};
 	});
 };


### PR DESCRIPTION
…e replies<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2518](https://rocketchat.atlassian.net/browse/CORE-2518)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2518]: https://rocketchat.atlassian.net/browse/CORE-2518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread message pagination when new replies arrive, including replies with matching timestamps, preventing messages from being skipped.
  * Preserved correct pagination behavior for newest-page offsets, older messages, deletions, and in-place edits.
  * Improved live-reply alignment and cache updates when thread messages are inserted or modified.

* **Tests**
  * Added coverage for pagination offsets, cache seeding, timestamp-tied inserts, live replies, deletions, and message edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->