### PR TITLE
regression: threads not loading when low Max Record Amount

### DIFF
--- a/apps/meteor/client/lib/utils/threadMessageUtils.ts
+++ b/apps/meteor/client/lib/utils/threadMessageUtils.ts
@@ -50,6 +50,7 @@ export const createDeleteCriteria = (params: NotifyRoomRidDeleteBulkEvent): ((me
 export type ThreadMessagesPage = {
 	items: IThreadMessage[];
 	itemCount: number;
+	pageSize?: number;
 };
 
 export type ThreadMessagesInfiniteData = InfiniteData<ThreadMessagesPage, number>;
@@ -106,7 +107,7 @@ export const mutateThreadMessagesInfiniteData = (
 			const take = isLastPage ? items.length - cursor : Math.min(originalPageLengths[pageIndex], items.length - cursor);
 			const slice = items.slice(cursor, cursor + Math.max(0, take));
 			cursor += slice.length;
-			pages.push({ items: slice, itemCount: newTotal });
+			pages.push({ items: slice, itemCount: newTotal, pageSize: old.pages[pageIndex].pageSize });
 		}
 
 		return {
@@ -161,7 +162,7 @@ export const markThreadMessagesAsRead = (messages: IThreadMessage[], until?: Dat
 			return msg;
 		}
 		const { unread: _, ...rest } = msg;
-		return rest as IThreadMessage;
+		return rest;
 	});
 };
 

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -29,6 +29,8 @@ import { useMessageListNavigation } from '../../../hooks/useMessageListNavigatio
 import { useThreadMessagesQuery } from '../hooks/useThreadMessagesQuery';
 import './threads.css';
 
+const MAX_AUTO_FILL_PAGES = 10;
+
 const isMessageSequential = (current: IMessage, previous: IMessage | undefined, groupingRange: number): boolean => {
 	if (!previous) {
 		return false;
@@ -93,19 +95,28 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 
 	const initialScrollDoneRef = useRef(false);
 
+	const autoFillCountRef = useRef(0);
+
 	const loadPreviousMessages = useDebouncedCallback(
 		() => {
-			if (
-				userInteractedRef.current &&
-				!isJumpingToMessageRef.current &&
-				initialScrollDoneRef.current &&
-				isAtBottom.current !== true &&
-				hasPreviousPage &&
-				!isFetchingPreviousPage
-			) {
-				isPrependRef.current = true;
-				void fetchPreviousPage();
+			if (isJumpingToMessageRef.current || !hasPreviousPage || isFetchingPreviousPage) {
+				return;
 			}
+
+			const handle = virtualizerRef.current;
+			const fitsViewport = !!handle && handle.scrollSize > 0 && handle.viewportSize > 0 && handle.scrollSize <= handle.viewportSize;
+
+			if (fitsViewport) {
+				if (autoFillCountRef.current >= MAX_AUTO_FILL_PAGES) {
+					return;
+				}
+				autoFillCountRef.current += 1;
+			} else if (!(userInteractedRef.current && initialScrollDoneRef.current && isAtBottom.current !== true)) {
+				return;
+			}
+
+			isPrependRef.current = true;
+			void fetchPreviousPage();
 		},
 		100,
 		[hasPreviousPage, isFetchingPreviousPage, fetchPreviousPage],
@@ -233,6 +244,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 		userInteractedRef.current = false;
 		isJumpingToMessageRef.current = false;
 		isPrependRef.current = false;
+		autoFillCountRef.current = 0;
 	}, [mainMessage._id]);
 
 	useEffect(() => {
@@ -419,7 +431,9 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 							</li>
 						) : null}
 						{!loading && hasPreviousPage ? (
-							<li className='load-more'>{isFetchingPreviousPage ? <LoadingMessagesIndicator /> : null}</li>
+							<li className='load-more'>
+								{isFetchingPreviousPage ? <LoadingMessagesIndicator /> : <InfiniteListAnchor loadMore={loadPreviousMessages} />}
+							</li>
 						) : null}
 						{!loading &&
 							items.map((message, index, { [index - 1]: previous }) => {

--- a/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
+++ b/apps/meteor/client/views/room/contextualBar/Threads/components/ThreadMessageList.tsx
@@ -164,6 +164,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 			return;
 		}
 		loadingWindowKeyRef.current = windowKey;
+		autoFillCountRef.current = 0;
 		loadMessageAround(msgJumpParam).catch(() => {
 			if (loadingWindowKeyRef.current === windowKey) {
 				loadingWindowKeyRef.current = undefined;
@@ -369,6 +370,7 @@ const ThreadMessageList = ({ mainMessage, shouldJumpToBottom, setShouldJumpToBot
 				}
 				if (msg.u._id === uid) {
 					if (hasNextPage) {
+						autoFillCountRef.current = 0;
 						void jumpToRecent().then(() => setShouldJumpToBottom(true));
 						return;
 					}

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.spec.ts
@@ -37,19 +37,23 @@ const newestPageIds = idsOf(allReplies.slice(TOTAL - PAGE_SIZE));
 
 type GetThreadMessagesParams = { tmid: string; offset?: number; count?: number; aroundId?: string; sort?: string };
 
-const setup = () => {
+const setup = ({ upperCountLimit = PAGE_SIZE }: { upperCountLimit?: number } = {}) => {
 	const getThreadMessages = jest.fn(({ offset = 0, count = PAGE_SIZE, aroundId }: GetThreadMessagesParams) => {
+		const limit = Math.min(count, upperCountLimit);
+
 		if (aroundId) {
 			const index = allReplies.findIndex(({ _id }) => _id === aroundId);
-			const start = Math.max(0, index - Math.floor(count / 2));
+			const start = Math.max(0, index - Math.floor(limit / 2));
+			const messages = allReplies.slice(start, start + limit);
 
-			return { messages: allReplies.slice(start, start + count), count, offset: start, total: TOTAL };
+			return { messages, count: messages.length, offset: start, total: TOTAL };
 		}
 
 		const end = TOTAL - offset;
-		const start = Math.max(0, end - count);
+		const start = Math.max(0, end - limit);
+		const messages = allReplies.slice(start, end);
 
-		return { messages: allReplies.slice(start, end), count, offset, total: TOTAL };
+		return { messages, count: messages.length, offset, total: TOTAL };
 	});
 
 	const wrapper = mockAppRoot()
@@ -88,6 +92,55 @@ describe('useThreadMessagesQuery', () => {
 
 		await waitFor(() => expect(result.current.hasNextPage).toBe(true));
 		expect(idsOf(result.current.data?.messages ?? [])).toEqual(idsOf(allReplies.slice(0, PAGE_SIZE)));
+	});
+
+	describe('when the server clamps the page size below the requested count', () => {
+		const UPPER_COUNT_LIMIT = 5;
+
+		it('still reports older replies to load', async () => {
+			const { result } = setup({ upperCountLimit: UPPER_COUNT_LIMIT });
+
+			await waitForLoaded(result);
+
+			expect(result.current.data?.messages).toHaveLength(UPPER_COUNT_LIMIT);
+			expect(result.current.hasPreviousPage).toBe(true);
+		});
+
+		it('walks back to the oldest reply without skipping any', async () => {
+			const { result } = setup({ upperCountLimit: UPPER_COUNT_LIMIT });
+
+			await waitForLoaded(result);
+
+			for (let i = 0; i < TOTAL && result.current.hasPreviousPage; i++) {
+				await act(async () => {
+					await result.current.fetchPreviousPage();
+				});
+			}
+
+			expect(idsOf(result.current.data?.messages ?? [])).toEqual(idsOf(allReplies));
+		});
+
+		it('walks forward to the newest reply without skipping any after jumping to an old reply', async () => {
+			const { result } = setup({ upperCountLimit: UPPER_COUNT_LIMIT });
+
+			await waitForLoaded(result);
+
+			await act(async () => {
+				await result.current.loadMessageAround('reply-10');
+			});
+			await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+			const [oldestLoadedId] = idsOf(result.current.data?.messages ?? []);
+
+			for (let i = 0; i < TOTAL && result.current.hasNextPage; i++) {
+				await act(async () => {
+					await result.current.fetchNextPage();
+				});
+			}
+
+			const oldestLoadedIndex = allReplies.findIndex(({ _id }) => _id === oldestLoadedId);
+			expect(idsOf(result.current.data?.messages ?? [])).toEqual(idsOf(allReplies.slice(oldestLoadedIndex)));
+		});
 	});
 
 	describe('jumpToRecent', () => {

--- a/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
+++ b/apps/meteor/client/views/room/contextualBar/Threads/hooks/useThreadMessagesQuery.ts
@@ -118,7 +118,12 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 
 			await queryClient.cancelQueries({ queryKey: currentQueryKey });
 
-			const { messages, total, offset } = await getThreadMessages({
+			const {
+				messages,
+				total,
+				offset,
+				count: pageSize,
+			} = await getThreadMessages({
 				tmid,
 				aroundId: messageId,
 				count,
@@ -128,10 +133,10 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			const filtered = filterThreadMessages(messages, tmid);
 			const processed = (await processMessages(filtered)) as IThreadMessage[];
 
-			const pageParam = Math.max(0, total - offset - count);
+			const pageParam = Math.max(0, total - offset - pageSize);
 
 			queryClient.setQueryData<ThreadMessagesInfiniteData>(currentQueryKey, {
-				pages: [{ items: processed, itemCount: total }],
+				pages: [{ items: processed, itemCount: total, pageSize }],
 				pageParams: [pageParam],
 			});
 		},
@@ -152,7 +157,11 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			const cachedData = offset === 0 ? queryClient.getQueryData<ThreadMessagesInfiniteData>(queryKey) : undefined;
 			const cachedMessages = cachedData?.pages.at(-1)?.items ?? [];
 
-			const { messages, total } = await getThreadMessages({
+			const {
+				messages,
+				total,
+				count: pageSize,
+			} = await getThreadMessages({
 				tmid,
 				offset,
 				count,
@@ -175,18 +184,20 @@ export const useThreadMessagesQuery = (tmid: IThreadMainMessage['_id'], rid?: IR
 			return {
 				items: processed,
 				itemCount: total,
+				pageSize,
 			};
 		},
 		initialPageParam: 0,
-		getNextPageParam: (_lastPage, _allPages, lastPageParam) => {
-			return lastPageParam > 0 ? Math.max(0, lastPageParam - count) : undefined;
+		getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+			const stride = lastPage.pageSize ?? count;
+			return lastPageParam > 0 && stride > 0 ? Math.max(0, lastPageParam - stride) : undefined;
 		},
 		getPreviousPageParam: (firstPage, _allPages, firstPageParam) => {
-			const pageSize = Math.min(firstPage.items.length, count);
-			if (pageSize <= 0) {
+			const stride = firstPage.pageSize ?? Math.min(firstPage.items.length, count);
+			if (stride <= 0) {
 				return undefined;
 			}
-			const next = firstPageParam + pageSize;
+			const next = firstPageParam + stride;
 			return next < firstPage.itemCount ? next : undefined;
 		},
 		select: ({ pages }) => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2641](https://rocketchat.atlassian.net/browse/CORE-2641)
## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[CORE-2641]: https://rocketchat.atlassian.net/browse/CORE-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Thread messages now automatically load earlier pages when content does not fill the available space, up to a set limit.
  - Pagination adapts to the page size returned by the server for more reliable navigation through thread replies.

- **Bug Fixes**
  - Improved loading of older and newer replies to prevent messages from being skipped when page sizes vary.
  - Previous-message loading remains available when additional content can be scrolled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->