### PR TITLE
fix: check room access in e2e.fetchUsersWaitingForGroupKey

### DIFF
--- a/.changeset/e2e-fetch-users-room-access.md
+++ b/.changeset/e2e-fetch-users-room-access.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Adds the missing room access check to the `e2e.fetchUsersWaitingForGroupKey` endpoint, so it only returns results for the rooms the caller can access

--- a/apps/meteor/server/api/v1/e2e.ts
+++ b/apps/meteor/server/api/v1/e2e.ts
@@ -365,7 +365,11 @@ const e2eEndpoints = API.v1
 			}
 
 			const { roomIds = [] } = this.queryParams;
-			const usersWaitingForE2EKeys = (await Subscriptions.findUsersWithPublicE2EKeyByRids(roomIds, this.userId).toArray()).reduce<
+			const uniqueRoomIds = [...new Set(roomIds)];
+			const roomAccess = await Promise.all(uniqueRoomIds.map((rid) => canAccessRoomIdAsync(rid, this.userId)));
+			const accessibleRoomIds = uniqueRoomIds.filter((_rid, index) => roomAccess[index]);
+
+			const usersWaitingForE2EKeys = (await Subscriptions.findUsersWithPublicE2EKeyByRids(accessibleRoomIds, this.userId).toArray()).reduce<
 				Record<string, { _id: string; public_key: string }[]>
 			>((acc, { rid, users }) => ({ [rid]: users, ...acc }), {});
 

--- a/apps/meteor/tests/end-to-end/api/e2e.ts
+++ b/apps/meteor/tests/end-to-end/api/e2e.ts
@@ -1,0 +1,103 @@
+import type { Credentials } from '@rocket.chat/api-client';
+import type { IRoom, IUser } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { after, before, describe, it } from 'mocha';
+
+import { api, getCredentials, request } from '../../data/api-data';
+import { updateSetting } from '../../data/permissions.helper';
+import { createRoom, deleteRoom } from '../../data/rooms.helper';
+import { password } from '../../data/user';
+import type { TestUser } from '../../data/users.helper';
+import { createUser, deleteUser, login } from '../../data/users.helper';
+
+describe('[E2E]', () => {
+	before((done) => getCredentials(done));
+
+	describe('/e2e.fetchUsersWaitingForGroupKey', () => {
+		let roomOwner: TestUser<IUser>;
+		let roomOwnerCredentials: Credentials;
+		let roomMember: TestUser<IUser>;
+		let outsider: TestUser<IUser>;
+		let outsiderCredentials: Credentials;
+		let ownerRoom: IRoom;
+		let outsiderRoom: IRoom;
+
+		const setKeys = (userCredentials: Credentials, keyName: string) =>
+			request
+				.post(api('e2e.setUserPublicAndPrivateKeys'))
+				.set(userCredentials)
+				.send({ public_key: `public-${keyName}`, private_key: `private-${keyName}`, force: true })
+				.expect(200);
+
+		const fetchUsersWaitingForGroupKey = (userCredentials: Credentials, roomIds: string[]) =>
+			request.get(api('e2e.fetchUsersWaitingForGroupKey')).set(userCredentials).query({ roomIds }).expect(200);
+
+		before(async () => {
+			await updateSetting('E2E_Enable', true);
+
+			[roomOwner, roomMember, outsider] = await Promise.all([createUser(), createUser(), createUser()]);
+
+			[roomOwnerCredentials, outsiderCredentials] = await Promise.all([
+				login(roomOwner.username, password),
+				login(outsider.username, password),
+			]);
+
+			const roomMemberCredentials = await login(roomMember.username, password);
+
+			await Promise.all([
+				setKeys(roomOwnerCredentials, 'owner'),
+				setKeys(roomMemberCredentials, 'member'),
+				setKeys(outsiderCredentials, 'outsider'),
+			]);
+
+			ownerRoom = (
+				await createRoom({
+					type: 'p',
+					name: `e2e-owner-room-${Date.now()}`,
+					members: [roomMember.username],
+					credentials: roomOwnerCredentials,
+				})
+			).body.group;
+
+			outsiderRoom = (
+				await createRoom({
+					type: 'p',
+					name: `e2e-outsider-room-${Date.now()}`,
+					members: [roomMember.username],
+					credentials: outsiderCredentials,
+				})
+			).body.group;
+		});
+
+		after(async () => {
+			await Promise.all([deleteRoom({ type: 'p', roomId: ownerRoom._id }), deleteRoom({ type: 'p', roomId: outsiderRoom._id })]);
+
+			await Promise.all([deleteUser(roomOwner), deleteUser(roomMember), deleteUser(outsider)]);
+
+			await updateSetting('E2E_Enable', false);
+		});
+
+		it('should return the users waiting for a group key of a room the caller belongs to', async () => {
+			const res = await fetchUsersWaitingForGroupKey(roomOwnerCredentials, [ownerRoom._id]);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.usersWaitingForE2EKeys).to.have.property(ownerRoom._id);
+			expect(res.body.usersWaitingForE2EKeys[ownerRoom._id].map(({ _id }: { _id: string }) => _id)).to.include(roomMember._id);
+		});
+
+		it('should not return any user for a room the caller does not belong to', async () => {
+			const res = await fetchUsersWaitingForGroupKey(outsiderCredentials, [ownerRoom._id]);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.usersWaitingForE2EKeys).to.not.have.property(ownerRoom._id);
+		});
+
+		it('should only return the rooms the caller belongs to when asked for a mix of rooms', async () => {
+			const res = await fetchUsersWaitingForGroupKey(outsiderCredentials, [ownerRoom._id, outsiderRoom._id]);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.usersWaitingForE2EKeys).to.not.have.property(ownerRoom._id);
+			expect(res.body.usersWaitingForE2EKeys).to.have.property(outsiderRoom._id);
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/api/v1/e2e.spec.ts
+++ b/apps/meteor/tests/unit/server/api/v1/e2e.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+type UsersWaitingForE2EKeys = Record<string, { _id: string; public_key: string }[]>;
+
+const registeredRoutes: Record<string, (this: any) => Promise<any>> = {};
+
+const apiStub = {
+	v1: {
+		get(name: string, _options: unknown, action: (this: any) => Promise<any>) {
+			registeredRoutes[name] = action;
+			return apiStub.v1;
+		},
+		post(name: string, _options: unknown, action: (this: any) => Promise<any>) {
+			registeredRoutes[name] = action;
+			return apiStub.v1;
+		},
+		success: (payload?: Record<string, unknown>) => ({ statusCode: 200, body: { success: true, ...payload } }),
+		failure: (error?: unknown) => ({ statusCode: 400, body: { success: false, error } }),
+		forbidden: (error?: unknown) => ({ statusCode: 403, body: { success: false, error } }),
+	},
+};
+
+const validatorStub = { compile: () => () => true };
+
+const canAccessRoomIdAsync = sinon.stub();
+const findUsersWithPublicE2EKeyByRids = sinon.stub();
+const settingsGet = sinon.stub();
+
+proxyquire.noCallThru().load('../../../../../server/api/v1/e2e', {
+	'@rocket.chat/models': {
+		Subscriptions: { findUsersWithPublicE2EKeyByRids },
+		Users: { fetchKeysByUserId: sinon.stub() },
+	},
+	'@rocket.chat/rest-typings': {
+		ajv: validatorStub,
+		ajvQuery: validatorStub,
+		validateUnauthorizedErrorResponse: {},
+		validateBadRequestErrorResponse: {},
+		validateForbiddenErrorResponse: {},
+		ise2eSetUserPublicAndPrivateKeysParamsPOST: {},
+	},
+	'../../lib/authorization/canAccessRoom': { canAccessRoomIdAsync },
+	'../../lib/authorization/hasPermission': { hasPermissionAsync: sinon.stub() },
+	'../../lib/e2e/functions/handleSuggestedGroupKey': { handleSuggestedGroupKey: sinon.stub() },
+	'../../lib/e2e/functions/provideUsersSuggestedGroupKeys': { provideUsersSuggestedGroupKeys: sinon.stub() },
+	'../../lib/e2e/functions/resetRoomKey': { resetRoomKey: sinon.stub() },
+	'../../meteor-methods/platform/getUsersOfRoomWithoutKey': { getUsersOfRoomWithoutKeyMethod: sinon.stub() },
+	'../../meteor-methods/platform/requestSubscriptionKeys': { requestSubscriptionKeysMethod: sinon.stub() },
+	'../../meteor-methods/platform/setRoomKeyID': { setRoomKeyIDMethod: sinon.stub() },
+	'../../meteor-methods/platform/setUserPublicAndPrivateKeys': { setUserPublicAndPrivateKeysMethod: sinon.stub() },
+	'../../meteor-methods/platform/updateGroupKey': { updateGroupKey: sinon.stub() },
+	'../../settings': { settings: { get: settingsGet } },
+	'../api': { API: apiStub },
+});
+
+describe('e2e.fetchUsersWaitingForGroupKey', () => {
+	const callerId = 'caller-id';
+
+	// The caller is subscribed to `joined-room` only. `foreign-room` is a room the caller
+	// has no subscription to, and `unknown-room` does not exist at all.
+	const roomsCallerCanAccess = ['joined-room'];
+
+	const subscriptionsByRoom: Record<string, { _id: string; public_key: string }[]> = {
+		'joined-room': [{ _id: 'member-of-joined-room', public_key: 'joined-public-key' }],
+		'foreign-room': [{ _id: 'member-of-foreign-room', public_key: 'foreign-public-key' }],
+	};
+
+	const callEndpoint = async (roomIds: string[]): Promise<UsersWaitingForE2EKeys> => {
+		const result = await registeredRoutes['e2e.fetchUsersWaitingForGroupKey'].call({
+			userId: callerId,
+			queryParams: { roomIds },
+		});
+
+		return result.body.usersWaitingForE2EKeys;
+	};
+
+	beforeEach(() => {
+		canAccessRoomIdAsync.reset();
+		findUsersWithPublicE2EKeyByRids.reset();
+		settingsGet.reset();
+
+		settingsGet.withArgs('E2E_Enable').returns(true);
+
+		canAccessRoomIdAsync.callsFake(async (rid: string, uid: string) => uid === callerId && roomsCallerCanAccess.includes(rid));
+
+		findUsersWithPublicE2EKeyByRids.callsFake((rids: string[]) => ({
+			toArray: async () => rids.filter((rid) => subscriptionsByRoom[rid]).map((rid) => ({ rid, users: subscriptionsByRoom[rid] })),
+		}));
+	});
+
+	it('should not return any user for a room the caller cannot access', async () => {
+		expect(await callEndpoint(['foreign-room'])).to.deep.equal({});
+	});
+
+	it('should return users only for the rooms the caller can access', async () => {
+		expect(await callEndpoint(['joined-room', 'foreign-room', 'unknown-room'])).to.deep.equal({
+			'joined-room': subscriptionsByRoom['joined-room'],
+		});
+	});
+
+	it('should return users for every requested room the caller can access', async () => {
+		expect(await callEndpoint(['joined-room'])).to.deep.equal({
+			'joined-room': subscriptionsByRoom['joined-room'],
+		});
+	});
+
+	it('should return an empty result when E2E is disabled', async () => {
+		settingsGet.withArgs('E2E_Enable').returns(false);
+
+		expect(await callEndpoint(['joined-room'])).to.deep.equal({});
+	});
+});


### PR DESCRIPTION
## Proposed changes 

`e2e.fetchUsersWaitingForGroupKey` passed the caller's `roomIds` straight to `Subscriptions.findUsersWithPublicE2EKeyByRids`, which only matches on `rid`. Nothing in the call path checked membership, so any logged in user could ask about a room they were not in and get back its members and their E2E public keys. The single room sibling, `e2e.getUsersOfRoomWithoutKey`, has always called `canAccessRoomIdAsync` first, and this endpoint is the only caller of that aggregation, so the check was missing entirely.

I dedupe the incoming ids, run `canAccessRoomIdAsync` over them with `Promise.all`, and query only the ones that pass. `Promise.all` because the endpoint takes a list and clients can have many rooms, matching how `getMessages` does it. Ids the caller cannot access are dropped rather than rejected, so the endpoint does not become an existence oracle. `provideUsersSuggestedGroupKeys` already filters the same way.

Behaviour change: a client asking about a room it has since left gets fewer entries back. Rooms with nobody waiting for a key are already omitted, so clients handle missing entries.

## Issue(s)

None.

## Steps to test or reproduce

Create a private group with two members, then as a third user who is not in it, call:

```
GET /api/v1/e2e.fetchUsersWaitingForGroupKey?roomIds[]=<group id>
```

Before, the response listed the group's members and their public keys. Now `usersWaitingForE2EKeys` has no entry for that room. A member of the group gets the same response as before.

## Further comments

`e2e.updateGroupKey` is the only other endpoint in the file taking a room id without an explicit access check. It is gated by a subscription lookup and returns success either way, so it does not leak. I left it alone.

Added a unit test at `apps/meteor/tests/unit/server/api/v1/e2e.spec.ts` and an API test at `apps/meteor/tests/end-to-end/api/e2e.ts`, both covering an inaccessible room, a mix, and rooms the caller is in. Unit tests, lint and typecheck pass locally. I could not run the REST API suite here since it needs a running server, so the new end-to-end file runs for the first time in CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restricted end-to-end encryption key status results to rooms the requesting user can access.
  - Ignored duplicate, unknown, and unauthorized room requests.
  - Ensured no results are returned when end-to-end encryption is disabled.

- **Tests**
  - Added unit and end-to-end coverage for authorized, unauthorized, mixed, and unknown room requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->