### PR TITLE
regression: `channels.list.joined` rejects the `fields` query param

### DIFF
--- a/apps/meteor/server/api/v1/channels.ts
+++ b/apps/meteor/server/api/v1/channels.ts
@@ -1511,6 +1511,7 @@ const channelsListJoinedQuery = ajvQuery.compile<{
 	count?: number;
 	offset?: number;
 	sort?: string;
+	fields?: string;
 }>({
 	type: 'object',
 	properties: {
@@ -1521,6 +1522,7 @@ const channelsListJoinedQuery = ajvQuery.compile<{
 		count: { type: 'number' },
 		offset: { type: 'number' },
 		sort: { type: 'string' },
+		fields: { type: 'string' },
 	},
 	required: [],
 	additionalProperties: false,

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -431,6 +431,60 @@ describe('[Channels]', () => {
 		expect(res.body).to.have.property('total');
 	});
 
+	describe('[/channels.list.joined]', () => {
+		it('should accept the `fields` query param', async () => {
+			const res = await request
+				.get(api('channels.list.joined'))
+				.set(credentials)
+				.query({
+					fields: JSON.stringify({ name: 1 }),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('channels').that.is.an('array');
+			expect(res.body).to.have.property('count');
+			expect(res.body).to.have.property('total');
+		});
+
+		it('should accept the `fields` query param alongside the other supported params', async () => {
+			const res = await request
+				.get(api('channels.list.joined'))
+				.set(credentials)
+				.query({
+					roomId: channel._id,
+					roomName: channel.name,
+					_id: channel._id,
+					query: JSON.stringify({}),
+					fields: JSON.stringify({ name: 1 }),
+					sort: JSON.stringify({ name: 1 }),
+					count: 1,
+					offset: 0,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body).to.have.property('channels').that.is.an('array');
+		});
+
+		it('should reject unknown query params', async () => {
+			await request
+				.get(api('channels.list.joined'))
+				.set(credentials)
+				.query({
+					invalidParam: 'invalid',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('error', 'must NOT have additional properties');
+				});
+		});
+	});
+
 	describe('/channels.counters', () => {
 		let room: IRoom;
 		let user1: IUser;


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`GET /api/v1/channels.list.joined` started returning HTTP 400 (`must NOT have additional properties`) whenever the `fields` query param was provided, even with `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=true`.

The typed-route migration in #41415 (b3eee9bf08) replaced the endpoint's loose params with a strict `ajvQuery` schema using `additionalProperties: false`, but the property list omitted `fields` — while the handler still reads it:

```ts
const { sort, fields } = await this.parseJsonQuery();
```

So the param was rejected at validation before the handler could apply (or ignore) it.

This adds `fields` back to the `channels.list.joined` query schema, restoring the 8.7.x behavior until the param's scheduled removal in 9.0.0:

- flag disabled — HTTP 200, `fields` ignored;
- flag enabled — HTTP 200, `fields` applied as the projection, with the existing deprecation warning.

`additionalProperties: false` is kept, so genuinely unknown params still get a 400.

No changeset: this is a regression against unreleased 8.8.0 code, not a change end users saw in a released version.

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-2644

Regression from #41415.

## Steps to test or reproduce

```sh
curl -i --get 'https://SERVER/api/v1/channels.list.joined' \
  -H 'X-User-Id: USER_ID' \
  -H 'X-Auth-Token: AUTH_TOKEN' \
  --data-urlencode 'fields={"topic":0}'
```

Before: HTTP 400 `must NOT have additional properties`. After: HTTP 200.

Automated coverage added in `apps/meteor/tests/end-to-end/api/channels.ts` under `[/channels.list.joined]`:

- `fields` alone is accepted (200 instead of 400);
- `fields` together with every other supported param (`roomId`, `roomName`, `_id`, `query`, `sort`, `count`, `offset`) is accepted, guarding the whole property list rather than the single key added;
- an unknown param still returns 400 `must NOT have additional properties`, proving the schema was not simply loosened.

The tests assert acceptance and response shape rather than the projection itself, since `parseJsonQuery` only honors `fields` when `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=TRUE`, which the e2e suite does not set.

## Further comments

`channels.list` has the same shape — its `isChannelsListProps` schema also omits `fields` while the handler reads it via `parseJsonQuery`. Left out of this PR to keep the regression fix scoped; worth a follow-up sweep over the other endpoints migrated in #41415.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting specific fields in joined channel list results.
  * Field selection works alongside filtering, sorting, pagination, and channel identifiers.

* **Bug Fixes**
  * Added validation to reject unsupported query parameters with a clear error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2644]

[CORE-2644]: https://rocketchat.atlassian.net/browse/CORE-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ