### PR TITLE
fix: Reject SAML profiles without a usable email address

### DIFF
--- a/.changeset/saml-empty-email-attribute.md
+++ b/.changeset/saml-empty-email-attribute.md
@@ -1,0 +1,5 @@
+---
+"@rocket.chat/meteor": patch
+---
+
+Fixed SAML login accepting a profile whose email attribute has no usable value. An attribute with no values, or one holding only blank values, is now rejected during profile mapping, and the account lookup no longer runs when there is no valid address to search for.

--- a/apps/meteor/server/lib/saml/lib/SAML.ts
+++ b/apps/meteor/server/lib/saml/lib/SAML.ts
@@ -128,10 +128,12 @@ export class SAML {
 
 		// Second, try searching by username or email (according to the immutableProperty setting)
 		if (!user) {
-			const expression = userObject.emailList.map((email) => `^${escapeRegExp(email)}$`).join('|');
-			const emailRegex = new RegExp(expression, 'i');
+			const validEmails = userObject.emailList.filter((email) => typeof email === 'string' && email.trim() !== '');
+			const expression = validEmails.map((email) => `^${escapeRegExp(email)}$`).join('|');
 
-			user = await SAML.findUser(userObject.username, emailRegex);
+			// An empty expression would compile to a pattern that matches every address, so no regex is
+			// built at all when there is nothing valid to search for.
+			user = await SAML.findUser(userObject.username, expression ? new RegExp(expression, 'i') : undefined);
 		}
 
 		const emails = userObject.emailList.map((email) => ({
@@ -553,7 +555,7 @@ export class SAML {
 		});
 	}
 
-	private static async findUser(username: string | undefined, emailRegex: RegExp): Promise<IUser | undefined | null> {
+	private static async findUser(username: string | undefined, emailRegex: RegExp | undefined): Promise<IUser | undefined | null> {
 		const { globalSettings } = SAMLUtils;
 
 		if (globalSettings.immutableProperty === 'Username') {
@@ -563,6 +565,10 @@ export class SAML {
 				});
 			}
 
+			return;
+		}
+
+		if (!emailRegex) {
 			return;
 		}
 

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -476,7 +476,10 @@ export class SAMLUtils {
 		const name = this.getProfileValue(profile, userDataMap.name, true);
 
 		// Even if we're not using the email to identify the user, it is still mandatory because it's a mandatory information on Rocket.Chat
-		if (!email) {
+		// An attribute with no values is parsed into an empty array, which is truthy, so the values have to be
+		// inspected individually to keep a blank email from reaching the user lookup.
+		const emailList = ensureArray<string>(email).filter((address) => typeof address === 'string' && address.trim() !== '');
+		if (!emailList.length) {
 			throw new Error('SAML Profile did not contain an email address');
 		}
 
@@ -487,7 +490,7 @@ export class SAMLUtils {
 				idpSession: profile.sessionIndex,
 				nameID: profile.nameID,
 			},
-			emailList: ensureArray<string>(email),
+			emailList,
 			fullName: name || profile.displayName || profile.username,
 			eppn: profile.eppn,
 			attributeList,

--- a/apps/meteor/tests/unit/server/lib/saml/insertOrUpdateSAMLUser.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/insertOrUpdateSAMLUser.spec.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+import type { ISAMLUser } from '../../../../../server/lib/saml/definition/ISAMLUser';
+
+const findOne = sinon.stub().resolves(null);
+
+const globalSettings = {
+	generateUsername: false,
+	immutableProperty: 'EMail',
+	nameOverwrite: false,
+	mailOverwrite: false,
+	channelsAttributeUpdate: false,
+	defaultUserRole: 'user',
+};
+
+const { SAML } = proxyquire.noCallThru().load('../../../../../server/lib/saml/lib/SAML', {
+	'@rocket.chat/models': {
+		Users: { findOne },
+		Rooms: {},
+		Roles: { findInIdsOrNames: () => ({ toArray: async () => [] }) },
+		CredentialTokens: {},
+		SamlUsedAssertions: {},
+	},
+	'@rocket.chat/random': { Random: { id: () => 'random-id' } },
+	'meteor/accounts-base': { Accounts: {} },
+	'meteor/meteor': { Meteor: { Error, absoluteUrl: () => 'http://localhost:3000/' } },
+	'./ServiceProvider': { SAMLServiceProvider: class {} },
+	'./Utils': { SAMLUtils: { globalSettings, log: sinon.stub(), error: sinon.stub(), events: { emit: sinon.stub() } } },
+	'./getSAMLEnvelope': { getSAMLEnvelope: sinon.stub() },
+	'../../../../app/utils/lib/i18n': { i18n: { t: sinon.stub().returns('') } },
+	'../../../settings': { settings: { get: sinon.stub().returns(false) } },
+	'../../logger/system': { SystemLogger: { warn: sinon.stub(), error: sinon.stub() } },
+	'../../rooms/addUserToRoom': { addUserToRoom: sinon.stub() },
+	'../../rooms/createRoom': { createRoom: sinon.stub() },
+	'../../users/getUsernameSuggestion': { generateUsernameSuggestion: sinon.stub() },
+	'../../users/saveUserIdentity': { saveUserIdentity: sinon.stub() },
+});
+
+const makeUserObject = (emailList: string[]): ISAMLUser =>
+	({
+		samlLogin: { provider: 'provider', idp: 'idp', idpSession: 'session', nameID: 'nameID' },
+		emailList,
+		fullName: 'Full Name',
+		username: 'username',
+		attributeList: new Map(),
+		identifier: { type: 'email' },
+	}) as unknown as ISAMLUser;
+
+// The lookup is the only part under test; user creation afterwards is out of scope, so failures past
+// that point are swallowed and only the queries issued against Users are asserted.
+const runLookup = async (emailList: string[]) => {
+	findOne.resetHistory();
+	await SAML.insertOrUpdateSAMLUser(makeUserObject(emailList)).catch(() => undefined);
+	return findOne.getCalls().map((call: sinon.SinonSpyCall) => call.args[0]);
+};
+
+describe('SAML insertOrUpdateSAMLUser', () => {
+	beforeEach(() => {
+		globalSettings.immutableProperty = 'EMail';
+		findOne.resetHistory();
+		findOne.resolves(null);
+	});
+
+	it('should not query for a user when the email list is empty', async () => {
+		const queries = await runLookup([]);
+
+		const emailQueries = queries.filter((query: Record<string, any>) => query && 'emails.address' in query);
+		expect(emailQueries).to.have.lengthOf(0);
+	});
+
+	it('should never build an email pattern that matches an arbitrary address', async () => {
+		for (const emailList of [[], [''], ['', ''], ['   ']]) {
+			const queries = await runLookup(emailList);
+
+			queries
+				.filter((query: Record<string, any>) => query && query['emails.address'] instanceof RegExp)
+				.forEach((query: Record<string, any>) => {
+					const pattern: RegExp = query['emails.address'];
+					expect(pattern.source, `pattern ${pattern} built from ${JSON.stringify(emailList)}`).to.not.equal('(?:)');
+					expect(pattern.test('victim@example.com'), `pattern ${pattern} matched an unrelated address`).to.be.false;
+				});
+		}
+	});
+
+	it('should still look the user up by a single valid email', async () => {
+		const queries = await runLookup(['valid@server.com']);
+
+		const emailQueries = queries.filter((query: Record<string, any>) => query && query['emails.address'] instanceof RegExp);
+		expect(emailQueries).to.have.lengthOf(1);
+
+		const pattern: RegExp = emailQueries[0]['emails.address'];
+		expect(pattern.test('valid@server.com')).to.be.true;
+		expect(pattern.test('victim@example.com')).to.be.false;
+	});
+
+	it('should still look the user up by any of several valid emails', async () => {
+		const queries = await runLookup(['first@server.com', 'second@server.com']);
+
+		const emailQueries = queries.filter((query: Record<string, any>) => query && query['emails.address'] instanceof RegExp);
+		expect(emailQueries).to.have.lengthOf(1);
+
+		const pattern: RegExp = emailQueries[0]['emails.address'];
+		expect(pattern.test('first@server.com')).to.be.true;
+		expect(pattern.test('second@server.com')).to.be.true;
+		expect(pattern.test('victim@example.com')).to.be.false;
+	});
+});

--- a/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
@@ -864,6 +864,58 @@ describe('SAML', () => {
 				}).to.throw('SAML Profile did not contain an email address');
 			});
 
+			describe('empty email attribute values', () => {
+				// An <Attribute> element with no <AttributeValue> children is parsed into an empty array, and
+				// every value below must be rejected before it can reach the user lookup in insertOrUpdateSAMLUser.
+				const useSingleEmailFieldMap = () => {
+					const { globalSettings } = SAMLUtils;
+					globalSettings.userDataFieldMap = JSON.stringify({ email: 'singleEmail' });
+					SAMLUtils.updateGlobalSettings(globalSettings);
+				};
+
+				const rejectedValues: [string, unknown][] = [
+					['an attribute with no values', []],
+					['an empty string', ''],
+					['an array of empty strings', ['', '']],
+					['a whitespace-only value', '   '],
+					['an array of whitespace-only values', ['  ', '\t']],
+				];
+
+				rejectedValues.forEach(([description, singleEmail]) => {
+					it(`should reject ${description}`, () => {
+						useSingleEmailFieldMap();
+
+						expect(() => {
+							SAMLUtils.mapProfileToUserObject({ ...profile, singleEmail });
+						}).to.throw('SAML Profile did not contain an email address');
+					});
+				});
+
+				it('should keep accepting a single valid email value', () => {
+					useSingleEmailFieldMap();
+
+					const userObject = SAMLUtils.mapProfileToUserObject({ ...profile, singleEmail: 'testing@server.com' });
+
+					expect(userObject).to.have.property('emailList').that.is.an('array').with.members(['testing@server.com']);
+				});
+
+				it('should keep accepting multiple valid email values', () => {
+					useSingleEmailFieldMap();
+
+					const userObject = SAMLUtils.mapProfileToUserObject({ ...profile, singleEmail: ['first@server.com', 'second@server.com'] });
+
+					expect(userObject).to.have.property('emailList').that.is.an('array').with.members(['first@server.com', 'second@server.com']);
+				});
+
+				it('should discard empty values while keeping the valid ones', () => {
+					useSingleEmailFieldMap();
+
+					const userObject = SAMLUtils.mapProfileToUserObject({ ...profile, singleEmail: ['', 'valid@server.com', '  '] });
+
+					expect(userObject).to.have.property('emailList').that.is.an('array').with.members(['valid@server.com']);
+				});
+			});
+
 			it('should load data from the default fields when the field map is lacking', () => {
 				const { globalSettings } = SAMLUtils;
 


### PR DESCRIPTION
## Proposed changes 

SAML login would accept a profile whose email attribute had no actual value in it.

The check in `mapProfileToUserObject` only tested that the value was truthy. Trouble is, an attribute with no `AttributeValue` children parses into an empty array, and `[]` is truthy, so it sailed straight through. That empty list then hit the lookup in `insertOrUpdateSAMLUser`, which joins the addresses into a regex. Join an empty list and you get an empty pattern, which matches every address in the database. So the lookup could come back with a completely unrelated account.

I patched both spots rather than just the guard, so one of them slipping doesn't matter.

Mapping now checks the values themselves instead of the container, and throws if none of them is a non-blank string. The lookup skips building a regex at all when there's nothing valid to search for. The username branch is untouched, it doesn't use the email pattern.

## Issue(s)

None. Found it while reading through the SAML mapping code.

## Steps to test or reproduce

```
cd apps/meteor
yarn mocha --config ./.mocharc.base.json tests/unit/server/lib/saml/server.tests.ts tests/unit/server/lib/saml/insertOrUpdateSAMLUser.spec.ts
```

Between the two files: empty array, empty string, array of empty strings, whitespace-only, and array of whitespace-only all get rejected, and single and multi-value addresses still work. The lookup spec also asserts no query goes out when the list is empty.

Both files fail on `develop` without the source change.

Against a real IdP: send an assertion where the email attribute is present but carries no value, with `SAML_Custom_<name>_immutable_property` left on its default of `EMail`.

## Further comments

Heads up on behaviour. Anyone logging in today on a blank email attribute will start getting the existing `SAML Profile did not contain an email address` error. That's the intent, but it'll be visible if some IdP out there is sending blanks.

Blanks mixed in with a real address just get dropped, so those profiles still log in fine. Single and multi-address profiles are unchanged.

SAML suites pass, 93 tests. Full `apps/meteor` unit run is 2243 passing with 3 failures in `parseMessageSearchQuery.spec.ts` that also fail on clean `develop`. Lint is clean, typecheck is the same as before my change.

Changeset added, patch bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SAML login handling for profiles with missing, empty, or whitespace-only email attributes.
  * Such profiles are now rejected with a clear missing-email error.
  * Prevented account searches from using overly broad matches when no valid email address is available.
  * Valid email addresses continue to support targeted account lookup, including profiles with multiple addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->