### PR TITLE
regression: Respect `UI_Use_Real_Name` setting in parent room button tooltip

### DIFF
--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
@@ -1,10 +1,9 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { isRoomFederated } from '@rocket.chat/core-typings';
-import { useRoomRoute } from '@rocket.chat/ui-client';
-import { useSetting } from '@rocket.chat/ui-contexts';
+import { useRoomRoute, useUserDisplayName } from '@rocket.chat/ui-client';
+import { useSetting, useUserSubscription } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
-import { getUserDisplayNames } from '../../../../../../lib/getUserDisplayNames';
 import ParentRoomButton from '../ParentRoomButton';
 
 export type ParentDiscussionProps = {
@@ -24,9 +23,10 @@ const ParentDiscussion = ({ loading = false, room }: ParentDiscussionProps) => {
 	const { t } = useTranslation();
 	const goToRoom = useRoomRoute();
 	const allowSpecialChars = useSetting('UI_Allow_room_names_with_special_chars', false);
-	const useRealName = useSetting<boolean>('UI_Use_Real_Name', false);
-	const [userDisplayName] = getUserDisplayNames(room.fname, room.name, useRealName);
-	const roomName = room.t === 'c' || room.t === 'p' ? getChannelRoomName(room, allowSpecialChars) : userDisplayName;
+	const parentRoom = useUserSubscription(room._id) ?? room;
+	const userDisplayName = useUserDisplayName({ name: parentRoom.fname, username: parentRoom.name });
+	const roomName =
+		parentRoom.t === 'c' || parentRoom.t === 'p' ? getChannelRoomName(parentRoom, allowSpecialChars) : (userDisplayName ?? '');
 
 	const handleRedirect = (): void => {
 		goToRoom({ rid: room._id, t: room.t, name: room.name });

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
@@ -4,6 +4,7 @@ import { useRoomRoute } from '@rocket.chat/ui-client';
 import { useSetting } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
+import { getUserDisplayNames } from '../../../../../../lib/getUserDisplayNames';
 import ParentRoomButton from '../ParentRoomButton';
 
 export type ParentDiscussionProps = {
@@ -23,7 +24,9 @@ const ParentDiscussion = ({ loading = false, room }: ParentDiscussionProps) => {
 	const { t } = useTranslation();
 	const goToRoom = useRoomRoute();
 	const allowSpecialChars = useSetting('UI_Allow_room_names_with_special_chars', false);
-	const roomName = room.t === 'c' || room.t === 'p' ? getChannelRoomName(room, allowSpecialChars) : room.fname || room.name || '';
+	const useRealName = useSetting<boolean>('UI_Use_Real_Name', false);
+	const [userDisplayName] = getUserDisplayNames(room.fname, room.name, useRealName);
+	const roomName = room.t === 'c' || room.t === 'p' ? getChannelRoomName(room, allowSpecialChars) : userDisplayName;
 
 	const handleRedirect = (): void => {
 		goToRoom({ rid: room._id, t: room.t, name: room.name });

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussion.tsx
@@ -1,7 +1,7 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { isRoomFederated } from '@rocket.chat/core-typings';
 import { useRoomRoute, useUserDisplayName } from '@rocket.chat/ui-client';
-import { useSetting, useUserSubscription } from '@rocket.chat/ui-contexts';
+import { useSetting } from '@rocket.chat/ui-contexts';
 import { useTranslation } from 'react-i18next';
 
 import ParentRoomButton from '../ParentRoomButton';
@@ -23,10 +23,8 @@ const ParentDiscussion = ({ loading = false, room }: ParentDiscussionProps) => {
 	const { t } = useTranslation();
 	const goToRoom = useRoomRoute();
 	const allowSpecialChars = useSetting('UI_Allow_room_names_with_special_chars', false);
-	const parentRoom = useUserSubscription(room._id) ?? room;
-	const userDisplayName = useUserDisplayName({ name: parentRoom.fname, username: parentRoom.name });
-	const roomName =
-		parentRoom.t === 'c' || parentRoom.t === 'p' ? getChannelRoomName(parentRoom, allowSpecialChars) : (userDisplayName ?? '');
+	const userDisplayName = useUserDisplayName({ name: room.fname, username: room.name });
+	const roomName = room.t === 'c' || room.t === 'p' ? getChannelRoomName(room, allowSpecialChars) : (userDisplayName ?? '');
 
 	const handleRedirect = (): void => {
 		goToRoom({ rid: room._id, t: room.t, name: room.name });

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
@@ -26,6 +26,7 @@ const ParentDiscussionRoute = ({ room }: ParentDiscussionRouteProps) => {
 						name: subscription.name,
 						fname: subscription.fname,
 						u: subscription.u,
+						federated: (subscription as any).federated,
 					}
 				: undefined,
 		[subscription],

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
@@ -1,5 +1,6 @@
 import type { IRoom } from '@rocket.chat/core-typings';
 import { useUserSubscription } from '@rocket.chat/ui-contexts';
+import { useMemo } from 'react';
 
 import ParentDiscussion from './ParentDiscussion';
 import ParentDiscussionWithData from './ParentDiscussionWithData';
@@ -16,9 +17,22 @@ const ParentDiscussionRoute = ({ room }: ParentDiscussionRouteProps) => {
 	}
 
 	const subscription = useUserSubscription(prid);
+	const parentRoomProps = useMemo(
+		() =>
+			subscription
+				? {
+						_id: subscription.rid,
+						t: subscription.t,
+						name: subscription.name,
+						fname: subscription.fname,
+						u: subscription.u,
+					}
+				: undefined,
+		[subscription],
+	);
 
-	if (subscription) {
-		return <ParentDiscussion room={{ ...subscription, _id: subscription.rid }} />;
+	if (subscription && parentRoomProps) {
+		return <ParentDiscussion room={parentRoomProps} />;
 	}
 
 	return <ParentDiscussionWithData rid={prid} />;

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
@@ -26,7 +26,7 @@ const ParentDiscussionRoute = ({ room }: ParentDiscussionRouteProps) => {
 						name: subscription.name,
 						fname: subscription.fname,
 						u: subscription.u,
-						federated: (subscription as any).federated,
+						federated: (subscription as any).federated as IRoom['federated'],
 					}
 				: undefined,
 		[subscription],

--- a/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
+++ b/apps/meteor/client/views/room/Header/ParentRoom/ParentDiscussion/ParentDiscussionRoute.tsx
@@ -18,7 +18,7 @@ const ParentDiscussionRoute = ({ room }: ParentDiscussionRouteProps) => {
 	const subscription = useUserSubscription(prid);
 
 	if (subscription) {
-		return <ParentDiscussion room={subscription} />;
+		return <ParentDiscussion room={{ ...subscription, _id: subscription.rid }} />;
 	}
 
 	return <ParentDiscussionWithData rid={prid} />;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
A recent refactor #41508 removed getting the channels name from roomCoordinator which was originally respecting the `UI_Use_Real_Name` setting, the refactor after it missed this setting. This PR fixes this issue by using an existing helper function `getUserDisplayNames`.
## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
- As an admin, confirm the setting "Use Real Name" is disabled.
- Start a direct message with a user whose display name differs from their username.
- Create a discussion from that direct message.
- Open the discussion and check the button at the top that navigates back to the parent room.
## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[CORE-2620](https://rocketchat.atlassian.net/browse/CORE-2620)
[CORE-2626](https://rocketchat.atlassian.net/browse/CORE-2626)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Parent discussions now display the correct parent room name more consistently.
  * Federated parent rooms are handled more reliably when opening or viewing discussions.
  * Existing naming behavior for channels, private groups, and other room types remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2620]: https://rocketchat.atlassian.net/browse/CORE-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ