### PR TITLE
regression: thread jump-to-reply pagination skips a page when Max Record Amount is set

### DIFF
--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
@@ -37,19 +37,21 @@ const newestPageIds = idsOf(allReplies.slice(TOTAL - PAGE_SIZE));
 
 type GetThreadMessagesParams = { tmid: string; offset?: number; count?: number; aroundId?: string; sort?: string };
 
-const setup = () => {
+const setup = ({ serverLimit = Infinity }: { serverLimit?: number } = {}) => {
 	const getThreadMessages = jest.fn(({ offset = 0, count = PAGE_SIZE, aroundId }: GetThreadMessagesParams) => {
+		const effectiveCount = Math.min(count, serverLimit);
+
 		if (aroundId) {
 			const index = allReplies.findIndex(({ _id }) => _id === aroundId);
-			const start = Math.max(0, index - Math.floor(count / 2));
+			const start = Math.max(0, index - Math.floor(effectiveCount / 2));
 
-			return { messages: allReplies.slice(start, start + count), count, offset: start, total: TOTAL };
+			return { messages: allReplies.slice(start, start + effectiveCount), count: effectiveCount, offset: start, total: TOTAL };
 		}
 
 		const end = TOTAL - offset;
-		const start = Math.max(0, end - count);
+		const start = Math.max(0, end - effectiveCount);
 
-		return { messages: allReplies.slice(start, end), count, offset, total: TOTAL };
+		return { messages: allReplies.slice(start, end), count: effectiveCount, offset, total: TOTAL };
 	});
 
 	const wrapper = mockAppRoot()
@@ -127,6 +129,57 @@ describe('useThreadMessagesQuery', () => {
 
 			await waitFor(() => expect(result.current.hasNextPage).toBe(false));
 			expect(idsOf(result.current.data?.messages ?? [])).toEqual(newestPageIds);
+		});
+	});
+
+	describe('when the server clamps the response size (e.g. "Max Record Amount")', () => {
+		const SERVER_LIMIT = 20;
+		const AROUND_INDEX = 60;
+
+		it('does not skip a batch of messages when loading the next page after jumping to an old reply', async () => {
+			const { result } = setup({ serverLimit: SERVER_LIMIT });
+
+			await waitForLoaded(result);
+
+			await act(async () => {
+				await result.current.loadMessageAround(`reply-${AROUND_INDEX}`);
+			});
+			await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+			const idsBeforeNextPage = idsOf(result.current.data?.messages ?? []);
+			const oldestLoadedIndex = allReplies.findIndex(({ _id }) => _id === idsBeforeNextPage[0]);
+			const newestLoadedIndex = allReplies.findIndex(({ _id }) => _id === idsBeforeNextPage[idsBeforeNextPage.length - 1]);
+
+			await act(async () => {
+				await result.current.fetchNextPage();
+			});
+			await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false));
+
+			// The newly-loaded batch must continue immediately after the previously loaded one, with no gap.
+			const idsAfterNextPage = idsOf(result.current.data?.messages ?? []);
+			expect(idsAfterNextPage).toEqual(idsOf(allReplies.slice(oldestLoadedIndex, newestLoadedIndex + 1 + SERVER_LIMIT)));
+		});
+
+		it('reaches the newest message without gaps after repeatedly loading next pages', async () => {
+			const { result } = setup({ serverLimit: SERVER_LIMIT });
+
+			await waitForLoaded(result);
+
+			await act(async () => {
+				await result.current.loadMessageAround(`reply-${AROUND_INDEX}`);
+			});
+			await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+			const oldestLoadedIndex = allReplies.findIndex(({ _id }) => _id === (result.current.data?.messages ?? [])[0]._id);
+
+			while (result.current.hasNextPage) {
+				await act(async () => {
+					await result.current.fetchNextPage();
+				});
+				await waitFor(() => expect(result.current.isFetchingNextPage).toBe(false));
+			}
+
+			expect(idsOf(result.current.data?.messages ?? [])).toEqual(idsOf(allReplies.slice(oldestLoadedIndex)));
 		});
 	});
 });

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -128,7 +128,8 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			const filtered = filterThreadMessages(messages, tmid);
 			const processed = (await processMessages(filtered)) as IThreadMessage[];
 
-			const pageParam = Math.max(0, total - offset - count);
+			const pageSize = Math.min(processed.length, count);
+			const pageParam = Math.max(0, total - offset - pageSize);
 
 			queryClient.setQueryData<ThreadMessagesInfiniteData>(currentQueryKey, {
 				pages: [{ items: processed, itemCount: total }],
@@ -178,8 +179,15 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			};
 		},
 		initialPageParam: 0,
-		getNextPageParam: (_lastPage, _allPages, lastPageParam) => {
-			return lastPageParam > 0 ? Math.max(0, lastPageParam - count) : undefined;
+		getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+			if (lastPageParam <= 0) {
+				return undefined;
+			}
+			const pageSize = Math.min(lastPage.items.length, count);
+			if (pageSize <= 0) {
+				return undefined;
+			}
+			return Math.max(0, lastPageParam - pageSize);
 		},
 		getPreviousPageParam: (firstPage, _allPages, firstPageParam) => {
 			const pageSize = Math.min(firstPage.items.length, count);


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->
[CORE-2514](https://rocketchat.atlassian.net/browse/CORE-2514)
<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


[CORE-2514]: https://rocketchat.atlassian.net/browse/CORE-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread message pagination when loading older replies.
  - Prevented gaps and duplicate offsets when the server returns fewer messages than requested.
  - Pagination now stops correctly when no additional messages are available.
  - Ensured users can continue loading messages through to the newest reply after jumping to older content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->