### PR TITLE
regression: thread reply deletion only clears the first cached duplicate

### DIFF
--- a/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.spec.ts
@@ -144,6 +144,51 @@ describe('mutateThreadMessagesInfiniteData', () => {
 		expect(data?.pages[0].itemCount).toBe(200);
 		expect(data?.pageParams).toEqual([75]);
 	});
+
+	it('removes a message from every cached page when its id was duplicated across pages, not just the first occurrence', () => {
+		const cache: ThreadMessagesInfiniteData = {
+			pages: [
+				{ items: [createMessage('reply-058', 58), createMessage('reply-059', 59), createMessage('reply-060', 60)], itemCount: 200 },
+				{ items: [createMessage('reply-060', 60), createMessage('reply-061', 61)], itemCount: 200 },
+			],
+			pageParams: [58, 60],
+		};
+		queryClient.setQueryData(queryKey, cache);
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, (messages) => {
+			const index = messages.findIndex((m) => m._id === 'reply-060');
+			messages.splice(index, 1);
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+		const allIds = data?.pages.flatMap((page) => page.items.map((m) => m._id)) ?? [];
+
+		expect(allIds).not.toContain('reply-060');
+		expect(data?.pages[0].itemCount).toBe(199);
+	});
+
+	it('collapses a duplicated id into a single entry, keeping the most recently updated copy, even when the mutation is a no-op', () => {
+		const stale = createMessage('reply-060', 60);
+		const fresh: IThreadMessage = { ...createMessage('reply-060', 60), msg: 'edited', _updatedAt: new Date(9999).toISOString() as any };
+		const cache: ThreadMessagesInfiniteData = {
+			pages: [
+				{ items: [stale], itemCount: 200 },
+				{ items: [fresh], itemCount: 200 },
+			],
+			pageParams: [60, 60],
+		};
+		queryClient.setQueryData(queryKey, cache);
+
+		mutateThreadMessagesInfiniteData(queryClient, queryKey, () => {
+			// no-op mutation: only the dedup pass should change the cache
+		});
+
+		const data = queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey);
+		const allItems = data?.pages.flatMap((page) => page.items) ?? [];
+
+		expect(allItems).toHaveLength(1);
+		expect(allItems[0].msg).toBe('edited');
+	});
 });
 
 describe('upsertThreadMessageInCache', () => {

--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -54,6 +54,26 @@ export type ThreadMessagesPage = {
 
 export type ThreadMessagesInfiniteData = InfiniteData<ThreadMessagesPage, number>;
 
+const dedupeThreadMessagesById = (messages: IThreadMessage[]): IThreadMessage[] => {
+	const byId = new Map<string, IThreadMessage>();
+
+	for (const message of messages) {
+		const existing = byId.get(message._id);
+		if (!existing) {
+			byId.set(message._id, message);
+			continue;
+		}
+
+		const messageTime = new Date(message._updatedAt ?? message.ts).getTime();
+		const existingTime = new Date(existing._updatedAt ?? existing.ts).getTime();
+		if (messageTime >= existingTime) {
+			byId.set(message._id, message);
+		}
+	}
+
+	return Array.from(byId.values());
+};
+
 export const mutateThreadMessagesInfiniteData = (
 	client: QueryClient,
 	queryKey: readonly unknown[],
@@ -64,7 +84,7 @@ export const mutateThreadMessagesInfiniteData = (
 			return old;
 		}
 
-		const items = old.pages.flatMap((page) => page.items);
+		const items = dedupeThreadMessagesById(old.pages.flatMap((page) => page.items));
 		const originalPageLengths = old.pages.map((page) => page.items.length);
 		const oldTotal = old.pages.at(-1)?.itemCount ?? 0;
 		const oldIds = new Set(items.map((message) => message._id));

--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -66,7 +66,7 @@ const dedupeThreadMessagesById = (messages: IThreadMessage[]): IThreadMessage[] 
 
 		const messageTime = new Date(message._updatedAt ?? message.ts).getTime();
 		const existingTime = new Date(existing._updatedAt ?? existing.ts).getTime();
-		if (messageTime >= existingTime) {
+		if (messageTime > existingTime) {
 			byId.set(message._id, message);
 		}
 	}


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2513](https://rocketchat.atlassian.net/browse/CORE-2513)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2513]: https://rocketchat.atlassian.net/browse/CORE-2513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate thread messages appearing in cached conversations.
  - Ensured the most recently updated version of a message is retained.
  - Deleting a thread message now removes all duplicate occurrences.
  - Improved cache consistency during message updates and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->