### PR TITLE
fix: TTL Retention Banner wrong date when using ENV vars

### DIFF
--- a/.changeset/timespan-setting-env-override.md
+++ b/.changeset/timespan-setting-env-override.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the retention policy warning message omitting the message age when the retention TTL settings are set through environment variables

--- a/.changeset/timespan-setting-env-override.md
+++ b/.changeset/timespan-setting-env-override.md
@@ -2,4 +2,6 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixes the retention policy warning message omitting the message age when the retention TTL settings are set through environment variables
+Fixes the retention policy warning message omitting the message age when the retention TTL settings are set through environment variables.
+
+Workspaces that already used those environment variables should be aware that the incorrect value was persisted to the database, and upgrading does not rewrite stored setting values. If the environment variable is still set, the correct value is written on the next startup and no action is needed. If it was removed before upgrading, the stored value stays incorrect and the warning message keeps omitting the message age until an administrator re-saves the affected setting under **Admin → Settings → Retention Policy**, which writes a valid value. This is not corrected automatically because stored setting values are only migrated in a major release.

--- a/apps/meteor/server/settings/functions/convertValue.ts
+++ b/apps/meteor/server/settings/functions/convertValue.ts
@@ -7,7 +7,7 @@ export const convertValue = (value: 'true' | 'false' | string, type: ISetting['t
 	if (value.toLowerCase() === 'false') {
 		return false;
 	}
-	if (type === 'int') {
+	if (type === 'int' || type === 'timespan') {
 		return parseInt(value);
 	}
 	if (type === 'multiSelect') {

--- a/apps/meteor/server/settings/functions/convertValue.ts
+++ b/apps/meteor/server/settings/functions/convertValue.ts
@@ -1,5 +1,23 @@
 import type { ISetting, SettingValue } from '@rocket.chat/core-typings';
 
+const INTEGER_PATTERN = /^[+-]?\d+$/;
+
+const parseIntegerValue = (value: string): number => {
+	const trimmed = value.trim();
+
+	if (!INTEGER_PATTERN.test(trimmed)) {
+		throw new Error(`Invalid integer value "${value}"`);
+	}
+
+	const parsed = Number(trimmed);
+
+	if (!Number.isSafeInteger(parsed)) {
+		throw new Error(`Invalid integer value "${value}"`);
+	}
+
+	return parsed;
+};
+
 export const convertValue = (value: 'true' | 'false' | string, type: ISetting['type']): SettingValue => {
 	if (value.toLowerCase() === 'true') {
 		return true;
@@ -8,7 +26,7 @@ export const convertValue = (value: 'true' | 'false' | string, type: ISetting['t
 		return false;
 	}
 	if (type === 'int' || type === 'timespan') {
-		return parseInt(value);
+		return parseIntegerValue(value);
 	}
 	if (type === 'multiSelect') {
 		return JSON.parse(value);

--- a/apps/meteor/server/settings/functions/convertValue.ts
+++ b/apps/meteor/server/settings/functions/convertValue.ts
@@ -1,17 +1,9 @@
 import type { ISetting, SettingValue } from '@rocket.chat/core-typings';
 
-const INTEGER_PATTERN = /^[+-]?\d+$/;
-
 const parseIntegerValue = (value: string): number => {
-	const trimmed = value.trim();
+	const parsed = Number(value);
 
-	if (!INTEGER_PATTERN.test(trimmed)) {
-		throw new Error(`Invalid integer value "${value}"`);
-	}
-
-	const parsed = Number(trimmed);
-
-	if (!Number.isSafeInteger(parsed)) {
+	if (value.trim() === '' || !Number.isSafeInteger(parsed)) {
 		throw new Error(`Invalid integer value "${value}"`);
 	}
 

--- a/apps/meteor/tests/unit/server/settings/functions/convertValue.tests.ts
+++ b/apps/meteor/tests/unit/server/settings/functions/convertValue.tests.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai';
+
+import { convertValue } from '../../../../../server/settings/functions/convertValue';
+
+describe('convertValue', () => {
+	(['true', 'True', 'TRUE'] as const).forEach((value) => {
+		it(`should convert '${value}' to true`, () => {
+			expect(convertValue(value, 'string')).to.be.equal(true);
+		});
+	});
+
+	(['false', 'False', 'FALSE'] as const).forEach((value) => {
+		it(`should convert '${value}' to false`, () => {
+			expect(convertValue(value, 'string')).to.be.equal(false);
+		});
+	});
+
+	(['int', 'timespan'] as const).forEach((type) => {
+		describe(type, () => {
+			const validValues: [string, number][] = [
+				['0', 0],
+				['10', 10],
+				['-5', -5],
+				['+5', 5],
+				['  7  ', 7],
+				['9007199254740991', 9007199254740991],
+			];
+
+			validValues.forEach(([value, expected]) => {
+				it(`should convert '${value}' to ${expected}`, () => {
+					expect(convertValue(value, type)).to.be.equal(expected);
+				});
+			});
+
+			const invalidValues = [
+				'',
+				'   ',
+				'abc',
+				'30d',
+				'30 days',
+				'10px',
+				'1.5',
+				'.5',
+				'1e3',
+				'0x10',
+				'NaN',
+				'Infinity',
+				'-Infinity',
+				'1,000',
+				'1_000',
+				'--1',
+				'9007199254740993',
+			];
+
+			invalidValues.forEach((value) => {
+				it(`should throw on '${value}'`, () => {
+					expect(() => convertValue(value, type)).to.throw(`Invalid integer value "${value}"`);
+				});
+			});
+		});
+	});
+
+	describe('multiSelect', () => {
+		it('should parse a JSON array', () => {
+			expect(convertValue('["a","b"]', 'multiSelect')).to.be.deep.equal(['a', 'b']);
+		});
+
+		it('should throw on malformed JSON', () => {
+			expect(() => convertValue('[a,b', 'multiSelect')).to.throw();
+		});
+	});
+
+	describe('other types', () => {
+		it('should return the raw string', () => {
+			expect(convertValue('some value', 'string')).to.be.equal('some value');
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/settings/functions/convertValue.tests.ts
+++ b/apps/meteor/tests/unit/server/settings/functions/convertValue.tests.ts
@@ -24,6 +24,8 @@ describe('convertValue', () => {
 				['+5', 5],
 				['  7  ', 7],
 				['9007199254740991', 9007199254740991],
+				['1e3', 1000],
+				['0x10', 16],
 			];
 
 			validValues.forEach(([value, expected]) => {
@@ -41,8 +43,6 @@ describe('convertValue', () => {
 				'10px',
 				'1.5',
 				'.5',
-				'1e3',
-				'0x10',
 				'NaN',
 				'Infinity',
 				'-Infinity',

--- a/apps/meteor/tests/unit/server/settings/functions/overrideGenerator.tests.ts
+++ b/apps/meteor/tests/unit/server/settings/functions/overrideGenerator.tests.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { getSettingDefaults } from '../../../../../server/settings/functions/getSettingDefaults';
 import { overrideGenerator } from '../../../../../server/settings/functions/overrideGenerator';
@@ -65,5 +66,45 @@ describe('overrideGenerator', () => {
 		const overwritten = overwrite(setting);
 
 		expect(setting).to.be.equal(overwritten);
+	});
+
+	describe('malformed numeric overrides', () => {
+		let consoleError: sinon.SinonStub;
+
+		beforeEach(() => {
+			consoleError = sinon.stub(console, 'error');
+		});
+
+		afterEach(() => {
+			consoleError.restore();
+		});
+
+		['30d', '30 days', 'abc', '', '1.5', '10px', 'NaN'].forEach((overwriteValue) => {
+			it(`should keep the default when the timespan override is '${overwriteValue}'`, () => {
+				const overwrite = overrideGenerator(() => overwriteValue);
+
+				const setting = getSettingDefaults({ _id: 'RetentionPolicy_TTL_Channels', value: 2592000000, type: 'timespan' });
+				const overwritten = overwrite(setting);
+
+				expect(setting).to.be.equal(overwritten);
+				expect(overwritten).to.have.property('value').that.equals(2592000000);
+				expect(overwritten).to.have.property('valueSource').that.equals('packageValue');
+				expect(overwritten).to.not.have.property('processEnvValue');
+				expect(consoleError.calledOnceWith('Error converting value for setting RetentionPolicy_TTL_Channels expected "timespan" type')).to
+					.be.true;
+			});
+		});
+
+		['abc', '10px', '1.5'].forEach((overwriteValue) => {
+			it(`should keep the default when the int override is '${overwriteValue}'`, () => {
+				const overwrite = overrideGenerator(() => overwriteValue);
+
+				const setting = getSettingDefaults({ _id: 'Message_MaxAllowedSize', value: 5000, type: 'int' });
+				const overwritten = overwrite(setting);
+
+				expect(setting).to.be.equal(overwritten);
+				expect(overwritten).to.have.property('value').that.equals(5000);
+			});
+		});
 	});
 });

--- a/apps/meteor/tests/unit/server/settings/functions/overrideGenerator.tests.ts
+++ b/apps/meteor/tests/unit/server/settings/functions/overrideGenerator.tests.ts
@@ -43,4 +43,27 @@ describe('overrideGenerator', () => {
 
 		expect(setting).to.be.equal(overwritten);
 	});
+
+	it('should convert timespan values to numbers', () => {
+		const overwrite = overrideGenerator(() => '31536000000');
+
+		const setting = getSettingDefaults({ _id: 'RetentionPolicy_TTL_Channels', value: 2592000000, type: 'timespan' });
+		const overwritten = overwrite(setting);
+
+		expect(overwritten).to.have.property('value').that.equals(31536000000);
+		expect(overwritten).to.have.property('processEnvValue').that.equals(31536000000);
+	});
+
+	it('should return the same object when the timespan value already matches the env stamp', () => {
+		const overwrite = overrideGenerator(() => '31536000000');
+
+		const setting = {
+			...getSettingDefaults({ _id: 'RetentionPolicy_TTL_Channels', value: 31536000000, type: 'timespan' }),
+			valueSource: 'processEnvValue' as const,
+			processEnvValue: 31536000000,
+		};
+		const overwritten = overwrite(setting);
+
+		expect(setting).to.be.equal(overwritten);
+	});
 });


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

When the retention policy TTL is set through an environment variable, the warning shown at the top of a room (and in channel info) leaves out the age:

> Unpinned messages older than **&nbsp;** will be pruned on August 27, 2026 at 12:00 AM.

It should say:

> Unpinned messages older than **1 year** will be pruned on August 27, 2026 at 12:00 AM.

Messages are still pruned at the right time. Only the text is wrong.

Env vars are always strings, so the server converts them to the right type before saving. `convertValue` only did that for `int` settings, and the TTL settings are `timespan`. So `31536000000` was saved as the string `"31536000000"` instead of a number.

The client then calls date-fns `intervalToDuration` with that string. date-fns only accepts a `Date` or a number, so it returns an invalid date, the duration comes back empty, and the age renders as an empty string.

Two side effects of the same cause:

- Saving the setting in the admin UI fixes the text, because the save path forces a number. A server restart re-applies the env var and breaks it again.
- Opening **Edit channel** on such a workspace throws `msToTimeUnit - invalid timespan:31536000000`, because that check uses `Number.isFinite`, which is false for a string.

This started in 8.4.0. Before that the client used moment, which accepted number-like strings.

`apps/meteor/server/settings/functions/convertValue.ts` now converts `timespan` settings to numbers, like it already did for `int`:

```diff
-	if (type === 'int') {
+	if (type === 'int' || type === 'timespan') {
```

Nothing else needs to change: every reader of these settings already expects a number (`settings.get<number>`, the numeric defaults in `useRetentionPolicy`, the migration that created the TTL settings, and the admin save path).

Workspaces that already have a string saved are fixed on the next restart, because the env var is applied again on startup.

Two cases added to `overrideGenerator.tests.ts`:

- a `timespan` env value becomes a number
- an env value that already matches the saved number returns the same object, so the setting is not rewritten on every restart (it was, since a string never equals a number)

Both fail without the fix and pass with it.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

[SUP-1112]

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

1. Start Rocket.Chat with:

   ```
   OVERWRITE_SETTING_RetentionPolicy_TTL_Channels=31536000000
   OVERWRITE_SETTING_RetentionPolicy_TTL_Groups=31536000000
   OVERWRITE_SETTING_RetentionPolicy_TTL_DMs=31536000000
   ```

2. Go to **Admin > Message > Retention Policy**, turn the policy on and enable it for channels. The TTL shows `365 days`, which looks right.
3. Open any channel. The warning at the top of the room has a gap where the age should be.
4. Open **Kebab menu > Edit** on that channel. It fails with `msToTimeUnit - invalid timespan:31536000000`.

Both are fixed by this PR. After the change, step 3 shows "1 year" and step 4 opens normally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retention policy warnings to display message age correctly when settings are configured through environment variables.
  * Improved validation for integer and timespan settings, rejecting malformed or unsafe values instead of partially interpreting them.
  * Invalid environment-based overrides now retain their configured defaults and report a conversion error.
  * Existing incorrectly stored retention values are not rewritten automatically; affected settings must be re-saved under **Admin → Settings → Retention Policy**.

* **Tests**
  * Added coverage for valid conversions, malformed inputs, environment overrides, and existing numeric values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SUP-1112]: https://rocketchat.atlassian.net/browse/SUP-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ