### PR TITLE
fix: Clear composer on slash command execution

### DIFF
--- a/.changeset/tired-camels-bow.md
+++ b/.changeset/tired-camels-bow.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Ensures the message composer is cleared after a slash command is executed.

--- a/apps/meteor/client/lib/chats/flows/processSlashCommand.ts
+++ b/apps/meteor/client/lib/chats/flows/processSlashCommand.ts
@@ -54,6 +54,7 @@ export const processSlashCommand = async (chat: ChatAPI, message: IMessage): Pro
 
 	if (typeof command === 'string') {
 		if (!settings.peek('Message_AllowUnrecognizedSlashCommand')) {
+			chat.composer?.clear();
 			await warnUnrecognizedSlashCommand(chat, t('No_such_command', { command: escapeHTML(command) }));
 			return true;
 		}
@@ -64,11 +65,13 @@ export const processSlashCommand = async (chat: ChatAPI, message: IMessage): Pro
 	const { permission, clientOnly, callback: handleOnClient, result: handleResult, appId, command: commandName } = command;
 
 	if (permission && !hasAtLeastOnePermission(permission, message.rid)) {
+		chat.composer?.clear();
 		await warnUnrecognizedSlashCommand(chat, t('You_do_not_have_permission_to_execute_this_command', { command: escapeHTML(commandName) }));
 		return true;
 	}
 
 	if (clientOnly && chat.uid) {
+		chat.composer?.clear();
 		handleOnClient?.({ command: commandName, message, params, userId: chat.uid });
 		return true;
 	}

--- a/apps/meteor/tests/e2e/message-composer.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer.spec.ts
@@ -2,7 +2,8 @@ import { faker } from '@faker-js/faker';
 
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
-import { createTargetChannel } from './utils';
+import { createTargetChannel, setSettingValueById } from './utils';
+import { preserveSettings } from './utils/preserveSettings';
 import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.user1.state });
@@ -185,6 +186,20 @@ test.describe.serial('message-composer', () => {
 		await expect(poHomeChannel.composer.boxPopup).toBeVisible();
 
 		await poHomeChannel.composer.inputMessage.fill('');
+	});
+
+	test('should clear the composer after running a client-only slash command', async () => {
+		await poHomeChannel.content.dispatchSlashCommand('/shrug');
+
+		await expect(poHomeChannel.content.lastUserMessageBody).toContainText('(ツ)');
+		await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
+	});
+
+	test('should clear the composer after an unrecognized slash command', async () => {
+		await poHomeChannel.content.dispatchSlashCommand('/notaslashcommand');
+
+		await expect(poHomeChannel.content.lastUserMessageBody).toContainText('No such command');
+		await expect(poHomeChannel.composer.inputMessage).toHaveValue('');
 	});
 
 	test.describe('audio recorder', () => {

--- a/apps/meteor/tests/e2e/message-composer.spec.ts
+++ b/apps/meteor/tests/e2e/message-composer.spec.ts
@@ -2,8 +2,7 @@ import { faker } from '@faker-js/faker';
 
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
-import { createTargetChannel, setSettingValueById } from './utils';
-import { preserveSettings } from './utils/preserveSettings';
+import { createTargetChannel } from './utils';
 import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.user1.state });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Message composer wasn't being always cleared after some slash command execution, this fixes it.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- Open a room
- Try any client side slash commands like `shrug` or `gimme`
- It should execute the slash command but doesn't clear the message composer
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2364](https://rocketchat.atlassian.net/browse/CORE-2364)

[CORE-2364]: https://rocketchat.atlassian.net/browse/CORE-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The message composer now clears after slash commands, including client-only, unrecognized, and unauthorized commands.
  * Previously entered command text no longer remains in the composer after the command is processed, helping prevent accidental reuse or confusion.
  * This behavior is now consistently applied across supported slash-command outcomes.

* **Release**
  * Included in a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->