### PR TITLE
feat: add chat.getMessages endpoint

### DIFF
--- a/.changeset/ddp-migrate-get-messages-caller.md
+++ b/.changeset/ddp-migrate-get-messages-caller.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Deprecates the `getMessages` real-time API method in favor of the new `POST /v1/chat.getMessages` endpoint. The method keeps working until it is removed in 9.0.0.

--- a/.changeset/rest-chat-get-messages.md
+++ b/.changeset/rest-chat-get-messages.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Adds a new `POST /v1/chat.getMessages` endpoint to fetch several messages at once by id, including messages from different rooms. The request fails if any of the messages belongs to a room the caller cannot read.

--- a/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
@@ -3,7 +3,8 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
 import { withDebouncing } from '../../../../../lib/utils/highOrderFunctions';
-import { callWithErrorHandling } from '../../../../lib/utils/callWithErrorHandling';
+import { sdk } from '../../../../lib/SDKClient';
+import { mapMessageFromApi } from '../../../../lib/utils/mapMessageFromApi';
 import { Messages } from '../../../../stores';
 
 const findParentMessage = (() => {
@@ -14,9 +15,15 @@ const findParentMessage = (() => {
 	});
 
 	const getMessages = withDebouncing({ wait: 500 })(async () => {
-		const _tmp = [...waiting];
+		const messageIds = [...waiting];
 		waiting.length = 0;
-		resolve(callWithErrorHandling('getMessages', _tmp));
+
+		resolve(
+			messageIds.length
+				? sdk.rest.post('/v1/chat.getMessages', { messageIds }).then(({ messages }) => messages.map((msg) => mapMessageFromApi(msg)))
+				: [],
+		);
+
 		pending = new Promise<IMessage[]>((r) => {
 			resolve = r;
 		});

--- a/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
@@ -7,6 +7,8 @@ import { sdk } from '../../../../lib/SDKClient';
 import { mapMessageFromApi } from '../../../../lib/utils/mapMessageFromApi';
 import { Messages } from '../../../../stores';
 
+const MAX_IDS_PER_REQUEST = 100;
+
 const findParentMessage = (() => {
 	const waiting: string[] = [];
 	let resolve: (resolved: IMessage[] | PromiseLike<IMessage[]>) => void;
@@ -18,10 +20,17 @@ const findParentMessage = (() => {
 		const messageIds = [...waiting];
 		waiting.length = 0;
 
+		const batches: string[][] = [];
+		for (let i = 0; i < messageIds.length; i += MAX_IDS_PER_REQUEST) {
+			batches.push(messageIds.slice(i, i + MAX_IDS_PER_REQUEST));
+		}
+
 		resolve(
-			messageIds.length
-				? sdk.rest.post('/v1/chat.getMessages', { messageIds }).then(({ messages }) => messages.map((msg) => mapMessageFromApi(msg)))
-				: [],
+			Promise.all(
+				batches.map((ids) =>
+					sdk.rest.post('/v1/chat.getMessages', { messageIds: ids }).then(({ messages }) => messages.map((msg) => mapMessageFromApi(msg))),
+				),
+			).then((results) => results.flat()),
 		);
 
 		pending = new Promise<IMessage[]>((r) => {

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -11,6 +11,7 @@ import {
 	isChatDeleteProps,
 	isChatSyncMessagesProps,
 	isChatGetMessageProps,
+	isChatGetMessagesProps,
 	isChatPostMessageProps,
 	isChatSearchProps,
 	isChatSendMessageProps,
@@ -26,6 +27,7 @@ import {
 	isChatGetDiscussionsProps,
 	validateBadRequestErrorResponse,
 	validateUnauthorizedErrorResponse,
+	validateForbiddenErrorResponse,
 } from '@rocket.chat/rest-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';
@@ -1469,6 +1471,42 @@ const chatEndpoints = API.v1
 			urlPreview.ignoreParse = true;
 
 			return API.v1.success({ urlPreview });
+		},
+	)
+	.post(
+		'chat.getMessages',
+		{
+			authRequired: true,
+			body: isChatGetMessagesProps,
+			response: {
+				200: ajv.compile<{ messages: IMessage[] }>({
+					type: 'object',
+					properties: {
+						messages: { type: 'array', items: { $ref: '#/components/schemas/IMessage' } },
+						success: { type: 'boolean', enum: [true] },
+					},
+					required: ['messages', 'success'],
+					additionalProperties: false,
+				}),
+				400: validateBadRequestErrorResponse,
+				401: validateUnauthorizedErrorResponse,
+				403: validateForbiddenErrorResponse,
+			},
+		},
+		async function action() {
+			const { messageIds } = this.bodyParams;
+
+			const messages = await Messages.findVisibleByIds(messageIds).toArray();
+
+			const rids = [...new Set(messages.map(({ rid }) => rid))];
+			const allowed = await Promise.all(rids.map((rid) => canAccessRoomIdAsync(rid, this.userId)));
+
+			// The batch spans rooms, so one unreadable room rejects the whole request.
+			if (!allowed.every(Boolean)) {
+				return API.v1.forbidden();
+			}
+
+			return API.v1.success({ messages: await normalizeMessagesForUser(messages, this.userId) });
 		},
 	);
 

--- a/apps/meteor/server/meteor-methods/messages/getMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getMessages.ts
@@ -5,6 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -15,6 +16,7 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async getMessages(messages) {
+		methodDeprecationLogger.method('getMessages', '9.0.0', '/v1/chat.getMessages');
 		check(messages, [String]);
 		const uid = Meteor.userId();
 

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -8,7 +8,7 @@ import type { Response } from 'supertest';
 import { retry } from './helpers/retry';
 import { sleep } from '../../../lib/utils/sleep';
 import { getCredentials, api, request, credentials, apiUrl } from '../../data/api-data';
-import { followMessage, sendSimpleMessage, deleteMessage, updateMessage } from '../../data/chat.helper';
+import { followMessage, sendMessage, sendSimpleMessage, deleteMessage, updateMessage } from '../../data/chat.helper';
 import { imgURL } from '../../data/interactions';
 import { mockServerHealthy, mockServerReset, mockServerSet } from '../../data/mock-server.helper';
 import { updatePermission, updateSetting } from '../../data/permissions.helper';
@@ -5289,6 +5289,112 @@ describe('Threads', () => {
 						expect(res.body.errorType).to.be.equal('error-not-allowed');
 					});
 			});
+		});
+	});
+
+	describe('[/chat.getMessages]', () => {
+		let firstRoom: IRoom;
+		let secondRoom: IRoom;
+		let privateRoom: IRoom;
+		let firstMessageId: IMessage['_id'];
+		let secondMessageId: IMessage['_id'];
+		let privateMessageId: IMessage['_id'];
+		let outsider: TestUser<IUser>;
+		let outsiderCredentials: Credentials;
+
+		before(async () => {
+			firstRoom = (await createRoom({ type: 'c', name: `chat.getMessages-first-${Date.now()}` })).body.channel;
+			secondRoom = (await createRoom({ type: 'c', name: `chat.getMessages-second-${Date.now()}` })).body.channel;
+			privateRoom = (await createRoom({ type: 'p', name: `chat.getMessages-private-${Date.now()}` })).body.group;
+
+			const [first, second, priv] = await Promise.all([
+				sendMessage({ message: { rid: firstRoom._id, msg: 'first room message' } }),
+				sendMessage({ message: { rid: secondRoom._id, msg: 'second room message' } }),
+				sendMessage({ message: { rid: privateRoom._id, msg: 'private room message' } }),
+			]);
+
+			firstMessageId = first.body.message._id;
+			secondMessageId = second.body.message._id;
+			privateMessageId = priv.body.message._id;
+
+			outsider = await createUser();
+			outsiderCredentials = await login(outsider.username, password);
+		});
+
+		after(async () => {
+			await Promise.all([
+				deleteRoom({ type: 'c', roomId: firstRoom._id }),
+				deleteRoom({ type: 'c', roomId: secondRoom._id }),
+				deleteRoom({ type: 'p', roomId: privateRoom._id }),
+				deleteUser(outsider),
+			]);
+		});
+
+		it('should return the requested messages', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(credentials)
+				.send({ messageIds: [firstMessageId] })
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.have.lengthOf(1);
+			expect(res.body.messages[0]).to.have.property('_id', firstMessageId);
+			expect(res.body.messages[0]).to.have.property('msg', 'first room message');
+		});
+
+		it('should resolve a batch spanning several rooms in a single request', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(credentials)
+				.send({ messageIds: [firstMessageId, secondMessageId] })
+				.expect(200);
+
+			expect(res.body.messages.map((message: IMessage) => message._id)).to.have.members([firstMessageId, secondMessageId]);
+		});
+
+		it('should omit ids that do not resolve to a message', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(credentials)
+				.send({ messageIds: [firstMessageId, 'does-not-exist'] })
+				.expect(200);
+
+			expect(res.body.messages.map((message: IMessage) => message._id)).to.deep.equal([firstMessageId]);
+		});
+
+		it('should reject the whole batch when any message belongs to an unreadable room', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(outsiderCredentials)
+				.send({ messageIds: [firstMessageId, privateMessageId] })
+				.expect(403);
+
+			expect(res.body).to.have.property('success', false);
+		});
+
+		it('should resolve the readable subset for the same user when the unreadable id is dropped', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(outsiderCredentials)
+				.send({ messageIds: [firstMessageId] })
+				.expect(200);
+
+			expect(res.body.messages).to.have.lengthOf(1);
+		});
+
+		it('should fail when messageIds is empty', async () => {
+			const res = await request.post(api('chat.getMessages')).set(credentials).send({ messageIds: [] }).expect(400);
+
+			expect(res.body).to.have.property('success', false);
+		});
+
+		it('should fail when unauthenticated', async () => {
+			await request
+				.post(api('chat.getMessages'))
+				.send({ messageIds: [firstMessageId] })
+				.expect(401);
 		});
 	});
 });

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -99,6 +99,31 @@ const ChatGetMessageSchema = {
 
 export const isChatGetMessageProps = ajv.compile<ChatGetMessage>(ChatGetMessageSchema);
 
+type ChatGetMessages = {
+	messageIds: IMessage['_id'][];
+};
+
+const ChatGetMessagesSchema = {
+	type: 'object',
+	description: 'Fetch several messages at once, possibly spanning different rooms.',
+	properties: {
+		messageIds: {
+			type: 'array',
+			items: {
+				type: 'string',
+				minLength: 1,
+			},
+			minItems: 1,
+			maxItems: 100,
+			description: 'The message ids to fetch.',
+		},
+	},
+	required: ['messageIds'],
+	additionalProperties: false,
+};
+
+export const isChatGetMessagesProps = ajv.compile<ChatGetMessages>(ChatGetMessagesSchema);
+
 type ChatGetDiscussions = PaginatedRequest<{
 	roomId: IRoom['_id'];
 	text?: string;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
[ARCH-2303]

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[ARCH-2303]: https://rocketchat.atlassian.net/browse/ARCH-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API endpoint to retrieve multiple chat messages by ID, including messages across rooms.
  * Requests are validated and denied when they include messages from inaccessible rooms.

* **Deprecation**
  * Deprecated the existing real-time message retrieval method. It remains available until version 9.0.0; use the new REST endpoint instead.

* **Improvements**
  * Parent messages are now retrieved through the new API, with large requests processed in batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->