### PR TITLE
feat: add rooms.history endpoint

### DIFF
--- a/.changeset/ddp-migrate-room-history-callers.md
+++ b/.changeset/ddp-migrate-room-history-callers.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Deprecates the `loadHistory` and `loadNextMessages` real-time API methods in favor of the new `GET /v1/rooms.history` endpoint. Both methods keep working until they are removed in 9.0.0.

--- a/.changeset/rest-rooms-history.md
+++ b/.changeset/rest-rooms-history.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Adds a new `GET /v1/rooms.history` endpoint to load a room's message history. Unlike the existing `channels.history`, `groups.history`, `im.history` and `dm.history` endpoints, it works with any room type through a single route, and can be used to read public channels anonymously when `Accounts_AllowAnonymousRead` is enabled.

--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -59,13 +59,7 @@ export type RoomHistoryState = {
 	};
 };
 
-/**
- * `rooms.history` cursors encode a message `ts`, so one can be reconstructed from any loaded message.
- *
- * This is a bridge for the window `loadSurroundingMessages` still rebuilds over DDP: a jump clears the
- * room and sets `hasMoreNext` without producing cursors, leaving paging with nothing to resume from.
- * Remove it once `loadSurroundingMessages` moves to `aroundId` and returns cursors of its own.
- */
+// Bridge until `loadSurroundingMessages` migrates: a jump rebuilds the window without cursors.
 const cursorFromMessageTs = (ts: Date): string => `${ts.getTime()}`;
 
 const roomStateEvent = (rid: IRoom['_id']) => `state:${rid}` as const;
@@ -163,8 +157,7 @@ class RoomHistoryManagerClass extends Emitter {
 
 			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
 
-			// `oldestTs` is the fallback for a window rebuilt by the still-DDP `loadSurroundingMessages`,
-			// which sets no cursor. A null cursor means exhausted, so it must not fall back.
+			// Not `??`: a null cursor means exhausted and must not fall back to a stale `oldestTs`.
 			const previous = room.cursorPrevious !== undefined ? room.cursorPrevious : room.oldestTs && cursorFromMessageTs(room.oldestTs);
 
 			const result = await sdk.rest.get('/v1/rooms.history', {
@@ -212,8 +205,7 @@ class RoomHistoryManagerClass extends Emitter {
 
 			room.loaded += visibleMessages.length;
 
-			// `count` bounds raw messages, so a page can be entirely system or thread messages and render
-			// as nothing. Without this the scroll stalls in rooms whose recent history is all system messages.
+			// `count` bounds raw messages, so a whole page can render as nothing and stall the scroll.
 			if (room.hasMore && visibleMessages.length === 0) {
 				return this.getMore(rid);
 			}
@@ -258,8 +250,7 @@ class RoomHistoryManagerClass extends Emitter {
 
 		const subscription = Subscriptions.state.find((record) => record.rid === rid);
 
-		// `lastMessage.ts` is the fallback for a window rebuilt by the still-DDP `loadSurroundingMessages`,
-		// which sets no cursor. A null cursor means exhausted, so it must not fall back.
+		// Not `??`: a null cursor means exhausted and must not fall back to the newest loaded message.
 		const next = room.cursorNext !== undefined ? room.cursorNext : lastMessage?.ts && cursorFromMessageTs(lastMessage.ts);
 
 		if (next) {

--- a/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/app/ui-utils/client/lib/RoomHistoryManager.ts
@@ -7,8 +7,10 @@ import { onClientMessageReceived } from '../../../../client/lib/onClientMessageR
 import { getUserId } from '../../../../client/lib/user';
 import { callWithErrorHandling } from '../../../../client/lib/utils/callWithErrorHandling';
 import { getConfig } from '../../../../client/lib/utils/getConfig';
+import { mapMessageFromApi } from '../../../../client/lib/utils/mapMessageFromApi';
 import { Messages, Subscriptions } from '../../../../client/stores';
 import { getUserPreference } from '../../../utils/client';
+import { sdk } from '../../../utils/client/lib/SDKClient';
 
 const processMessage = async (msg: IMessage & { ignored?: boolean }, { subscription }: { subscription?: ISubscription }) => {
 	const userId = msg.u?._id;
@@ -49,11 +51,22 @@ export type RoomHistoryState = {
 	firstUnread: IMessage | undefined;
 	loaded: number | undefined;
 	oldestTs?: Date;
+	cursorPrevious?: string | null;
+	cursorNext?: string | null;
 	scroll?: {
 		scrollHeight: number;
 		scrollTop: number;
 	};
 };
+
+/**
+ * `rooms.history` cursors encode a message `ts`, so one can be reconstructed from any loaded message.
+ *
+ * This is a bridge for the window `loadSurroundingMessages` still rebuilds over DDP: a jump clears the
+ * room and sets `hasMoreNext` without producing cursors, leaving paging with nothing to resume from.
+ * Remove it once `loadSurroundingMessages` moves to `aroundId` and returns cursors of its own.
+ */
+const cursorFromMessageTs = (ts: Date): string => `${ts.getTime()}`;
 
 const roomStateEvent = (rid: IRoom['_id']) => `state:${rid}` as const;
 
@@ -149,25 +162,27 @@ class RoomHistoryManagerClass extends Emitter {
 			}
 
 			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
-			const result = await callWithErrorHandling(
-				'loadHistory',
-				rid,
-				room.oldestTs,
-				limit,
-				ls ? String(ls) : undefined,
-				showThreadsInMainChannel,
-			);
 
-			if (!result) {
-				throw new Error('loadHistory returned nothing');
-			}
+			// `oldestTs` is the fallback for a window rebuilt by the still-DDP `loadSurroundingMessages`,
+			// which sets no cursor. A null cursor means exhausted, so it must not fall back.
+			const previous = room.cursorPrevious !== undefined ? room.cursorPrevious : room.oldestTs && cursorFromMessageTs(room.oldestTs);
+
+			const result = await sdk.rest.get('/v1/rooms.history', {
+				roomId: rid,
+				...(previous && { previous }),
+				...(ls && { lastSeen: new Date(ls).toISOString() }),
+				count: limit,
+				showThreadMessages: showThreadsInMainChannel,
+			});
 
 			this.unqueue();
 
-			const { messages = [] } = result;
+			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 			this.updateRoom(rid, {
-				unreadNotLoaded: result.unreadNotLoaded,
-				firstUnread: result.firstUnread,
+				unreadNotLoaded: result.unreadNotLoaded ?? 0,
+				firstUnread: result.firstUnread && mapMessageFromApi(result.firstUnread),
+				cursorPrevious: result.cursor.previous,
+				hasMore: result.cursor.previous !== null,
 			});
 
 			if (messages.length > 0) {
@@ -197,10 +212,8 @@ class RoomHistoryManagerClass extends Emitter {
 
 			room.loaded += visibleMessages.length;
 
-			if (messages.length < limit) {
-				this.updateRoom(rid, { hasMore: false });
-			}
-
+			// `count` bounds raw messages, so a page can be entirely system or thread messages and render
+			// as nothing. Without this the scroll stalls in rooms whose recent history is all system messages.
 			if (room.hasMore && visibleMessages.length === 0) {
 				return this.getMore(rid);
 			}
@@ -245,25 +258,39 @@ class RoomHistoryManagerClass extends Emitter {
 
 		const subscription = Subscriptions.state.find((record) => record.rid === rid);
 
-		if (lastMessage?.ts) {
-			const { ts } = lastMessage;
-			const result = await callWithErrorHandling('loadNextMessages', rid, ts, defaultLimit);
+		// `lastMessage.ts` is the fallback for a window rebuilt by the still-DDP `loadSurroundingMessages`,
+		// which sets no cursor. A null cursor means exhausted, so it must not fall back.
+		const next = room.cursorNext !== undefined ? room.cursorNext : lastMessage?.ts && cursorFromMessageTs(lastMessage.ts);
+
+		if (next) {
+			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
+
+			const result = await sdk.rest.get('/v1/rooms.history', {
+				roomId: rid,
+				next,
+				count: defaultLimit,
+				showThreadMessages: showThreadsInMainChannel,
+			});
+
+			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
+
 			await upsertMessageBulk({
-				msgs: Array.from(result.messages).filter((msg) => msg.t !== 'command'),
+				msgs: messages.filter((msg) => msg.t !== 'command'),
 				subscription,
 			});
 
 			this.emit('loaded-messages');
 
-			this.updateRoom(rid, { isLoading: false });
+			this.updateRoom(rid, {
+				isLoading: false,
+				cursorNext: result.cursor.next,
+				hasMoreNext: result.cursor.next !== null,
+			});
 			if (!room.loaded) {
 				room.loaded = 0;
 			}
 
-			room.loaded += result.messages.length;
-			if (result.messages.length < defaultLimit) {
-				this.updateRoom(rid, { hasMoreNext: false });
-			}
+			room.loaded += messages.length;
 		}
 		this.unqueue();
 	}
@@ -302,6 +329,8 @@ class RoomHistoryManagerClass extends Emitter {
 			isLoading: false,
 			hasMore: true,
 			hasMoreNext: false,
+			cursorPrevious: undefined,
+			cursorNext: undefined,
 		});
 	}
 

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -38,6 +38,7 @@ import {
 	isRoomsAutocompleteChannelAndPrivateWithPaginationProps,
 	isRoomsAutocompleteAvailableForTeamsProps,
 	isRoomsSaveRoomSettingsProps,
+	isRoomsHistoryProps,
 	validateBadRequestErrorResponse,
 	validateUnauthorizedErrorResponse,
 	validateForbiddenErrorResponse,
@@ -48,7 +49,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { adminFields } from '../../../lib/rooms/adminFields';
 import { omit } from '../../../lib/utils/omit';
-import { canAccessRoomAsync, canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { canAccessRoomAsync, canAccessRoomIdAsync, roomAccessAttributes } from '../../lib/authorization/canAccessRoom';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { stripABACManagedFieldsForAdmin } from '../../lib/authorization/isABACManagedRoom';
 import { banUserFromRoomMethod } from '../../lib/banUserFromRoom';
@@ -57,6 +58,7 @@ import * as dataExport from '../../lib/dataExport';
 import { eraseRoom } from '../../lib/eraseRoom';
 import { findUsersOfRoomOrderedByRole } from '../../lib/findUsersOfRoomOrderedByRole';
 import { FileUpload } from '../../lib/media/file-upload';
+import { loadRoomHistory, type RoomHistoryResult } from '../../lib/messages/loadRoomHistory';
 import { notifyOnSubscriptionChanged } from '../../lib/notifyListener';
 import { openRoom } from '../../lib/openRoom';
 import type { RoomRoles } from '../../lib/roles/getRoomRoles';
@@ -1423,6 +1425,27 @@ const roomsBannedUsersResponseSchema = ajv.compile<{
 	additionalProperties: false,
 });
 
+const roomsHistoryResponseSchema = ajv.compile<RoomHistoryResult>({
+	type: 'object',
+	properties: {
+		messages: { type: 'array', items: { $ref: '#/components/schemas/IMessage' } },
+		cursor: {
+			type: 'object',
+			properties: {
+				next: { type: 'string', nullable: true },
+				previous: { type: 'string', nullable: true },
+			},
+			required: ['next', 'previous'],
+			additionalProperties: false,
+		},
+		firstUnread: { $ref: '#/components/schemas/IMessage' },
+		unreadNotLoaded: { type: 'number' },
+		success: { type: 'boolean', enum: [true] },
+	},
+	required: ['messages', 'cursor', 'success'],
+	additionalProperties: false,
+});
+
 export const roomEndpoints = API.v1
 	.get(
 		'rooms.roles',
@@ -1727,6 +1750,56 @@ export const roomEndpoints = API.v1
 				offset,
 				total,
 			});
+		},
+	)
+	.get(
+		'rooms.history',
+		{
+			authOrAnonRequired: true,
+			query: isRoomsHistoryProps,
+			response: {
+				200: roomsHistoryResponseSchema,
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+				404: validateNotFoundErrorResponse,
+			},
+		},
+		async function action() {
+			const { roomId, next, previous, lastSeen, count = 20, showThreadMessages = true } = this.queryParams;
+
+			const room = await Rooms.findOneById(roomId, { projection: { ...roomAccessAttributes, t: 1, sysMes: 1 } });
+
+			if (!room) {
+				return API.v1.notFound();
+			}
+
+			// Also covers anonymous reads: the auth middleware already gated on Accounts_AllowAnonymousRead.
+			if (!(await canAccessRoomAsync(room, this.user))) {
+				return API.v1.forbidden();
+			}
+
+			if (
+				this.userId &&
+				room.t === 'c' &&
+				!(await hasPermissionAsync(this.userId, 'preview-c-room')) &&
+				!(await Subscriptions.findOneByRoomIdAndUserId(roomId, this.userId, { projection: { _id: 1 } }))
+			) {
+				return API.v1.forbidden();
+			}
+
+			const result = await loadRoomHistory({
+				userId: this.userId,
+				rid: roomId,
+				next,
+				previous,
+				lastSeen: lastSeen ? new Date(lastSeen) : undefined,
+				count,
+				showThreadMessages,
+				room,
+			});
+
+			return API.v1.success(result);
 		},
 	);
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1793,7 +1793,6 @@ export const roomEndpoints = API.v1
 
 			const result = await loadRoomHistory({
 				userId: this.userId,
-				rid: roomId,
 				next,
 				previous,
 				lastSeen: lastSeen ? new Date(lastSeen) : undefined,

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1766,7 +1766,10 @@ export const roomEndpoints = API.v1
 			},
 		},
 		async function action() {
-			const { roomId, next, previous, lastSeen, count = 20, showThreadMessages = true } = this.queryParams;
+			const { roomId, next, previous, lastSeen, showThreadMessages = true } = this.queryParams;
+			// Defaults to 20 (matching the replaced DDP method) instead of API_Default_Count, but still
+			// honors the API_Upper_Count_Limit cap.
+			const { count } = await getPaginationItems({ count: this.queryParams.count ?? 20 });
 
 			const room = await Rooms.findOneById(roomId, { projection: { ...roomAccessAttributes, t: 1, sysMes: 1 } });
 

--- a/apps/meteor/server/lib/messages/attachMessage.ts
+++ b/apps/meteor/server/lib/messages/attachMessage.ts
@@ -29,7 +29,7 @@ export const attachMessage = function (
 		author_name: getUserDisplayName(name, username, useRealName),
 		author_icon: getUserAvatarURL(username) as string,
 		message_link: `${roomCoordinator.getRouteLink(room.t, room)}?msg=${_id}`,
-		attachments,
+		...(attachments && { attachments }),
 		ts,
 	};
 };

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -26,10 +26,13 @@ export function encodeHistoryCursor(ts: Date): string {
 }
 
 export function decodeHistoryCursor(cursor: string): Date {
-	const timestamp = parseInt(cursor, 10);
-	const date = new Date(timestamp);
+	if (!/^\d+$/.test(cursor)) {
+		throw new Error('error-invalid-cursor');
+	}
 
-	if (Number.isNaN(timestamp) || date.toString() === 'Invalid Date') {
+	const date = new Date(parseInt(cursor, 10));
+
+	if (date.toString() === 'Invalid Date') {
 		throw new Error('error-invalid-cursor');
 	}
 

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -1,0 +1,168 @@
+import type { IMessage, IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
+import { Messages, Rooms } from '@rocket.chat/models';
+import type { FindOptions } from 'mongodb';
+
+import { settings } from '../../settings/cached';
+import { getHiddenSystemMessages } from '../messaging/getHiddenSystemMessages';
+import { normalizeMessagesForUser } from '../utils/lib/normalizeMessagesForUser';
+
+// Upper bound for forward paging. `findVisibleByRoomIdBetweenTimestampsNotContainingTypes` needs a
+// closed range, and messages can carry a `ts` slightly ahead of the server clock (client-supplied
+// timestamps, federation), so `new Date()` would silently drop them.
+const FAR_FUTURE = new Date(8640000000000000);
+
+export type RoomHistoryCursor = {
+	next: string | null;
+	previous: string | null;
+};
+
+export type RoomHistoryResult = {
+	messages: IMessage[];
+	cursor: RoomHistoryCursor;
+	firstUnread?: IMessage;
+	unreadNotLoaded?: number;
+};
+
+export function encodeHistoryCursor(ts: Date): string {
+	return `${ts.getTime()}`;
+}
+
+export function decodeHistoryCursor(cursor: string): Date {
+	const timestamp = parseInt(cursor, 10);
+	const date = new Date(timestamp);
+
+	if (Number.isNaN(timestamp) || date.toString() === 'Invalid Date') {
+		throw new Error('error-invalid-cursor');
+	}
+
+	return date;
+}
+
+/**
+ * Cursor-paginated room history, ordered newest-first regardless of paging direction.
+ *
+ * Cursors encode a message `ts`, mirroring the `next`/`previous` contract of `chat.syncMessages`
+ * (which encodes `_updatedAt` instead). `previous` walks backwards into older messages, `next`
+ * walks forwards into newer ones; passing neither returns the newest page.
+ *
+ * `lastSeen` is the client's subscription marker and is used *only* to position the unread divider.
+ * It is deliberately not a pagination bound — conflating the two silently truncates the page at the
+ * last-seen marker, which is the bug that makes the per-type `*.history` endpoints unusable here.
+ *
+ * @param userId - undefined when the caller is reading anonymously
+ */
+export async function loadRoomHistory({
+	userId,
+	rid,
+	next,
+	previous,
+	lastSeen,
+	count = 20,
+	showThreadMessages = true,
+	room: providedRoom,
+}: {
+	userId?: string;
+	rid: IRoom['_id'];
+	next?: string;
+	previous?: string;
+	lastSeen?: Date;
+	count?: number;
+	showThreadMessages?: boolean;
+	room?: IRoom;
+}): Promise<RoomHistoryResult> {
+	if (next && previous) {
+		throw new Error('error-cursor-conflict');
+	}
+
+	const room = providedRoom ?? (await Rooms.findOneById(rid, { projection: { sysMes: 1, t: 1 } }));
+
+	if (!room) {
+		throw new Error('error-invalid-room');
+	}
+
+	const hiddenMessageTypes = getHiddenSystemMessages(room, settings.get<MessageTypesValues[]>('Hide_System_Messages'));
+
+	// One extra document tells us whether a further page exists without a second round trip.
+	const options: FindOptions<IMessage> = { sort: { ts: next ? 1 : -1 }, limit: count + 1 };
+
+	const records = next
+		? await Messages.findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+				rid,
+				decodeHistoryCursor(next),
+				FAR_FUTURE,
+				hiddenMessageTypes,
+				options,
+				showThreadMessages,
+			).toArray()
+		: await Messages.findVisibleByRoomIdBeforeTimestampNotContainingTypes(
+				rid,
+				previous ? decodeHistoryCursor(previous) : FAR_FUTURE,
+				hiddenMessageTypes,
+				options,
+				showThreadMessages,
+			).toArray();
+
+	const hasMoreInPagingDirection = records.length > count;
+
+	if (hasMoreInPagingDirection) {
+		records.pop();
+	}
+
+	// Normalize to newest-first so callers get one ordering contract in both directions.
+	if (next) {
+		records.reverse();
+	}
+
+	const newest = records[0];
+	const oldest = records[records.length - 1];
+
+	// A null cursor means "no more in that direction", matching `chat.syncMessages`. In the direction
+	// we travelled the extra document answers it; in the direction we came from more messages exist by
+	// definition — except on the first page, which starts at the newest end and so has nothing newer.
+	const hasNewer = next ? hasMoreInPagingDirection : Boolean(previous);
+	const hasOlder = next ? true : hasMoreInPagingDirection;
+
+	const cursor: RoomHistoryCursor = {
+		next: newest && hasNewer ? encodeHistoryCursor(newest.ts) : null,
+		previous: oldest && hasOlder ? encodeHistoryCursor(oldest.ts) : null,
+	};
+
+	const [messages, unread] = await Promise.all([
+		normalizeMessagesForUser(records, userId),
+		computeUnread({ rid, lastSeen, oldest, hiddenMessageTypes, showThreadMessages }),
+	]);
+
+	return { messages, cursor, ...unread };
+}
+
+async function computeUnread({
+	rid,
+	lastSeen,
+	oldest,
+	hiddenMessageTypes,
+	showThreadMessages,
+}: {
+	rid: IRoom['_id'];
+	lastSeen?: Date;
+	oldest?: IMessage;
+	hiddenMessageTypes: MessageTypesValues[];
+	showThreadMessages: boolean;
+}): Promise<{ firstUnread?: IMessage; unreadNotLoaded?: number }> {
+	if (!lastSeen || Number.isNaN(lastSeen.getTime()) || !oldest || !(new Date(oldest.ts) > lastSeen)) {
+		return { firstUnread: undefined, unreadNotLoaded: 0 };
+	}
+
+	const [firstUnreadRecords, unreadNotLoaded] = await Promise.all([
+		Messages.findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+			rid,
+			lastSeen,
+			oldest.ts,
+			hiddenMessageTypes,
+			{ limit: 1, sort: { ts: 1 } },
+			showThreadMessages,
+		).toArray(),
+		Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(rid, lastSeen, oldest.ts, hiddenMessageTypes, showThreadMessages),
+	]);
+
+	return { firstUnread: firstUnreadRecords[0], unreadNotLoaded };
+}

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -118,7 +118,7 @@ export async function loadRoomHistory({
 
 	const [messages, unread] = await Promise.all([
 		normalizeMessagesForUser(records, userId),
-		computeUnread({ rid, lastSeen, oldest, hiddenMessageTypes, showThreadMessages }),
+		computeUnread({ rid, userId, lastSeen, oldest, hiddenMessageTypes, showThreadMessages }),
 	]);
 
 	return { messages, cursor, ...unread };
@@ -126,12 +126,14 @@ export async function loadRoomHistory({
 
 async function computeUnread({
 	rid,
+	userId,
 	lastSeen,
 	oldest,
 	hiddenMessageTypes,
 	showThreadMessages,
 }: {
 	rid: IRoom['_id'];
+	userId?: string;
 	lastSeen?: Date;
 	oldest?: IMessage;
 	hiddenMessageTypes: MessageTypesValues[];
@@ -153,5 +155,7 @@ async function computeUnread({
 		Messages.countVisibleByRoomIdBetweenTimestampsNotContainingTypes(rid, lastSeen, oldest.ts, hiddenMessageTypes, showThreadMessages),
 	]);
 
-	return { firstUnread: firstUnreadRecords[0], unreadNotLoaded };
+	const [firstUnread] = await normalizeMessagesForUser(firstUnreadRecords, userId);
+
+	return { firstUnread, unreadNotLoaded };
 }

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -93,6 +93,11 @@ export async function loadRoomHistory({
 				showThreadMessages,
 			).toArray();
 
+	// In-memory `_id` tie-break for equal `ts`: the `{ rid, ts, _updatedAt }` index cannot back a
+	// `{ ts, _id }` sort, and without it MongoDB's order among equal timestamps is unspecified.
+	const direction = next ? 1 : -1;
+	records.sort((a, b) => (a.ts.getTime() - b.ts.getTime() || (a._id < b._id ? -1 : 1)) * direction);
+
 	const hasMoreInPagingDirection = records.length > count;
 
 	if (hasMoreInPagingDirection) {

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -1,5 +1,5 @@
 import type { IMessage, IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
-import { Messages, Rooms } from '@rocket.chat/models';
+import { Messages } from '@rocket.chat/models';
 import type { FindOptions } from 'mongodb';
 
 import { settings } from '../../settings/cached';
@@ -44,32 +44,26 @@ export function decodeHistoryCursor(cursor: string): Date {
  */
 export async function loadRoomHistory({
 	userId,
-	rid,
 	next,
 	previous,
 	lastSeen,
 	count = 20,
 	showThreadMessages = true,
-	room: providedRoom,
+	room,
 }: {
 	userId?: string;
-	rid: IRoom['_id'];
 	next?: string;
 	previous?: string;
 	lastSeen?: Date;
 	count?: number;
 	showThreadMessages?: boolean;
-	room?: IRoom;
+	room: IRoom;
 }): Promise<RoomHistoryResult> {
 	if (next && previous) {
 		throw new Error('error-cursor-conflict');
 	}
 
-	const room = providedRoom ?? (await Rooms.findOneById(rid, { projection: { sysMes: 1, t: 1 } }));
-
-	if (!room) {
-		throw new Error('error-invalid-room');
-	}
+	const rid = room._id;
 
 	const hiddenMessageTypes = getHiddenSystemMessages(room, settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -6,9 +6,7 @@ import { settings } from '../../settings/cached';
 import { getHiddenSystemMessages } from '../messaging/getHiddenSystemMessages';
 import { normalizeMessagesForUser } from '../utils/lib/normalizeMessagesForUser';
 
-// Upper bound for forward paging. `findVisibleByRoomIdBetweenTimestampsNotContainingTypes` needs a
-// closed range, and messages can carry a `ts` slightly ahead of the server clock (client-supplied
-// timestamps, federation), so `new Date()` would silently drop them.
+// The range query needs a closed upper bound; `new Date()` would drop client-stamped future `ts`.
 const FAR_FUTURE = new Date(8640000000000000);
 
 export type RoomHistoryCursor = {
@@ -41,15 +39,8 @@ export function decodeHistoryCursor(cursor: string): Date {
 /**
  * Cursor-paginated room history, ordered newest-first regardless of paging direction.
  *
- * Cursors encode a message `ts`, mirroring the `next`/`previous` contract of `chat.syncMessages`
- * (which encodes `_updatedAt` instead). `previous` walks backwards into older messages, `next`
- * walks forwards into newer ones; passing neither returns the newest page.
- *
- * `lastSeen` is the client's subscription marker and is used *only* to position the unread divider.
- * It is deliberately not a pagination bound — conflating the two silently truncates the page at the
- * last-seen marker, which is the bug that makes the per-type `*.history` endpoints unusable here.
- *
- * @param userId - undefined when the caller is reading anonymously
+ * `lastSeen` positions the unread divider only. Using it as a pagination bound instead would truncate
+ * the page at the marker, which is why the per-type `*.history` endpoints cannot serve this.
  */
 export async function loadRoomHistory({
 	userId,
@@ -82,7 +73,7 @@ export async function loadRoomHistory({
 
 	const hiddenMessageTypes = getHiddenSystemMessages(room, settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 
-	// One extra document tells us whether a further page exists without a second round trip.
+	// One extra document reveals whether a further page exists.
 	const options: FindOptions<IMessage> = { sort: { ts: next ? 1 : -1 }, limit: count + 1 };
 
 	const records = next
@@ -108,7 +99,6 @@ export async function loadRoomHistory({
 		records.pop();
 	}
 
-	// Normalize to newest-first so callers get one ordering contract in both directions.
 	if (next) {
 		records.reverse();
 	}
@@ -116,9 +106,8 @@ export async function loadRoomHistory({
 	const newest = records[0];
 	const oldest = records[records.length - 1];
 
-	// A null cursor means "no more in that direction", matching `chat.syncMessages`. In the direction
-	// we travelled the extra document answers it; in the direction we came from more messages exist by
-	// definition — except on the first page, which starts at the newest end and so has nothing newer.
+	// Null means no more in that direction. The side we came from always has more — except the first
+	// page, which starts at the newest end.
 	const hasNewer = next ? hasMoreInPagingDirection : Boolean(previous);
 	const hasOlder = next ? true : hasMoreInPagingDirection;
 

--- a/apps/meteor/server/meteor-methods/messages/loadHistory.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadHistory.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomAsync, roomAccessAttributes } from '../../lib/authorization';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { loadMessageHistory } from '../../lib/messages/loadMessageHistory';
 import { settings } from '../../settings';
 
@@ -30,6 +31,7 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async loadHistory(rid, end, limit = 20, ls, showThreadMessages = true) {
+		methodDeprecationLogger.method('loadHistory', '9.0.0', '/v1/rooms.history');
 		check(rid, String);
 		const fromUser = await Meteor.userAsync();
 

--- a/apps/meteor/server/meteor-methods/messages/loadNextMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadNextMessages.ts
@@ -5,6 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
 
 declare module '@rocket.chat/ddp-client' {
@@ -16,6 +17,7 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async loadNextMessages(rid, end, limit = 20) {
+		methodDeprecationLogger.method('loadNextMessages', '9.0.0', '/v1/rooms.history');
 		check(rid, String);
 		check(limit, Number);
 

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5303,7 +5303,7 @@ describe('[Rooms]', () => {
 	});
 });
 
-describe.only('[/rooms.history]', () => {
+describe('[/rooms.history]', () => {
 	let testChannel: IRoom;
 	const messageIds: IMessage['_id'][] = [];
 	const messageCount = 12;
@@ -5313,7 +5313,6 @@ describe.only('[/rooms.history]', () => {
 	before(async () => {
 		testChannel = (await createRoom({ type: 'c', name: `rooms-history-${Date.now()}` })).body.channel;
 
-		// Sequential so `ts` ordering is deterministic; the endpoint pages strictly by `ts`.
 		for (let i = 0; i < messageCount; i++) {
 			const res = await sendMessage({ message: { rid: testChannel._id, msg: `message-${i}` } });
 			messageIds.push(res.body.message._id);
@@ -5335,7 +5334,6 @@ describe.only('[/rooms.history]', () => {
 		expect(res.body.cursor).to.have.property('next', null);
 		expect(res.body.cursor.previous).to.be.a('string');
 
-		// newest-first
 		expect(res.body.messages[0]._id).to.equal(messageIds[messageCount - 1]);
 		expect(res.body.messages[0].msg).to.equal(`message-${messageCount - 1}`);
 	});
@@ -5375,7 +5373,6 @@ describe.only('[/rooms.history]', () => {
 		const timestamps = forwards.body.messages.map((m: IMessage) => new Date(m.ts).getTime());
 		expect(timestamps).to.deep.equal([...timestamps].sort((a, b) => b - a));
 
-		// walking forward from the older page lands back on the newest page
 		expect(forwards.body.messages.map((m: IMessage) => m._id)).to.have.members(firstPage.body.messages.map((m: IMessage) => m._id));
 	});
 
@@ -5409,7 +5406,6 @@ describe.only('[/rooms.history]', () => {
 			.query({ roomId: testChannel._id, count: messageCount })
 			.expect(200);
 
-		// marker in the middle of the room's history
 		const marker = all.body.messages[Math.floor(messageCount / 2)];
 
 		const res = await request
@@ -5418,7 +5414,7 @@ describe.only('[/rooms.history]', () => {
 			.query({ roomId: testChannel._id, count: 5, lastSeen: new Date(marker.ts).toISOString() })
 			.expect(200);
 
-		// `lastSeen` positions the unread divider only — it must not bound the page like `oldest` does
+		// `lastSeen` must not bound the page the way `oldest` does
 		expect(res.body.messages).to.have.lengthOf(5);
 		expect(res.body).to.have.property('unreadNotLoaded');
 		expect(res.body.unreadNotLoaded).to.be.a('number');
@@ -5444,9 +5440,7 @@ describe.only('[/rooms.history]', () => {
 		await deleteRoom({ type: 'p', roomId: group._id });
 	});
 
-	// A discussion's first message carries a quote attachment persisted with `attachments: null`, a shape
-	// the generated IMessage schema rejects. Response validation runs under TEST_MODE only, so this turns
-	// a correct 200 into a 400 in CI and the room renders empty.
+	// Regression: a null `attachments` on the quote attachment used to fail response validation.
 	it('should return messages carrying a quote attachment', async () => {
 		const parent = await sendMessage({ message: { rid: testChannel._id, msg: 'parent of a discussion' } });
 

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5437,7 +5437,7 @@ describe('[/rooms.history]', () => {
 		expect(dmRes.body).to.have.property('success', true);
 		expect(dmRes.body.messages[0].msg).to.equal('dm message');
 
-		await deleteRoom({ type: 'p', roomId: group._id });
+		await Promise.all([deleteRoom({ type: 'p', roomId: group._id }), deleteRoom({ type: 'd', roomId: dm._id })]);
 	});
 
 	// Regression: a null `attachments` on the quote attachment used to fail response validation.

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5302,3 +5302,158 @@ describe('[Rooms]', () => {
 		});
 	});
 });
+
+describe('[/rooms.history]', () => {
+	let testChannel: IRoom;
+	const messageIds: IMessage['_id'][] = [];
+	const messageCount = 12;
+
+	before((done) => getCredentials(done));
+
+	before(async () => {
+		testChannel = (await createRoom({ type: 'c', name: `rooms-history-${Date.now()}` })).body.channel;
+
+		// Sequential so `ts` ordering is deterministic; the endpoint pages strictly by `ts`.
+		for (let i = 0; i < messageCount; i++) {
+			const res = await sendSimpleMessage({ roomId: testChannel._id, text: `message-${i}` });
+			messageIds.push(res.body.message._id);
+		}
+	});
+
+	after(() => deleteRoom({ type: 'c', roomId: testChannel._id }));
+
+	it('should return the newest page with no forward cursor', async () => {
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: 5 })
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body.messages).to.have.lengthOf(5);
+		expect(res.body.cursor).to.have.property('next', null);
+		expect(res.body.cursor.previous).to.be.a('string');
+
+		// newest-first
+		expect(res.body.messages[0].msg).to.equal(`message-${messageCount - 1}`);
+	});
+
+	it('should page backwards through `previous` without repeating messages', async () => {
+		const firstPage = await request.get(api('rooms.history')).set(credentials).query({ roomId: testChannel._id, count: 5 }).expect(200);
+
+		const secondPage = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: 5, previous: firstPage.body.cursor.previous })
+			.expect(200);
+
+		const firstIds = firstPage.body.messages.map((m: IMessage) => m._id);
+		const secondIds = secondPage.body.messages.map((m: IMessage) => m._id);
+
+		expect(secondIds).to.have.lengthOf(5);
+		expect(firstIds.filter((id: string) => secondIds.includes(id))).to.be.empty;
+		expect(secondPage.body.cursor.next).to.be.a('string');
+	});
+
+	it('should page forwards through `next` and still return newest-first', async () => {
+		const firstPage = await request.get(api('rooms.history')).set(credentials).query({ roomId: testChannel._id, count: 5 }).expect(200);
+
+		const older = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: 5, previous: firstPage.body.cursor.previous })
+			.expect(200);
+
+		const forwards = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: 5, next: older.body.cursor.next })
+			.expect(200);
+
+		const timestamps = forwards.body.messages.map((m: IMessage) => new Date(m.ts).getTime());
+		expect(timestamps).to.deep.equal([...timestamps].sort((a, b) => b - a));
+
+		// walking forward from the older page lands back on the newest page
+		expect(forwards.body.messages.map((m: IMessage) => m._id)).to.have.members(firstPage.body.messages.map((m: IMessage) => m._id));
+	});
+
+	it('should exhaust the room and close the backward cursor', async () => {
+		let cursor: string | null = null;
+		const seen = new Set<string>();
+
+		for (let page = 0; page < 10; page++) {
+			const res: Awaited<ReturnType<typeof request.get>> = await request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, count: 5, ...(cursor && { previous: cursor }) })
+				.expect(200);
+
+			res.body.messages.forEach((m: IMessage) => seen.add(m._id));
+			cursor = res.body.cursor.previous;
+
+			if (cursor === null) {
+				break;
+			}
+		}
+
+		expect(cursor).to.be.null;
+		messageIds.forEach((id) => expect(seen.has(id)).to.be.true);
+	});
+
+	it('should report unreads from `lastSeen` without truncating the page', async () => {
+		const all = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: messageCount })
+			.expect(200);
+
+		// marker in the middle of the room's history
+		const marker = all.body.messages[Math.floor(messageCount / 2)];
+
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, count: 5, lastSeen: new Date(marker.ts).toISOString() })
+			.expect(200);
+
+		// `lastSeen` positions the unread divider only — it must not bound the page like `oldest` does
+		expect(res.body.messages).to.have.lengthOf(5);
+		expect(res.body).to.have.property('unreadNotLoaded');
+		expect(res.body.unreadNotLoaded).to.be.a('number');
+	});
+
+	it('should serve private groups and DMs through the same endpoint', async () => {
+		const { group } = (await createRoom({ type: 'p', name: `rooms-history-group-${Date.now()}` })).body;
+		await sendSimpleMessage({ roomId: group._id, text: 'group message' });
+
+		const groupRes = await request.get(api('rooms.history')).set(credentials).query({ roomId: group._id }).expect(200);
+
+		expect(groupRes.body).to.have.property('success', true);
+		expect(groupRes.body.messages[0].msg).to.equal('group message');
+
+		const dm = (await createRoom({ type: 'd', username: 'rocket.cat' })).body.room;
+		await sendSimpleMessage({ roomId: dm._id, text: 'dm message' });
+
+		const dmRes = await request.get(api('rooms.history')).set(credentials).query({ roomId: dm._id }).expect(200);
+
+		expect(dmRes.body).to.have.property('success', true);
+		expect(dmRes.body.messages[0].msg).to.equal('dm message');
+
+		await deleteRoom({ type: 'p', roomId: group._id });
+	});
+
+	it('should fail when both cursors are provided', async () => {
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, next: '1', previous: '1' })
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+	});
+
+	it('should fail for a room that does not exist', async () => {
+		await request.get(api('rooms.history')).set(credentials).query({ roomId: 'does-not-exist' }).expect(404);
+	});
+});

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -20,7 +20,7 @@ import { after, afterEach, before, beforeEach, describe, it } from 'mocha';
 
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials } from '../../data/api-data';
-import { sendSimpleMessage, deleteMessage } from '../../data/chat.helper';
+import { sendSimpleMessage, sendMessage, deleteMessage } from '../../data/chat.helper';
 import { imgURL } from '../../data/interactions';
 import {
 	getSettingValueById,
@@ -5303,7 +5303,7 @@ describe('[Rooms]', () => {
 	});
 });
 
-describe('[/rooms.history]', () => {
+describe.only('[/rooms.history]', () => {
 	let testChannel: IRoom;
 	const messageIds: IMessage['_id'][] = [];
 	const messageCount = 12;
@@ -5315,7 +5315,7 @@ describe('[/rooms.history]', () => {
 
 		// Sequential so `ts` ordering is deterministic; the endpoint pages strictly by `ts`.
 		for (let i = 0; i < messageCount; i++) {
-			const res = await sendSimpleMessage({ roomId: testChannel._id, text: `message-${i}` });
+			const res = await sendMessage({ message: { rid: testChannel._id, msg: `message-${i}` } });
 			messageIds.push(res.body.message._id);
 		}
 	});
@@ -5336,6 +5336,7 @@ describe('[/rooms.history]', () => {
 		expect(res.body.cursor.previous).to.be.a('string');
 
 		// newest-first
+		expect(res.body.messages[0]._id).to.equal(messageIds[messageCount - 1]);
 		expect(res.body.messages[0].msg).to.equal(`message-${messageCount - 1}`);
 	});
 
@@ -5425,7 +5426,7 @@ describe('[/rooms.history]', () => {
 
 	it('should serve private groups and DMs through the same endpoint', async () => {
 		const { group } = (await createRoom({ type: 'p', name: `rooms-history-group-${Date.now()}` })).body;
-		await sendSimpleMessage({ roomId: group._id, text: 'group message' });
+		await sendMessage({ message: { rid: group._id, msg: 'group message' } });
 
 		const groupRes = await request.get(api('rooms.history')).set(credentials).query({ roomId: group._id }).expect(200);
 
@@ -5433,7 +5434,7 @@ describe('[/rooms.history]', () => {
 		expect(groupRes.body.messages[0].msg).to.equal('group message');
 
 		const dm = (await createRoom({ type: 'd', username: 'rocket.cat' })).body.room;
-		await sendSimpleMessage({ roomId: dm._id, text: 'dm message' });
+		await sendMessage({ message: { rid: dm._id, msg: 'dm message' } });
 
 		const dmRes = await request.get(api('rooms.history')).set(credentials).query({ roomId: dm._id }).expect(200);
 
@@ -5441,6 +5442,35 @@ describe('[/rooms.history]', () => {
 		expect(dmRes.body.messages[0].msg).to.equal('dm message');
 
 		await deleteRoom({ type: 'p', roomId: group._id });
+	});
+
+	// A discussion's first message carries a quote attachment persisted with `attachments: null`, a shape
+	// the generated IMessage schema rejects. Response validation runs under TEST_MODE only, so this turns
+	// a correct 200 into a 400 in CI and the room renders empty.
+	it('should return messages carrying a quote attachment', async () => {
+		const parent = await sendMessage({ message: { rid: testChannel._id, msg: 'parent of a discussion' } });
+
+		const discussion = await request
+			.post(api('rooms.createDiscussion'))
+			.set(credentials)
+			.send({
+				prid: testChannel._id,
+				pmid: parent.body.message._id,
+				t_name: `rooms-history-discussion-${Date.now()}`,
+			})
+			.expect(200);
+
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: discussion.body.discussion._id })
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body.messages[0].attachments).to.be.an('array');
+
+		await deleteRoom({ type: 'c', roomId: discussion.body.discussion._id });
 	});
 
 	it('should fail when both cursors are provided', async () => {

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -1059,3 +1059,47 @@ export type RoomsEndpoints = {
 		POST: (params: RoomsInviteProps) => void;
 	};
 };
+
+export type RoomsHistoryProps = {
+	roomId: IRoom['_id'];
+	next?: string;
+	previous?: string;
+	lastSeen?: string;
+	count?: number;
+	showThreadMessages?: boolean;
+};
+
+const RoomsHistorySchema = {
+	type: 'object',
+	properties: {
+		roomId: {
+			type: 'string',
+			minLength: 1,
+		},
+		next: {
+			type: 'string',
+			nullable: true,
+		},
+		previous: {
+			type: 'string',
+			nullable: true,
+		},
+		lastSeen: {
+			type: 'string',
+			format: 'iso-date-time',
+			nullable: true,
+		},
+		count: {
+			type: 'number',
+			nullable: true,
+		},
+		showThreadMessages: {
+			type: 'boolean',
+			nullable: true,
+		},
+	},
+	required: ['roomId'],
+	additionalProperties: false,
+};
+
+export const isRoomsHistoryProps = ajvQuery.compile<RoomsHistoryProps>(RoomsHistorySchema);

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -1090,7 +1090,8 @@ const RoomsHistorySchema = {
 			nullable: true,
 		},
 		count: {
-			type: 'number',
+			type: 'integer',
+			minimum: 1,
 			nullable: true,
 		},
 		showThreadMessages: {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[ARCH-2303]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[ARCH-2303]: https://rocketchat.atlassian.net/browse/ARCH-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `GET /v1/rooms.history` API for paginated room history across supported room types.
  * Added cursor-based navigation, unread-message metadata, filtering, and optional thread messages.
  * Added support for anonymous public-channel history where enabled.

* **Bug Fixes**
  * Improved history loading when pages contain no visible messages.
  * Message responses now omit empty attachment fields.

* **Deprecations**
  * Deprecated legacy real-time history methods; they remain available until version 9.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->