### PR TITLE
fix: run LDAP team removal independently of team additions

### DIFF
--- a/.changeset/ldap-team-removal-early-return.md
+++ b/.changeset/ldap-team-removal-early-return.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Makes LDAP team removal run independently of team additions, so a user removed from a mapped LDAP group is removed from the corresponding team even when the sync has no teams to add

--- a/apps/meteor/ee/server/lib/ldap/Manager.spec.ts
+++ b/apps/meteor/ee/server/lib/ldap/Manager.spec.ts
@@ -4,14 +4,20 @@ import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 const settingsStub = { get: sinon.stub() };
-const roomsStub = { findOneByNonValidatedName: sinon.stub() };
+const roomsStub = { findOneByNonValidatedName: sinon.stub(), findPrivateRoomsByIdsWithAbacAttributes: sinon.stub() };
 const subscriptionsStub = { findOneByRoomIdAndUserId: sinon.stub() };
+const teamStub = {
+	listByNames: sinon.stub(),
+	listTeamsBySubscriberUserId: sinon.stub(),
+	insertMemberOnTeams: sinon.stub(),
+	removeMemberFromTeams: sinon.stub(),
+};
 const addUserToRoomStub = sinon.stub();
 const removeUserFromRoomStub = sinon.stub();
 const loggerStub = { debug: sinon.stub(), error: sinon.stub(), info: sinon.stub(), warn: sinon.stub() };
 
 const { LDAPEEManager } = proxyquire.noCallThru().load('./Manager', {
-	'@rocket.chat/core-services': { Abac: {}, Team: {} },
+	'@rocket.chat/core-services': { Abac: {}, Team: teamStub },
 	'@rocket.chat/license': { License: { hasModule: () => false } },
 	'@rocket.chat/models': { Users: {}, Roles: {}, Subscriptions: subscriptionsStub, Rooms: roomsStub },
 	'../../../../server/lib/import/definitions/IConversionCallbacks': {},
@@ -106,5 +112,93 @@ describe('LDAPEEManager syncUserChannels', () => {
 
 		expect(addUserToRoomStub.calledWith('ridA', user)).to.be.true;
 		expect(removeUserFromRoomStub.calledWith('ridB', user)).to.be.true;
+	});
+});
+
+const teamsMap = {
+	groupA: 'team-a',
+	groupB: 'team-b',
+};
+
+const allTeams = [
+	{ _id: 'teamA', name: 'team-a', roomId: 'teamRoomA' },
+	{ _id: 'teamB', name: 'team-b', roomId: 'teamRoomB' },
+];
+
+const setupTeamSettings = () => {
+	settingsStub.get.reset();
+	settingsStub.get.withArgs('LDAP_Enable_LDAP_Groups_To_RC_Teams').returns(true);
+	settingsStub.get.withArgs('LDAP_Validate_Teams_For_Each_Login').returns(true);
+	settingsStub.get.withArgs('LDAP_Teams_BaseDN').returns('dc=example,dc=com');
+	settingsStub.get.withArgs('LDAP_Query_To_Get_User_Teams').returns('(member=#{username})');
+	settingsStub.get.withArgs('LDAP_Teams_Name_Field').returns('ou');
+	settingsStub.get.withArgs('LDAP_Groups_To_Rocket_Chat_Teams').returns(JSON.stringify(teamsMap));
+	settingsStub.get.withArgs('ABAC_Enabled').returns(true);
+};
+
+const abacManagedTeams = (teamIds: string[]) => ({
+	map: (fn: (doc: { teamId: string }) => string) => ({
+		toArray: () => Promise.resolve(teamIds.map((teamId) => fn({ teamId }))),
+	}),
+});
+
+const syncUserTeams = (ldapUserGroups: string[]) => {
+	const groupsStub = sinon.stub(LDAPEEManager as any, 'getLdapGroupsByUsername').resolves(ldapUserGroups);
+	return (LDAPEEManager as any)
+		.syncUserTeams({ options: { baseDN: 'dc=example,dc=com' } }, user, 'dn', false)
+		.finally(() => groupsStub.restore());
+};
+
+const calledWithTeams = (stub: sinon.SinonStub) => stub.getCalls().filter(({ args }) => args[1]?.length);
+
+describe('LDAPEEManager syncUserTeams', () => {
+	beforeEach(() => {
+		teamStub.listByNames.reset();
+		teamStub.listTeamsBySubscriberUserId.reset();
+		teamStub.insertMemberOnTeams.reset();
+		teamStub.removeMemberFromTeams.reset();
+		roomsStub.findPrivateRoomsByIdsWithAbacAttributes.reset();
+		setupTeamSettings();
+
+		teamStub.listByNames.resolves(allTeams);
+		teamStub.insertMemberOnTeams.resolves();
+		teamStub.removeMemberFromTeams.resolves();
+		roomsStub.findPrivateRoomsByIdsWithAbacAttributes.returns(abacManagedTeams([]));
+	});
+
+	it('should remove the user from a team they left in LDAP even when there is nothing to add', async () => {
+		teamStub.listTeamsBySubscriberUserId.resolves([{ teamId: 'teamA' }, { teamId: 'teamB' }]);
+
+		await syncUserTeams(['groupA']);
+
+		expect(teamStub.removeMemberFromTeams.calledWith(user._id, ['teamB'])).to.be.true;
+	});
+
+	it('should add and remove teams in the same sync', async () => {
+		teamStub.listTeamsBySubscriberUserId.resolves([{ teamId: 'teamB' }]);
+
+		await syncUserTeams(['groupA']);
+
+		expect(teamStub.insertMemberOnTeams.calledWith(user._id, ['teamA'])).to.be.true;
+		expect(teamStub.removeMemberFromTeams.calledWith(user._id, ['teamB'])).to.be.true;
+	});
+
+	it('should not write anything when there is nothing to add and nothing to remove', async () => {
+		teamStub.listTeamsBySubscriberUserId.resolves([{ teamId: 'teamA' }]);
+
+		await syncUserTeams(['groupA']);
+
+		expect(calledWithTeams(teamStub.insertMemberOnTeams)).to.have.lengthOf(0);
+		expect(calledWithTeams(teamStub.removeMemberFromTeams)).to.have.lengthOf(0);
+	});
+
+	it('should still remove teams when the ABAC filter drops every team that was going to be added', async () => {
+		teamStub.listTeamsBySubscriberUserId.resolves([{ teamId: 'teamB' }]);
+		roomsStub.findPrivateRoomsByIdsWithAbacAttributes.returns(abacManagedTeams(['teamA']));
+
+		await syncUserTeams(['groupA']);
+
+		expect(calledWithTeams(teamStub.insertMemberOnTeams)).to.have.lengthOf(0);
+		expect(teamStub.removeMemberFromTeams.calledWith(user._id, ['teamB'])).to.be.true;
 	});
 });

--- a/apps/meteor/ee/server/lib/ldap/Manager.ts
+++ b/apps/meteor/ee/server/lib/ldap/Manager.ts
@@ -566,12 +566,11 @@ export class LDAPEEManager extends LDAPManager {
 			logger.debug({ msg: 'Some teams will be ignored from sync because they are abac managed', roomsWithAbacAttributes });
 
 			teamsToAdd = teamsToAdd.filter((teamId) => !roomsWithAbacAttributes.includes(teamId));
-			if (!teamsToAdd.length) {
-				return;
-			}
 		}
 
-		await Team.insertMemberOnTeams(user._id, teamsToAdd);
+		if (teamsToAdd.length) {
+			await Team.insertMemberOnTeams(user._id, teamsToAdd);
+		}
 		if (teamsToRemove) {
 			await Team.removeMemberFromTeams(user._id, teamsToRemove);
 		}


### PR DESCRIPTION
## Proposed changes

`syncUserTeams` computes the teams a user should join and the teams they should leave in one pass, then does the insert and the removal at the end of the method. The ABAC branch added `if (!teamsToAdd.length) return;` after filtering out ABAC managed teams, and that return sits above the `removeMemberFromTeams` call. So whenever a sync had nothing to join, it also did nothing to leave. With ABAC and LDAP groups to teams sync both on, taking a user out of a mapped LDAP group did not take them out of the team, and they kept access until some unrelated group addition happened to let the sync reach the removal.

The guard was only ever meant to skip the insert, so I wrapped the insert in it instead of returning from the method. Nothing runs after that point, so no other side effect depended on the early return. I did not touch how `teamsToAdd` or `teamsToRemove` are computed, and removal keeps its own existing guard.

I checked the rest of the LDAP sync path for the same shape. `syncUserChannels` uses `continue` inside the add loop for its ABAC check, so its removal block still runs, and `syncUserRoles` hands adds and removes to `syncUserRoles` together with no early return in between. This is the only place with the problem.

Worth flagging for admins: the first sync after this lands will remove everyone who should already have been removed while the bug was live. On a large directory that can look like a mass departure in the audit log. It is the backlog draining, not a new removal wave.

## Issue(s)

None.

## Steps to test or reproduce

Turn on ABAC and LDAP groups to teams sync, map an LDAP group to a team, and log a user in so they get added. Remove that user from the LDAP group, leave everything else alone so the next sync has nothing to add, and sync again. Before this change the user was still in the team. Now they are removed. A sync that has both a team to add and a team to remove behaves the same as before.

## Further comments

I added four cases to `apps/meteor/ee/server/lib/ldap/Manager.spec.ts`, next to the existing channel sync tests and using the same proxyquire harness: removal with nothing to add, add and remove together, nothing to add and nothing to remove, and the ABAC filter dropping every candidate team. The first and last fail on develop and pass with this change.

I ran the unit suites (`mocha --config ./.mocharc.js` and `--config ./.mocharc.definition.js`, plus jest), eslint on both changed files, and `tsc --noEmit --skipLibCheck`. Unit tests pass, eslint reports no errors, and the typecheck output is byte for byte identical to develop on my machine.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed LDAP team synchronization so users are removed from mapped teams when they no longer belong to the corresponding LDAP groups.
  - Team removals now occur even when there are no teams to add or additions are filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->