### PR TITLE
chore!: drop unused indexes from livechat_visitor and subscription collections

### DIFF
--- a/.changeset/drop-livechat-visitor-activity-index.md
+++ b/.changeset/drop-livechat-visitor-activity-index.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/models': major
+'@rocket.chat/meteor': major
+---
+
+Removes unused indexes: `activity` on `rocketchat_livechat_visitor` and `desktopNotifications`, `mobilePushNotifications`, `emailNotifications` on `rocketchat_subscription`. No query relies on them; removing them avoids unnecessary index maintenance on writes. On upgrade the indexes are dropped from the database.

--- a/apps/meteor/server/startup/migrations/index.ts
+++ b/apps/meteor/server/startup/migrations/index.ts
@@ -47,5 +47,6 @@ import './v338';
 import './v339';
 import './v340';
 import './v341';
+import './v342';
 
 export * from './xrun';

--- a/apps/meteor/server/startup/migrations/v342.ts
+++ b/apps/meteor/server/startup/migrations/v342.ts
@@ -1,0 +1,22 @@
+import { LivechatVisitors, Subscriptions } from '@rocket.chat/models';
+
+import { addMigration } from '../../lib/migrations';
+
+addMigration({
+	version: 342,
+	name: 'Drop unused indexes from rocketchat_livechat_visitor and rocketchat_subscription',
+	async up() {
+		try {
+			await Subscriptions.col.dropIndex('desktopNotifications_1');
+			await Subscriptions.col.dropIndex('mobilePushNotifications_1');
+			await Subscriptions.col.dropIndex('emailNotifications_1');
+			// activity_1 stopped being created in 7.3 while the subscription indexes lasted until 8.7,
+			// so it must be dropped last: an IndexNotFound here aborts the try block
+			await LivechatVisitors.col.dropIndex('activity_1');
+		} catch (e: any) {
+			if (e?.code !== 27 && e?.codeName !== 'IndexNotFound') {
+				throw e;
+			}
+		}
+	},
+});

--- a/apps/meteor/server/startup/migrations/v342.ts
+++ b/apps/meteor/server/startup/migrations/v342.ts
@@ -7,16 +7,17 @@ addMigration({
 	name: 'Drop unused indexes from rocketchat_livechat_visitor and rocketchat_subscription',
 	async up() {
 		try {
+			await LivechatVisitors.col.dropIndex('activity_1');
+		} catch {
+			// ignore
+		}
+
+		try {
 			await Subscriptions.col.dropIndex('desktopNotifications_1');
 			await Subscriptions.col.dropIndex('mobilePushNotifications_1');
 			await Subscriptions.col.dropIndex('emailNotifications_1');
-			// activity_1 stopped being created in 7.3 while the subscription indexes lasted until 8.7,
-			// so it must be dropped last: an IndexNotFound here aborts the try block
-			await LivechatVisitors.col.dropIndex('activity_1');
-		} catch (e: any) {
-			if (e?.code !== 27 && e?.codeName !== 'IndexNotFound') {
-				throw e;
-			}
+		} catch {
+			// ignore
 		}
 	},
 });

--- a/packages/models/src/models/LivechatVisitors.ts
+++ b/packages/models/src/models/LivechatVisitors.ts
@@ -36,8 +36,6 @@ export class LivechatVisitorsRaw extends BaseRaw<ILivechatVisitor> implements IL
 			{ key: { username: 1 } },
 			{ key: { 'contactMananger.username': 1 }, sparse: true },
 			{ key: { 'livechatData.$**': 1 } },
-			// TODO: remove this index in the next major release (8.0.0)
-			// { key: { activity: 1 }, partialFilterExpression: { activity: { $exists: true } } },
 			{ key: { disabled: 1 }, partialFilterExpression: { disabled: { $exists: true } } },
 		];
 	}

--- a/packages/models/src/models/Subscriptions.ts
+++ b/packages/models/src/models/Subscriptions.ts
@@ -46,10 +46,6 @@ export class SubscriptionsRaw extends BaseRaw<ISubscription> implements ISubscri
 			{ key: { alert: 1 } },
 			{ key: { ts: 1 } },
 			{ key: { ls: 1 } },
-			// TODO: remove these indexes in the next major release (8.0.0) - their only consumers (the per-room notification-preference finders) were removed
-			// { key: { desktopNotifications: 1 }, sparse: true },
-			// { key: { mobilePushNotifications: 1 }, sparse: true },
-			// { key: { emailNotifications: 1 }, sparse: true },
 			{ key: { autoTranslate: 1 }, sparse: true },
 			{ key: { autoTranslateLanguage: 1 }, sparse: true },
 			{ key: { 'userHighlights.0': 1 }, sparse: true },


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Removes index declarations that have been commented out in the models but still exist on databases of workspaces created before the removal:

- `activity_1` on `rocketchat_livechat_visitor` (stopped being created in 7.3)
- `desktopNotifications_1`, `mobilePushNotifications_1`, `emailNotifications_1` on `rocketchat_subscription` (stopped being created in 8.7)

Migration v342 drops them from existing databases, one try/catch per collection since each set can be independently missing depending on when the workspace was created.

## Issue(s)
https://rocketchat.atlassian.net/browse/CORE-2594
https://rocketchat.atlassian.net/browse/CORE-2595

## Steps to test or reproduce

1. Start a workspace on a version < 9.0 so the indexes exist
2. Upgrade to this branch
3. Verify migration 342 runs and the four indexes are gone from `rocketchat_livechat_visitor` and `rocketchat_subscription`

## Further comments

None of these fields are used as query filters anywhere in the codebase — they are only read via projections or written on preference saves, so no query plan can regress from dropping the indexes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Removed several unused database indexes during upgrade.
  * Improved database efficiency by eliminating indexes no longer needed for application queries.
* **Release**
  * Includes a major version update for the models and application packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->