### PR TITLE
fix: unescapeHTML decodes astral numeric HTML entities

### DIFF
--- a/.changeset/unescape-astral-entities.md
+++ b/.changeset/unescape-astral-entities.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/tools': patch
+---
+
+Fixed `unescapeHTML` decoding astral (non-BMP) numeric entities such as `&#128512;` or `&#x1F600;` into a truncated character. It now uses `String.fromCodePoint` so emoji and other code points above U+FFFF decode correctly, while numeric entities above U+10FFFF are left untouched instead of throwing.

--- a/packages/tools/src/unescapeHTML.spec.ts
+++ b/packages/tools/src/unescapeHTML.spec.ts
@@ -27,4 +27,17 @@ describe('unescapeHTML', () => {
 		expect(unescapeHTML(undefined as unknown as string)).toBe('');
 		expect(unescapeHTML(5 as unknown as string)).toBe('5');
 	});
+
+	it('decodes astral (non-BMP) numeric entities', () => {
+		expect(unescapeHTML('&#128512;')).toBe('😀');
+		expect(unescapeHTML('&#x1F600;')).toBe('😀');
+		expect(unescapeHTML('smile &#128512; here')).toBe('smile 😀 here');
+	});
+
+	it('leaves out-of-range numeric entities untouched', () => {
+		// 999999999 is within the entity length limit but above U+10FFFF, so
+		// String.fromCodePoint would throw; the entity must be returned as-is.
+		expect(unescapeHTML('&#999999999;')).toBe('&#999999999;');
+		expect(unescapeHTML('&#x110000;')).toBe('&#x110000;');
+	});
 });

--- a/packages/tools/src/unescapeHTML.ts
+++ b/packages/tools/src/unescapeHTML.ts
@@ -27,14 +27,23 @@ export const unescapeHTML = (str: string): string =>
 			return htmlEntityCodeToCharacter[htmlEntityCode];
 		}
 
+		// `fromCodePoint` (not `fromCharCode`) so astral code points such as
+		// emoji (`&#128512;`, `&#x1F600;`) decode to a full character instead of
+		// a truncated UTF-16 code unit. Guard the range: `fromCodePoint` throws on
+		// values above U+10FFFF, and the entity length limit still admits a
+		// 9-digit decimal that exceeds it.
+		const MAX_CODE_POINT = 0x10ffff;
+
 		match = htmlEntityCode.match(/^#x([\da-fA-F]+)$/);
 		if (match) {
-			return String.fromCharCode(parseInt(match[1], 16));
+			const codePoint = parseInt(match[1], 16);
+			return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : entity;
 		}
 
 		match = htmlEntityCode.match(/^#(\d+)$/);
 		if (match) {
-			return String.fromCharCode(~~match[1]);
+			const codePoint = parseInt(match[1], 10);
+			return codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : entity;
 		}
 
 		return entity;


### PR DESCRIPTION
## Proposed changes

`unescapeHTML` (`@rocket.chat/tools`) decoded numeric HTML entities with `String.fromCharCode`, which takes a single UTF-16 code unit. Any code point above U+FFFF was therefore truncated to the wrong character:

- `unescapeHTML('&#128512;')` and `unescapeHTML('&#x1F600;')` returned a broken character instead of `😀`.

This affects any astral character (emoji, many CJK extension characters, mathematical symbols) that arrives as a numeric entity.

The fix switches both the decimal and hex numeric branches to `String.fromCodePoint`, which handles the full Unicode range. `fromCodePoint` throws for values above U+10FFFF, and the entity length limit (`{1,10}`) still admits a 9-digit decimal that exceeds it, so the code point is range-checked and an out-of-range entity is returned unchanged rather than throwing.

All existing behaviour (BMP entities, named entities, malformed entities left untouched) is preserved.

## Testing

Added unit tests in `unescapeHTML.spec.ts`:
- astral decimal and hex entities decode to `😀`, including inside surrounding text;
- out-of-range entities (`&#999999999;`, `&#x110000;`) are returned unchanged.

Verified the full existing spec plus the new cases pass (20/20) against the updated logic. A changeset (`@rocket.chat/tools` patch) is included.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly decodes numeric HTML entities representing astral Unicode characters, including emoji.
  * Leaves numeric entities outside the valid Unicode range unchanged instead of causing an error.

* **Tests**
  * Added coverage for decimal and hexadecimal entities, inline text, and out-of-range values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->