### PR TITLE
regression: video calls failing when forced E2EE meets persistent chat

### DIFF
--- a/apps/meteor/ee/server/settings/video-conference.ts
+++ b/apps/meteor/ee/server/settings/video-conference.ts
@@ -33,16 +33,13 @@ export function addSettings(): Promise<void> {
 				});
 
 				const discussionsEnabled = { _id: 'Discussion_enabled', value: true };
-				// Persistent chat discussions are always created unencrypted, so they can not be used while the
-				// workspace enforces encryption on private rooms.
-				const encryptionNotEnforced = { _id: 'E2E_Force_Encryption_For_Private_Rooms', value: false };
 
 				await this.add('VideoConf_Enable_Persistent_Chat', false, {
 					type: 'boolean',
 					public: true,
 					invalidValue: false,
 					alert: 'VideoConf_Enable_Persistent_Chat_Alert',
-					enableQuery: [discussionsEnabled, encryptionNotEnforced],
+					enableQuery: [discussionsEnabled],
 				});
 
 				const persistentChatEnabled = { _id: 'VideoConf_Enable_Persistent_Chat', value: true };

--- a/apps/meteor/ee/server/settings/video-conference.ts
+++ b/apps/meteor/ee/server/settings/video-conference.ts
@@ -33,13 +33,16 @@ export function addSettings(): Promise<void> {
 				});
 
 				const discussionsEnabled = { _id: 'Discussion_enabled', value: true };
+				// Persistent chat discussions are always created unencrypted, so they can not be used while the
+				// workspace enforces encryption on private rooms.
+				const encryptionNotEnforced = { _id: 'E2E_Force_Encryption_For_Private_Rooms', value: false };
 
 				await this.add('VideoConf_Enable_Persistent_Chat', false, {
 					type: 'boolean',
 					public: true,
 					invalidValue: false,
 					alert: 'VideoConf_Enable_Persistent_Chat_Alert',
-					enableQuery: [discussionsEnabled],
+					enableQuery: [discussionsEnabled, encryptionNotEnforced],
 				});
 
 				const persistentChatEnabled = { _id: 'VideoConf_Enable_Persistent_Chat', value: true };

--- a/apps/meteor/server/services/video-conference/service.ts
+++ b/apps/meteor/server/services/video-conference/service.ts
@@ -1115,7 +1115,11 @@ export class VideoConfService extends ServiceClassInternal implements IVideoConf
 	}
 
 	private isPersistentChatEnabled(): boolean {
-		return settings.get<boolean>('VideoConf_Enable_Persistent_Chat') && settings.get<boolean>('Discussion_enabled');
+		// Persistent chat discussions are always created unencrypted, so persistent chat is treated as disabled
+		// while the workspace enforces encryption on private rooms.
+		const encryptionEnforced = settings.get<boolean>('E2E_Enable') && settings.get<boolean>('E2E_Force_Encryption_For_Private_Rooms');
+
+		return settings.get<boolean>('VideoConf_Enable_Persistent_Chat') && settings.get<boolean>('Discussion_enabled') && !encryptionEnforced;
 	}
 
 	private async maybeCreateDiscussion(callId: VideoConference['_id'], createdBy?: IUser): Promise<void> {

--- a/apps/meteor/server/settings/e2e.ts
+++ b/apps/meteor/server/settings/e2e.ts
@@ -32,6 +32,7 @@ export const createE2ESettings = () =>
 			type: 'boolean',
 			i18nLabel: 'Force_Encryption_For_Private_Rooms',
 			i18nDescription: 'Force_Encryption_For_Private_Rooms_Description',
+			alert: 'Force_Encryption_For_Private_Rooms_Alert',
 			public: true,
 			enableQuery: { _id: 'E2E_Enable', value: true },
 		});

--- a/apps/meteor/tests/end-to-end/apps/video-conferences.ts
+++ b/apps/meteor/tests/end-to-end/apps/video-conferences.ts
@@ -602,6 +602,119 @@ describe('Apps - Video Conferences', () => {
 				});
 			});
 
+			describe('[Persistent Chat provider with the persistent chat feature enabled and encryption forced on private rooms]', () => {
+				let callId: string | undefined;
+
+				before(async () => {
+					if (!process.env.IS_EE) {
+						return;
+					}
+
+					await updateSetting('VideoConf_Default_Provider', 'persistentchat');
+					await updateSetting('Discussion_enabled', true);
+					await updateSetting('VideoConf_Enable_Persistent_Chat', true);
+					await Promise.all([updateSetting('E2E_Enable', true), updateSetting('E2E_Force_Encryption_For_Private_Rooms', true)]);
+
+					const res = await request.post(api('video-conference.start')).set(credentials).send({
+						roomId,
+					});
+
+					callId = res.body.data?.callId;
+				});
+
+				after(async () => {
+					if (!process.env.IS_EE) {
+						return;
+					}
+
+					await Promise.all([updateSetting('E2E_Enable', false), updateSetting('E2E_Force_Encryption_For_Private_Rooms', false)]);
+				});
+
+				it('should start the call and treat persistent chat as disabled', async function () {
+					if (!process.env.IS_EE) {
+						this.skip();
+					}
+
+					expect(callId).to.be.a('string');
+
+					await request
+						.get(api('video-conference.info'))
+						.set(credentials)
+						.query({
+							callId,
+						})
+						.expect(200)
+						.expect((res: Response) => {
+							expect(res.body.success).to.be.equal(true);
+							expect(res.body).to.have.a.property('_id').equal(callId);
+							expect(res.body).to.have.a.property('rid').equal(roomId);
+							// the call must be fully started, since persistent chat is skipped instead of attempted
+							expect(res.body).to.have.a.property('url').that.is.a('string');
+							expect(res.body).to.have.a.property('status').equal(1);
+							expect(res.body).to.have.a.property('messages').that.is.an('object');
+							expect(res.body.messages).to.have.a.property('started').that.is.a('string');
+							// even with VideoConf_Enable_Persistent_Chat on, enforcing encryption disables persistent chat
+							expect(res.body).to.not.have.a.property('discussionRid');
+						});
+				});
+			});
+
+			describe('[Persistent Chat provider with the persistent chat feature enabled and encryption forced but E2EE off]', () => {
+				let callId: string | undefined;
+				let discussionRid: string | undefined;
+
+				before(async () => {
+					if (!process.env.IS_EE) {
+						return;
+					}
+
+					await updateSetting('VideoConf_Default_Provider', 'persistentchat');
+					await updateSetting('Discussion_enabled', true);
+					await updateSetting('VideoConf_Enable_Persistent_Chat', true);
+					// the encryption policy only takes effect while E2EE is enabled, so persistent chat must keep working
+					await Promise.all([updateSetting('E2E_Enable', false), updateSetting('E2E_Force_Encryption_For_Private_Rooms', true)]);
+
+					const res = await request.post(api('video-conference.start')).set(credentials).send({
+						roomId,
+					});
+
+					callId = res.body.data?.callId;
+				});
+
+				after(async () => {
+					if (!process.env.IS_EE) {
+						return;
+					}
+
+					await Promise.all([
+						updateSetting('E2E_Force_Encryption_For_Private_Rooms', false),
+						...(discussionRid ? [deleteRoom({ type: 'p', roomId: discussionRid })] : []),
+					]);
+				});
+
+				it('should still create the persistent chat discussion', async function () {
+					if (!process.env.IS_EE) {
+						this.skip();
+					}
+
+					expect(callId).to.be.a('string');
+
+					await request
+						.get(api('video-conference.info'))
+						.set(credentials)
+						.query({
+							callId,
+						})
+						.expect(200)
+						.expect((res: Response) => {
+							discussionRid = res.body.discussionRid;
+							expect(res.body.success).to.be.equal(true);
+							expect(res.body).to.have.a.property('_id').equal(callId);
+							expect(res.body).to.have.a.property('discussionRid').that.is.a('string');
+						});
+				});
+			});
+
 			describe('[Persistent Chat provider with the persistent chat feature enabled and custom discussion names]', () => {
 				let callId: string | undefined;
 				let discussionRid: string | undefined;

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -6019,7 +6019,7 @@
   "VideoConf_Enable_DMs": "Enable in direct messages",
   "VideoConf_Enable_Groups": "Enable in private channels",
   "VideoConf_Enable_Persistent_Chat": "Enable Persistent Chat",
-  "VideoConf_Enable_Persistent_Chat_Alert": "Persistent Chat will not work if discussions are disabled on the workspace. It will also not work if the provider app being used do not explicitly support this feature.",
+  "VideoConf_Enable_Persistent_Chat_Alert": "Persistent Chat will not work if discussions are disabled on the workspace, or if E2E encryption is mandatory. It will also not work if the provider app being used do not explicitly support this feature.",
   "VideoConf_Enable_Persistent_Chat_description": "When persistent chat is enabled, Rocket.Chat will create a discussion every time a conference call is initiated. The provider app is responsible for sending the chat messages to this discussion.",
   "VideoConf_Enable_Teams": "Enable in teams",
   "VideoConf_Mobile_Ringing": "Enable mobile ringing",

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -2559,6 +2559,7 @@
   "Force_Disable_OpLog_For_Cache": "Force Disable OpLog for Cache",
   "Force_Disable_OpLog_For_Cache_Description": "Will not use OpLog to sync cache even when it's available",
   "Force_Encryption_For_Private_Rooms": "Force end-to-end encryption on private rooms",
+  "Force_Encryption_For_Private_Rooms_Alert": "<b>Not compatible with video conference persistent chat</b><br/>Persistent chat discussions are unencrypted, so while this setting is enabled persistent chat is treated as disabled and video calls will not create a chat history discussion.",
   "Force_Encryption_For_Private_Rooms_Description": "When enabled, all newly created private rooms will be encrypted by default, and users will not be able to disable encryption for them.",
   "Force_SSL": "Force SSL",
   "Force_SSL_Description": "*Caution!* _Force SSL_ should never be used with reverse proxy. If you have a reverse proxy, you should do the redirect THERE. This option exists for deployments like Heroku, that does not allow the redirect configuration at the reverse proxy.",


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Targets `release-8.8.0`, where the feature landed. Fixes a regression introduced by #41095: starting a video call from a direct message or private room fails when **Force end-to-end encryption on private rooms** and video conference persistent chat are both enabled.

### Root cause

Persistent chat creates its discussion with `encrypted: false` hardcoded ([`service.ts` `createDiscussionForConference`](https://github.com/RocketChat/Rocket.Chat/blob/develop/apps/meteor/server/services/video-conference/service.ts)), and `getDiscussionType` returns `'p'` for a private/DM parent. The forced-encryption policy added in #41095 therefore rejects the room creation with `error-encrypted-private-rooms-enforced`.

The damage comes from *where* that throw happens. In both `startDirect` and `startGroup`, `maybeCreateDiscussion` runs **before** the rest of the start sequence and was not guarded, so the throw aborted everything after it — while the `VideoConference` record had already been inserted:

| Step | Order | Result on throw |
|---|---|---|
| `VideoConferenceModel.createDirect/createGroup` | before | ✅ record already inserted |
| `maybeCreateDiscussion` | — | 💥 throws |
| `setUrlById` | after | ❌ no call URL |
| `createMessage` / `setMessageById` | after | ❌ no start message |
| 40s auto-cancel timer (direct) | after | ❌ never scheduled → stuck in `CALLING` |
| `sendPushNotification` / `ring` broadcast | after | ❌ no notifications |

That matches the report exactly, including direct calls stuck in `CALLING` and group calls in `STARTED`. The error is then swallowed by the endpoint's `catch`, which returns `diagnoseProvider(...)` — and since the provider is healthy that resolves to `undefined`, so the client only shows the generic `error-videoconf-unexpected`.

### The fix

Persistent chat discussions are unencrypted, so the two features are simply incompatible. Rather than letting the room creation fail and recovering from it, persistent chat is now treated as disabled while the policy is on, so the discussion is never attempted and the call start path is untouched.

`isPersistentChatEnabled()` already gathers every setting that must be active for persistent chat, so the policy was added there as one more condition — inactive instead of active:

```ts
private isPersistentChatEnabled(): boolean {
	const encryptionEnforced = settings.get<boolean>('E2E_Enable') && settings.get<boolean>('E2E_Force_Encryption_For_Private_Rooms');

	return settings.get<boolean>('VideoConf_Enable_Persistent_Chat') && settings.get<boolean>('Discussion_enabled') && !encryptionEnforced;
}
```

No setting is written based on another — `VideoConf_Enable_Persistent_Chat` keeps whatever value the admin gave it, and both settings are simply validated together where it matters. So even with persistent chat on, enforcing encryption makes the code treat it as off.

The policy is also a requirement of the persistent chat setting itself (`enableQuery`), so it can no longer be turned on while encryption is enforced.

`E2E_Enable` is checked alongside the policy because the policy only takes effect when E2EE is on — that mirrors `beforeCreateRoom.ts` and the create-room modals, which validate the same pair.

### Files

- `apps/meteor/server/services/video-conference/service.ts` — treat persistent chat as disabled while the policy is on
- `apps/meteor/ee/server/settings/video-conference.ts` — the policy is a requirement of `VideoConf_Enable_Persistent_Chat`
- `apps/meteor/server/settings/e2e.ts` — `alert` on `E2E_Force_Encryption_For_Private_Rooms`
- `packages/i18n/src/locales/en.i18n.json` — `Force_Encryption_For_Private_Rooms_Alert`
- `apps/meteor/tests/end-to-end/apps/video-conferences.ts` — regression test

No changeset: this completes the feature shipped in #41095 rather than fixing a bug that ever reached production, and that feature already carries its own changeset.

## Issue(s)

[CORE-2621]
Regression from #41095, which is part of 8.8.0.

## Steps to test or reproduce

1. Enable `E2E_Enable`, `E2E_Force_Encryption_For_Private_Rooms`, `Discussion_enabled` and `VideoConf_Enable_Persistent_Chat`.
2. Configure a video conference provider that supports persistent chat.
3. Open a direct message or a private room and start a video call.

**Before:** call creation fails, server throws `error-encrypted-private-rooms-enforced`, client shows `error-videoconf-unexpected`, and an unusable conference record is left behind (no URL, no discussion, no start message, no notifications; direct calls stuck in `CALLING`, private-room calls in `STARTED`).

**After:** the call starts normally and no persistent chat discussion is created. In **Admin → Settings → Video Conference**, *Enable persistent chat* is also greyed out while the policy is on.

Also check **Admin → Settings → End-to-End Encryption**: the *Force end-to-end encryption on private rooms* setting now shows the incompatibility warning.

## Further comments

Gating the feature is preferable to catching the failure: nothing is attempted, so there is no error to recover from and no partially built conference record to reason about.

Note this disables persistent chat for every call while the policy is on, including calls in public channels where the discussion would not have been rejected. That is intentional — it keeps the rule predictable for admins and matches what the setting warning states.

Worth noting separately (not changed here): the start sequence inserts the conference record before it can guarantee a usable call, so *any* failure between those points still leaves an unusable record with direct calls stuck in `CALLING`. That is pre-existing and no longer reachable through this path, but it is the underlying fragility.

Worth noting separately (not changed here): `video-conference.start` discards the real error in its `catch` and returns `diagnoseProvider(...)`, which is why this failure was invisible from the client. Making that endpoint surface the underlying error would help diagnose similar issues, but it is out of scope for this regression fix.

Validated locally against `release-8.8.0`: `tsc --noEmit` reports the exact same 49 errors with and without this change (all pre-existing on that branch, in unrelated client sidebar components), so it introduces none. ESLint reports 0 errors on all changed files — the 5 remaining warnings in `service.ts` are pre-existing — and the i18n sort/validity check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[CORE-2621]: https://rocketchat.atlassian.net/browse/CORE-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alert explaining that forced end-to-end encryption disables persistent video-conference chat in private rooms.

* **Bug Fixes**
  * Persistent video-conference chat is now automatically disabled when encryption is mandatory, preventing chat history discussions from being created.
  * Persistent chat remains available when encryption enforcement is disabled.

* **Documentation**
  * Updated settings guidance to clarify compatibility between end-to-end encryption and persistent video-conference chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->