### PR TITLE
regression: add chat.sendMessage rate limiter

### DIFF
--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -18,7 +18,7 @@ import type { RateLimiterOptionsToCheck } from 'meteor/rate-limit';
 import { RateLimiter } from 'meteor/rate-limit';
 import _ from 'underscore';
 
-import { checkPermissions, parseDeprecation } from './api.helpers';
+import { canBypassRateLimit, checkPermissions, parseDeprecation } from './api.helpers';
 import type {
 	FailureResult,
 	ForbiddenResult,
@@ -45,7 +45,6 @@ import type { APIActionContext } from './router';
 import { RocketChatAPIRouter } from './router';
 import { isObject } from '../../lib/utils/isObject';
 import { checkCodeForUser } from '../lib/2fa/code';
-import { hasPermissionAsync } from '../lib/authorization/hasPermission';
 import { getNestedProp } from '../lib/getNestedProp';
 import { notifyOnUserChangeAsync } from '../lib/notifyListener';
 import { shouldBreakInVersion } from '../lib/shouldBreakInVersion';
@@ -130,6 +129,7 @@ interface IAPIDefaultFieldsToExclude {
 export type RateLimiterOptions = {
 	numRequestsAllowed?: number;
 	intervalTimeInMS?: number;
+	bypassPermissions?: string[];
 };
 
 export const defaultRateLimiterOptions: RateLimiterOptions = {
@@ -420,7 +420,7 @@ export class APIClass<TBasePath extends string = '', TOperations extends Record<
 			rateLimiterDictionary.hasOwnProperty(route) &&
 			settings.get<boolean>('API_Enable_Rate_Limiter') === true &&
 			(process.env.NODE_ENV !== 'development' || settings.get<boolean>('API_Enable_Rate_Limiter_Dev') === true) &&
-			!(userId && (await hasPermissionAsync(userId, 'api-bypass-rate-limit')))
+			!(userId && (await canBypassRateLimit(userId, rateLimiterDictionary[route].options.bypassPermissions)))
 		);
 	}
 

--- a/apps/meteor/server/api/ApiClass.ts
+++ b/apps/meteor/server/api/ApiClass.ts
@@ -27,6 +27,7 @@ import type {
 	NotFoundResult,
 	Operations,
 	Options,
+	RateLimiterOptions,
 	SuccessResult,
 	TypedThis,
 	TypedAction,
@@ -125,12 +126,6 @@ interface IAPIDefaultFieldsToExclude {
 	settings: number;
 	inviteToken: number;
 }
-
-export type RateLimiterOptions = {
-	numRequestsAllowed?: number;
-	intervalTimeInMS?: number;
-	bypassPermissions?: string[];
-};
 
 export const defaultRateLimiterOptions: RateLimiterOptions = {
 	numRequestsAllowed: settings.get<number>('API_Enable_Rate_Limiter_Limit_Calls_Default'),

--- a/apps/meteor/server/api/api.helpers.ts
+++ b/apps/meteor/server/api/api.helpers.ts
@@ -39,6 +39,10 @@ const isPermissionsPayload = (permissionsPayload: PermissionsRequiredKey): permi
 	);
 };
 
+export async function canBypassRateLimit(userId: IUser['_id'], bypassPermissions: string[] = []): Promise<boolean> {
+	return hasAtLeastOnePermissionAsync(userId, ['api-bypass-rate-limit', ...bypassPermissions]);
+}
+
 export async function checkPermissionsForInvocation(
 	userId: IUser['_id'],
 	permissionsPayload: PermissionsPayload,

--- a/apps/meteor/server/api/api.ts
+++ b/apps/meteor/server/api/api.ts
@@ -5,6 +5,7 @@ import type express from 'express';
 import { WebApp } from 'meteor/webapp';
 
 import { APIClass } from './ApiClass';
+import type { RateLimiterOptions } from './definition';
 import { type APIActionHandler, RocketChatAPIRouter } from './router';
 import { metrics } from '../lib/metrics';
 import { settings } from '../settings';
@@ -21,10 +22,7 @@ export type Prettify<T> = {
 	[K in keyof T]: T[K];
 } & unknown;
 
-export type RateLimiterOptions = {
-	numRequestsAllowed?: number;
-	intervalTimeInMS?: number;
-};
+export type { RateLimiterOptions } from './definition';
 
 export const defaultRateLimiterOptions: RateLimiterOptions = {
 	numRequestsAllowed: settings.get<number>('API_Enable_Rate_Limiter_Limit_Calls_Default'),

--- a/apps/meteor/server/api/definition.ts
+++ b/apps/meteor/server/api/definition.ts
@@ -99,6 +99,12 @@ export type NonEnterpriseTwoFactorOptions = {
 	twoFactorOptions: ITwoFactorOptions;
 };
 
+export type RateLimiterOptions = {
+	numRequestsAllowed?: number;
+	intervalTimeInMS?: number;
+	bypassPermissions?: string[];
+};
+
 export type Options = SharedOptions<'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'>;
 
 export type SharedOptions<TMethod extends string> = (
@@ -112,12 +118,7 @@ export type SharedOptions<TMethod extends string> = (
 			authRequired?: boolean;
 			userWithoutUsername?: boolean;
 			forceTwoFactorAuthenticationForNonEnterprise?: boolean;
-			rateLimiterOptions?:
-				| {
-						numRequestsAllowed?: number;
-						intervalTimeInMS?: number;
-				  }
-				| boolean;
+			rateLimiterOptions?: RateLimiterOptions | boolean;
 			queryOperations?: string[];
 			queryFields?: string[];
 	  }
@@ -132,12 +133,7 @@ export type SharedOptions<TMethod extends string> = (
 			userWithoutUsername?: boolean;
 			twoFactorRequired: true;
 			twoFactorOptions?: ITwoFactorOptions;
-			rateLimiterOptions?:
-				| {
-						numRequestsAllowed?: number;
-						intervalTimeInMS?: number;
-				  }
-				| boolean;
+			rateLimiterOptions?: RateLimiterOptions | boolean;
 
 			queryOperations?: string[];
 			queryFields?: string[];

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -895,6 +895,7 @@ const chatEndpoints = API.v1
 		'chat.sendMessage',
 		{
 			authRequired: true,
+			rateLimiterOptions: { numRequestsAllowed: 5, intervalTimeInMS: 1000 },
 			body: isChatSendMessageProps,
 			response: {
 				200: ajv.compile<{ message: IMessage }>({

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -895,7 +895,7 @@ const chatEndpoints = API.v1
 		'chat.sendMessage',
 		{
 			authRequired: true,
-			rateLimiterOptions: { numRequestsAllowed: 5, intervalTimeInMS: 1000 },
+			rateLimiterOptions: { numRequestsAllowed: 5, intervalTimeInMS: 1000, bypassPermissions: ['send-many-messages'] },
 			body: isChatSendMessageProps,
 			response: {
 				200: ajv.compile<{ message: IMessage }>({

--- a/apps/meteor/tests/unit/server/api/canBypassRateLimit.spec.ts
+++ b/apps/meteor/tests/unit/server/api/canBypassRateLimit.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import mock from 'proxyquire';
+
+const userPermissions: Record<string, string[]> = {
+	bot: ['api-bypass-rate-limit', 'send-many-messages'],
+	legacyBot: ['send-many-messages'],
+	regular: [],
+};
+
+const mocks = {
+	'../lib/authorization/hasPermission': {
+		hasAtLeastOnePermissionAsync: async (userId: string, permissions: string[]): Promise<boolean> =>
+			permissions.some((permission) => userPermissions[userId].includes(permission)),
+	},
+	'../lib/deprecationWarningLogger': {
+		apiDeprecationLogger: { endpoint: () => undefined },
+	},
+};
+
+const { canBypassRateLimit } = mock.noCallThru().load('../../../../server/api/api.helpers', mocks);
+
+describe('canBypassRateLimit', () => {
+	it('should let a user holding api-bypass-rate-limit through on any route', async () => {
+		expect(await canBypassRateLimit('bot')).to.be.true;
+	});
+
+	it('should not let a regular user through', async () => {
+		expect(await canBypassRateLimit('regular')).to.be.false;
+		expect(await canBypassRateLimit('regular', ['send-many-messages'])).to.be.false;
+	});
+
+	it('should let a user holding a route specific permission through', async () => {
+		expect(await canBypassRateLimit('legacyBot', ['send-many-messages'])).to.be.true;
+	});
+
+	it('should not let a route specific permission apply to routes that do not declare it', async () => {
+		expect(await canBypassRateLimit('legacyBot')).to.be.false;
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`POST /v1/chat.sendMessage` declared no `rateLimiterOptions`, so it fell back to the REST API default of 10 requests per 60 seconds — a default added in #11251 (2019) for machine-to-machine traffic.

When the web client's send flow moved from the `sendMessage` Meteor method to REST in #40675, it inherited that budget. The method had its own rule (5 messages per second, since 2015), so the allowance dropped from 300 to 10 messages per minute and the 11th message returned `429`.

This declares the previous allowance on the endpoint, the same way `users.setStatus` does:

```ts
rateLimiterOptions: { numRequestsAllowed: 5, intervalTimeInMS: 1000 },
```

## Issue(s)

- [CORE-2629](https://rocketchat.atlassian.net/browse/CORE-2629)

## Steps to test or reproduce

Requires a server started **without** `TEST_MODE` and with `API_Enable_Rate_Limiter_Dev` enabled — otherwise no rule is registered and no `X-RateLimit-*` headers are returned.

As a regular user without `api-bypass-rate-limit`:

1. Send 12 messages ~300 ms apart → all `200`. The 11th used to return `429`.
2. Send 10 messages as fast as possible → first 5 `200`, rest `429`.
3. Wait ~1 s and send again → `200`. The window is 1 second, not 60.
4. Repeat step 2 with the `bot` role → no rejections.

## Further comments

The REST limiter buckets by **IP address, not by user** — the counter key is `IPAddr` + route, with no per-route way to change it. This allowance is therefore shared by everyone behind one address, unlike the Meteor rule, which was keyed by `userId`. Keying on `userId` would remove that ceiling, but it affects every route and is deliberately left out of this fix.

There's a follow up task to handle per user: [CORE-2637](https://rocketchat.atlassian.net/browse/CORE-2637)


[CORE-2629]: https://rocketchat.atlassian.net/browse/CORE-2629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rate limiting to chat message requests, allowing up to 5 requests per second.
  - Authorized integrations can bypass limits when granted the appropriate permissions.
  - API rate-limit bypasses now support route-specific permissions for more flexible access control.

- **Bug Fixes**
  - Improved rate-limit exemption handling to apply permissions consistently across API routes.
  - Ensured users without the required permissions remain subject to configured request limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2637]: https://rocketchat.atlassian.net/browse/CORE-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ