### PR TITLE
fix: AppMetadataStorage.updatePartialAndReturnDocument return type allows null

### DIFF
--- a/.changeset/fix-app-storage-update-null.md
+++ b/.changeset/fix-app-storage-update-null.md
@@ -3,4 +3,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes a type-safety bug where `AppMetadataStorage.updatePartialAndReturnDocument` was asserted to always return a document, even though `findOneAndUpdate` returns `null` when no matching document is found. The method now correctly returns `IAppStorageItem | null`, and callers that expect an update to have found a document now throw a clear error instead of silently continuing with an undefined value.
+Fixes a type-safety bug where `AppMetadataStorage.updatePartialAndReturnDocument` was asserted to always return a document, even though `findOneAndUpdate` returns `null` when no matching document is found. The method now correctly returns `IAppStorageItem | null`, and callers that expect an update to have found a document now throw a clear error instead of silently continuing with a null result.

--- a/.changeset/fix-app-storage-update-null.md
+++ b/.changeset/fix-app-storage-update-null.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/apps': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes a type-safety bug where `AppMetadataStorage.updatePartialAndReturnDocument` was asserted to always return a document, even though `findOneAndUpdate` returns `null` when no matching document is found. The method now correctly returns `IAppStorageItem | null`, and callers that expect an update to have found a document now throw a clear error instead of silently continuing with an undefined value.

--- a/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
+++ b/apps/meteor/ee/server/apps/storage/AppRealStorage.ts
@@ -60,7 +60,7 @@ export class AppRealStorage extends AppMetadataStorage {
 	public async updatePartialAndReturnDocument(
 		{ _id, ...item }: IAppStorageItem,
 		{ unsetPermissionsGranted = false } = {},
-	): Promise<IAppStorageItem> {
+	): Promise<IAppStorageItem | null> {
 		if (!_id) {
 			throw new Error('Property _id is required to update an app storage item');
 		}
@@ -74,9 +74,7 @@ export class AppRealStorage extends AppMetadataStorage {
 			updateQuery.$unset = { permissionsGranted: 1 };
 		}
 
-		// TODO need to change method return type to IAppStorageItem | null, because findOneAndUpdate can return null if the document is not found.
-		// But for now, we are asserting that it will always return a document.
-		return this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' }) as Promise<IAppStorageItem>;
+		return this.db.findOneAndUpdate({ _id }, updateQuery, { returnDocument: 'after' });
 	}
 
 	public async updateStatus(_id: string, status: AppStatus): Promise<boolean> {

--- a/apps/meteor/ee/tests/unit/server/apps/AppRealStorage.spec.ts
+++ b/apps/meteor/ee/tests/unit/server/apps/AppRealStorage.spec.ts
@@ -215,6 +215,15 @@ describe('AppRealStorage', () => {
 
 			expect(mockDb.findOneAndUpdate.calledWith({ _id: 'test-id' }, { $set: mockAppStorageItem }, { returnDocument: 'after' })).to.be.true;
 		});
+
+		it('should return null when the document is not found', async () => {
+			const updatedItem = { ...mockAppStorageItem, _id: 'test-id' };
+			mockDb.findOneAndUpdate.resolves(null);
+
+			const result = await storage.updatePartialAndReturnDocument(updatedItem);
+
+			expect(result).to.be.null;
+		});
 	});
 
 	describe('updateStatus', () => {

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -927,7 +927,12 @@ export class AppManager {
 				}
 
 				const appStorageItem = app.getStorageItem();
-				const { subscriptionInfo } = appStorageItem.marketplaceInfo?.[0] || {};
+
+				if (!appStorageItem.marketplaceInfo?.length) {
+					return;
+				}
+
+				const { subscriptionInfo } = appStorageItem.marketplaceInfo[0];
 
 				if (subscriptionInfo?.license.license === appInfo.subscriptionInfo.license.license) {
 					return;

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -541,6 +541,10 @@ export class AppManager {
 		const { marketplaceInfo, signature, migrated, _id } = storageItem;
 		const stored = await this.appMetadataStorage.updatePartialAndReturnDocument({ marketplaceInfo, signature, migrated, _id });
 
+		if (!stored) {
+			throw new Error(`App with id ${id} couldn't be found`);
+		}
+
 		await this.updateLocal(stored, app);
 		await this.bridges
 			.getAppActivationBridge()
@@ -765,6 +769,10 @@ export class AppManager {
 		const stored = await this.appMetadataStorage.updatePartialAndReturnDocument(descriptor, {
 			unsetPermissionsGranted: typeof permissionsGranted === 'undefined',
 		});
+
+		if (!stored) {
+			throw new Error(`App with id ${descriptor.id} couldn't be found`);
+		}
 
 		// Errors here don't really prevent the process from dying, so we don't really need to do anything on the catch
 		await this.getRuntime()

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -933,20 +933,38 @@ export class AppManager {
 					return;
 				}
 
-				appStorageItem.marketplaceInfo[0].subscriptionInfo = appInfo.subscriptionInfo;
-				appStorageItem.signature = await this.getSignatureManager().signApp(appStorageItem);
+				// Compute the update against a local copy first. The live storageItem is only
+				// mutated once persistence has been confirmed, so a failed/missing update never
+				// leaves the in-memory app out of sync with what's actually stored. Any failure
+				// for this one app (signing or persistence) is logged and skipped rather than
+				// aborting the whole batch, matching the previous best-effort semantics.
+				try {
+					const updatedMarketplaceInfo = [
+						{ ...appStorageItem.marketplaceInfo[0], subscriptionInfo: appInfo.subscriptionInfo },
+						...appStorageItem.marketplaceInfo.slice(1),
+					];
+					const signature = await this.getSignatureManager().signApp({ ...appStorageItem, marketplaceInfo: updatedMarketplaceInfo });
 
-				const stored = await this.appMetadataStorage.updatePartialAndReturnDocument({
-					_id: appStorageItem._id,
-					marketplaceInfo: appStorageItem.marketplaceInfo,
-					signature: appStorageItem.signature,
-				});
+					const stored = await this.appMetadataStorage.updatePartialAndReturnDocument({
+						_id: appStorageItem._id,
+						marketplaceInfo: updatedMarketplaceInfo,
+						signature,
+					});
 
-				if (!stored) {
-					throw new Error(`App with id ${appStorageItem._id} couldn't be found`);
+					if (!stored) {
+						// Missing-document policy: the app was removed/uninstalled concurrently. Log
+						// and skip it rather than retaining the unsigned-off mutation in memory.
+						console.warn(`App with id ${appStorageItem._id} couldn't be found while updating marketplace info`);
+						return;
+					}
+
+					appStorageItem.marketplaceInfo = updatedMarketplaceInfo;
+					appStorageItem.signature = signature;
+				} catch (error) {
+					console.error(`Error while updating marketplace info for App ${appStorageItem._id}:`, error);
 				}
 			}),
-		).catch(() => {});
+		);
 
 		const queue = [] as Array<Promise<void>>;
 

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -938,11 +938,6 @@ export class AppManager {
 					return;
 				}
 
-				// Compute the update against a local copy first. The live storageItem is only
-				// mutated once persistence has been confirmed, so a failed/missing update never
-				// leaves the in-memory app out of sync with what's actually stored. Any failure
-				// for this one app (signing or persistence) is logged and skipped rather than
-				// aborting the whole batch, matching the previous best-effort semantics.
 				try {
 					const updatedMarketplaceInfo = [
 						{ ...appStorageItem.marketplaceInfo[0], subscriptionInfo: appInfo.subscriptionInfo },
@@ -957,8 +952,6 @@ export class AppManager {
 					});
 
 					if (!stored) {
-						// Missing-document policy: the app was removed/uninstalled concurrently. Log
-						// and skip it rather than retaining the unsigned-off mutation in memory.
 						console.warn(`App with id ${appStorageItem._id} couldn't be found while updating marketplace info`);
 						return;
 					}

--- a/packages/apps/src/server/AppManager.ts
+++ b/packages/apps/src/server/AppManager.ts
@@ -936,11 +936,15 @@ export class AppManager {
 				appStorageItem.marketplaceInfo[0].subscriptionInfo = appInfo.subscriptionInfo;
 				appStorageItem.signature = await this.getSignatureManager().signApp(appStorageItem);
 
-				return this.appMetadataStorage.updatePartialAndReturnDocument({
+				const stored = await this.appMetadataStorage.updatePartialAndReturnDocument({
 					_id: appStorageItem._id,
 					marketplaceInfo: appStorageItem.marketplaceInfo,
 					signature: appStorageItem.signature,
 				});
+
+				if (!stored) {
+					throw new Error(`App with id ${appStorageItem._id} couldn't be found`);
+				}
 			}),
 		).catch(() => {});
 

--- a/packages/apps/src/server/storage/AppMetadataStorage.ts
+++ b/packages/apps/src/server/storage/AppMetadataStorage.ts
@@ -25,7 +25,7 @@ export abstract class AppMetadataStorage {
 	public abstract updatePartialAndReturnDocument(
 		item: Partial<IAppStorageItem>,
 		options?: { unsetPermissionsGranted?: boolean },
-	): Promise<IAppStorageItem>;
+	): Promise<IAppStorageItem | null>;
 
 	public abstract updateStatus(_id: string, status: AppStatus): Promise<boolean>;
 


### PR DESCRIPTION
findOneAndUpdate can return null when no matching document is found, but the method asserted a document always existed. Return type is now IAppStorageItem | null, and callers now throw a clear error instead of silently continuing with an undefined value.
Fixes #41873

<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - App metadata updates now correctly indicate when the requested record is not found.
  - App migration and update operations report a clear error instead of treating a missing record as successful.
  - Marketplace metadata updates now confirm changes were saved before reflecting them.
  - Marketplace updates continue processing other apps when an individual update fails.
  - Apps without marketplace information are skipped cleanly.
  - Update operations consistently handle cases where no matching record exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->