### PR TITLE
fix: users not added to default channels on first username

### DIFF
--- a/.changeset/proud-pears-wait.md
+++ b/.changeset/proud-pears-wait.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes users not being added to the default channels (such as `#general`) when they are assigned their first username, which affected the admin created by the setup wizard on a brand new workspace and OAuth, SAML and LDAP users that pick a username through the "Register Username" screen.

--- a/apps/meteor/server/lib/callbacks.ts
+++ b/apps/meteor/server/lib/callbacks.ts
@@ -97,6 +97,7 @@ interface EventLikeCallbackSignatures {
 	'livechat.afterDepartmentDisabled': (department: ILivechatDepartmentRecord) => void;
 	'livechat.afterDepartmentArchived': (department: Pick<ILivechatDepartmentRecord, '_id' | 'businessHourId'>) => void;
 	'beforeSaveUser': ({ user, oldUser }: { user: IUser; oldUser?: IUser }) => void;
+	'afterCreateUser': (user: AtLeast<IUser, '_id' | 'username' | 'roles'>) => void;
 	'afterSaveUser': ({ user, oldUser }: { user: IUser; oldUser?: IUser | null }) => void;
 	'livechat.afterTagRemoved': (tag: ILivechatTagRecord) => void;
 	'afterUserImport': (data: { inserted: IUser['_id'][]; updated: IUser['_id']; skipped: number; failed: number }) => void;
@@ -116,7 +117,6 @@ type ChainedCallbackSignatures = {
 		newRoom: IOmnichannelRoom,
 		props: { user: Required<Pick<IUser, '_id' | 'username' | 'name'>>; oldRoom: IOmnichannelRoom },
 	) => IOmnichannelRoom;
-	'afterCreateUser': (user: AtLeast<IUser, '_id' | 'username' | 'roles'>) => IUser;
 	'afterDeleteRoom': (rid: IRoom['_id']) => IRoom['_id'];
 	'livechat:afterOnHold': (room: Pick<IOmnichannelRoom, '_id'>) => Pick<IOmnichannelRoom, '_id'>;
 	'livechat:afterOnHoldChatResumed': (room: Pick<IOmnichannelRoom, '_id'>) => Pick<IOmnichannelRoom, '_id'>;

--- a/apps/meteor/server/lib/users/setUsername.ts
+++ b/apps/meteor/server/lib/users/setUsername.ts
@@ -149,7 +149,7 @@ export const _setUsername = async function (
 	await onceTransactionCommitedSuccessfully(async () => {
 		if (!previousUsername) {
 			await joinDefaultChannels(user._id);
-			setImmediate(() => void callbacks.run('afterCreateUser', user));
+			callbacks.runAsync('afterCreateUser', user);
 		}
 
 		// If it's the first username and the user has an invite Token, then join the invite room

--- a/apps/meteor/server/lib/users/setUsername.ts
+++ b/apps/meteor/server/lib/users/setUsername.ts
@@ -28,7 +28,7 @@ const isUserInFederatedRooms = async (userId: string): Promise<boolean> => {
 	return hasAny;
 };
 
-export const setUsernameWithValidation = async (userId: string, username: string, joinDefaultChannelsSilenced?: boolean): Promise<void> => {
+export const setUsernameWithValidation = async (userId: string, username: string): Promise<void> => {
 	if (!username) {
 		throw new Meteor.Error('error-invalid-username', 'Invalid username', { method: 'setUsername' });
 	}
@@ -71,11 +71,6 @@ export const setUsernameWithValidation = async (userId: string, username: string
 		throw new Meteor.Error('error-could-not-change-username', 'Could not change username', {
 			method: 'setUsername',
 		});
-	}
-
-	if (!user.username) {
-		await joinDefaultChannels(user._id, joinDefaultChannelsSilenced);
-		setImmediate(async () => callbacks.run('afterCreateUser', user));
 	}
 
 	void notifyOnUserChange({ clientAction: 'updated', id: user._id, diff: { username } });
@@ -152,6 +147,13 @@ export const _setUsername = async function (
 	}
 
 	await onceTransactionCommitedSuccessfully(async () => {
+		// A first username means the account has just been created,
+		// so run what `insertUserDoc` skipped
+		if (!previousUsername) {
+			await joinDefaultChannels(user._id);
+			setImmediate(() => void callbacks.run('afterCreateUser', user));
+		}
+
 		// If it's the first username and the user has an invite Token, then join the invite room
 		if (!previousUsername && user.inviteToken) {
 			const inviteData = await Invites.findOneById(user.inviteToken);

--- a/apps/meteor/server/lib/users/setUsername.ts
+++ b/apps/meteor/server/lib/users/setUsername.ts
@@ -147,8 +147,6 @@ export const _setUsername = async function (
 	}
 
 	await onceTransactionCommitedSuccessfully(async () => {
-		// A first username means the account has just been created,
-		// so run what `insertUserDoc` skipped
 		if (!previousUsername) {
 			await joinDefaultChannels(user._id);
 			setImmediate(() => void callbacks.run('afterCreateUser', user));

--- a/apps/meteor/tests/unit/server/lib/users/setUsername.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/users/setUsername.spec.ts
@@ -28,6 +28,7 @@ describe('setUsername', () => {
 		},
 		callbacks: {
 			run: sinon.stub(),
+			runAsync: sinon.stub(),
 		},
 		checkUsernameAvailability: sinon.stub(),
 		validateUsername: sinon.stub(),
@@ -79,6 +80,7 @@ describe('setUsername', () => {
 		stubs.api.broadcast.reset();
 		stubs.Invites.findOneById.reset();
 		stubs.callbacks.run.reset();
+		stubs.callbacks.runAsync.reset();
 		stubs.checkUsernameAvailability.reset();
 		stubs.validateUsername.reset();
 		stubs.saveUserIdentity.reset();
@@ -262,13 +264,10 @@ describe('setUsername', () => {
 			stubs.checkUsernameAvailability.resolves(true);
 
 			await _setUsername(userId, username, mockUser);
-			await new Promise((resolve) => {
-				setImmediate(resolve);
-			});
 
 			expect(stubs.joinDefaultChannels.calledOnceWith(userId)).to.be.true;
-			expect(stubs.callbacks.run.calledWith('afterCreateUser')).to.be.true;
-			expect(stubs.callbacks.run.withArgs('afterCreateUser').firstCall.args[1]).to.include({ username });
+			expect(stubs.callbacks.runAsync.calledWith('afterCreateUser')).to.be.true;
+			expect(stubs.callbacks.runAsync.withArgs('afterCreateUser').firstCall.args[1]).to.include({ username });
 		});
 
 		it('should not join the default channels when the username is only being changed', async () => {
@@ -277,12 +276,9 @@ describe('setUsername', () => {
 			stubs.checkUsernameAvailability.resolves(true);
 
 			await _setUsername(userId, username, mockUser);
-			await new Promise((resolve) => {
-				setImmediate(resolve);
-			});
 
 			expect(stubs.joinDefaultChannels.notCalled).to.be.true;
-			expect(stubs.callbacks.run.calledWith('afterCreateUser')).to.be.false;
+			expect(stubs.callbacks.runAsync.calledWith('afterCreateUser')).to.be.false;
 		});
 
 		it('should set avatar if Accounts_SetDefaultAvatar is enabled', async () => {

--- a/apps/meteor/tests/unit/server/lib/users/setUsername.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/users/setUsername.spec.ts
@@ -193,7 +193,6 @@ describe('setUsername', () => {
 			await setUsernameWithValidation(userId, 'newUsername');
 
 			expect(stubs.saveUserIdentity.calledOnce).to.be.true;
-			expect(stubs.joinDefaultChannels.calledOnceWith(userId, undefined)).to.be.true;
 		});
 	});
 
@@ -255,6 +254,35 @@ describe('setUsername', () => {
 			expect(stubs.Users.setUsername.calledOnceWith(userId, username));
 			expect(stubs.checkUsernameAvailability.calledOnceWith(username));
 			expect(stubs.api.broadcast.calledOnceWith('user.autoupdate', { user: mockUser }));
+		});
+
+		it('should join the default channels and run afterCreateUser on the first username', async () => {
+			const mockUser = { _id: userId, roles: ['user'] };
+			stubs.validateUsername.returns(true);
+			stubs.checkUsernameAvailability.resolves(true);
+
+			await _setUsername(userId, username, mockUser);
+			await new Promise((resolve) => {
+				setImmediate(resolve);
+			});
+
+			expect(stubs.joinDefaultChannels.calledOnceWith(userId)).to.be.true;
+			expect(stubs.callbacks.run.calledWith('afterCreateUser')).to.be.true;
+			expect(stubs.callbacks.run.withArgs('afterCreateUser').firstCall.args[1]).to.include({ username });
+		});
+
+		it('should not join the default channels when the username is only being changed', async () => {
+			const mockUser = { _id: userId, username: 'oldUsername', roles: ['user'] };
+			stubs.validateUsername.returns(true);
+			stubs.checkUsernameAvailability.resolves(true);
+
+			await _setUsername(userId, username, mockUser);
+			await new Promise((resolve) => {
+				setImmediate(resolve);
+			});
+
+			expect(stubs.joinDefaultChannels.notCalled).to.be.true;
+			expect(stubs.callbacks.run.calledWith('afterCreateUser')).to.be.false;
 		});
 
 		it('should set avatar if Accounts_SetDefaultAvatar is enabled', async () => {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

On a brand new workspace the admin created by the setup wizard is not a member of `#general` — the room is created with `default: true` but has `usersCount: 0` and no subscription. The same happens to OAuth, SAML and LDAP users with no username mapping, who pick a username on the Register Username screen. Both flows also skip the `afterCreateUser` callback.

An account can be created without a username, and `Accounts.insertUserDoc` skips the join in that case by design — the account is not usable yet. Joining happens instead when the user is assigned their **first** username, the very next request in the wizard and possibly much later on the Register Username screen, and that code lived in `setUsernameWithValidation`, behind the `setUsername` Meteor method both flows called. PR #36146, a deprecation chore, swapped that method for `POST /v1/users.updateOwnBasicInfo` in `SetupWizardProvider.tsx` and `RegisterUsername.tsx`, and that endpoint routes to `saveUserProfile` → `saveUserIdentity` → `_setUsername`: the username is written, but `setUsernameWithValidation` is never reached. Nothing was deleted — the block is still there, which is why `POST /v1/users.register` keeps working; two callers just started using a different door.

The fix moves `joinDefaultChannels` and `afterCreateUser` one layer down, into `_setUsername`, which every username assignment converges on — `users.register` through `setUsernameWithValidation`, and both regressed flows through `saveUserProfile`, all of them via `saveUserIdentity`. `setUsernameWithValidation` also loses its now-unused `joinDefaultChannelsSilenced` parameter, and `afterCreateUser` now receives the user with the username populated instead of the pre-save snapshot.

## Issue(s)

- [CORE-2600](https://rocketchat.atlassian.net/browse/CORE-2600)
- Regression from #36146

## Steps to test or reproduce

1. Complete the setup wizard against an empty database — the admin must be a member of `#general`. Before the fix, `rocketchat_subscription` for `rid: "GENERAL"` is empty and the room has `usersCount: 0`.
2. Log in through an auth provider with no username mapping and pick a username on the Register Username screen — the user must be a member of `#general`.

Regression checks: `users.register` still joins exactly once, `users.create` is unchanged, and changing an existing username creates no new subscription.

## Further comments

- **Why `_setUsername` and not `saveUserProfile`** (the candidate fix on the issue): `_setUsername` is already where the first-username side effects live, and all of them already fire on admin edits today, so the "never the previous behaviour" argument does not hold. `saveUserProfile` would also add a third copy of the rule and leave future callers of `saveUserIdentity` regressing the same way.
- **Known collateral:** the importer generates a username for an existing account that has none, so those users now join the default channels during an import, against the opt-outs it passes at creation. Closing it means threading those flags through `saveUserIdentity` — happy to add here if preferred.


[CORE-2600]: https://rocketchat.atlassian.net/browse/CORE-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where users were not automatically added to default channels after choosing their first username.
  - This now works consistently for setup-wizard administrators and users signing in through OAuth, SAML, or LDAP.
  - Existing username changes no longer trigger first-time setup actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->