### PR TITLE
regression: thread not loading latest messages when jumping to recent (sending a message)

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -73,6 +73,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 		hasPreviousPage,
 		isFetchingPreviousPage,
 		loadMessageAround,
+		jumpToRecent,
 	} = useThreadMessagesQuery(mainMessage._id);
 	const messages = useMemo(() => data?.messages ?? [], [data?.messages]);
 
@@ -259,7 +260,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 		prevItemsLengthRef.current = items.length;
 		if (items.length > prev && uid) {
 			const lastItem = items.at(-1);
-			if (lastItem?.temp && lastItem.u._id === uid) {
+			if (lastItem?.temp && lastItem.u._id === uid && !hasNextPage) {
 				setShouldJumpToBottom(true);
 			}
 		}
@@ -287,6 +288,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 		uid,
 		isFetchingPreviousPage,
 		isFetchingNextPage,
+		hasNextPage,
 	]);
 
 	useEffect(() => {
@@ -354,6 +356,10 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 					return;
 				}
 				if (msg.u._id === uid) {
+					if (hasNextPage) {
+						void jumpToRecent().then(() => setShouldJumpToBottom(true));
+						return;
+					}
 					setShouldJumpToBottom(true);
 				}
 			},
@@ -364,7 +370,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 		return () => {
 			clientCallbacks.remove('streamNewMessage', handlerId);
 		};
-	}, [room._id, uid, mainMessage._id, setShouldJumpToBottom]);
+	}, [room._id, uid, mainMessage._id, setShouldJumpToBottom, hasNextPage, jumpToRecent]);
 
 	const keepMountedMessages = useKeepMountedMessages(items);
 

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
@@ -1,0 +1,132 @@
+import type { IMessage, Serialized } from '@rocket.chat/core-typings';
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useThreadMessagesQuery } from './useThreadMessagesQuery';
+import { createFakeRoom } from '../../../../../../tests/mocks/data';
+
+const room = createFakeRoom({ _id: 'room-id', t: 'c' });
+
+jest.mock('../../../contexts/RoomContext', () => ({
+	useRoom: () => room,
+}));
+
+const TMID = 'thread-id';
+const TOTAL = 120;
+const PAGE_SIZE = 50;
+
+const createSerializedReply = (index: number): Serialized<IMessage> => {
+	const ts = new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString();
+
+	return {
+		_id: `reply-${index}`,
+		rid: room._id,
+		tmid: TMID,
+		msg: `reply ${index}`,
+		ts,
+		_updatedAt: ts,
+		u: { _id: 'user-id', username: 'user', name: 'User' },
+	} as unknown as Serialized<IMessage>;
+};
+
+const allReplies = Array.from({ length: TOTAL }, (_, index) => createSerializedReply(index));
+
+const idsOf = (messages: { _id: string }[]) => messages.map(({ _id }) => _id);
+
+const newestPageIds = idsOf(allReplies.slice(TOTAL - PAGE_SIZE));
+
+type GetThreadMessagesParams = { tmid: string; offset?: number; count?: number; aroundId?: string; sort?: string };
+
+const setup = () => {
+	const getThreadMessages = jest.fn(({ offset = 0, count = PAGE_SIZE, aroundId }: GetThreadMessagesParams) => {
+		if (aroundId) {
+			const index = allReplies.findIndex(({ _id }) => _id === aroundId);
+			const start = Math.max(0, index - Math.floor(count / 2));
+
+			return { messages: allReplies.slice(start, start + count), count, offset: start, total: TOTAL };
+		}
+
+		const end = TOTAL - offset;
+		const start = Math.max(0, end - count);
+
+		return { messages: allReplies.slice(start, end), count, offset, total: TOTAL };
+	});
+
+	const wrapper = mockAppRoot()
+		.withJohnDoe()
+		.withEndpoint('GET', '/v1/chat.getThreadMessages', getThreadMessages)
+		.withEndpoint('POST', '/v1/chat.readThread', () => null)
+		.build();
+
+	const { result } = renderHook(() => useThreadMessagesQuery(TMID), { wrapper });
+
+	return { result, getThreadMessages };
+};
+
+const waitForLoaded = async (result: { current: ReturnType<typeof useThreadMessagesQuery> }) =>
+	waitFor(() => expect(result.current.isLoading).toBe(false));
+
+describe('useThreadMessagesQuery', () => {
+	it('reports no unloaded newer messages after the initial load', async () => {
+		const { result } = setup();
+
+		await waitForLoaded(result);
+
+		expect(result.current.hasNextPage).toBe(false);
+		expect(result.current.hasPreviousPage).toBe(true);
+		expect(idsOf(result.current.data?.messages ?? [])).toEqual(newestPageIds);
+	});
+
+	it('reports unloaded newer messages after jumping to an old reply', async () => {
+		const { result } = setup();
+
+		await waitForLoaded(result);
+
+		await act(async () => {
+			await result.current.loadMessageAround('reply-10');
+		});
+
+		await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+		expect(idsOf(result.current.data?.messages ?? [])).toEqual(idsOf(allReplies.slice(0, PAGE_SIZE)));
+	});
+
+	describe('jumpToRecent', () => {
+		it('refetches from the newest page and clears the unloaded-newer-messages flag', async () => {
+			const { result, getThreadMessages } = setup();
+
+			await waitForLoaded(result);
+
+			await act(async () => {
+				await result.current.loadMessageAround('reply-10');
+			});
+			await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+			getThreadMessages.mockClear();
+
+			await act(async () => {
+				await result.current.jumpToRecent();
+			});
+
+			await waitFor(() => expect(result.current.hasNextPage).toBe(false));
+			expect(getThreadMessages).toHaveBeenCalledWith(expect.objectContaining({ tmid: TMID, offset: 0 }));
+		});
+
+		it('discards the detached window instead of merging it into the newest page', async () => {
+			const { result } = setup();
+
+			await waitForLoaded(result);
+
+			await act(async () => {
+				await result.current.loadMessageAround('reply-10');
+			});
+			await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+			await act(async () => {
+				await result.current.jumpToRecent();
+			});
+
+			await waitFor(() => expect(result.current.hasNextPage).toBe(false));
+			expect(idsOf(result.current.data?.messages ?? [])).toEqual(newestPageIds);
+		});
+	});
+});

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -138,6 +138,10 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 		[queryClient, getThreadMessages, roomId, tmid, count],
 	);
 
+	const jumpToRecent = useCallback(async () => {
+		await queryClient.resetQueries({ queryKey: roomsQueryKeys.threadMessages(roomId, tmid) });
+	}, [queryClient, roomId, tmid]);
+
 	const query = useInfiniteQuery({
 		queryKey,
 		queryFn: async ({ pageParam: offset }) => {
@@ -201,5 +205,5 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 		refetchOnWindowFocus: false,
 	});
 
-	return { ...query, loadMessageAround };
+	return { ...query, loadMessageAround, jumpToRecent };
 };


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->
[CORE-2519](https://rocketchat.atlassian.net/browse/CORE-2519)
<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2519]: https://rocketchat.atlassian.net/browse/CORE-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread navigation when newer replies are available.
  * New messages posted by you now reliably appear at the bottom of the thread.
  * Jumping to the latest thread replies now refreshes the message view correctly.
  * Improved handling when navigating between older and newer portions of a thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->