### PR TITLE
refactor(rest-typings): dedup route declarations against migrated endpoints

### DIFF
--- a/.changeset/chat-endpoints-dedup.md
+++ b/.changeset/chat-endpoints-dedup.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/rest-typings': patch
+'@rocket.chat/ddp-client': patch
+'@rocket.chat/meteor': patch
+---
+
+Deduplicates REST route type declarations: routes whose migrated implementations already declare their types via `ExtractRoutesFromAPI` (chat, dm/im, e2e, emoji-custom, invites, push, roles, rooms, teams, and one omnichannel route) no longer carry a second hand-written declaration in `@rocket.chat/rest-typings`. Routes still registered through the legacy `API.v1.addRoute`, and routes whose extracted types are weaker than the hand-written ones or that standalone packages consume, stay declared in rest-typings and are omitted from the meteor augmentation. The ddp-client legacy SDK now carries local response contracts for the chat routes it calls. No runtime behavior changes.

--- a/.changeset/chat-endpoints-dedup.md
+++ b/.changeset/chat-endpoints-dedup.md
@@ -1,7 +1,8 @@
 ---
 '@rocket.chat/rest-typings': patch
 '@rocket.chat/ddp-client': patch
+'@rocket.chat/fuselage-ui-kit': patch
 '@rocket.chat/meteor': patch
 ---
 
-Deduplicates REST route type declarations: routes whose migrated implementations already declare their types via `ExtractRoutesFromAPI` (chat, dm/im, e2e, emoji-custom, invites, push, roles, rooms, teams, and one omnichannel route) no longer carry a second hand-written declaration in `@rocket.chat/rest-typings`. Routes still registered through the legacy `API.v1.addRoute`, and routes whose extracted types are weaker than the hand-written ones or that standalone packages consume, stay declared in rest-typings and are omitted from the meteor augmentation. The ddp-client legacy SDK now carries local response contracts for the chat routes it calls. No runtime behavior changes.
+Deduplicates REST route type declarations: every route whose migrated implementation declares its types via `ExtractRoutesFromAPI` (chat, dm/im, e2e, emoji-custom, invites, push, roles, rooms, teams, and one omnichannel route) no longer carries a second hand-written declaration in `@rocket.chat/rest-typings` — the augmentation is authoritative. Standalone route registrations are captured into the extracted types, and previously weak extractions were strengthened at the source (typed response generics, query validators). Only routes still registered through the legacy `API.v1.addRoute` stay declared in rest-typings. Standalone packages that consume migrated routes without the meteor augmentation (ddp-client SDKs, fuselage-ui-kit) carry their own minimal local contracts mirroring the server responses. No runtime behavior changes, except that `GET /v1/rooms.info` and `GET /v1/emoji-custom.all` now validate their query params (permissively, matching what the handlers already accepted).

--- a/apps/meteor/client/hooks/roomActions/useE2EERoomAction.ts
+++ b/apps/meteor/client/hooks/roomActions/useE2EERoomAction.ts
@@ -71,10 +71,8 @@ export const useE2EERoomAction = () => {
 	});
 
 	const handleToogleE2E = async () => {
-		const { success } = await toggleE2E({ rid: room._id, encrypted: !room.encrypted });
-		if (!success) {
-			return;
-		}
+		// the endpoint client throws on a failed request, so reaching this point means success
+		await toggleE2E({ rid: room._id, encrypted: !room.encrypted });
 
 		imperativeModal.close();
 

--- a/apps/meteor/client/hooks/useRoomInfoEndpoint.ts
+++ b/apps/meteor/client/hooks/useRoomInfoEndpoint.ts
@@ -6,36 +6,18 @@ import { minutesToMilliseconds } from 'date-fns';
 
 import { roomsQueryKeys } from '../lib/queryKeys';
 
-type UseRoomInfoEndpointOptions<
-	TData = Serialized<{
-		room: IRoom | undefined;
-		parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-		team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
-	}>,
-> = Omit<
-	UseQueryOptions<
-		Serialized<{
-			room: IRoom | undefined;
-			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
-		}>,
-		{ success: boolean; error: string },
-		TData,
-		ReturnType<typeof roomsQueryKeys.info>
-	>,
+type RoomInfoResponse = Serialized<{
+	room: IRoom | null;
+	parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't'> & Partial<Pick<IRoom, 'prid' | 'u'>>;
+	team?: Pick<ITeam, 'name' | 'roomId' | 'type'>;
+}>;
+
+type UseRoomInfoEndpointOptions<TData = RoomInfoResponse> = Omit<
+	UseQueryOptions<RoomInfoResponse, { success: boolean; error: string }, TData, ReturnType<typeof roomsQueryKeys.info>>,
 	'queryKey' | 'queryFn'
 >;
 
-export const useRoomInfoEndpoint = <
-	TData = Serialized<{
-		room: IRoom | undefined;
-		parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-		team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
-	}>,
->(
-	rid: IRoom['_id'],
-	options?: UseRoomInfoEndpointOptions<TData>,
-) => {
+export const useRoomInfoEndpoint = <TData = RoomInfoResponse>(rid: IRoom['_id'], options?: UseRoomInfoEndpointOptions<TData>) => {
 	const getRoomInfo = useEndpoint('GET', '/v1/rooms.info');
 	const uid = useUserId();
 	return useQuery({

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -130,7 +130,7 @@ const CreateTeamModal = ({ onClose }: CreateTeamModalProps) => {
 		const params = {
 			name,
 			members,
-			type: isPrivate ? 1 : 0,
+			type: isPrivate ? (1 as const) : (0 as const),
 			room: {
 				readOnly,
 				extraData: {

--- a/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
+++ b/apps/meteor/client/navbar/NavBarPagesGroup/actions/CreateTeamModal.tsx
@@ -130,7 +130,7 @@ const CreateTeamModal = ({ onClose, onSuccess }: CreateTeamModalProps) => {
 		const params = {
 			name,
 			members,
-			type: isPrivate ? 1 : 0,
+			type: isPrivate ? (1 as const) : (0 as const),
 			room: {
 				readOnly,
 				extraData: {

--- a/apps/meteor/client/startup/roles.ts
+++ b/apps/meteor/client/startup/roles.ts
@@ -6,9 +6,11 @@ import { userIdStore } from '../lib/user';
 import { Roles } from '../stores';
 
 onLoggedIn(async () => {
+	// the endpoint projects _updatedAt away; stamp the sync time locally
 	const { roles } = await sdk.rest.get('/v1/roles.list');
 	// if a role is checked before this collection is populated, it will return undefined
-	Roles.state.replaceAll(roles.map((role) => ({ ...role, _updatedAt: new Date(role._updatedAt) })));
+	const _updatedAt = new Date();
+	Roles.state.replaceAll(roles.map((role) => ({ ...role, _updatedAt })));
 });
 
 type ClientAction = 'inserted' | 'updated' | 'removed' | 'changed';

--- a/apps/meteor/client/views/admin/users/AdminUserForm.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUserForm.tsx
@@ -50,7 +50,7 @@ export type AdminUserFormProps = {
 	onReload: () => void;
 	context: string;
 	refetchUserFormData?: () => void;
-	roleData: { roles: Serialized<IRole>[] } | undefined;
+	roleData: { roles: Serialized<Omit<IRole, '_updatedAt'>>[] } | undefined;
 	roleError: Error | null;
 };
 

--- a/apps/meteor/client/views/admin/users/AdminUserFormWithData.tsx
+++ b/apps/meteor/client/views/admin/users/AdminUserFormWithData.tsx
@@ -11,7 +11,7 @@ export type AdminUserFormWithDataProps = {
 	uid: IUser['_id'];
 	onReload: () => void;
 	context: string;
-	roleData: { roles: Serialized<IRole>[] } | undefined;
+	roleData: { roles: Serialized<Omit<IRole, '_updatedAt'>>[] } | undefined;
 	roleError: Error | null;
 };
 

--- a/apps/meteor/client/views/admin/users/UsersTable/UsersTable.tsx
+++ b/apps/meteor/client/views/admin/users/UsersTable/UsersTable.tsx
@@ -24,7 +24,7 @@ import { useShowVoipExtension } from '../useShowVoipExtension';
 
 export type UsersTableProps = {
 	tab: AdminUsersTab;
-	roleData: { roles: Serialized<IRole>[] } | undefined;
+	roleData: { roles: Serialized<Omit<IRole, '_updatedAt'>>[] } | undefined;
 	users: Serialized<DefaultUserInfo>[];
 	total: number;
 	isLoading: boolean;

--- a/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
+++ b/apps/meteor/client/views/admin/users/UsersTable/UsersTableFilters.tsx
@@ -11,7 +11,7 @@ import type { UsersFilters } from '../AdminUsersPage';
 
 export type UsersTableFiltersProps = {
 	setUsersFilters: Dispatch<SetStateAction<UsersFilters>>;
-	roleData: { roles: Serialized<IRole>[] } | undefined;
+	roleData: { roles: Serialized<Omit<IRole, '_updatedAt'>>[] } | undefined;
 };
 
 const UsersTableFilters = ({ roleData, setUsersFilters }: UsersTableFiltersProps) => {

--- a/apps/meteor/client/views/hooks/useMembersList.ts
+++ b/apps/meteor/client/views/hooks/useMembersList.ts
@@ -23,7 +23,8 @@ const endpointsByRoomType = {
 
 export type RoomMember = Serialized<
 	Pick<IUser, 'username' | '_id' | 'name' | 'status' | 'federated' | 'freeSwitchExtension'> & { roles?: IRole['_id'][] } & {
-		subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'>;
+		// im.members can return an empty subscription object when none is found
+		subscription: Partial<Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'>>;
 	}
 >;
 
@@ -138,16 +139,18 @@ export const useMembersList = (options: MembersListOptions) => {
 
 	return useInfiniteQuery({
 		queryKey: roomsQueryKeys.members(options.rid, options.roomType, options.type, options.debouncedText),
-		queryFn: async ({ pageParam }) => {
+		queryFn: async ({ pageParam }): Promise<MembersListPage> => {
 			const start = pageParam ?? 0;
 
-			return getMembers({
+			const { members, count, offset, total } = await getMembers({
 				roomId: options.rid,
 				offset: start,
 				count: options.limit,
 				...(options.debouncedText && { filter: options.debouncedText }),
 				...(options.type !== 'all' && { status: [options.type] }),
 			});
+
+			return { members, count, offset, total };
 		},
 		getNextPageParam: (lastPage) => {
 			const offset = lastPage.offset + lastPage.count;

--- a/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembersItem.tsx
+++ b/apps/meteor/client/views/room/contextualBar/RoomMembers/RoomMembersItem.tsx
@@ -96,7 +96,7 @@ const RoomMembersItem = ({
 			<OptionContent data-qa={`MemberItem-${username}`}>
 				{nameOrUsername} {displayUsername && <OptionDescription>@{displayUsername}</OptionDescription>}
 			</OptionContent>
-			{subscription?.status === 'INVITED' && (
+			{subscription?.status === 'INVITED' && subscription.ts && (
 				<OptionColumn>
 					<InvitationBadge marginBlockStart={2} size='x20' invitationDate={subscription.ts} />
 				</OptionColumn>

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -90,7 +90,9 @@ type ConvertToRoute<TRoute extends MinimalRoute> = {
 				) => ExtractValidation<Extract<TRoute, { path: K; method: K2 }>['response'][200]>
 			: K2 extends 'POST' | 'PUT'
 				? (
-						params: ExtractValidation<Extract<TRoute, { path: K; method: K2 }>['body']>,
+						...args: [ExtractValidation<Extract<TRoute, { path: K; method: K2 }>['body']>] extends [never]
+							? [params?: never]
+							: [params: ExtractValidation<Extract<TRoute, { path: K; method: K2 }>['body']>]
 					) => ExtractValidation<
 						200 extends keyof Extract<TRoute, { path: K; method: K2 }>['response']
 							? Extract<TRoute, { path: K; method: K2 }>['response'][200]

--- a/apps/meteor/server/api/v1/e2e.ts
+++ b/apps/meteor/server/api/v1/e2e.ts
@@ -528,8 +528,6 @@ const e2eEndpoints = API.v1
 type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<E2eEndpoints, '/v1/e2e.requestSubscriptionKeys'> {}
+	interface Endpoints extends E2eEndpoints {}
 }

--- a/apps/meteor/server/api/v1/e2e.ts
+++ b/apps/meteor/server/api/v1/e2e.ts
@@ -528,8 +528,8 @@ const e2eEndpoints = API.v1
 type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<E2eEndpoints, '/v1/e2e.requestSubscriptionKeys'> {}
 }

--- a/apps/meteor/server/api/v1/e2e.ts
+++ b/apps/meteor/server/api/v1/e2e.ts
@@ -529,5 +529,7 @@ type E2eEndpoints = ExtractRoutesFromAPI<typeof e2eEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends E2eEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<E2eEndpoints, '/v1/e2e.requestSubscriptionKeys'> {}
 }

--- a/apps/meteor/server/api/v1/emoji-custom.ts
+++ b/apps/meteor/server/api/v1/emoji-custom.ts
@@ -314,5 +314,7 @@ export type EmojiCustomEndpoints = EmojiCustomCreateEndpoints;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends EmojiCustomCreateEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<EmojiCustomCreateEndpoints, '/v1/emoji-custom.all'> {}
 }

--- a/apps/meteor/server/api/v1/emoji-custom.ts
+++ b/apps/meteor/server/api/v1/emoji-custom.ts
@@ -1,7 +1,14 @@
 import { Media } from '@rocket.chat/core-services';
 import type { IEmojiCustom, RocketChatRecordDeleted } from '@rocket.chat/core-typings';
 import { EmojiCustom } from '@rocket.chat/models';
-import { ajv, isEmojiCustomList, validateUnauthorizedErrorResponse, validateBadRequestErrorResponse } from '@rocket.chat/rest-typings';
+import type { PaginatedRequest } from '@rocket.chat/rest-typings';
+import {
+	ajv,
+	ajvQuery,
+	isEmojiCustomList,
+	validateUnauthorizedErrorResponse,
+	validateBadRequestErrorResponse,
+} from '@rocket.chat/rest-typings';
 import { escapeRegExp } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';
 import type { WithId } from 'mongodb';
@@ -135,6 +142,17 @@ const emojiCustomCreateEndpoints = API.v1
 		'emoji-custom.all',
 		{
 			authRequired: true,
+			// open schema (no additionalProperties: false): pagination/query helpers travel alongside `name`
+			query: ajvQuery.compile<PaginatedRequest<{ name?: string }, 'name'>>({
+				type: 'object',
+				properties: {
+					name: { type: 'string' },
+					count: { type: 'number' },
+					offset: { type: 'number' },
+					sort: { type: 'string' },
+					query: { type: 'string' },
+				},
+			}),
 			response: {
 				200: emojiCustomAllResponseSchema,
 				401: validateUnauthorizedErrorResponse,
@@ -313,8 +331,6 @@ type EmojiCustomCreateEndpoints = ExtractRoutesFromAPI<typeof emojiCustomCreateE
 export type EmojiCustomEndpoints = EmojiCustomCreateEndpoints;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<EmojiCustomCreateEndpoints, '/v1/emoji-custom.all'> {}
+	interface Endpoints extends EmojiCustomCreateEndpoints {}
 }

--- a/apps/meteor/server/api/v1/emoji-custom.ts
+++ b/apps/meteor/server/api/v1/emoji-custom.ts
@@ -313,8 +313,8 @@ type EmojiCustomCreateEndpoints = ExtractRoutesFromAPI<typeof emojiCustomCreateE
 export type EmojiCustomEndpoints = EmojiCustomCreateEndpoints;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<EmojiCustomCreateEndpoints, '/v1/emoji-custom.all'> {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1033,10 +1033,9 @@ const dmEndpoints = API.v1
 export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
-	// legacy SDK consumes it); every other route flows from this extraction.
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// legacy SDK consumes it); the other omitted routes keep their stronger
+	// hand-written declaration there until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1034,5 +1034,9 @@ export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends DmEndpoints {}
+	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
+	// legacy SDK consumes it); every other route flows from this extraction.
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1,8 +1,9 @@
 /**
  * Docs: https://github.com/RocketChat/developer-docs/blob/master/reference/api/rest-api/endpoints/team-collaboration-endpoints/im-endpoints
  */
-import type { IMessage, IRoom, ISubscription, IUser } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, ISubscription, IUploadWithUser, IUser } from '@rocket.chat/core-typings';
 import { Subscriptions, Uploads, Messages, Rooms, Users } from '@rocket.chat/models';
+import type { PaginatedResult } from '@rocket.chat/rest-typings';
 import {
 	ajv,
 	ajvQuery,
@@ -435,7 +436,7 @@ const dmCountersAction = <Path extends string>(_path: Path): TypedAction<typeof 
 		});
 	};
 
-const dmFilesResponseSchema = ajv.compile<{ files: object[]; count: number; offset: number; total: number }>({
+const dmFilesResponseSchema = ajv.compile<PaginatedResult<{ files: IUploadWithUser[] }>>({
 	type: 'object',
 	properties: {
 		files: { type: 'array', items: { type: 'object' } }, // relaxed: IUpload with addUserToFileObj transform
@@ -502,7 +503,13 @@ const dmFilesAction = <Path extends string>(_path: Path): TypedAction<typeof dmF
 		});
 	};
 
-const dmMembersResponseSchema = ajv.compile<{ members: object[]; count: number; offset: number; total: number }>({
+const dmMembersResponseSchema = ajv.compile<
+	PaginatedResult<{
+		members: (Pick<IUser, '_id' | 'status' | 'statusText' | 'name' | 'username' | 'utcOffset' | 'federated' | 'freeSwitchExtension'> & {
+			subscription: Partial<Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'>>;
+		})[];
+	}>
+>({
 	type: 'object',
 	properties: {
 		members: { type: 'array', items: { type: 'object' } }, // relaxed: projected IUser + subscription info
@@ -1033,9 +1040,6 @@ const dmEndpoints = API.v1
 export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
-	// legacy SDK consumes it); the other omitted routes keep their stronger
-	// hand-written declaration there until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
+	interface Endpoints extends DmEndpoints {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1036,5 +1036,9 @@ export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends DmEndpoints {}
+	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
+	// legacy SDK consumes it); every other route flows from this extraction.
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1,8 +1,9 @@
 /**
  * Docs: https://github.com/RocketChat/developer-docs/blob/master/reference/api/rest-api/endpoints/team-collaboration-endpoints/im-endpoints
  */
-import type { IMessage, IRoom, ISubscription, IUser, UserStatus } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, ISubscription, IUploadWithUser, IUser, UserStatus } from '@rocket.chat/core-typings';
 import { Subscriptions, Uploads, Messages, Rooms, Users } from '@rocket.chat/models';
+import type { PaginatedResult } from '@rocket.chat/rest-typings';
 import {
 	ajv,
 	ajvQuery,
@@ -436,7 +437,7 @@ const dmCountersAction = <Path extends string>(_path: Path): TypedAction<typeof 
 		});
 	};
 
-const dmFilesResponseSchema = ajv.compile<{ files: object[]; count: number; offset: number; total: number }>({
+const dmFilesResponseSchema = ajv.compile<PaginatedResult<{ files: IUploadWithUser[] }>>({
 	type: 'object',
 	properties: {
 		files: { type: 'array', items: { type: 'object' } }, // relaxed: IUpload with addUserToFileObj transform
@@ -503,7 +504,13 @@ const dmFilesAction = <Path extends string>(_path: Path): TypedAction<typeof dmF
 		});
 	};
 
-const dmMembersResponseSchema = ajv.compile<{ members: object[]; count: number; offset: number; total: number }>({
+const dmMembersResponseSchema = ajv.compile<
+	PaginatedResult<{
+		members: (Pick<IUser, '_id' | 'status' | 'statusText' | 'name' | 'username' | 'utcOffset' | 'federated' | 'freeSwitchExtension'> & {
+			subscription: Partial<Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'>>;
+		})[];
+	}>
+>({
 	type: 'object',
 	properties: {
 		members: { type: 'array', items: { type: 'object' } }, // relaxed: projected IUser + subscription info
@@ -1035,9 +1042,6 @@ const dmEndpoints = API.v1
 export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
-	// legacy SDK consumes it); the other omitted routes keep their stronger
-	// hand-written declaration there until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
+	interface Endpoints extends DmEndpoints {}
 }

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1035,10 +1035,9 @@ const dmEndpoints = API.v1
 export type DmEndpoints = ExtractRoutesFromAPI<typeof dmEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// im.create stays declared in @rocket.chat/rest-typings (the ddp-client
-	// legacy SDK consumes it); every other route flows from this extraction.
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// legacy SDK consumes it); the other omitted routes keep their stronger
+	// hand-written declaration there until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<DmEndpoints, '/v1/im.create' | '/v1/im.files' | '/v1/im.members' | '/v1/dm.files' | '/v1/dm.members'> {}
 }

--- a/apps/meteor/server/api/v1/invites.ts
+++ b/apps/meteor/server/api/v1/invites.ts
@@ -18,7 +18,7 @@ import { validateInviteToken } from '../../lib/rooms/invites/validateInviteToken
 import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
 
-const removeInviteResponseSchema = ajv.compile({
+const removeInviteResponseSchema = ajv.compile<boolean>({
 	type: 'boolean',
 	enum: [true],
 });
@@ -297,5 +297,7 @@ type InvitesEndpoints = ExtractRoutesFromAPI<typeof invites>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends InvitesEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<InvitesEndpoints, '/v1/findOrCreateInvite'> {}
 }

--- a/apps/meteor/server/api/v1/invites.ts
+++ b/apps/meteor/server/api/v1/invites.ts
@@ -296,8 +296,8 @@ const invites = API.v1
 type InvitesEndpoints = ExtractRoutesFromAPI<typeof invites>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<InvitesEndpoints, '/v1/findOrCreateInvite'> {}
 }

--- a/apps/meteor/server/api/v1/invites.ts
+++ b/apps/meteor/server/api/v1/invites.ts
@@ -111,7 +111,7 @@ const invites = API.v1
 			authRequired: true,
 			body: isFindOrCreateInviteParams,
 			response: {
-				200: ajv.compile({
+				200: ajv.compile<IInvite>({
 					additionalProperties: false,
 					type: 'object',
 					properties: {
@@ -296,8 +296,6 @@ const invites = API.v1
 type InvitesEndpoints = ExtractRoutesFromAPI<typeof invites>;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<InvitesEndpoints, '/v1/findOrCreateInvite'> {}
+	interface Endpoints extends InvitesEndpoints {}
 }

--- a/apps/meteor/server/api/v1/omnichannel/room.ts
+++ b/apps/meteor/server/api/v1/omnichannel/room.ts
@@ -395,10 +395,8 @@ const livechatVisitorDepartmentTransfer = API.v1.post(
 
 type LivechatAnalyticsEndpoints = ExtractRoutesFromAPI<typeof livechatVisitorDepartmentTransfer>;
 declare module '@rocket.chat/rest-typings' {
-	// livechat/visitor/department.transfer stays declared in
-	// @rocket.chat/rest-typings (the ddp-client livechat SDK consumes it).
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<LivechatAnalyticsEndpoints, '/v1/livechat/visitor/department.transfer'> {}
+	interface Endpoints extends LivechatAnalyticsEndpoints {}
 }
 
 API.v1.addRoute(

--- a/apps/meteor/server/api/v1/omnichannel/room.ts
+++ b/apps/meteor/server/api/v1/omnichannel/room.ts
@@ -395,9 +395,9 @@ const livechatVisitorDepartmentTransfer = API.v1.post(
 
 type LivechatAnalyticsEndpoints = ExtractRoutesFromAPI<typeof livechatVisitorDepartmentTransfer>;
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// livechat/visitor/department.transfer stays declared in
 	// @rocket.chat/rest-typings (the ddp-client livechat SDK consumes it).
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<LivechatAnalyticsEndpoints, '/v1/livechat/visitor/department.transfer'> {}
 }
 

--- a/apps/meteor/server/api/v1/omnichannel/room.ts
+++ b/apps/meteor/server/api/v1/omnichannel/room.ts
@@ -396,7 +396,9 @@ const livechatVisitorDepartmentTransfer = API.v1.post(
 type LivechatAnalyticsEndpoints = ExtractRoutesFromAPI<typeof livechatVisitorDepartmentTransfer>;
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends LivechatAnalyticsEndpoints {}
+	// livechat/visitor/department.transfer stays declared in
+	// @rocket.chat/rest-typings (the ddp-client livechat SDK consumes it).
+	interface Endpoints extends Omit<LivechatAnalyticsEndpoints, '/v1/livechat/visitor/department.transfer'> {}
 }
 
 API.v1.addRoute(

--- a/apps/meteor/server/api/v1/roles.ts
+++ b/apps/meteor/server/api/v1/roles.ts
@@ -365,8 +365,6 @@ const rolesRoutes = API.v1
 type RolesEndpoints = ExtractRoutesFromAPI<typeof rolesRoutes>;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<RolesEndpoints, '/v1/roles.list'> {}
+	interface Endpoints extends RolesEndpoints {}
 }

--- a/apps/meteor/server/api/v1/roles.ts
+++ b/apps/meteor/server/api/v1/roles.ts
@@ -365,8 +365,8 @@ const rolesRoutes = API.v1
 type RolesEndpoints = ExtractRoutesFromAPI<typeof rolesRoutes>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<RolesEndpoints, '/v1/roles.list'> {}
 }

--- a/apps/meteor/server/api/v1/roles.ts
+++ b/apps/meteor/server/api/v1/roles.ts
@@ -366,5 +366,7 @@ type RolesEndpoints = ExtractRoutesFromAPI<typeof rolesRoutes>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RolesEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<RolesEndpoints, '/v1/roles.list'> {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -3,6 +3,8 @@ import {
 	type IRoom,
 	type IRoomAbacRedaction,
 	type IMessage,
+	type ISubscription,
+	type ITeam,
 	type IUpload,
 	type RequiredField,
 	type RoomAdminFieldsType,
@@ -133,7 +135,7 @@ export async function findRoomByIdOrName({
 	return room;
 }
 
-API.v1.get(
+const roomsNameExistsEndpoint = API.v1.get(
 	'rooms.nameExists',
 	{
 		authRequired: true,
@@ -216,7 +218,7 @@ const roomDeleteEndpoint = API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsGetEndpoint = API.v1.get(
 	'rooms.get',
 	{
 		authRequired: true,
@@ -469,7 +471,7 @@ const roomsSaveDraftEndpoint = API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsCleanHistoryEndpoint = API.v1.post(
 	'rooms.cleanHistory',
 	{
 		authRequired: true,
@@ -516,12 +518,28 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+// Open schema (no additionalProperties: false): pagination/query helpers
+// (`fields`, `query`, ...) travel alongside the room identifier.
+const roomsInfoQuerySchema = ajvQuery.compile<{ roomId: string } | { roomName: string }>({
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		roomName: { type: 'string' },
+	},
+	anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+});
+
+const roomsInfoEndpoint = API.v1.get(
 	'rooms.info',
 	{
 		authRequired: true,
+		query: roomsInfoQuerySchema,
 		response: {
-			200: ajv.compile<{ room: IRoom | null }>({
+			200: ajv.compile<{
+				room: IRoom | null;
+				parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't'> & Partial<Pick<IRoom, 'prid' | 'u'>>;
+				team?: Pick<ITeam, 'name' | 'roomId' | 'type'>;
+			}>({
 				type: 'object',
 				properties: {
 					room: { type: ['object', 'null'] },
@@ -546,7 +564,7 @@ API.v1.get(
 
 		const discussionParent =
 			room.prid &&
-			(await Rooms.findOneById<Pick<IRoom, 'name' | 'fname' | 't' | 'prid' | 'u'>>(room.prid, {
+			(await Rooms.findOneById<Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>>(room.prid, {
 				projection: { name: 1, fname: 1, t: 1, prid: 1, u: 1 },
 			}));
 		const { team, parentRoom } = await Team.getRoomInfo(room);
@@ -560,7 +578,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsCreateDiscussionEndpoint = API.v1.post(
 	'rooms.createDiscussion',
 	{
 		authRequired: true,
@@ -598,7 +616,7 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsGetDiscussionsEndpoint = API.v1.get(
 	'rooms.getDiscussions',
 	{
 		authRequired: true,
@@ -648,7 +666,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsImagesEndpoint = API.v1.get(
 	'rooms.images',
 	{
 		authRequired: true,
@@ -711,7 +729,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAdminRoomsEndpoint = API.v1.get(
 	'rooms.adminRooms',
 	{
 		authRequired: true,
@@ -758,7 +776,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteAdminRoomsEndpoint = API.v1.get(
 	'rooms.autocomplete.adminRooms',
 	{
 		authRequired: true,
@@ -789,7 +807,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAdminRoomsGetRoomEndpoint = API.v1.get(
 	'rooms.adminRooms.getRoom',
 	{
 		authRequired: true,
@@ -826,7 +844,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteChannelAndPrivateEndpoint = API.v1.get(
 	'rooms.autocomplete.channelAndPrivate',
 	{
 		authRequired: true,
@@ -857,7 +875,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteChannelAndPrivateWithPaginationEndpoint = API.v1.get(
 	'rooms.autocomplete.channelAndPrivate.withPagination',
 	{
 		authRequired: true,
@@ -896,7 +914,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteAvailableForTeamsEndpoint = API.v1.get(
 	'rooms.autocomplete.availableForTeams',
 	{
 		authRequired: true,
@@ -927,7 +945,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsSaveRoomSettingsEndpoint = API.v1.post(
 	'rooms.saveRoomSettings',
 	{
 		authRequired: true,
@@ -962,7 +980,7 @@ const successResponseSchema = ajv.compile<void>({
 	additionalProperties: false,
 });
 
-API.v1.post(
+const roomsChangeArchivationStateEndpoint = API.v1.post(
 	'rooms.changeArchivationState',
 	{
 		authRequired: true,
@@ -986,7 +1004,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsExportEndpoint = API.v1.post(
 	'rooms.export',
 	{
 		authRequired: true,
@@ -1073,7 +1091,7 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsIsMemberEndpoint = API.v1.get(
 	'rooms.isMember',
 	{
 		authRequired: true,
@@ -1116,13 +1134,18 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsMembersOrderedByRoleEndpoint = API.v1.get(
 	'rooms.membersOrderedByRole',
 	{
 		authRequired: true,
 		query: isRoomsMembersOrderedByRoleProps,
 		response: {
-			200: ajv.compile<{ members: IUser[]; count: number; offset: number; total: number }>({
+			200: ajv.compile<{
+				members: (IUser & { subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'> })[];
+				count: number;
+				offset: number;
+				total: number;
+			}>({
 				type: 'object',
 				properties: {
 					members: { type: 'array', items: { type: 'object' } }, // relaxed: projected IUser with role priority
@@ -1186,7 +1209,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsMuteUserEndpoint = API.v1.post(
 	'rooms.muteUser',
 	{
 		authRequired: true,
@@ -1210,7 +1233,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsUnmuteUserEndpoint = API.v1.post(
 	'rooms.unmuteUser',
 	{
 		authRequired: true,
@@ -1234,7 +1257,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsOpenEndpoint = API.v1.post(
 	'rooms.open',
 	{
 		authRequired: true,
@@ -1254,7 +1277,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsJoinEndpoint = API.v1.post(
 	'rooms.join',
 	{
 		authRequired: true,
@@ -1285,7 +1308,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsHideEndpoint = API.v1.post(
 	'rooms.hide',
 	{
 		authRequired: true,
@@ -1732,12 +1755,32 @@ export const roomEndpoints = API.v1
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
 	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsNameExistsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsGetEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsCleanHistoryEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsInfoEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsCreateDiscussionEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsGetDiscussionsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsImagesEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAdminRoomsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteAdminRoomsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAdminRoomsGetRoomEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteChannelAndPrivateEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteChannelAndPrivateWithPaginationEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteAvailableForTeamsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsSaveRoomSettingsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsChangeArchivationStateEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsExportEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsIsMemberEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsMembersOrderedByRoleEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsMuteUserEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsUnmuteUserEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsOpenEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsJoinEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsHideEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
-	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
-	// @rocket.chat/rest-typings (standalone packages consume them); every other
-	// route flows from this extraction.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
+	interface Endpoints extends RoomEndpoints {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1735,9 +1735,9 @@ type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
 	// @rocket.chat/rest-typings (standalone packages consume them); every other
 	// route flows from this extraction.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1736,5 +1736,8 @@ type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RoomEndpoints {}
+	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
+	// @rocket.chat/rest-typings (standalone packages consume them); every other
+	// route flows from this extraction.
+	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1828,9 +1828,9 @@ type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
 	// @rocket.chat/rest-typings (standalone packages consume them); every other
 	// route flows from this extraction.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1829,5 +1829,8 @@ type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends RoomEndpoints {}
+	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
+	// @rocket.chat/rest-typings (standalone packages consume them); every other
+	// route flows from this extraction.
+	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
 }

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -3,6 +3,8 @@ import {
 	type IRoom,
 	type IRoomAbacRedaction,
 	type IMessage,
+	type ISubscription,
+	type ITeam,
 	type IUpload,
 	type RequiredField,
 	type RoomAdminFieldsType,
@@ -137,7 +139,7 @@ export async function findRoomByIdOrName({
 	return room;
 }
 
-API.v1.get(
+const roomsNameExistsEndpoint = API.v1.get(
 	'rooms.nameExists',
 	{
 		authRequired: true,
@@ -220,7 +222,7 @@ const roomDeleteEndpoint = API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsGetEndpoint = API.v1.get(
 	'rooms.get',
 	{
 		authRequired: true,
@@ -473,7 +475,7 @@ const roomsSaveDraftEndpoint = API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsCleanHistoryEndpoint = API.v1.post(
 	'rooms.cleanHistory',
 	{
 		authRequired: true,
@@ -520,12 +522,28 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+// Open schema (no additionalProperties: false): pagination/query helpers
+// (`fields`, `query`, ...) travel alongside the room identifier.
+const roomsInfoQuerySchema = ajvQuery.compile<{ roomId: string } | { roomName: string }>({
+	type: 'object',
+	properties: {
+		roomId: { type: 'string' },
+		roomName: { type: 'string' },
+	},
+	anyOf: [{ required: ['roomId'] }, { required: ['roomName'] }],
+});
+
+const roomsInfoEndpoint = API.v1.get(
 	'rooms.info',
 	{
 		authRequired: true,
+		query: roomsInfoQuerySchema,
 		response: {
-			200: ajv.compile<{ room: IRoom | null }>({
+			200: ajv.compile<{
+				room: IRoom | null;
+				parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't'> & Partial<Pick<IRoom, 'prid' | 'u'>>;
+				team?: Pick<ITeam, 'name' | 'roomId' | 'type'>;
+			}>({
 				type: 'object',
 				properties: {
 					room: { type: ['object', 'null'] },
@@ -550,7 +568,7 @@ API.v1.get(
 
 		const discussionParent =
 			room.prid &&
-			(await Rooms.findOneById<Pick<IRoom, 'name' | 'fname' | 't' | 'prid' | 'u'>>(room.prid, {
+			(await Rooms.findOneById<Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>>(room.prid, {
 				projection: { name: 1, fname: 1, t: 1, prid: 1, u: 1 },
 			}));
 		const { team, parentRoom } = await Team.getRoomInfo(room);
@@ -564,7 +582,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsCreateDiscussionEndpoint = API.v1.post(
 	'rooms.createDiscussion',
 	{
 		authRequired: true,
@@ -602,7 +620,7 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsGetDiscussionsEndpoint = API.v1.get(
 	'rooms.getDiscussions',
 	{
 		authRequired: true,
@@ -652,7 +670,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsImagesEndpoint = API.v1.get(
 	'rooms.images',
 	{
 		authRequired: true,
@@ -715,7 +733,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAdminRoomsEndpoint = API.v1.get(
 	'rooms.adminRooms',
 	{
 		authRequired: true,
@@ -762,7 +780,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteAdminRoomsEndpoint = API.v1.get(
 	'rooms.autocomplete.adminRooms',
 	{
 		authRequired: true,
@@ -793,7 +811,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAdminRoomsGetRoomEndpoint = API.v1.get(
 	'rooms.adminRooms.getRoom',
 	{
 		authRequired: true,
@@ -830,7 +848,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteChannelAndPrivateEndpoint = API.v1.get(
 	'rooms.autocomplete.channelAndPrivate',
 	{
 		authRequired: true,
@@ -861,7 +879,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteChannelAndPrivateWithPaginationEndpoint = API.v1.get(
 	'rooms.autocomplete.channelAndPrivate.withPagination',
 	{
 		authRequired: true,
@@ -900,7 +918,7 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsAutocompleteAvailableForTeamsEndpoint = API.v1.get(
 	'rooms.autocomplete.availableForTeams',
 	{
 		authRequired: true,
@@ -931,7 +949,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsSaveRoomSettingsEndpoint = API.v1.post(
 	'rooms.saveRoomSettings',
 	{
 		authRequired: true,
@@ -966,7 +984,7 @@ const successResponseSchema = ajv.compile<void>({
 	additionalProperties: false,
 });
 
-API.v1.post(
+const roomsChangeArchivationStateEndpoint = API.v1.post(
 	'rooms.changeArchivationState',
 	{
 		authRequired: true,
@@ -990,7 +1008,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsExportEndpoint = API.v1.post(
 	'rooms.export',
 	{
 		authRequired: true,
@@ -1077,7 +1095,7 @@ API.v1.post(
 	},
 );
 
-API.v1.get(
+const roomsIsMemberEndpoint = API.v1.get(
 	'rooms.isMember',
 	{
 		authRequired: true,
@@ -1120,13 +1138,18 @@ API.v1.get(
 	},
 );
 
-API.v1.get(
+const roomsMembersOrderedByRoleEndpoint = API.v1.get(
 	'rooms.membersOrderedByRole',
 	{
 		authRequired: true,
 		query: isRoomsMembersOrderedByRoleProps,
 		response: {
-			200: ajv.compile<{ members: IUser[]; count: number; offset: number; total: number }>({
+			200: ajv.compile<{
+				members: (IUser & { subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'> })[];
+				count: number;
+				offset: number;
+				total: number;
+			}>({
 				type: 'object',
 				properties: {
 					members: { type: 'array', items: { type: 'object' } }, // relaxed: projected IUser with role priority
@@ -1191,7 +1214,7 @@ API.v1.get(
 	},
 );
 
-API.v1.post(
+const roomsMuteUserEndpoint = API.v1.post(
 	'rooms.muteUser',
 	{
 		authRequired: true,
@@ -1215,7 +1238,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsUnmuteUserEndpoint = API.v1.post(
 	'rooms.unmuteUser',
 	{
 		authRequired: true,
@@ -1239,7 +1262,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsOpenEndpoint = API.v1.post(
 	'rooms.open',
 	{
 		authRequired: true,
@@ -1259,7 +1282,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsJoinEndpoint = API.v1.post(
 	'rooms.join',
 	{
 		authRequired: true,
@@ -1290,7 +1313,7 @@ API.v1.post(
 	},
 );
 
-API.v1.post(
+const roomsHideEndpoint = API.v1.post(
 	'rooms.hide',
 	{
 		authRequired: true,
@@ -1825,12 +1848,32 @@ export const roomEndpoints = API.v1
 type RoomEndpoints = ExtractRoutesFromAPI<typeof roomEndpoints> &
 	ExtractRoutesFromAPI<typeof roomDeleteEndpoint> &
 	ExtractRoutesFromAPI<typeof roomsSaveNotificationEndpoint> &
-	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint>;
+	ExtractRoutesFromAPI<typeof roomsSaveDraftEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsNameExistsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsGetEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsCleanHistoryEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsInfoEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsCreateDiscussionEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsGetDiscussionsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsImagesEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAdminRoomsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteAdminRoomsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAdminRoomsGetRoomEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteChannelAndPrivateEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteChannelAndPrivateWithPaginationEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsAutocompleteAvailableForTeamsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsSaveRoomSettingsEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsChangeArchivationStateEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsExportEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsIsMemberEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsMembersOrderedByRoleEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsMuteUserEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsUnmuteUserEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsOpenEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsJoinEndpoint> &
+	ExtractRoutesFromAPI<typeof roomsHideEndpoint>;
 
 declare module '@rocket.chat/rest-typings' {
-	// rooms.info and rooms.autocomplete.channelAndPrivate stay declared in
-	// @rocket.chat/rest-typings (standalone packages consume them); every other
-	// route flows from this extraction.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<RoomEndpoints, '/v1/rooms.info' | '/v1/rooms.autocomplete.channelAndPrivate'> {}
+	interface Endpoints extends RoomEndpoints {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -814,8 +814,6 @@ API.v1.post(
 export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
+	interface Endpoints extends TeamsEndpoints {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -815,5 +815,7 @@ export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends TeamsEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -814,8 +814,8 @@ API.v1.post(
 export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -822,5 +822,7 @@ export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends TeamsEndpoints {}
+	// Routes omitted here keep their stronger hand-written declaration in
+	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -821,8 +821,6 @@ API.v1.post(
 export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// Routes omitted here keep their stronger hand-written declaration in
-	// @rocket.chat/rest-typings until this extraction's emit matches it.
 	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
-	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
+	interface Endpoints extends TeamsEndpoints {}
 }

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -821,8 +821,8 @@ API.v1.post(
 export type TeamsEndpoints = ExtractRoutesFromAPI<typeof teamsEndpoints>;
 
 declare module '@rocket.chat/rest-typings' {
-	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	// Routes omitted here keep their stronger hand-written declaration in
 	// @rocket.chat/rest-typings until this extraction's emit matches it.
+	// eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-empty-interface
 	interface Endpoints extends Omit<TeamsEndpoints, '/v1/teams.create'> {}
 }

--- a/docs/typescript-7-migration.md
+++ b/docs/typescript-7-migration.md
@@ -85,17 +85,29 @@ Unpinning any of these is just a version bump once its tool supports TS7.
 
 ## Canary status
 
-At the time of this migration the canary (`scripts/ts7-typecheck.sh`) is
-green for 72 of 73 workspace tsconfigs. The one red package is
-`apps/meteor`, with a single root cause repeated ~140 times: TS7 rejects the
-`Endpoints` interface simultaneously extending the legacy `ChatEndpoints`
-from `@rocket.chat/rest-typings` and the `ExtractRoutesFromAPI` augmentation
-that the migrated chat endpoints declare (error TS2320) — the two
-declarations of the `/v1/chat.*` routes are no longer considered identical.
-Resolving it means finishing the chat portion of the
-[API endpoint migration](api-endpoint-migration.md) so each route is
-declared exactly once. TS5.9 tolerated the duplicate; nothing behaves
-differently at runtime.
+The canary (`scripts/ts7-typecheck.sh`) is green for all 73 workspace
+tsconfigs. TS7 rejects the `Endpoints` interface simultaneously extending a
+legacy hand-written family type from `@rocket.chat/rest-typings` and the
+`ExtractRoutesFromAPI` augmentation the migrated implementation declares
+(error TS2320) when the two declarations differ; TS5.9 tolerated it. The
+dedup resolved this by making each route's stronger declaration the only
+one:
+
+- Routes whose extracted types are complete now live only in the
+  augmentation — their hand-written declarations were deleted from
+  rest-typings (chat, dm/im, e2e, emoji-custom, invites, push, roles,
+  rooms, teams families).
+- Routes still registered via the legacy `API.v1.addRoute` (e.g. most
+  `/v1/rooms.*`, `/v1/chat.getMessageReadReceipts`, `/v1/im.kick`) keep
+  their rest-typings declarations until they are migrated.
+- Routes whose extracted emit is weaker than the hand-written type
+  (`params: never`/`undefined`, `object`-typed `$ref` responses), or that
+  standalone packages consume without seeing the meteor augmentation, stay
+  canonical in rest-typings and are `Omit`ted from the corresponding
+  augmentation, each with a comment naming the reason. Deleting such a
+  route from rest-typings (after strengthening its extraction or migrating
+  its consumers) automatically promotes the extracted type — the Omit list
+  is the remaining ratchet.
 
 ## Follow-ups
 
@@ -103,5 +115,8 @@ differently at runtime.
   TS6-bridge) support and drop the pins.
 - Move the typia toolchain to a released `typescript@7` binary instead of
   `@typescript/native-preview` once ttsc resolves it directly.
-- Burn down the remaining red packages in the TS7 canary until it can become
-  a blocking check.
+- The canary is fully green — consider making it a blocking check.
+- Burn down the Omit ratchet: strengthen the weak extractions (typed response
+  schemas, query validators) and migrate the remaining legacy addRoute
+  routes, deleting each rest-typings declaration as its extraction becomes
+  authoritative.

--- a/docs/typescript-7-migration.md
+++ b/docs/typescript-7-migration.md
@@ -116,24 +116,31 @@ tsconfigs. TS7 rejects the `Endpoints` interface simultaneously extending a
 legacy hand-written family type from `@rocket.chat/rest-typings` and the
 `ExtractRoutesFromAPI` augmentation the migrated implementation declares
 (error TS2320) when the two declarations differ; TS5.9 tolerated it. The
-dedup resolved this by making each route's stronger declaration the only
-one:
+dedup resolved this by making the augmentation authoritative wherever one
+exists:
 
-- Routes whose extracted types are complete now live only in the
-  augmentation — their hand-written declarations were deleted from
+- Every migrated route is typed only by its `ExtractRoutesFromAPI`
+  augmentation — the hand-written declarations were deleted from
   rest-typings (chat, dm/im, e2e, emoji-custom, invites, push, roles,
-  rooms, teams families).
-- Routes still registered via the legacy `API.v1.addRoute` (e.g. most
-  `/v1/rooms.*`, `/v1/chat.getMessageReadReceipts`, `/v1/im.kick`) keep
-  their rest-typings declarations until they are migrated.
-- Routes whose extracted emit is weaker than the hand-written type
-  (`params: never`/`undefined`, `object`-typed `$ref` responses), or that
-  standalone packages consume without seeing the meteor augmentation, stay
-  canonical in rest-typings and are `Omit`ted from the corresponding
-  augmentation, each with a comment naming the reason. Deleting such a
-  route from rest-typings (after strengthening its extraction or migrating
-  its consumers) automatically promotes the extracted type — the Omit list
-  is the remaining ratchet.
+  rooms, teams families and the omnichannel department-transfer route).
+  Standalone registrations (`API.v1.get(...)` calls outside a builder
+  chain, e.g. most `/v1/rooms.*`) are captured into named consts and
+  intersected into the family's extracted type. Where the extracted emit
+  was weaker than the old hand-written claim, the route's own schemas were
+  strengthened (typed `ajv.compile` generics, query validators); where the
+  old claim was a lie (e.g. `roles.list` never returns `_updatedAt` — the
+  projection strips it), the consumers were fixed to the truthful type.
+- Only routes still registered via the legacy `API.v1.addRoute`
+  (`/v1/rooms.media/:rid`, `/v1/rooms.mediaConfirm/:rid/:fileId`,
+  `/v1/chat.getMessageReadReceipts`, `/v1/im.kick`, ...) keep their
+  rest-typings declarations, until they are migrated.
+- Standalone packages that consume migrated routes without seeing the
+  meteor augmentation carry their own minimal local contracts mirroring
+  the server responses: `ddp-client` (legacy SDK `types/legacyChatRoutes.ts`
+  for the chat routes, `rooms.info` and `im.create`; livechat SDK
+  `types/livechatRoutes.ts` for `department.transfer`) and
+  `fuselage-ui-kit` (locally-typed `useEndpoint` wrappers for `rooms.info`
+  and `rooms.autocomplete.channelAndPrivate`).
 
 ## Follow-ups
 
@@ -142,7 +149,7 @@ one:
 - Move the typia toolchain to a released `typescript@7` binary instead of
   `@typescript/native-preview` once ttsc resolves it directly.
 - The canary is fully green — consider making it a blocking check.
-- Burn down the Omit ratchet: strengthen the weak extractions (typed response
-  schemas, query validators) and migrate the remaining legacy addRoute
-  routes, deleting each rest-typings declaration as its extraction becomes
-  authoritative.
+- Migrate the remaining legacy `API.v1.addRoute` routes, deleting each
+  rest-typings declaration as its extraction becomes authoritative, and
+  fold the standalone packages' local contracts back into a shared source
+  once the extracted route types are publishable outside the meteor app.

--- a/docs/typescript-7-migration.md
+++ b/docs/typescript-7-migration.md
@@ -111,17 +111,29 @@ Unpinning any of these is just a version bump once its tool supports TS7.
 
 ## Canary status
 
-At the time of this migration the canary (`scripts/ts7-typecheck.sh`) is
-green for 72 of 73 workspace tsconfigs. The one red package is
-`apps/meteor`, with a single root cause repeated ~140 times: TS7 rejects the
-`Endpoints` interface simultaneously extending the legacy `ChatEndpoints`
-from `@rocket.chat/rest-typings` and the `ExtractRoutesFromAPI` augmentation
-that the migrated chat endpoints declare (error TS2320) — the two
-declarations of the `/v1/chat.*` routes are no longer considered identical.
-Resolving it means finishing the chat portion of the
-[API endpoint migration](api-endpoint-migration.md) so each route is
-declared exactly once. TS5.9 tolerated the duplicate; nothing behaves
-differently at runtime.
+The canary (`scripts/ts7-typecheck.sh`) is green for all 73 workspace
+tsconfigs. TS7 rejects the `Endpoints` interface simultaneously extending a
+legacy hand-written family type from `@rocket.chat/rest-typings` and the
+`ExtractRoutesFromAPI` augmentation the migrated implementation declares
+(error TS2320) when the two declarations differ; TS5.9 tolerated it. The
+dedup resolved this by making each route's stronger declaration the only
+one:
+
+- Routes whose extracted types are complete now live only in the
+  augmentation — their hand-written declarations were deleted from
+  rest-typings (chat, dm/im, e2e, emoji-custom, invites, push, roles,
+  rooms, teams families).
+- Routes still registered via the legacy `API.v1.addRoute` (e.g. most
+  `/v1/rooms.*`, `/v1/chat.getMessageReadReceipts`, `/v1/im.kick`) keep
+  their rest-typings declarations until they are migrated.
+- Routes whose extracted emit is weaker than the hand-written type
+  (`params: never`/`undefined`, `object`-typed `$ref` responses), or that
+  standalone packages consume without seeing the meteor augmentation, stay
+  canonical in rest-typings and are `Omit`ted from the corresponding
+  augmentation, each with a comment naming the reason. Deleting such a
+  route from rest-typings (after strengthening its extraction or migrating
+  its consumers) automatically promotes the extracted type — the Omit list
+  is the remaining ratchet.
 
 ## Follow-ups
 
@@ -129,5 +141,8 @@ differently at runtime.
   TS6-bridge) support and drop the pins.
 - Move the typia toolchain to a released `typescript@7` binary instead of
   `@typescript/native-preview` once ttsc resolves it directly.
-- Burn down the remaining red packages in the TS7 canary until it can become
-  a blocking check.
+- The canary is fully green — consider making it a blocking check.
+- Burn down the Omit ratchet: strengthen the weak extractions (typed response
+  schemas, query validators) and migrate the remaining legacy addRoute
+  routes, deleting each rest-typings declaration as its extraction becomes
+  authoritative.

--- a/packages/ddp-client/__tests__/ClientStream.spec.ts
+++ b/packages/ddp-client/__tests__/ClientStream.spec.ts
@@ -207,7 +207,7 @@ describe('subscribe procedures', () => {
 			}),
 		);
 
-		expect(unsubPromise).resolves.toEqual({
+		await expect(unsubPromise).resolves.toEqual({
 			msg: 'nosub',
 			id: subscription.id,
 		});

--- a/packages/ddp-client/src/legacy/RocketchatSDKLegacy.ts
+++ b/packages/ddp-client/src/legacy/RocketchatSDKLegacy.ts
@@ -22,7 +22,13 @@ import type {
 	RocketchatSdkLegacyEventsKeys,
 	RocketchatSdkLegacyEventsValues,
 } from './types/SDKLegacy';
-import type { ChatSendMessageResponse, ChatSyncMessagesResponse, ChatUpdateResponse } from './types/legacyChatRoutes';
+import type {
+	ChatSendMessageResponse,
+	ChatSyncMessagesResponse,
+	ChatUpdateResponse,
+	DmCreateResponse,
+	RoomsInfoResponse,
+} from './types/legacyChatRoutes';
 
 declare module '../ClientStream' {
 	interface ClientStream {
@@ -112,8 +118,8 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 					| {
 							roomName: string;
 					  },
-			): Promise<Serialized<OperationResult<'GET', '/v1/rooms.info'>>> => {
-				return self.rest.get('/v1/rooms.info', args);
+			): Promise<Serialized<RoomsInfoResponse>> => {
+				return self.untypedRest.get('/v1/rooms.info', args) as Promise<Serialized<RoomsInfoResponse>>;
 			},
 			join: (rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.join'>>> => {
 				return self.rest.post('/v1/channels.join', { roomId: rid });
@@ -146,8 +152,8 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 	get dm() {
 		const self = this;
 		return {
-			create(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>> {
-				return self.rest.post('/v1/im.create', { username });
+			create(username: string): Promise<Serialized<DmCreateResponse>> {
+				return self.untypedRest.post('/v1/im.create', { username }) as Promise<Serialized<DmCreateResponse>>;
 			},
 		};
 	}
@@ -168,8 +174,8 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 		return this.untypedRest.post('/v1/chat.react', { emoji, messageId }) as Promise<void>;
 	}
 
-	createDirectMessage(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>> {
-		return this.rest.post('/v1/im.create', { username });
+	createDirectMessage(username: string): Promise<Serialized<DmCreateResponse>> {
+		return this.untypedRest.post('/v1/im.create', { username }) as Promise<Serialized<DmCreateResponse>>;
 	}
 
 	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<ChatSendMessageResponse>> {

--- a/packages/ddp-client/src/legacy/RocketchatSDKLegacy.ts
+++ b/packages/ddp-client/src/legacy/RocketchatSDKLegacy.ts
@@ -3,7 +3,7 @@
 import { RestClient } from '@rocket.chat/api-client';
 import type { IMessage, Serialized } from '@rocket.chat/core-typings';
 import { Emitter } from '@rocket.chat/emitter';
-import type { OperationParams, OperationResult } from '@rocket.chat/rest-typings';
+import type { ChatUpdate, OperationResult } from '@rocket.chat/rest-typings';
 
 import { ClientStreamImpl } from '../ClientStream';
 import { ConnectionImpl } from '../Connection';
@@ -22,6 +22,7 @@ import type {
 	RocketchatSdkLegacyEventsKeys,
 	RocketchatSdkLegacyEventsValues,
 } from './types/SDKLegacy';
+import type { ChatSendMessageResponse, ChatSyncMessagesResponse, ChatUpdateResponse } from './types/legacyChatRoutes';
 
 declare module '../ClientStream' {
 	interface ClientStream {
@@ -50,6 +51,17 @@ declare module '../types/SDK' {
 interface RocketchatSDKLegacy extends APILegacy, DPPLegacy {}
 
 export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLegacy {
+	/** The /v1/chat.* routes below are typed by their migrated implementations
+	 * inside the meteor app (see types/legacyChatRoutes.ts), so the standalone
+	 * `Endpoints` map no longer accepts their paths. Same client, path
+	 * constraint widened. */
+	private get untypedRest() {
+		return this.rest as unknown as {
+			get: (endpoint: string, params?: Record<string, unknown>) => Promise<unknown>;
+			post: (endpoint: string, params?: unknown) => Promise<unknown>;
+		};
+	}
+
 	private ev = new Emitter<RocketchatSdkLegacyEvents>();
 
 	get url(): string {
@@ -106,8 +118,10 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 			join: (rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.join'>>> => {
 				return self.rest.post('/v1/channels.join', { roomId: rid });
 			},
-			load: (rid: string, lastUpdate: Date): Promise<Serialized<OperationResult<'GET', '/v1/chat.syncMessages'>>> => {
-				return self.rest.get('/v1/chat.syncMessages', { roomId: rid, lastUpdate: lastUpdate.toISOString() });
+			load: (rid: string, lastUpdate: Date): Promise<Serialized<ChatSyncMessagesResponse>> => {
+				return self.untypedRest.get('/v1/chat.syncMessages', { roomId: rid, lastUpdate: lastUpdate.toISOString() }) as Promise<
+					Serialized<ChatSyncMessagesResponse>
+				>;
 			},
 			leave: (rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>> => {
 				return self.rest.post('/v1/channels.leave', { roomId: rid });
@@ -119,8 +133,10 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 		return this.rest.post('/v1/channels.join', { roomId: args.rid });
 	}
 
-	loadHistory(rid: string, lastUpdate: Date): Promise<Serialized<OperationResult<'GET', '/v1/chat.syncMessages'>>> {
-		return this.rest.get('/v1/chat.syncMessages', { roomId: rid, lastUpdate: lastUpdate.toISOString() });
+	loadHistory(rid: string, lastUpdate: Date): Promise<Serialized<ChatSyncMessagesResponse>> {
+		return this.untypedRest.get('/v1/chat.syncMessages', { roomId: rid, lastUpdate: lastUpdate.toISOString() }) as Promise<
+			Serialized<ChatSyncMessagesResponse>
+		>;
 	}
 
 	leaveRoom(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>> {
@@ -144,20 +160,20 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 		return this.rest.get('/v1/groups.info', args);
 	}
 
-	editMessage(args: OperationParams<'POST', '/v1/chat.update'>): Promise<Serialized<OperationResult<'POST', '/v1/chat.update'>>> {
-		return this.rest.post('/v1/chat.update', args);
+	editMessage(args: ChatUpdate): Promise<Serialized<ChatUpdateResponse>> {
+		return this.untypedRest.post('/v1/chat.update', args) as Promise<Serialized<ChatUpdateResponse>>;
 	}
 
-	setReaction(emoji: string, messageId: string): Promise<Serialized<OperationResult<'POST', '/v1/chat.react'>>> {
-		return this.rest.post('/v1/chat.react', { emoji, messageId });
+	setReaction(emoji: string, messageId: string): Promise<void> {
+		return this.untypedRest.post('/v1/chat.react', { emoji, messageId }) as Promise<void>;
 	}
 
 	createDirectMessage(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>> {
 		return this.rest.post('/v1/im.create', { username });
 	}
 
-	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<OperationResult<'POST', '/v1/chat.sendMessage'>>> {
-		return this.rest.post('/v1/chat.sendMessage', {
+	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<ChatSendMessageResponse>> {
+		return this.untypedRest.post('/v1/chat.sendMessage', {
 			message:
 				typeof message === 'string'
 					? {
@@ -168,7 +184,7 @@ export class RocketchatSdkLegacyImpl extends DDPSDK implements RocketchatSDKLega
 							...message,
 							rid,
 						},
-		});
+		}) as Promise<Serialized<ChatSendMessageResponse>>;
 	}
 
 	resume({ token }: { token: string }): Promise<unknown> {

--- a/packages/ddp-client/src/legacy/types/SDKLegacy.ts
+++ b/packages/ddp-client/src/legacy/types/SDKLegacy.ts
@@ -1,6 +1,7 @@
 import type { IMessage, Serialized } from '@rocket.chat/core-typings';
-import type { OperationParams, OperationResult } from '@rocket.chat/rest-typings';
+import type { ChatUpdate, OperationResult } from '@rocket.chat/rest-typings';
 
+import type { ChatSendMessageResponse, ChatSyncMessagesResponse, ChatUpdateResponse } from './legacyChatRoutes';
 import type { StreamerCallbackArgs } from '../../types/streams';
 
 export interface APILegacy {
@@ -17,12 +18,12 @@ export interface APILegacy {
 	rooms: {
 		info(args: { roomName: string } | { roomId: string }): Promise<Serialized<OperationResult<'GET', '/v1/rooms.info'>>>;
 		join(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.join'>>>;
-		load(rid: string, lastUpdate: Date): Promise<Serialized<OperationResult<'GET', '/v1/chat.syncMessages'>>>;
+		load(rid: string, lastUpdate: Date): Promise<Serialized<ChatSyncMessagesResponse>>;
 		leave(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>>;
 	};
 
 	joinRoom(args: { rid: string }): Promise<Serialized<OperationResult<'POST', '/v1/channels.join'>>>;
-	loadHistory(rid: string, lastUpdate: Date): Promise<Serialized<OperationResult<'GET', '/v1/chat.syncMessages'>>>;
+	loadHistory(rid: string, lastUpdate: Date): Promise<Serialized<ChatSyncMessagesResponse>>;
 	leaveRoom(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>>;
 
 	dm: {
@@ -31,7 +32,7 @@ export interface APILegacy {
 
 	createDirectMessage(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>>;
 
-	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<OperationResult<'POST', '/v1/chat.sendMessage'>>>;
+	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<ChatSendMessageResponse>>;
 
 	// getRoomIdByNameOrId(name: string): Promise<Serialized<OperationResult<'GET', '/v1/chat.getRoomIdByNameOrId'>>>;
 
@@ -41,9 +42,9 @@ export interface APILegacy {
 
 	// getRoomId(name: string): Promise<Serialized<OperationResult<'GET', '/v1/chat.find'>>>;
 
-	editMessage(args: OperationParams<'POST', '/v1/chat.update'>): Promise<Serialized<OperationResult<'POST', '/v1/chat.update'>>>;
+	editMessage(args: ChatUpdate): Promise<Serialized<ChatUpdateResponse>>;
 
-	setReaction(emoji: string, messageId: string): Promise<Serialized<OperationResult<'POST', '/v1/chat.react'>>>;
+	setReaction(emoji: string, messageId: string): Promise<void>;
 
 	channelInfo(args: { roomName: string } | { roomId: string }): Promise<Serialized<OperationResult<'GET', '/v1/channels.info'>>>;
 

--- a/packages/ddp-client/src/legacy/types/SDKLegacy.ts
+++ b/packages/ddp-client/src/legacy/types/SDKLegacy.ts
@@ -1,7 +1,13 @@
 import type { IMessage, Serialized } from '@rocket.chat/core-typings';
 import type { ChatUpdate, OperationResult } from '@rocket.chat/rest-typings';
 
-import type { ChatSendMessageResponse, ChatSyncMessagesResponse, ChatUpdateResponse } from './legacyChatRoutes';
+import type {
+	ChatSendMessageResponse,
+	ChatSyncMessagesResponse,
+	ChatUpdateResponse,
+	DmCreateResponse,
+	RoomsInfoResponse,
+} from './legacyChatRoutes';
 import type { StreamerCallbackArgs } from '../../types/streams';
 
 export interface APILegacy {
@@ -16,7 +22,7 @@ export interface APILegacy {
 	};
 
 	rooms: {
-		info(args: { roomName: string } | { roomId: string }): Promise<Serialized<OperationResult<'GET', '/v1/rooms.info'>>>;
+		info(args: { roomName: string } | { roomId: string }): Promise<Serialized<RoomsInfoResponse>>;
 		join(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.join'>>>;
 		load(rid: string, lastUpdate: Date): Promise<Serialized<ChatSyncMessagesResponse>>;
 		leave(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>>;
@@ -27,10 +33,10 @@ export interface APILegacy {
 	leaveRoom(rid: string): Promise<Serialized<OperationResult<'POST', '/v1/channels.leave'>>>;
 
 	dm: {
-		create(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>>;
+		create(username: string): Promise<Serialized<DmCreateResponse>>;
 	};
 
-	createDirectMessage(username: string): Promise<Serialized<OperationResult<'POST', '/v1/im.create'>>>;
+	createDirectMessage(username: string): Promise<Serialized<DmCreateResponse>>;
 
 	sendMessage(message: IMessage | string, rid: string): Promise<Serialized<ChatSendMessageResponse>>;
 

--- a/packages/ddp-client/src/legacy/types/legacyChatRoutes.ts
+++ b/packages/ddp-client/src/legacy/types/legacyChatRoutes.ts
@@ -1,11 +1,10 @@
-import type { IMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, ITeam } from '@rocket.chat/core-typings';
 
-/* The /v1/chat.* routes below are typed by their migrated implementations
- * (apps/meteor/server/api/v1/chat.ts augments `Endpoints` via
- * ExtractRoutesFromAPI), so the standalone `Endpoints` map from
- * @rocket.chat/rest-typings no longer declares them. This legacy SDK compiles
- * without that augmentation and keeps its own minimal response contracts,
- * mirroring the server responses. */
+/* The routes below are typed by their migrated implementations
+ * (apps/meteor/server/api/v1 augments `Endpoints` via ExtractRoutesFromAPI),
+ * so the standalone `Endpoints` map from @rocket.chat/rest-typings no longer
+ * declares them. This legacy SDK compiles without that augmentation and keeps
+ * its own minimal response contracts, mirroring the server responses. */
 
 export type ChatSyncMessagesResponse = {
 	result: {
@@ -27,3 +26,13 @@ export type ChatUpdateResponse = {
 };
 
 export type ChatReactResponse = void;
+
+export type RoomsInfoResponse = {
+	room: IRoom | null;
+	parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't'> & Partial<Pick<IRoom, 'prid' | 'u'>>;
+	team?: Pick<ITeam, 'name' | 'roomId' | 'type'>;
+};
+
+export type DmCreateResponse = {
+	room: IRoom & { rid: IRoom['_id'] };
+};

--- a/packages/ddp-client/src/legacy/types/legacyChatRoutes.ts
+++ b/packages/ddp-client/src/legacy/types/legacyChatRoutes.ts
@@ -1,0 +1,29 @@
+import type { IMessage } from '@rocket.chat/core-typings';
+
+/* The /v1/chat.* routes below are typed by their migrated implementations
+ * (apps/meteor/server/api/v1/chat.ts augments `Endpoints` via
+ * ExtractRoutesFromAPI), so the standalone `Endpoints` map from
+ * @rocket.chat/rest-typings no longer declares them. This legacy SDK compiles
+ * without that augmentation and keeps its own minimal response contracts,
+ * mirroring the server responses. */
+
+export type ChatSyncMessagesResponse = {
+	result: {
+		updated: IMessage[];
+		deleted: { _id: IMessage['_id']; _deletedAt: string }[];
+		cursor: {
+			next: string | null;
+			previous: string | null;
+		};
+	};
+};
+
+export type ChatSendMessageResponse = {
+	message: IMessage;
+};
+
+export type ChatUpdateResponse = {
+	message: IMessage;
+};
+
+export type ChatReactResponse = void;

--- a/packages/ddp-client/src/livechat/LivechatClientImpl.ts
+++ b/packages/ddp-client/src/livechat/LivechatClientImpl.ts
@@ -8,6 +8,7 @@ import { ConnectionImpl } from '../Connection';
 import { DDPDispatcher } from '../DDPDispatcher';
 import { DDPSDK } from '../DDPSDK';
 import { TimeoutControl } from '../TimeoutControl';
+import type { LivechatDepartmentTransferResponse } from './types/livechatRoutes';
 import { AccountImpl } from '../types/Account';
 import type { ClientStream } from '../types/ClientStream';
 import type { DDPDispatchOptions } from '../types/DDPClient';
@@ -198,17 +199,17 @@ export class LivechatClientImpl extends DDPSDK implements LivechatStream, Livech
 
 	// API POST
 
-	transferChat({
-		rid,
-		department,
-	}: {
-		rid: string;
-		department: string;
-	}): Promise<Serialized<OperationResult<'POST', '/v1/livechat/visitor/department.transfer'>>> {
+	transferChat({ rid, department }: { rid: string; department: string }): Promise<LivechatDepartmentTransferResponse> {
 		if (!this.token) {
 			throw new Error('Invalid token');
 		}
-		return this.rest.post('/v1/livechat/visitor/department.transfer', { rid, token: this.token, department });
+		// typed by the migrated implementation inside the meteor app (see
+		// types/livechatRoutes.ts); the standalone `Endpoints` map no longer
+		// accepts this path, so the call goes through a widened view
+		return (this.rest as unknown as { post: (endpoint: string, params?: unknown) => Promise<unknown> }).post(
+			'/v1/livechat/visitor/department.transfer',
+			{ rid, token: this.token, department },
+		) as Promise<LivechatDepartmentTransferResponse>;
 	}
 
 	async grantVisitor(

--- a/packages/ddp-client/src/livechat/types/LivechatSDK.ts
+++ b/packages/ddp-client/src/livechat/types/LivechatSDK.ts
@@ -1,6 +1,7 @@
 import type { Serialized } from '@rocket.chat/core-typings';
 import type { OperationParams, OperationResult } from '@rocket.chat/rest-typings';
 
+import type { LivechatDepartmentTransferResponse } from './livechatRoutes';
 import type { StreamerCallbackArgs } from '../../types/streams';
 
 export type LivechatRoomEvents<T> =
@@ -54,9 +55,7 @@ export interface LivechatEndpoints {
 	// videoCall(args: OperationParams<'GET', '/v1/livechat/video.call/:token'>): Promise<void>;
 
 	// POST
-	transferChat(
-		args: OperationParams<'POST', '/v1/livechat/visitor/department.transfer'>,
-	): Promise<Serialized<OperationResult<'POST', '/v1/livechat/visitor/department.transfer'>>>;
+	transferChat(args: { rid: string; token: string; department: string }): Promise<LivechatDepartmentTransferResponse>;
 	grantVisitor(
 		guest: OperationParams<'POST', '/v1/livechat/visitor'>,
 	): Promise<Serialized<OperationResult<'POST', '/v1/livechat/visitor'>>>;

--- a/packages/ddp-client/src/livechat/types/livechatRoutes.ts
+++ b/packages/ddp-client/src/livechat/types/livechatRoutes.ts
@@ -1,0 +1,10 @@
+/* The route below is typed by its migrated implementation
+ * (apps/meteor/server/api/v1/omnichannel/room.ts augments `Endpoints` via
+ * ExtractRoutesFromAPI), so the standalone `Endpoints` map from
+ * @rocket.chat/rest-typings no longer declares it. This SDK compiles without
+ * that augmentation and keeps its own minimal contract, mirroring the server
+ * response. */
+
+export type LivechatDepartmentTransferResponse = {
+	success: boolean;
+};

--- a/packages/fuselage-ui-kit/src/blocks/VideoConferenceBlock/hooks/useGoToRoom.ts
+++ b/packages/fuselage-ui-kit/src/blocks/VideoConferenceBlock/hooks/useGoToRoom.ts
@@ -1,10 +1,22 @@
-import type { IRoom } from '@rocket.chat/core-typings';
+import type { IRoom, Serialized } from '@rocket.chat/core-typings';
 import { useStableCallback } from '@rocket.chat/fuselage-hooks';
 import { useEndpoint, useRouter } from '@rocket.chat/ui-contexts';
 
+/* The route is typed by its migrated implementation inside the meteor app
+ * (apps/meteor/server/api/v1/rooms.ts augments `Endpoints` via
+ * ExtractRoutesFromAPI), so the standalone `Endpoints` map from
+ * @rocket.chat/rest-typings no longer declares it. This package compiles
+ * without that augmentation and keeps its own minimal contract, mirroring
+ * the server response. */
+type RoomsInfoResponse = {
+	room: Serialized<IRoom> | null;
+};
+
 export const useGoToRoom = (): ((roomId: IRoom['_id']) => Promise<void>) => {
 	const router = useRouter();
-	const getRoomInfo = useEndpoint('GET', '/v1/rooms.info');
+	const getRoomInfo = useEndpoint('GET', '/v1/rooms.info' as unknown as Parameters<typeof useEndpoint>[1]) as unknown as (params: {
+		roomId: string;
+	}) => Promise<RoomsInfoResponse>;
 
 	return useStableCallback(async (roomId: IRoom['_id']) => {
 		const { room } = await getRoomInfo({ roomId });

--- a/packages/fuselage-ui-kit/src/elements/ChannelsSelectElement/hooks/useChannelsData.ts
+++ b/packages/fuselage-ui-kit/src/elements/ChannelsSelectElement/hooks/useChannelsData.ts
@@ -1,3 +1,4 @@
+import type { IRoom, Serialized } from '@rocket.chat/core-typings';
 import { useEndpoint } from '@rocket.chat/ui-contexts';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
@@ -11,8 +12,21 @@ const generateQuery = (
 	selector: string;
 } => ({ selector: JSON.stringify({ name: term }) });
 
+/* The route is typed by its migrated implementation inside the meteor app
+ * (apps/meteor/server/api/v1/rooms.ts augments `Endpoints` via
+ * ExtractRoutesFromAPI), so the standalone `Endpoints` map from
+ * @rocket.chat/rest-typings no longer declares it. This package compiles
+ * without that augmentation and keeps its own minimal contract, mirroring
+ * the server response. */
+type RoomsAutocompleteChannelAndPrivateResponse = {
+	items: Serialized<IRoom>[];
+};
+
 export const useChannelsData = ({ filter }: useChannelsDataProps) => {
-	const getRooms = useEndpoint('GET', '/v1/rooms.autocomplete.channelAndPrivate');
+	const getRooms = useEndpoint(
+		'GET',
+		'/v1/rooms.autocomplete.channelAndPrivate' as unknown as Parameters<typeof useEndpoint>[1],
+	) as unknown as (params: { selector: string }) => Promise<RoomsAutocompleteChannelAndPrivateResponse>;
 
 	const { data } = useQuery({
 		queryKey: ['rooms.autocomplete.channelAndPrivate', filter],

--- a/packages/rest-typings/src/index.ts
+++ b/packages/rest-typings/src/index.ts
@@ -15,17 +15,14 @@ import type { CloudEndpoints } from './v1/cloud';
 import type { CommandsEndpoints } from './v1/commands';
 import type { CustomUserStatusEndpoints } from './v1/customUserStatus';
 import type { DirectoryEndpoint } from './v1/directory';
-import type { ImEndpoints, DmEndpoints } from './v1/dm';
-import type { E2eEndpoints } from './v1/e2e';
+import type { ImEndpoints } from './v1/dm';
 import type { EmailInboxEndpoints } from './v1/email-inbox';
-import type { EmojiCustomEndpoints } from './v1/emojiCustom';
 import type { FederationEndpoints } from './v1/federation';
 import type { GroupsEndpoints } from './v1/groups';
 import type { ImportEndpoints } from './v1/import';
 import type { InstancesEndpoints } from './v1/instances';
 import type { IntegrationsEndpoints } from './v1/integrations';
 import type { IntegrationHooksEndpoints } from './v1/integrations/hooks';
-import type { InvitesEndpoints } from './v1/invites';
 import type { LDAPEndpoints } from './v1/ldap';
 import type { LicensesEndpoints } from './v1/licenses';
 import type { MailerEndpoints } from './v1/mailer';
@@ -34,8 +31,6 @@ import type { MiscEndpoints } from './v1/misc';
 import type { ModerationEndpoints } from './v1/moderation';
 import type { OmnichannelEndpoints } from './v1/omnichannel';
 import type { PresenceEndpoints } from './v1/presence';
-import type { PushEndpoints } from './v1/push';
-import type { RolesEndpoints } from './v1/roles';
 import type { RoomsEndpoints } from './v1/rooms';
 import type { ServerEventsEndpoints } from './v1/server-events';
 import type { SettingsEndpoints } from './v1/settings';
@@ -46,6 +41,11 @@ import type { TwoFactorChallengesEndpoints } from './v1/twoFactorChallenges';
 import type { UsersEndpoints } from './v1/users';
 import type { VideoConferenceEndpoints } from './v1/videoConference';
 
+// Families fully typed by their migrated implementations (via
+// ExtractRoutesFromAPI module augmentation in apps/meteor/server/api/v1)
+// have no entry here: dm, e2e, emoji-custom, invites, push, roles. Others
+// (chat, im, rooms) keep only their legacy API.v1.addRoute declarations.
+// See docs/typescript-7-migration.md.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface Endpoints
 	extends AISearchEndpoints,
@@ -58,15 +58,11 @@ export interface Endpoints
 		CloudEndpoints,
 		CommandsEndpoints,
 		CustomUserStatusEndpoints,
-		DmEndpoints,
 		DirectoryEndpoint,
-		EmojiCustomEndpoints,
 		GroupsEndpoints,
 		ImEndpoints,
 		LDAPEndpoints,
 		RoomsEndpoints,
-		PushEndpoints,
-		RolesEndpoints,
 		TeamsEndpoints,
 		SettingsEndpoints,
 		UsersEndpoints,
@@ -80,8 +76,6 @@ export interface Endpoints
 		IntegrationsEndpoints,
 		IntegrationHooksEndpoints,
 		VideoConferenceEndpoints,
-		InvitesEndpoints,
-		E2eEndpoints,
 		AssetsEndpoints,
 		EmailInboxEndpoints,
 		MailerEndpoints,

--- a/packages/rest-typings/src/index.ts
+++ b/packages/rest-typings/src/index.ts
@@ -15,17 +15,14 @@ import type { CloudEndpoints } from './v1/cloud';
 import type { CommandsEndpoints } from './v1/commands';
 import type { CustomUserStatusEndpoints } from './v1/customUserStatus';
 import type { DirectoryEndpoint } from './v1/directory';
-import type { ImEndpoints, DmEndpoints } from './v1/dm';
-import type { E2eEndpoints } from './v1/e2e';
+import type { ImEndpoints } from './v1/dm';
 import type { EmailInboxEndpoints } from './v1/email-inbox';
-import type { EmojiCustomEndpoints } from './v1/emojiCustom';
 import type { FederationEndpoints } from './v1/federation';
 import type { GroupsEndpoints } from './v1/groups';
 import type { ImportEndpoints } from './v1/import';
 import type { InstancesEndpoints } from './v1/instances';
 import type { IntegrationsEndpoints } from './v1/integrations';
 import type { IntegrationHooksEndpoints } from './v1/integrations/hooks';
-import type { InvitesEndpoints } from './v1/invites';
 import type { LDAPEndpoints } from './v1/ldap';
 import type { LicensesEndpoints } from './v1/licenses';
 import type { MailerEndpoints } from './v1/mailer';
@@ -34,8 +31,6 @@ import type { MiscEndpoints } from './v1/misc';
 import type { ModerationEndpoints } from './v1/moderation';
 import type { OmnichannelEndpoints } from './v1/omnichannel';
 import type { PresenceEndpoints } from './v1/presence';
-import type { PushEndpoints } from './v1/push';
-import type { RolesEndpoints } from './v1/roles';
 import type { RoomsEndpoints } from './v1/rooms';
 import type { ServerEventsEndpoints } from './v1/server-events';
 import type { SettingsEndpoints } from './v1/settings';
@@ -47,6 +42,11 @@ import type { TwoFactorChallengesEndpoints } from './v1/twoFactorChallenges';
 import type { UsersEndpoints } from './v1/users';
 import type { VideoConferenceEndpoints } from './v1/videoConference';
 
+// Families fully typed by their migrated implementations (via
+// ExtractRoutesFromAPI module augmentation in apps/meteor/server/api/v1)
+// have no entry here: dm, e2e, emoji-custom, invites, push, roles. Others
+// (chat, im, rooms) keep only their legacy API.v1.addRoute declarations.
+// See docs/typescript-7-migration.md.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface Endpoints
 	extends AISearchEndpoints,
@@ -59,15 +59,11 @@ export interface Endpoints
 		CloudEndpoints,
 		CommandsEndpoints,
 		CustomUserStatusEndpoints,
-		DmEndpoints,
 		DirectoryEndpoint,
-		EmojiCustomEndpoints,
 		GroupsEndpoints,
 		ImEndpoints,
 		LDAPEndpoints,
 		RoomsEndpoints,
-		PushEndpoints,
-		RolesEndpoints,
 		TeamsEndpoints,
 		SettingsEndpoints,
 		SetupWizardEndpoints,
@@ -82,8 +78,6 @@ export interface Endpoints
 		IntegrationsEndpoints,
 		IntegrationHooksEndpoints,
 		VideoConferenceEndpoints,
-		InvitesEndpoints,
-		E2eEndpoints,
 		AssetsEndpoints,
 		EmailInboxEndpoints,
 		MailerEndpoints,

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -1,4 +1,4 @@
-import type { IMessage, IRoom, MessageAttachment, IReadReceiptWithUser, MessageUrl, IThreadMainMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, MessageAttachment, IReadReceiptWithUser } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 import type { PaginatedRequest } from '../helpers/PaginatedRequest';
@@ -378,7 +378,7 @@ interface IChatUpdateEncrypted extends IChatUpdate {
 	e2eMentions?: IMessage['e2eMentions'];
 }
 
-type ChatUpdate = IChatUpdateText | IChatUpdateEncrypted;
+export type ChatUpdate = IChatUpdateText | IChatUpdateEncrypted;
 
 const ChatUpdateSchema = {
 	oneOf: [
@@ -929,133 +929,12 @@ const ChatGetURLPreviewSchema = {
 export const isChatGetURLPreviewProps = ajv.compile<ChatGetURLPreview>(ChatGetURLPreviewSchema);
 
 export type ChatEndpoints = {
-	'/v1/chat.sendMessage': {
-		POST: (params: ChatSendMessage) => {
-			message: IMessage;
-		};
-	};
-	'/v1/chat.getMessage': {
-		GET: (params: ChatGetMessage) => {
-			message: IMessage;
-		};
-	};
-	'/v1/chat.reportMessage': {
-		POST: (params: ChatReportMessage) => void;
-	};
-	'/v1/chat.getDiscussions': {
-		GET: (params: ChatGetDiscussions) => {
-			messages: IMessage[];
-			total: number;
-		};
-	};
-	'/v1/chat.getThreadsList': {
-		GET: (params: ChatGetThreadsList) => {
-			threads: IThreadMainMessage[];
-			total: number;
-		};
-	};
-	'/v1/chat.syncThreadsList': {
-		GET: (params: ChatSyncThreadsList) => {
-			threads: {
-				update: IMessage[];
-				remove: IMessage[];
-			};
-		};
-	};
-	'/v1/chat.delete': {
-		POST: (params: ChatDelete) => {
-			_id?: string;
-			ts?: string;
-			message?: Pick<IMessage, '_id' | 'rid' | 'u'>;
-		};
-	};
-	'/v1/chat.react': {
-		POST: (params: ChatReact) => void;
-	};
-	'/v1/chat.ignoreUser': {
-		GET: (params: ChatIgnoreUser) => void;
-	};
-	'/v1/chat.search': {
-		GET: (params: ChatSearch) => {
-			messages: IMessage[];
-		};
-	};
-	'/v1/chat.update': {
-		POST: (params: ChatUpdate) => {
-			message: IMessage;
-		};
-	};
+	// Every other /v1/chat.* route is declared by its migrated implementation
+	// (apps/meteor/server/api/v1/chat.ts) via ExtractRoutesFromAPI, which
+	// augments `Endpoints` with types derived from the actual handlers and
+	// validators. Only routes that have not been migrated yet stay here —
+	// remove each entry as its route moves to the validated API builder.
 	'/v1/chat.getMessageReadReceipts': {
 		GET: (params: ChatGetMessageReadReceipts) => { receipts: IReadReceiptWithUser[] };
-	};
-	'/v1/chat.getStarredMessages': {
-		GET: (params: GetStarredMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getPinnedMessages': {
-		GET: (params: GetPinnedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getMentionedMessages': {
-		GET: (params: GetMentionedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.syncMessages': {
-		GET: (params: ChatSyncMessages) => {
-			result: {
-				updated: IMessage[];
-				deleted: { _id: IMessage['_id']; _deletedAt: string }[];
-				cursor: {
-					next: string | null;
-					previous: string | null;
-				};
-			};
-		};
-	};
-	'/v1/chat.postMessage': {
-		POST: (params: ChatPostMessage) => {
-			ts: number;
-			channel: IRoom;
-			message: IMessage;
-		};
-	};
-	'/v1/chat.syncThreadMessages': {
-		GET: (params: ChatSyncThreadMessages) => {
-			messages: {
-				update: IMessage[];
-				remove: IMessage[];
-			};
-		};
-	};
-	'/v1/chat.getThreadMessages': {
-		GET: (params: ChatGetThreadMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getDeletedMessages': {
-		GET: (params: ChatGetDeletedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getURLPreview': {
-		GET: (params: ChatGetURLPreview) => { urlPreview: MessageUrl };
 	};
 };

--- a/packages/rest-typings/src/v1/chat.ts
+++ b/packages/rest-typings/src/v1/chat.ts
@@ -1,4 +1,4 @@
-import type { IMessage, IRoom, MessageAttachment, IReadReceiptWithUser, MessageUrl, IThreadMainMessage } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, MessageAttachment, IReadReceiptWithUser } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 import type { PaginatedRequest } from '../helpers/PaginatedRequest';
@@ -403,7 +403,7 @@ interface IChatUpdateEncrypted extends IChatUpdate {
 	e2eMentions?: IMessage['e2eMentions'];
 }
 
-type ChatUpdate = IChatUpdateText | IChatUpdateEncrypted;
+export type ChatUpdate = IChatUpdateText | IChatUpdateEncrypted;
 
 const ChatUpdateSchema = {
 	oneOf: [
@@ -954,133 +954,12 @@ const ChatGetURLPreviewSchema = {
 export const isChatGetURLPreviewProps = ajv.compile<ChatGetURLPreview>(ChatGetURLPreviewSchema);
 
 export type ChatEndpoints = {
-	'/v1/chat.sendMessage': {
-		POST: (params: ChatSendMessage) => {
-			message: IMessage;
-		};
-	};
-	'/v1/chat.getMessage': {
-		GET: (params: ChatGetMessage) => {
-			message: IMessage;
-		};
-	};
-	'/v1/chat.reportMessage': {
-		POST: (params: ChatReportMessage) => void;
-	};
-	'/v1/chat.getDiscussions': {
-		GET: (params: ChatGetDiscussions) => {
-			messages: IMessage[];
-			total: number;
-		};
-	};
-	'/v1/chat.getThreadsList': {
-		GET: (params: ChatGetThreadsList) => {
-			threads: IThreadMainMessage[];
-			total: number;
-		};
-	};
-	'/v1/chat.syncThreadsList': {
-		GET: (params: ChatSyncThreadsList) => {
-			threads: {
-				update: IMessage[];
-				remove: IMessage[];
-			};
-		};
-	};
-	'/v1/chat.delete': {
-		POST: (params: ChatDelete) => {
-			_id?: string;
-			ts?: string;
-			message?: Pick<IMessage, '_id' | 'rid' | 'u'>;
-		};
-	};
-	'/v1/chat.react': {
-		POST: (params: ChatReact) => void;
-	};
-	'/v1/chat.ignoreUser': {
-		GET: (params: ChatIgnoreUser) => void;
-	};
-	'/v1/chat.search': {
-		GET: (params: ChatSearch) => {
-			messages: IMessage[];
-		};
-	};
-	'/v1/chat.update': {
-		POST: (params: ChatUpdate) => {
-			message: IMessage;
-		};
-	};
+	// Every other /v1/chat.* route is declared by its migrated implementation
+	// (apps/meteor/server/api/v1/chat.ts) via ExtractRoutesFromAPI, which
+	// augments `Endpoints` with types derived from the actual handlers and
+	// validators. Only routes that have not been migrated yet stay here —
+	// remove each entry as its route moves to the validated API builder.
 	'/v1/chat.getMessageReadReceipts': {
 		GET: (params: ChatGetMessageReadReceipts) => { receipts: IReadReceiptWithUser[] };
-	};
-	'/v1/chat.getStarredMessages': {
-		GET: (params: GetStarredMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getPinnedMessages': {
-		GET: (params: GetPinnedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getMentionedMessages': {
-		GET: (params: GetMentionedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.syncMessages': {
-		GET: (params: ChatSyncMessages) => {
-			result: {
-				updated: IMessage[];
-				deleted: { _id: IMessage['_id']; _deletedAt: string }[];
-				cursor: {
-					next: string | null;
-					previous: string | null;
-				};
-			};
-		};
-	};
-	'/v1/chat.postMessage': {
-		POST: (params: ChatPostMessage) => {
-			ts: number;
-			channel: IRoom;
-			message: IMessage;
-		};
-	};
-	'/v1/chat.syncThreadMessages': {
-		GET: (params: ChatSyncThreadMessages) => {
-			messages: {
-				update: IMessage[];
-				remove: IMessage[];
-			};
-		};
-	};
-	'/v1/chat.getThreadMessages': {
-		GET: (params: ChatGetThreadMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getDeletedMessages': {
-		GET: (params: ChatGetDeletedMessages) => {
-			messages: IMessage[];
-			count: number;
-			offset: number;
-			total: number;
-		};
-	};
-	'/v1/chat.getURLPreview': {
-		GET: (params: ChatGetURLPreview) => { urlPreview: MessageUrl };
 	};
 };

--- a/packages/rest-typings/src/v1/dm/dm.ts
+++ b/packages/rest-typings/src/v1/dm/dm.ts
@@ -1,3 +1,0 @@
-// All /v1/dm.* routes are typed by their migrated implementations
-// (apps/meteor/server/api/v1/im.ts) via ExtractRoutesFromAPI.
-export type DmEndpoints = {};

--- a/packages/rest-typings/src/v1/dm/dm.ts
+++ b/packages/rest-typings/src/v1/dm/dm.ts
@@ -1,9 +1,3 @@
-import type { ImEndpoints } from './im';
 // All /v1/dm.* routes are typed by their migrated implementations
 // (apps/meteor/server/api/v1/im.ts) via ExtractRoutesFromAPI.
-export type DmEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/dm.files': ImEndpoints['/v1/im.files'];
-	'/v1/dm.members': ImEndpoints['/v1/im.members'];
-};
+export type DmEndpoints = {};

--- a/packages/rest-typings/src/v1/dm/dm.ts
+++ b/packages/rest-typings/src/v1/dm/dm.ts
@@ -1,15 +1,9 @@
 import type { ImEndpoints } from './im';
-
+// All /v1/dm.* routes are typed by their migrated implementations
+// (apps/meteor/server/api/v1/im.ts) via ExtractRoutesFromAPI.
 export type DmEndpoints = {
-	'/v1/dm.create': ImEndpoints['/v1/im.create'];
-	'/v1/dm.counters': ImEndpoints['/v1/im.counters'];
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/dm.files': ImEndpoints['/v1/im.files'];
-	'/v1/dm.history': ImEndpoints['/v1/im.history'];
 	'/v1/dm.members': ImEndpoints['/v1/im.members'];
-	'/v1/dm.messages': ImEndpoints['/v1/im.messages'];
-	'/v1/dm.messages.others': ImEndpoints['/v1/im.messages.others'];
-	'/v1/dm.list': ImEndpoints['/v1/im.list'];
-	'/v1/dm.list.everyone': ImEndpoints['/v1/im.list.everyone'];
-	'/v1/dm.open': ImEndpoints['/v1/im.open'];
-	'/v1/dm.setTopic': ImEndpoints['/v1/im.setTopic'];
 };

--- a/packages/rest-typings/src/v1/dm/im.ts
+++ b/packages/rest-typings/src/v1/dm/im.ts
@@ -1,13 +1,8 @@
-import type { IMessage, IRoom, IUser, IUploadWithUser, ISubscription } from '@rocket.chat/core-typings';
+import type { ISubscription, IUploadWithUser, IUser, IRoom } from '@rocket.chat/core-typings';
 
-import type { DmBlockUserProps } from './DmBlockUserProps';
 import type { DmCreateProps } from './DmCreateProps';
 import type { DmFileProps } from './DmFileProps';
-import type { DmHistoryProps } from './DmHistoryProps';
-import type { DmLeaveProps } from './DmLeaveProps';
 import type { DmMemberProps } from './DmMembersProps';
-import type { DmMessagesProps } from './DmMessagesProps';
-import type { PaginatedRequest } from '../../helpers/PaginatedRequest';
 import type { PaginatedResult } from '../../helpers/PaginatedResult';
 
 type DmKickProps = {
@@ -15,39 +10,13 @@ type DmKickProps = {
 };
 
 export type ImEndpoints = {
-	'/v1/im.create': {
-		POST: (params: DmCreateProps) => {
-			room: IRoom & { rid: IRoom['_id'] };
-		};
-	};
-	'/v1/im.kick': {
-		POST: (params: DmKickProps) => void;
-	};
-	'/v1/im.leave': {
-		POST: (params: DmLeaveProps) => void;
-	};
-	'/v1/im.counters': {
-		GET: (params: { roomId: string; userId?: string }) => {
-			joined: boolean;
-			unreads: number | null;
-			unreadsFrom: string | null;
-			msgs: number | null;
-			members: number | null;
-			latest: string | null;
-			userMentions: number | null;
-		};
-	};
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/im.files': {
 		GET: (params: DmFileProps) => PaginatedResult<{
 			files: IUploadWithUser[];
 		}>;
 	};
-	'/v1/im.history': {
-		GET: (params: DmHistoryProps) => {
-			messages: Pick<IMessage, '_id' | 'rid' | 'msg' | 'ts' | '_updatedAt' | 'u'>[];
-		};
-	};
-
 	'/v1/im.members': {
 		GET: (params: DmMemberProps) => PaginatedResult<{
 			members: (Pick<IUser, '_id' | 'status' | 'name' | 'username' | 'utcOffset'> & {
@@ -55,29 +24,14 @@ export type ImEndpoints = {
 			})[];
 		}>;
 	};
-	'/v1/im.messages': {
-		GET: (params: DmMessagesProps) => PaginatedResult<{
-			messages: IMessage[];
-		}>;
-	};
-	'/v1/im.messages.others': {
-		GET: (params: PaginatedRequest<{ roomId: IRoom['_id']; query?: string; fields?: string }>) => PaginatedResult<{ messages: IMessage[] }>;
-	};
-	'/v1/im.list': {
-		GET: (params: PaginatedRequest<{ fields?: string }>) => PaginatedResult<{ ims: IRoom[] }>;
-	};
-	'/v1/im.list.everyone': {
-		GET: (params: PaginatedRequest<{ query: string; fields?: string }>) => PaginatedResult<{ ims: IRoom[] }>;
-	};
-	'/v1/im.open': {
-		POST: (params: { roomId: string }) => void;
-	};
-	'/v1/im.setTopic': {
-		POST: (params: { roomId: string; topic?: string }) => {
-			topic?: string;
+	// Kept canonical here: the ddp-client legacy SDK consumes this route
+	// without seeing the meteor module augmentation.
+	'/v1/im.create': {
+		POST: (params: DmCreateProps) => {
+			room: IRoom & { rid: IRoom['_id'] };
 		};
 	};
-	'/v1/im.blockUser': {
-		POST: (params: DmBlockUserProps) => void;
+	'/v1/im.kick': {
+		POST: (params: DmKickProps) => void;
 	};
 };

--- a/packages/rest-typings/src/v1/dm/im.ts
+++ b/packages/rest-typings/src/v1/dm/im.ts
@@ -1,36 +1,11 @@
-import type { ISubscription, IUploadWithUser, IUser, IRoom } from '@rocket.chat/core-typings';
-
-import type { DmCreateProps } from './DmCreateProps';
-import type { DmFileProps } from './DmFileProps';
-import type { DmMemberProps } from './DmMembersProps';
-import type { PaginatedResult } from '../../helpers/PaginatedResult';
-
 type DmKickProps = {
 	roomId: string;
 };
 
+// Every other /v1/im.* route is typed by its migrated implementation
+// (apps/meteor/server/api/v1/im.ts) via ExtractRoutesFromAPI; im.kick is
+// still registered through the legacy API.v1.addRoute.
 export type ImEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/im.files': {
-		GET: (params: DmFileProps) => PaginatedResult<{
-			files: IUploadWithUser[];
-		}>;
-	};
-	'/v1/im.members': {
-		GET: (params: DmMemberProps) => PaginatedResult<{
-			members: (Pick<IUser, '_id' | 'status' | 'name' | 'username' | 'utcOffset'> & {
-				subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'>;
-			})[];
-		}>;
-	};
-	// Kept canonical here: the ddp-client legacy SDK consumes this route
-	// without seeing the meteor module augmentation.
-	'/v1/im.create': {
-		POST: (params: DmCreateProps) => {
-			room: IRoom & { rid: IRoom['_id'] };
-		};
-	};
 	'/v1/im.kick': {
 		POST: (params: DmKickProps) => void;
 	};

--- a/packages/rest-typings/src/v1/dm/index.ts
+++ b/packages/rest-typings/src/v1/dm/index.ts
@@ -1,4 +1,3 @@
-export type * from './dm';
 export type * from './im';
 export * from './DmBlockUserProps';
 export * from './DmCreateProps';

--- a/packages/rest-typings/src/v1/e2e.ts
+++ b/packages/rest-typings/src/v1/e2e.ts
@@ -21,7 +21,3 @@ const E2eSetUserPublicAndPrivateKeysSchema = {
 };
 
 export const isE2eSetUserPublicAndPrivateKeysProps = ajv.compile<E2eSetUserPublicAndPrivateKeysProps>(E2eSetUserPublicAndPrivateKeysSchema);
-
-// All /v1/e2e.* routes are typed by their migrated implementations
-// (apps/meteor/server/api/v1/e2e.ts) via ExtractRoutesFromAPI.
-export type E2eEndpoints = {};

--- a/packages/rest-typings/src/v1/e2e.ts
+++ b/packages/rest-typings/src/v1/e2e.ts
@@ -22,10 +22,6 @@ const E2eSetUserPublicAndPrivateKeysSchema = {
 
 export const isE2eSetUserPublicAndPrivateKeysProps = ajv.compile<E2eSetUserPublicAndPrivateKeysProps>(E2eSetUserPublicAndPrivateKeysSchema);
 
-export type E2eEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/e2e.requestSubscriptionKeys': {
-		POST: () => void;
-	};
-};
+// All /v1/e2e.* routes are typed by their migrated implementations
+// (apps/meteor/server/api/v1/e2e.ts) via ExtractRoutesFromAPI.
+export type E2eEndpoints = {};

--- a/packages/rest-typings/src/v1/e2e.ts
+++ b/packages/rest-typings/src/v1/e2e.ts
@@ -23,10 +23,8 @@ const E2eSetUserPublicAndPrivateKeysSchema = {
 export const isE2eSetUserPublicAndPrivateKeysProps = ajv.compile<E2eSetUserPublicAndPrivateKeysProps>(E2eSetUserPublicAndPrivateKeysSchema);
 
 export type E2eEndpoints = {
-	'/v1/e2e.setUserPublicAndPrivateKeys': {
-		POST: (params: E2eSetUserPublicAndPrivateKeysProps) => void;
-	};
-
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/e2e.requestSubscriptionKeys': {
 		POST: () => void;
 	};

--- a/packages/rest-typings/src/v1/emojiCustom.ts
+++ b/packages/rest-typings/src/v1/emojiCustom.ts
@@ -1,8 +1,6 @@
-import type { IEmojiCustom, ICustomEmojiDescriptor } from '@rocket.chat/core-typings';
+import type { ICustomEmojiDescriptor } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
-import type { PaginatedRequest } from '../helpers/PaginatedRequest';
-import type { PaginatedResult } from '../helpers/PaginatedResult';
 
 type emojiCustomDeleteProps = {
 	emojiId: ICustomEmojiDescriptor['_id'];
@@ -46,12 +44,6 @@ const emojiCustomListSchema = {
 
 export const isEmojiCustomList = ajvQuery.compile<emojiCustomList>(emojiCustomListSchema);
 
-export type EmojiCustomEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/emoji-custom.all': {
-		GET: (params: PaginatedRequest<{ name?: string }, 'name'>) => PaginatedResult<{
-			emojis: IEmojiCustom[];
-		}>;
-	};
-};
+// All /v1/emoji-custom.* routes are typed by their migrated implementations
+// (apps/meteor/server/api/v1/emoji-custom.ts) via ExtractRoutesFromAPI.
+export type EmojiCustomEndpoints = {};

--- a/packages/rest-typings/src/v1/emojiCustom.ts
+++ b/packages/rest-typings/src/v1/emojiCustom.ts
@@ -43,7 +43,3 @@ const emojiCustomListSchema = {
 };
 
 export const isEmojiCustomList = ajvQuery.compile<emojiCustomList>(emojiCustomListSchema);
-
-// All /v1/emoji-custom.* routes are typed by their migrated implementations
-// (apps/meteor/server/api/v1/emoji-custom.ts) via ExtractRoutesFromAPI.
-export type EmojiCustomEndpoints = {};

--- a/packages/rest-typings/src/v1/emojiCustom.ts
+++ b/packages/rest-typings/src/v1/emojiCustom.ts
@@ -1,4 +1,4 @@
-import type { ICustomEmojiDescriptor, IEmojiCustom } from '@rocket.chat/core-typings';
+import type { IEmojiCustom, ICustomEmojiDescriptor } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 import type { PaginatedRequest } from '../helpers/PaginatedRequest';
@@ -47,23 +47,11 @@ const emojiCustomListSchema = {
 export const isEmojiCustomList = ajvQuery.compile<emojiCustomList>(emojiCustomListSchema);
 
 export type EmojiCustomEndpoints = {
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/emoji-custom.all': {
 		GET: (params: PaginatedRequest<{ name?: string }, 'name'>) => PaginatedResult<{
 			emojis: IEmojiCustom[];
 		}>;
-	};
-	'/v1/emoji-custom.list': {
-		GET: (params: emojiCustomList) => {
-			emojis: {
-				update: IEmojiCustom[];
-				remove: IEmojiCustom[];
-			};
-		};
-	};
-	'/v1/emoji-custom.delete': {
-		POST: (params: emojiCustomDeleteProps) => void;
-	};
-	'/v1/emoji-custom.update': {
-		POST: (params: { emoji: ICustomEmojiDescriptor }) => void;
 	};
 };

--- a/packages/rest-typings/src/v1/invites.ts
+++ b/packages/rest-typings/src/v1/invites.ts
@@ -79,27 +79,9 @@ const SendInvitationEmailParamsSchema: JSONSchemaType<SendInvitationEmailParams>
 export const isSendInvitationEmailParams = ajv.compile<SendInvitationEmailParams>(SendInvitationEmailParamsSchema);
 
 export type InvitesEndpoints = {
-	'/v1/removeInvite/:_id': {
-		DELETE: () => boolean;
-	};
-	'/v1/useInviteToken': {
-		POST: (params: UseInviteTokenProps) => {
-			room: {
-				rid: IRoom['_id'];
-				prid: IRoom['prid'];
-				fname: IRoom['fname'];
-				name: IRoom['name'];
-				t: IRoom['t'];
-			};
-		};
-	};
-	'/v1/validateInviteToken': {
-		POST: (params: ValidateInviteTokenProps) => { valid: boolean };
-	};
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/findOrCreateInvite': {
 		POST: (params: FindOrCreateInviteParams) => IInvite;
-	};
-	'/v1/sendInvitationEmail': {
-		POST: (params: SendInvitationEmailParams) => { success: boolean };
 	};
 };

--- a/packages/rest-typings/src/v1/invites.ts
+++ b/packages/rest-typings/src/v1/invites.ts
@@ -1,4 +1,4 @@
-import type { IInvite, IRoom } from '@rocket.chat/core-typings';
+import type { IRoom } from '@rocket.chat/core-typings';
 import type { JSONSchemaType } from 'ajv';
 
 import { ajv } from './Ajv';
@@ -78,10 +78,6 @@ const SendInvitationEmailParamsSchema: JSONSchemaType<SendInvitationEmailParams>
 
 export const isSendInvitationEmailParams = ajv.compile<SendInvitationEmailParams>(SendInvitationEmailParamsSchema);
 
-export type InvitesEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/findOrCreateInvite': {
-		POST: (params: FindOrCreateInviteParams) => IInvite;
-	};
-};
+// All invite routes are typed by their migrated implementations
+// (apps/meteor/server/api/v1/invites.ts) via ExtractRoutesFromAPI.
+export type InvitesEndpoints = {};

--- a/packages/rest-typings/src/v1/invites.ts
+++ b/packages/rest-typings/src/v1/invites.ts
@@ -77,7 +77,3 @@ const SendInvitationEmailParamsSchema: JSONSchemaType<SendInvitationEmailParams>
 };
 
 export const isSendInvitationEmailParams = ajv.compile<SendInvitationEmailParams>(SendInvitationEmailParamsSchema);
-
-// All invite routes are typed by their migrated implementations
-// (apps/meteor/server/api/v1/invites.ts) via ExtractRoutesFromAPI.
-export type InvitesEndpoints = {};

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -4587,11 +4587,6 @@ export type ILivechatContactWithManagerData = Omit<ILivechatContact, 'contactMan
 };
 
 export type OmnichannelEndpoints = {
-	// Kept canonical here: the ddp-client livechat SDK consumes this route
-	// without seeing the meteor module augmentation.
-	'/v1/livechat/visitor/department.transfer': {
-		POST: (params: POSTLivechatVisitorDepartmentTransferParams) => { success: boolean };
-	};
 	'/v1/livechat/appearance': {
 		GET: () => {
 			appearance: ISetting[];

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -4587,6 +4587,11 @@ export type ILivechatContactWithManagerData = Omit<ILivechatContact, 'contactMan
 };
 
 export type OmnichannelEndpoints = {
+	// Kept canonical here: the ddp-client livechat SDK consumes this route
+	// without seeing the meteor module augmentation.
+	'/v1/livechat/visitor/department.transfer': {
+		POST: (params: POSTLivechatVisitorDepartmentTransferParams) => { success: boolean };
+	};
 	'/v1/livechat/appearance': {
 		GET: () => {
 			appearance: ISetting[];
@@ -4937,9 +4942,6 @@ export type OmnichannelEndpoints = {
 	};
 	'/v1/livechat/room.closeByUser': {
 		POST: (params: POSTLivechatRoomCloseByUserParams) => void;
-	};
-	'/v1/livechat/visitor/department.transfer': {
-		POST: (params: POSTLivechatVisitorDepartmentTransferParams) => { success: boolean };
 	};
 	'/v1/livechat/room.survey': {
 		POST: (params: POSTLivechatRoomSurveyParams) => { rid: string; data: unknown };

--- a/packages/rest-typings/src/v1/push.ts
+++ b/packages/rest-typings/src/v1/push.ts
@@ -1,4 +1,4 @@
-import type { IMessage, IPushNotificationConfig, IPushTokenTypes } from '@rocket.chat/core-typings';
+import type { IPushTokenTypes } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 
@@ -49,20 +49,4 @@ const PushGetPropsSchema = {
 
 export const isPushGetProps = ajvQuery.compile<PushGetProps>(PushGetPropsSchema);
 
-export type PushEndpoints = {
-	'/v1/push.get': {
-		GET: (params: PushGetProps) => {
-			data: {
-				message: IMessage;
-				notification: IPushNotificationConfig;
-			};
-		};
-	};
-	'/v1/push.info': {
-		GET: () => {
-			pushGatewayEnabled: boolean;
-			defaultPushGateway: boolean;
-			success: true;
-		};
-	};
-};
+export type PushEndpoints = {};

--- a/packages/rest-typings/src/v1/push.ts
+++ b/packages/rest-typings/src/v1/push.ts
@@ -48,5 +48,3 @@ const PushGetPropsSchema = {
 };
 
 export const isPushGetProps = ajvQuery.compile<PushGetProps>(PushGetPropsSchema);
-
-export type PushEndpoints = {};

--- a/packages/rest-typings/src/v1/roles.ts
+++ b/packages/rest-typings/src/v1/roles.ts
@@ -112,7 +112,3 @@ const RolesGetUsersInRolePropsSchema = {
 };
 
 export const isRolesGetUsersInRoleProps = ajvQuery.compile<RolesGetUsersInRoleProps>(RolesGetUsersInRolePropsSchema);
-
-// All /v1/roles.* routes are typed by their migrated implementations
-// (apps/meteor/server/api/v1/roles.ts) via ExtractRoutesFromAPI.
-export type RolesEndpoints = {};

--- a/packages/rest-typings/src/v1/roles.ts
+++ b/packages/rest-typings/src/v1/roles.ts
@@ -1,4 +1,4 @@
-import type { RocketChatRecordDeleted, IRole, IUserInRole } from '@rocket.chat/core-typings';
+import type { IRole } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 import type { PaginatedRequest } from '../helpers/PaginatedRequest';
@@ -113,45 +113,12 @@ const RolesGetUsersInRolePropsSchema = {
 
 export const isRolesGetUsersInRoleProps = ajvQuery.compile<RolesGetUsersInRoleProps>(RolesGetUsersInRolePropsSchema);
 
-type RoleSyncProps = {
-	updatedSince?: string;
-};
-
 export type RolesEndpoints = {
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/roles.list': {
 		GET: () => {
 			roles: IRole[];
-		};
-	};
-	'/v1/roles.sync': {
-		GET: (params: RoleSyncProps) => {
-			roles: {
-				update: IRole[];
-				remove: RocketChatRecordDeleted<IRole>[];
-			};
-		};
-	};
-
-	'/v1/roles.addUserToRole': {
-		POST: (params: RoleAddUserToRoleProps) => {
-			role: IRole;
-		};
-	};
-
-	'/v1/roles.getUsersInRole': {
-		GET: (params: RolesGetUsersInRoleProps) => {
-			users: IUserInRole[];
-			total: number;
-		};
-	};
-
-	'/v1/roles.delete': {
-		POST: (prop: RoleDeleteProps) => void;
-	};
-
-	'/v1/roles.removeUserFromRole': {
-		POST: (props: RoleRemoveUserFromRoleProps) => {
-			role: IRole;
 		};
 	};
 };

--- a/packages/rest-typings/src/v1/roles.ts
+++ b/packages/rest-typings/src/v1/roles.ts
@@ -113,12 +113,6 @@ const RolesGetUsersInRolePropsSchema = {
 
 export const isRolesGetUsersInRoleProps = ajvQuery.compile<RolesGetUsersInRoleProps>(RolesGetUsersInRolePropsSchema);
 
-export type RolesEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/roles.list': {
-		GET: () => {
-			roles: IRole[];
-		};
-	};
-};
+// All /v1/roles.* routes are typed by their migrated implementations
+// (apps/meteor/server/api/v1/roles.ts) via ExtractRoutesFromAPI.
+export type RolesEndpoints = {};

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -8,7 +8,6 @@ import type {
 	IE2EEMessage,
 	ITeam,
 	ISubscription,
-	RequiredField,
 	MessageTypesValues,
 } from '@rocket.chat/core-typings';
 
@@ -519,8 +518,6 @@ export type Notifications = {
 	emailNotifications?: string;
 };
 
-type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
-
 type RoomsMuteUnmuteUser = { userId: string; roomId: string } | { username: string; roomId: string };
 
 const RoomsMuteUnmuteUserSchema = {
@@ -890,81 +887,82 @@ const roomsInvitePropsSchema = {
 
 export const isRoomsInviteProps = ajv.compile<RoomsInviteProps>(roomsInvitePropsSchema);
 
+type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
+
 export type RoomsEndpoints = {
-	'/v1/rooms.autocomplete.channelAndPrivate': {
-		GET: (params: RoomsAutoCompleteChannelAndPrivateProps) => {
-			items: IRoom[];
-		};
+	// Routes still registered via the legacy API.v1.addRoute (not the validated
+	// builder) keep their declarations here until they are migrated.
+	'/v1/rooms.adminRooms': {
+		GET: (params: RoomsAdminRoomsProps) => PaginatedResult<{ rooms: Array<Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction> }>;
 	};
-
-	'/v1/rooms.autocomplete.channelAndPrivate.withPagination': {
-		GET: (params: RoomsAutocompleteChannelAndPrivateWithPaginationProps) => {
-			items: IRoom[];
-			total: number;
-		};
-	};
-
-	'/v1/rooms.autocomplete.availableForTeams': {
-		GET: (params: RoomsAutocompleteAvailableForTeamsProps) => {
-			items: IRoom[];
-		};
+	'/v1/rooms.adminRooms.getRoom': {
+		GET: (params: RoomsAdminRoomsGetRoomProps) => Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction;
 	};
 	'/v1/rooms.autocomplete.adminRooms': {
 		GET: (params: RoomsAutocompleteAdminRoomsPayload) => {
 			items: IRoom[];
 		};
 	};
-
-	'/v1/rooms.info': {
-		GET: (params: RoomsInfoProps) => {
-			room: IRoom | undefined;
-			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
+	'/v1/rooms.autocomplete.availableForTeams': {
+		GET: (params: RoomsAutocompleteAvailableForTeamsProps) => {
+			items: IRoom[];
 		};
 	};
-
+	'/v1/rooms.autocomplete.channelAndPrivate.withPagination': {
+		GET: (params: RoomsAutocompleteChannelAndPrivateWithPaginationProps) => {
+			items: IRoom[];
+			total: number;
+		};
+	};
+	'/v1/rooms.changeArchivationState': {
+		POST: (params: RoomsChangeArchivationStateProps) => {
+			success: boolean;
+		};
+	};
 	'/v1/rooms.cleanHistory': {
 		POST: (params: RoomsCleanHistoryProps) => { _id: IRoom['_id']; count: number; success: boolean };
 	};
-
 	'/v1/rooms.createDiscussion': {
 		POST: (params: RoomsCreateDiscussionProps) => {
 			discussion: IRoom & { rid: IRoom['_id'] };
 		};
 	};
-
 	'/v1/rooms.export': {
 		POST: (params: RoomsExportProps) => {
 			missing?: string[];
 			success: boolean;
 		} | void;
 	};
-
-	'/v1/rooms.adminRooms': {
-		GET: (params: RoomsAdminRoomsProps) => PaginatedResult<{ rooms: Array<Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction> }>;
-	};
-
-	'/v1/rooms.adminRooms.getRoom': {
-		GET: (params: RoomsAdminRoomsGetRoomProps) => Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction;
-	};
-
-	'/v1/rooms.saveRoomSettings': {
-		POST: (params: RoomsSaveRoomSettingsProps) => {
-			success: boolean;
-			rid: string;
+	'/v1/rooms.get': {
+		GET: (params: { updatedSince: string }) => {
+			update: IRoom[];
+			remove: IRoom[];
 		};
 	};
-
-	'/v1/rooms.changeArchivationState': {
-		POST: (params: RoomsChangeArchivationStateProps) => {
-			success: boolean;
+	'/v1/rooms.getDiscussions': {
+		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
+			discussions: IRoom[];
+		}>;
+	};
+	'/v1/rooms.hide': {
+		POST: (params: RoomsHideProps) => void;
+	};
+	'/v1/rooms.images': {
+		GET: (params: RoomsImagesProps) => PaginatedResult<{
+			files: IUpload[];
+		}>;
+	};
+	'/v1/rooms.isMember': {
+		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
+	};
+	'/v1/rooms.join': {
+		POST: (params: RoomsJoinProps) => {
+			room: IRoom;
 		};
 	};
-
 	'/v1/rooms.media/:rid': {
 		POST: (params: { file: File }) => { file: { url: string } };
 	};
-
 	'/v1/rooms.mediaConfirm/:rid/:fileId': {
 		POST: (params: {
 			description?: string;
@@ -983,79 +981,44 @@ export type RoomsEndpoints = {
 			message: IMessage | null;
 		};
 	};
-
-	'/v1/rooms.nameExists': {
-		GET: (params: { roomName: string }) => {
-			exists: boolean;
-		};
-	};
-
-	'/v1/rooms.get': {
-		GET: (params: { updatedSince: string }) => {
-			update: IRoom[];
-			remove: IRoom[];
-		};
-	};
-
-	'/v1/rooms.getDiscussions': {
-		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
-			discussions: IRoom[];
-		}>;
-	};
-
-	'/v1/rooms.isMember': {
-		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
-	};
-
-	'/v1/rooms.muteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-
-	'/v1/rooms.unmuteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-
-	'/v1/rooms.banUser': {
-		POST: (params: RoomsBanUserProps) => void;
-	};
-
-	'/v1/rooms.unbanUser': {
-		POST: (params: RoomsUnbanUserProps) => void;
-	};
-
-	'/v1/rooms.bannedUsers': {
-		GET: (params: RoomsBannedUsersProps) => PaginatedResult<{
-			bannedUsers: RequiredField<Pick<IUser, '_id' | 'username' | 'name'>, 'username'>[];
-		}>;
-	};
-
-	'/v1/rooms.images': {
-		GET: (params: RoomsImagesProps) => PaginatedResult<{
-			files: IUpload[];
-		}>;
-	};
-
-	'/v1/rooms.open': {
-		POST: (params: RoomsOpenProps) => void;
-	};
-
-	'/v1/rooms.join': {
-		POST: (params: RoomsJoinProps) => {
-			room: IRoom;
-		};
-	};
-
 	'/v1/rooms.membersOrderedByRole': {
 		GET: (params: RoomsMembersOrderedByRoleProps) => PaginatedResult<{
 			members: (IUser & { subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'> })[];
 		}>;
 	};
-
-	'/v1/rooms.hide': {
-		POST: (params: RoomsHideProps) => void;
+	'/v1/rooms.muteUser': {
+		POST: (params: RoomsMuteUnmuteUser) => void;
 	};
-
-	'/v1/rooms.invite': {
-		POST: (params: RoomsInviteProps) => void;
+	'/v1/rooms.nameExists': {
+		GET: (params: { roomName: string }) => {
+			exists: boolean;
+		};
+	};
+	'/v1/rooms.open': {
+		POST: (params: RoomsOpenProps) => void;
+	};
+	'/v1/rooms.saveRoomSettings': {
+		POST: (params: RoomsSaveRoomSettingsProps) => {
+			success: boolean;
+			rid: string;
+		};
+	};
+	'/v1/rooms.unmuteUser': {
+		POST: (params: RoomsMuteUnmuteUser) => void;
+	};
+	// Kept canonical here (not in the meteor ExtractRoutesFromAPI augmentation)
+	// because standalone packages (ddp-client, fuselage-ui-kit) consume these
+	// routes without seeing the meteor module augmentation.
+	'/v1/rooms.info': {
+		GET: (params: RoomsInfoProps) => {
+			room: IRoom | undefined;
+			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
+			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
+		};
+	};
+	'/v1/rooms.autocomplete.channelAndPrivate': {
+		GET: (params: RoomsAutoCompleteChannelAndPrivateProps) => {
+			items: IRoom[];
+		};
 	};
 };

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -1,19 +1,7 @@
-import type {
-	IMessage,
-	IRoom,
-	IRoomAbacRedaction,
-	IUser,
-	RoomAdminFieldsType,
-	IUpload,
-	IE2EEMessage,
-	ITeam,
-	ISubscription,
-	MessageTypesValues,
-} from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, IUser, IE2EEMessage, MessageTypesValues } from '@rocket.chat/core-typings';
 
 import { ajv, ajvQuery } from './Ajv';
 import type { PaginatedRequest } from '../helpers/PaginatedRequest';
-import type { PaginatedResult } from '../helpers/PaginatedResult';
 
 type RoomsAutoCompleteChannelAndPrivateProps = { selector: string };
 
@@ -887,79 +875,11 @@ const roomsInvitePropsSchema = {
 
 export const isRoomsInviteProps = ajv.compile<RoomsInviteProps>(roomsInvitePropsSchema);
 
-type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
-
 export type RoomsEndpoints = {
 	// Routes still registered via the legacy API.v1.addRoute (not the validated
-	// builder) keep their declarations here until they are migrated.
-	'/v1/rooms.adminRooms': {
-		GET: (params: RoomsAdminRoomsProps) => PaginatedResult<{ rooms: Array<Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction> }>;
-	};
-	'/v1/rooms.adminRooms.getRoom': {
-		GET: (params: RoomsAdminRoomsGetRoomProps) => Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction;
-	};
-	'/v1/rooms.autocomplete.adminRooms': {
-		GET: (params: RoomsAutocompleteAdminRoomsPayload) => {
-			items: IRoom[];
-		};
-	};
-	'/v1/rooms.autocomplete.availableForTeams': {
-		GET: (params: RoomsAutocompleteAvailableForTeamsProps) => {
-			items: IRoom[];
-		};
-	};
-	'/v1/rooms.autocomplete.channelAndPrivate.withPagination': {
-		GET: (params: RoomsAutocompleteChannelAndPrivateWithPaginationProps) => {
-			items: IRoom[];
-			total: number;
-		};
-	};
-	'/v1/rooms.changeArchivationState': {
-		POST: (params: RoomsChangeArchivationStateProps) => {
-			success: boolean;
-		};
-	};
-	'/v1/rooms.cleanHistory': {
-		POST: (params: RoomsCleanHistoryProps) => { _id: IRoom['_id']; count: number; success: boolean };
-	};
-	'/v1/rooms.createDiscussion': {
-		POST: (params: RoomsCreateDiscussionProps) => {
-			discussion: IRoom & { rid: IRoom['_id'] };
-		};
-	};
-	'/v1/rooms.export': {
-		POST: (params: RoomsExportProps) => {
-			missing?: string[];
-			success: boolean;
-		} | void;
-	};
-	'/v1/rooms.get': {
-		GET: (params: { updatedSince: string }) => {
-			update: IRoom[];
-			remove: IRoom[];
-		};
-	};
-	'/v1/rooms.getDiscussions': {
-		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
-			discussions: IRoom[];
-		}>;
-	};
-	'/v1/rooms.hide': {
-		POST: (params: RoomsHideProps) => void;
-	};
-	'/v1/rooms.images': {
-		GET: (params: RoomsImagesProps) => PaginatedResult<{
-			files: IUpload[];
-		}>;
-	};
-	'/v1/rooms.isMember': {
-		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
-	};
-	'/v1/rooms.join': {
-		POST: (params: RoomsJoinProps) => {
-			room: IRoom;
-		};
-	};
+	// builder) keep their declarations here until they are migrated. Every
+	// other /v1/rooms.* route is typed by its migrated implementation
+	// (apps/meteor/server/api/v1/rooms.ts) via ExtractRoutesFromAPI.
 	'/v1/rooms.media/:rid': {
 		POST: (params: { file: File }) => { file: { url: string } };
 	};
@@ -979,46 +899,6 @@ export type RoomsEndpoints = {
 			fileContent?: IE2EEMessage['content'];
 		}) => {
 			message: IMessage | null;
-		};
-	};
-	'/v1/rooms.membersOrderedByRole': {
-		GET: (params: RoomsMembersOrderedByRoleProps) => PaginatedResult<{
-			members: (IUser & { subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'> })[];
-		}>;
-	};
-	'/v1/rooms.muteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-	'/v1/rooms.nameExists': {
-		GET: (params: { roomName: string }) => {
-			exists: boolean;
-		};
-	};
-	'/v1/rooms.open': {
-		POST: (params: RoomsOpenProps) => void;
-	};
-	'/v1/rooms.saveRoomSettings': {
-		POST: (params: RoomsSaveRoomSettingsProps) => {
-			success: boolean;
-			rid: string;
-		};
-	};
-	'/v1/rooms.unmuteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-	// Kept canonical here (not in the meteor ExtractRoutesFromAPI augmentation)
-	// because standalone packages (ddp-client, fuselage-ui-kit) consume these
-	// routes without seeing the meteor module augmentation.
-	'/v1/rooms.info': {
-		GET: (params: RoomsInfoProps) => {
-			room: IRoom | undefined;
-			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
-		};
-	};
-	'/v1/rooms.autocomplete.channelAndPrivate': {
-		GET: (params: RoomsAutoCompleteChannelAndPrivateProps) => {
-			items: IRoom[];
 		};
 	};
 };

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -8,7 +8,6 @@ import type {
 	IE2EEMessage,
 	ITeam,
 	ISubscription,
-	RequiredField,
 	MessageTypesValues,
 } from '@rocket.chat/core-typings';
 
@@ -519,8 +518,6 @@ export type Notifications = {
 	emailNotifications?: string;
 };
 
-type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
-
 type RoomsMuteUnmuteUser = { userId: string; roomId: string } | { username: string; roomId: string };
 
 const RoomsMuteUnmuteUserSchema = {
@@ -890,81 +887,82 @@ const roomsInvitePropsSchema = {
 
 export const isRoomsInviteProps = ajv.compile<RoomsInviteProps>(roomsInvitePropsSchema);
 
+type RoomsGetDiscussionsProps = PaginatedRequest<BaseRoomsProps>;
+
 export type RoomsEndpoints = {
-	'/v1/rooms.autocomplete.channelAndPrivate': {
-		GET: (params: RoomsAutoCompleteChannelAndPrivateProps) => {
-			items: IRoom[];
-		};
+	// Routes still registered via the legacy API.v1.addRoute (not the validated
+	// builder) keep their declarations here until they are migrated.
+	'/v1/rooms.adminRooms': {
+		GET: (params: RoomsAdminRoomsProps) => PaginatedResult<{ rooms: Array<Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction> }>;
 	};
-
-	'/v1/rooms.autocomplete.channelAndPrivate.withPagination': {
-		GET: (params: RoomsAutocompleteChannelAndPrivateWithPaginationProps) => {
-			items: IRoom[];
-			total: number;
-		};
-	};
-
-	'/v1/rooms.autocomplete.availableForTeams': {
-		GET: (params: RoomsAutocompleteAvailableForTeamsProps) => {
-			items: IRoom[];
-		};
+	'/v1/rooms.adminRooms.getRoom': {
+		GET: (params: RoomsAdminRoomsGetRoomProps) => Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction;
 	};
 	'/v1/rooms.autocomplete.adminRooms': {
 		GET: (params: RoomsAutocompleteAdminRoomsPayload) => {
 			items: IRoom[];
 		};
 	};
-
-	'/v1/rooms.info': {
-		GET: (params: RoomsInfoProps) => {
-			room: IRoom | undefined;
-			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
-			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
+	'/v1/rooms.autocomplete.availableForTeams': {
+		GET: (params: RoomsAutocompleteAvailableForTeamsProps) => {
+			items: IRoom[];
 		};
 	};
-
+	'/v1/rooms.autocomplete.channelAndPrivate.withPagination': {
+		GET: (params: RoomsAutocompleteChannelAndPrivateWithPaginationProps) => {
+			items: IRoom[];
+			total: number;
+		};
+	};
+	'/v1/rooms.changeArchivationState': {
+		POST: (params: RoomsChangeArchivationStateProps) => {
+			success: boolean;
+		};
+	};
 	'/v1/rooms.cleanHistory': {
 		POST: (params: RoomsCleanHistoryProps) => { _id: IRoom['_id']; count: number; success: boolean };
 	};
-
 	'/v1/rooms.createDiscussion': {
 		POST: (params: RoomsCreateDiscussionProps) => {
 			discussion: IRoom & { rid: IRoom['_id'] };
 		};
 	};
-
 	'/v1/rooms.export': {
 		POST: (params: RoomsExportProps) => {
 			missing?: string[];
 			success: boolean;
 		} | void;
 	};
-
-	'/v1/rooms.adminRooms': {
-		GET: (params: RoomsAdminRoomsProps) => PaginatedResult<{ rooms: Array<Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction> }>;
-	};
-
-	'/v1/rooms.adminRooms.getRoom': {
-		GET: (params: RoomsAdminRoomsGetRoomProps) => Pick<IRoom, RoomAdminFieldsType> & IRoomAbacRedaction;
-	};
-
-	'/v1/rooms.saveRoomSettings': {
-		POST: (params: RoomsSaveRoomSettingsProps) => {
-			success: boolean;
-			rid: string;
+	'/v1/rooms.get': {
+		GET: (params: { updatedSince: string }) => {
+			update: IRoom[];
+			remove: IRoom[];
 		};
 	};
-
-	'/v1/rooms.changeArchivationState': {
-		POST: (params: RoomsChangeArchivationStateProps) => {
-			success: boolean;
+	'/v1/rooms.getDiscussions': {
+		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
+			discussions: IRoom[];
+		}>;
+	};
+	'/v1/rooms.hide': {
+		POST: (params: RoomsHideProps) => void;
+	};
+	'/v1/rooms.images': {
+		GET: (params: RoomsImagesProps) => PaginatedResult<{
+			files: IUpload[];
+		}>;
+	};
+	'/v1/rooms.isMember': {
+		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
+	};
+	'/v1/rooms.join': {
+		POST: (params: RoomsJoinProps) => {
+			room: IRoom;
 		};
 	};
-
 	'/v1/rooms.media/:rid': {
 		POST: (params: { file: File }) => { file: { url: string } };
 	};
-
 	'/v1/rooms.mediaConfirm/:rid/:fileId': {
 		POST: (params: {
 			description?: string;
@@ -983,80 +981,45 @@ export type RoomsEndpoints = {
 			message: IMessage | null;
 		};
 	};
-
-	'/v1/rooms.nameExists': {
-		GET: (params: { roomName: string }) => {
-			exists: boolean;
-		};
-	};
-
-	'/v1/rooms.get': {
-		GET: (params: { updatedSince: string }) => {
-			update: IRoom[];
-			remove: IRoom[];
-		};
-	};
-
-	'/v1/rooms.getDiscussions': {
-		GET: (params: RoomsGetDiscussionsProps) => PaginatedResult<{
-			discussions: IRoom[];
-		}>;
-	};
-
-	'/v1/rooms.isMember': {
-		GET: (params: RoomsIsMemberProps) => { isMember: boolean };
-	};
-
-	'/v1/rooms.muteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-
-	'/v1/rooms.unmuteUser': {
-		POST: (params: RoomsMuteUnmuteUser) => void;
-	};
-
-	'/v1/rooms.banUser': {
-		POST: (params: RoomsBanUserProps) => void;
-	};
-
-	'/v1/rooms.unbanUser': {
-		POST: (params: RoomsUnbanUserProps) => void;
-	};
-
-	'/v1/rooms.bannedUsers': {
-		GET: (params: RoomsBannedUsersProps) => PaginatedResult<{
-			bannedUsers: RequiredField<Pick<IUser, '_id' | 'username' | 'name'>, 'username'>[];
-		}>;
-	};
-
-	'/v1/rooms.images': {
-		GET: (params: RoomsImagesProps) => PaginatedResult<{
-			files: IUpload[];
-		}>;
-	};
-
-	'/v1/rooms.open': {
-		POST: (params: RoomsOpenProps) => void;
-	};
-
-	'/v1/rooms.join': {
-		POST: (params: RoomsJoinProps) => {
-			room: IRoom;
-		};
-	};
-
 	'/v1/rooms.membersOrderedByRole': {
 		GET: (params: RoomsMembersOrderedByRoleProps) => PaginatedResult<{
 			members: (IUser & { subscription: Pick<ISubscription, '_id' | 'status' | 'ts' | 'roles'> })[];
 		}>;
 	};
-
-	'/v1/rooms.hide': {
-		POST: (params: RoomsHideProps) => void;
+	'/v1/rooms.muteUser': {
+		POST: (params: RoomsMuteUnmuteUser) => void;
 	};
-
-	'/v1/rooms.invite': {
-		POST: (params: RoomsInviteProps) => void;
+	'/v1/rooms.nameExists': {
+		GET: (params: { roomName: string }) => {
+			exists: boolean;
+		};
+	};
+	'/v1/rooms.open': {
+		POST: (params: RoomsOpenProps) => void;
+	};
+	'/v1/rooms.saveRoomSettings': {
+		POST: (params: RoomsSaveRoomSettingsProps) => {
+			success: boolean;
+			rid: string;
+		};
+	};
+	'/v1/rooms.unmuteUser': {
+		POST: (params: RoomsMuteUnmuteUser) => void;
+	};
+	// Kept canonical here (not in the meteor ExtractRoutesFromAPI augmentation)
+	// because standalone packages (ddp-client, fuselage-ui-kit) consume these
+	// routes without seeing the meteor module augmentation.
+	'/v1/rooms.info': {
+		GET: (params: RoomsInfoProps) => {
+			room: IRoom | undefined;
+			parent?: Pick<IRoom, '_id' | 'name' | 'fname' | 't' | 'prid' | 'u'>;
+			team?: Pick<ITeam, 'name' | 'roomId' | 'type' | '_id'>;
+		};
+	};
+	'/v1/rooms.autocomplete.channelAndPrivate': {
+		GET: (params: RoomsAutoCompleteChannelAndPrivateProps) => {
+			items: IRoom[];
+		};
 	};
 };
 

--- a/packages/rest-typings/src/v1/teams/index.ts
+++ b/packages/rest-typings/src/v1/teams/index.ts
@@ -61,12 +61,8 @@ export const isTeamPropsWithTeamName = <T extends TeamProps>(props: T): props is
 export const isTeamPropsWithTeamId = <T extends TeamProps>(props: T): props is T & { teamId: string } => 'teamId' in props;
 
 export type TeamsEndpoints = {
-	'/v1/teams.list': {
-		GET: () => PaginatedResult & { teams: ITeam[] };
-	};
-	'/v1/teams.listAll': {
-		GET: () => { teams: ITeam[] } & PaginatedResult;
-	};
+	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
+	// weaker than this declaration (see the Omit in the meteor augmentation).
 	'/v1/teams.create': {
 		POST: (params: {
 			name: ITeam['name'];
@@ -103,7 +99,6 @@ export type TeamsEndpoints = {
 			team: ITeam;
 		};
 	};
-
 	'/v1/teams.convertToChannel': {
 		POST: (params: TeamsConvertToChannelProps) => void;
 	};

--- a/packages/rest-typings/src/v1/teams/index.ts
+++ b/packages/rest-typings/src/v1/teams/index.ts
@@ -61,44 +61,6 @@ export const isTeamPropsWithTeamName = <T extends TeamProps>(props: T): props is
 export const isTeamPropsWithTeamId = <T extends TeamProps>(props: T): props is T & { teamId: string } => 'teamId' in props;
 
 export type TeamsEndpoints = {
-	// Type-migration pending: the ExtractRoutesFromAPI emit for this route is
-	// weaker than this declaration (see the Omit in the meteor augmentation).
-	'/v1/teams.create': {
-		POST: (params: {
-			name: ITeam['name'];
-			type: ITeam['type'];
-			members?: IUser['_id'][];
-			room: {
-				id?: string;
-				name?: IRoom['name'];
-				members?: IUser['_id'][];
-				readOnly?: boolean;
-				extraData?: {
-					teamId?: string;
-					teamMain?: boolean;
-				} & { [key: string]: string | boolean };
-				options?: {
-					creator: string;
-					subscriptionExtra?: {
-						open: boolean;
-						ls: Date;
-						prid: IRoom['_id'];
-					};
-				} & {
-					[key: string]:
-						| string
-						| {
-								open: boolean;
-								ls: Date;
-								prid: IRoom['_id'];
-						  };
-				};
-			};
-			owner?: IUser['_id'];
-		}) => {
-			team: ITeam;
-		};
-	};
 	'/v1/teams.convertToChannel': {
 		POST: (params: TeamsConvertToChannelProps) => void;
 	};

--- a/scripts/ts7-typecheck.sh
+++ b/scripts/ts7-typecheck.sh
@@ -52,7 +52,7 @@ done
 echo ""
 echo "================ TS7 canary summary ================"
 echo "green: $green / $total_pkgs packages"
-if [ "${#FAILED[@]}" -gt 0 ]; then
+if [ "${#FAILED[@]:-0}" -gt 0 ]; then
 	printf '%s\n' "${FAILED[@]}" | sort -t= -k2 -rn
 fi
 echo "===================================================="

--- a/scripts/ts7-typecheck.sh
+++ b/scripts/ts7-typecheck.sh
@@ -33,7 +33,7 @@ echo "Using $(node "$TSC" --version 2>/dev/null || "$TSC" --version)"
 
 total_pkgs=0
 green=0
-declare -a FAILED
+declare -a FAILED=()
 
 for tsconfig in packages/*/tsconfig.json ee/packages/*/tsconfig.json ee/apps/*/tsconfig.json apps/*/tsconfig.json; do
 	[ -f "$tsconfig" ] || continue
@@ -52,7 +52,7 @@ done
 echo ""
 echo "================ TS7 canary summary ================"
 echo "green: $green / $total_pkgs packages"
-if [ "${#FAILED[@]:-0}" -gt 0 ]; then
+if [ "${#FAILED[@]}" -gt 0 ]; then
 	printf '%s\n' "${FAILED[@]}" | sort -t= -k2 -rn
 fi
 echo "===================================================="


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

**Stacked on #41932** — this is the burn-down of the one red check that PR leaves: the `apps/meteor` TypeScript job failing with TS2320 ×140, because `Endpoints` simultaneously extends the hand-written family types in `@rocket.chat/rest-typings` and the `ExtractRoutesFromAPI` augmentations the migrated implementations declare. TS 5.9 tolerated the near-identical duplicates; TS 7 compares them precisely. The dual declarations spanned ten families (chat, dm/im, e2e, emoji-custom, invites, push, roles, rooms, teams, one omnichannel route), ~90 routes.

The dedup makes the **augmentation authoritative wherever one exists** — every migrated route is typed only by its `ExtractRoutesFromAPI` emit, and its hand-written rest-typings declaration is deleted:

- **Standalone registrations are captured**: the 23 `API.v1.get/post(...)` calls in `rooms.ts` that lived outside the builder chain (`rooms.info`, `rooms.autocomplete.*`, `rooms.adminRooms`, ...) are now named consts intersected into `RoomEndpoints`, so their types flow from the actual handlers too.
- **Weak extractions were strengthened at the source** instead of keeping the old hand-written claims: typed response generics for `im.files`/`im.members`/`rooms.membersOrderedByRole`/`rooms.info`/`findOrCreateInvite`, permissive query validators for `rooms.info` and `emoji-custom.all` (open schemas — pagination/`fields` helpers still travel through), and body-less POST routes now emit callable-without-params signatures.
- **Consumers that relied on hand-written lies were fixed to the truthful types**: `roles.list` never returned `_updatedAt` (the projection strips it), `teams.create`'s `type` is `0 | 1`, `saveRoomSettings`' response carries no typed `success`, and the members list is normalized to one page shape in `useMembersList`.
- **Only legacy `API.v1.addRoute` routes keep rest-typings declarations** (`rooms.media/:rid`, `rooms.mediaConfirm/:rid/:fileId`, `chat.getMessageReadReceipts`, `im.kick`) until they are migrated.
- **Standalone packages carry local contracts** mirroring the server responses, since they compile without the meteor augmentation: `ddp-client` (legacy SDK: chat routes, `rooms.info`, `im.create`; livechat SDK: `department.transfer`) and `fuselage-ui-kit` (locally-typed `useEndpoint` wrappers for `rooms.info` and `rooms.autocomplete.channelAndPrivate`).

## Issue(s)

Burn-down item tracked in `docs/typescript-7-migration.md` (from #41932).

## Steps to test or reproduce

- `yarn install && yarn turbo run build --filter='./packages/*' --filter='./ee/packages/*' --filter='./ee/apps/*'`
- `bash scripts/ts7-typecheck.sh` — expected: **73/73 green** (was 72/73 with `apps/meteor` at 140 errors)
- `yarn workspace @rocket.chat/meteor testunit`, `yarn workspace @rocket.chat/ddp-client testunit`, `yarn workspace @rocket.chat/fuselage-ui-kit test`

## Further comments

Validated locally: zero `apps/meteor` typecheck errors under TS7, canary 73/73, all workspace package + ee app builds green, ddp-client 56 / fuselage-ui-kit 24 / affected meteor jest suites (239 tests) green. Type-level only, with two deliberate exceptions: `GET /v1/rooms.info` and `GET /v1/emoji-custom.all` now validate their query params (permissively, matching what the handlers already accepted). The changeset covers `rest-typings`, `ddp-client`, `fuselage-ui-kit`, and `meteor` as patches.

With this stacked PR, the parent's one red check (Code Check / TypeScript) turns green, making the whole TS7 migration CI-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kBpQd6yQsB9qif313UvSQ