### PR TITLE
chore!: remove deprecated DELETE /v1/canned-responses endpoint

### DIFF
--- a/.changeset/remove-canned-responses-delete-endpoint.md
+++ b/.changeset/remove-canned-responses-delete-endpoint.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': major
+'@rocket.chat/meteor': major
+---
+
+Removes the deprecated `DELETE /v1/canned-responses` endpoint, which received the canned response id in the request body. Use `DELETE /v1/canned-responses/:_id` instead.

--- a/apps/meteor/ee/server/api/v1/canned-responses.ts
+++ b/apps/meteor/ee/server/api/v1/canned-responses.ts
@@ -1,5 +1,5 @@
 import type { ILivechatDepartment, IOmnichannelCannedResponse, IUser } from '@rocket.chat/core-typings';
-import { isPOSTCannedResponsesProps, isCannedResponsesProps, isDELETECannedResponsesProps } from '@rocket.chat/rest-typings';
+import { isPOSTCannedResponsesProps, isCannedResponsesProps } from '@rocket.chat/rest-typings';
 import type { PaginatedResult, PaginatedRequest } from '@rocket.chat/rest-typings';
 
 import { API } from '../../../../server/api';
@@ -32,7 +32,6 @@ declare module '@rocket.chat/rest-typings' {
 				tags?: any;
 				departmentId?: ILivechatDepartment['_id'];
 			}) => void;
-			DELETE: (params: { _id: IOmnichannelCannedResponse['_id'] }) => void;
 		};
 		'/v1/canned-responses/:_id': {
 			GET: () => {
@@ -55,61 +54,13 @@ API.v1.addRoute(
 	},
 );
 
-/**
- * @deprecated
- * @openapi
- * /api/v1/canned-responses:
- *  delete:
- *  	deprecated: true
- *  	security:
- *    	$ref: '#/security/authenticated'
- *  	parameters:
- *    	- in: body
- *      	name: body
- *      	description: |
- *        	**_id** (required): Canned Response ID to be removed.
- *      	schema:
- *        	type: object
- *        	required:
- *          	- _id
- *        	properties:
- *          	_id:
- *            	type: string
- *  	tags:
- *    	- Canned_Responses
- *  	responses:
- *    	200:
- *      	description: Successful Response
- *      	schema:
- *        	type: object
- *        	properties:
- *          	status:
- *            	type: string
- *            	example: success
- *          	data:
- *            	type: object
- *            	description: The response data
- *            	properties:
- *              	success:
- *                	type: boolean
- *                	example: true
- *    	401:
- *      	$ref: '#/responses/Unauthorized'
- *    	403:
- *      	$ref: '#/responses/Forbidden'
- *    	404:
- *      	$ref: '#/responses/NotFound'
- *    	500:
- *      	$ref: '#/responses/InternalServerError'
- */
 API.v1.addRoute(
 	'canned-responses',
 	{
 		authRequired: true,
-		permissionsRequired: { GET: ['view-canned-responses'], POST: ['save-canned-responses'], DELETE: ['remove-canned-responses'] },
-		validateParams: { POST: isPOSTCannedResponsesProps, DELETE: isDELETECannedResponsesProps, GET: isCannedResponsesProps },
+		permissionsRequired: { GET: ['view-canned-responses'], POST: ['save-canned-responses'] },
+		validateParams: { POST: isPOSTCannedResponsesProps, GET: isCannedResponsesProps },
 		license: ['canned-responses'],
-		deprecations: { DELETE: { version: '8.0.0', alternatives: ['/v1/canned-responses/:_id'] } },
 	},
 	{
 		async get() {
@@ -151,12 +102,6 @@ API.v1.addRoute(
 				},
 				_id,
 			);
-			return API.v1.success();
-		},
-		// deprecated
-		async delete() {
-			const { _id } = this.bodyParams;
-			await removeCannedResponse(this.userId, _id);
 			return API.v1.success();
 		},
 	},

--- a/apps/meteor/tests/end-to-end/api/livechat/15-canned-responses.ts
+++ b/apps/meteor/tests/end-to-end/api/livechat/15-canned-responses.ts
@@ -279,9 +279,9 @@ import { IS_EE } from '../../../e2e/config/constants';
 			await updatePermission('remove-canned-responses', []);
 			return request.delete(api('canned-responses/sfdads')).set(credentials).expect(403);
 		});
-		it('should fail if _id is not on the request', async () => {
+		it('should fail if canned response does not exist', async () => {
 			await updatePermission('remove-canned-responses', ['livechat-agent', 'livechat-monitor', 'livechat-manager', 'admin']);
-			return request.delete(api('canned-responses')).set(credentials).expect(400);
+			return request.delete(api('canned-responses/invalid-id')).set(credentials).expect(400);
 		});
 		it('should delete a canned response', async () => {
 			const response = await createCannedResponse();

--- a/packages/rest-typings/src/v1/omnichannel.ts
+++ b/packages/rest-typings/src/v1/omnichannel.ts
@@ -3023,23 +3023,6 @@ const POSTCannedResponsesPropsSchema = {
 
 export const isPOSTCannedResponsesProps = ajv.compile<POSTCannedResponsesProps>(POSTCannedResponsesPropsSchema);
 
-type DELETECannedResponsesProps = {
-	_id: string;
-};
-
-const DELETECannedResponsesPropsSchema = {
-	type: 'object',
-	properties: {
-		_id: {
-			type: 'string',
-		},
-	},
-	required: ['_id'],
-	additionalProperties: false,
-};
-
-export const isDELETECannedResponsesProps = ajv.compile<DELETECannedResponsesProps>(DELETECannedResponsesPropsSchema);
-
 type POSTLivechatUsersTypeProps = {
 	username: string;
 };
@@ -4810,7 +4793,6 @@ export type OmnichannelEndpoints = {
 			cannedResponses: IOmnichannelCannedResponse[];
 		}>;
 		POST: (params: POSTCannedResponsesProps) => void;
-		DELETE: (params: DELETECannedResponsesProps) => void;
 	};
 
 	'/v1/canned-responses/:_id': {


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Removes the body-based `DELETE /v1/canned-responses` endpoint. It declared a removal target of 8.0.0 with `DELETE /v1/canned-responses/:_id` as the replacement, which has existed since the endpoint was introduced and is what the web client already uses.

The deprecation declaration never actually engaged: the option was spelled `deprecations` (plural) while the router only reads `deprecation` (singular), so no warning was ever logged, no `x-deprecation-*` headers were ever sent, the Prometheus deprecation counters never incremented and `shouldBreakInVersion` never fired. Since 9.0.0 is a major release and the replacement endpoint has been available for years (documented as deprecated in the OpenAPI annotations), the endpoint is removed now rather than re-deprecated.

## Issue(s)
https://rocketchat.atlassian.net/browse/CORE-2593
## Steps to test or reproduce

1. `DELETE /api/v1/canned-responses` with `{ "_id": "..." }` in the body → 404 (endpoint removed)
2. `DELETE /api/v1/canned-responses/:_id` → still deletes the canned response

## Further comments

Part of the 9.0.0 overdue-deprecations cleanup. This was the only route in the codebase declaring a route-level deprecation, which is why the typo went unnoticed. A compile-time guard so unrecognized route options can't be silently ignored will be done separately on develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated `DELETE /v1/canned-responses` endpoint.
  * To delete a canned response, use `DELETE /v1/canned-responses/:_id` instead.
  * Requests targeting a nonexistent canned response now return a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->