### PR TITLE
fix: auto-translate using stale provider after switching providers

### DIFF
--- a/.changeset/autotranslate-provider-switch.md
+++ b/.changeset/autotranslate-provider-switch.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed auto-translate continuing to translate messages with the previously selected service provider after switching providers, until the server was restarted

--- a/.changeset/autotranslate-provider-switch.md
+++ b/.changeset/autotranslate-provider-switch.md
@@ -2,4 +2,4 @@
 '@rocket.chat/meteor': patch
 ---
 
-Fixed auto-translate continuing to translate messages with the previously selected service provider after switching providers, until the server was restarted
+Fixes auto-translate continuing to translate messages with the previously selected service provider after switching providers, until the server was restarted or the feature was disabled and re-enabled.

--- a/apps/meteor/server/lib/autotranslate/autotranslate.ts
+++ b/apps/meteor/server/lib/autotranslate/autotranslate.ts
@@ -102,7 +102,7 @@ export class TranslationProviderRegistry {
 
 		callbacks.add(
 			'afterSaveMessage',
-			async (message, { room }) => (await TranslationProviderRegistry.translateMessage(message, room)) ?? message,
+			(message, { room }) => TranslationProviderRegistry.translateMessage(message, room),
 			callbacks.priority.MEDIUM,
 			'autotranslate',
 		);

--- a/apps/meteor/server/lib/autotranslate/autotranslate.ts
+++ b/apps/meteor/server/lib/autotranslate/autotranslate.ts
@@ -85,13 +85,7 @@ export class TranslationProviderRegistry {
 	}
 
 	static setCurrentProvider(provider: string): void {
-		if (provider === TranslationProviderRegistry[Provider]) {
-			return;
-		}
-
 		TranslationProviderRegistry[Provider] = provider;
-
-		TranslationProviderRegistry.registerCallbacks();
 	}
 
 	static setEnable(enabled: boolean): void {
@@ -106,14 +100,9 @@ export class TranslationProviderRegistry {
 			return;
 		}
 
-		const provider = TranslationProviderRegistry.getActiveProvider();
-		if (!provider) {
-			return;
-		}
-
 		callbacks.add(
 			'afterSaveMessage',
-			(message, { room }) => provider.translateMessage(message, { room }),
+			async (message, { room }) => (await TranslationProviderRegistry.translateMessage(message, room)) ?? message,
 			callbacks.priority.MEDIUM,
 			'autotranslate',
 		);

--- a/apps/meteor/tests/unit/server/lib/autotranslate/autotranslate.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/autotranslate/autotranslate.spec.ts
@@ -71,12 +71,12 @@ describe('TranslationProviderRegistry', () => {
 		expect(providerA.translateMessage.calledOnce).to.be.true;
 	});
 
-	it('should return the message unchanged when no provider is active', async () => {
+	it('should resolve null when no provider is active, letting the callback chain keep the original message', async () => {
 		TranslationProviderRegistry.setCurrentProvider('missing');
 		TranslationProviderRegistry.setEnable(true);
 
 		const result = await getRegisteredCallback()(message, { room });
 
-		expect(result).to.equal(message);
+		expect(result).to.be.null;
 	});
 });

--- a/apps/meteor/tests/unit/server/lib/autotranslate/autotranslate.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/autotranslate/autotranslate.spec.ts
@@ -1,0 +1,82 @@
+import type { IMessage, IRoom } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+describe('TranslationProviderRegistry', () => {
+	let TranslationProviderRegistry: any;
+	let addStub: sinon.SinonStub;
+	let removeStub: sinon.SinonStub;
+
+	const message = { _id: 'msg1', rid: 'room1', msg: 'hello' } as IMessage;
+	const room = { _id: 'room1' } as IRoom;
+
+	const makeProvider = (name: string) => ({
+		_getProviderMetadata: () => ({ name }),
+		translateMessage: sinon.stub().resolves({ ...message, translations: { [name]: 'translated' } }),
+	});
+
+	const getRegisteredCallback = () => addStub.firstCall.args[1];
+
+	beforeEach(() => {
+		addStub = sinon.stub();
+		removeStub = sinon.stub();
+
+		({ TranslationProviderRegistry } = proxyquire
+			.noCallThru()
+			.noPreserveCache()
+			.load('../../../../../server/lib/autotranslate/autotranslate', {
+				'meteor/meteor': { Meteor: { startup: sinon.stub() } },
+				'@rocket.chat/models': { Messages: {}, Subscriptions: {} },
+				'../../settings': { settings: { watch: sinon.stub(), get: sinon.stub() } },
+				'../callbacks': { callbacks: { add: addStub, remove: removeStub, priority: { MEDIUM: 2 } } },
+				'../messaging/markdown': { Markdown: {} },
+				'../notifyListener': { notifyOnMessageChange: sinon.stub() },
+			}));
+	});
+
+	it('should remove the afterSaveMessage callback and not register a new one when disabled', () => {
+		TranslationProviderRegistry.setEnable(false);
+
+		expect(removeStub.calledOnceWith('afterSaveMessage', 'autotranslate')).to.be.true;
+		expect(addStub.called).to.be.false;
+	});
+
+	it('should register the afterSaveMessage callback when enabled', () => {
+		TranslationProviderRegistry.setEnable(true);
+
+		expect(addStub.calledOnce).to.be.true;
+		expect(addStub.firstCall.args[0]).to.equal('afterSaveMessage');
+		expect(addStub.firstCall.args[3]).to.equal('autotranslate');
+	});
+
+	it('should translate with the newly selected provider after switching providers while enabled', async () => {
+		const providerA = makeProvider('a');
+		const providerB = makeProvider('b');
+		TranslationProviderRegistry.registerProvider(providerA);
+		TranslationProviderRegistry.registerProvider(providerB);
+
+		TranslationProviderRegistry.setCurrentProvider('a');
+		TranslationProviderRegistry.setEnable(true);
+
+		const callback = getRegisteredCallback();
+
+		await callback(message, { room });
+		expect(providerA.translateMessage.calledOnce).to.be.true;
+
+		TranslationProviderRegistry.setCurrentProvider('b');
+
+		await callback(message, { room });
+		expect(providerB.translateMessage.calledOnce).to.be.true;
+		expect(providerA.translateMessage.calledOnce).to.be.true;
+	});
+
+	it('should return the message unchanged when no provider is active', async () => {
+		TranslationProviderRegistry.setCurrentProvider('missing');
+		TranslationProviderRegistry.setEnable(true);
+
+		const result = await getRegisteredCallback()(message, { room });
+
+		expect(result).to.equal(message);
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

When the AutoTranslate service provider is changed while auto-translate is enabled, messages keep being translated by the previous provider until the server is restarted.

Root cause (identified by @prathamesh04 in #41330): the `afterSaveMessage` callback captured the active provider in its closure at registration time, and `callbacks.add()` with an existing id silently no-ops instead of replacing, so `setCurrentProvider` → `registerCallbacks` never swapped the callback.

Instead of removing/re-adding the callback on every provider change, the callback now resolves the active provider at run time via `TranslationProviderRegistry.translateMessage`, which already checks enabled state and active provider per call. Provider switches take effect immediately and `setCurrentProvider` no longer needs to re-register anything. The callback chain handles the `null` return (disabled/no provider) by falling back to the original message.

Includes unit tests for the callback registration lifecycle, including a regression test for the provider-switch scenario (verified to fail against the previous implementation).

Credit to @prathamesh04 for the diagnosis and original fix in #41330 (co-authored).

## Issue(s)

Closes #41197
Closes #41330

## Steps to test or reproduce

1. Enable Auto-Translate with the default provider (google-translate)
2. Switch Service Provider to another (e.g. libre-translate) while Auto-Translate remains enabled
3. Send a message in a channel with auto-translate enabled for a member
4. Message should be translated by the newly selected provider, without restarting the server

## Further comments

Supersedes #41330, which targets the old file location (`apps/meteor/app/autotranslate/server/autotranslate.ts`, since moved to `apps/meteor/server/lib/autotranslate/autotranslate.ts`) and conflicts with develop. The runtime-resolution approach removes the whole class of stale-closure bugs rather than patching the re-registration path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

https://rocketchat.atlassian.net/browse/CORE-2639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Auto-translation now uses the newly selected provider immediately, without requiring a server restart or toggling the feature off and on.
  - Messages remain unchanged when no translation provider is active.
  - Enabling and disabling auto-translation now consistently updates translation behavior.
  - Translation callbacks now follow the currently selected provider, ensuring new messages are translated using the intended service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->