### PR TITLE
regression: `channels.list` rejects the `fields` query param

### DIFF
--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -414,6 +414,58 @@ describe('[Channels]', () => {
 			} = await request.get(api('channels.list')).set(credentials).query({ offset: 1 });
 			expect(channels1).to.not.deep.equal(channels2);
 		});
+
+		it('should accept the `fields` query param', async () => {
+			await request
+				.get(api('channels.list'))
+				.set(credentials)
+				.query({
+					fields: JSON.stringify({ name: 1 }),
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('channels').that.is.an('array');
+					expect(res.body).to.have.property('count');
+					expect(res.body).to.have.property('total');
+				});
+		});
+
+		it('should accept the `fields` query param alongside the other supported params', async () => {
+			await request
+				.get(api('channels.list'))
+				.set(credentials)
+				.query({
+					_id: testChannel._id,
+					query: JSON.stringify({}),
+					fields: JSON.stringify({ name: 1 }),
+					sort: JSON.stringify({ name: 1 }),
+					count: 1,
+					offset: 0,
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', true);
+					expect(res.body).to.have.property('channels').that.is.an('array');
+				});
+		});
+
+		it('should reject unknown query params', async () => {
+			await request
+				.get(api('channels.list'))
+				.set(credentials)
+				.query({
+					invalidParam: 'invalid',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(400)
+				.expect((res) => {
+					expect(res.body).to.have.property('success', false);
+					expect(res.body).to.have.property('error', 'must NOT have additional properties');
+				});
+		});
 	});
 
 	it('/channels.list.joined', async () => {

--- a/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
+++ b/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
@@ -1,7 +1,11 @@
 import type { PaginatedRequest } from '../../helpers/PaginatedRequest';
 import { ajvQuery } from '../Ajv';
 
-export type ChannelsListProps = PaginatedRequest<{ _id?: string }>;
+export type ChannelsListProps = PaginatedRequest<{
+	_id?: string;
+	/* deprecated */
+	fields?: string;
+}>;
 
 const channelsListPropsSchema = {
 	type: 'object',
@@ -19,6 +23,9 @@ const channelsListPropsSchema = {
 			type: 'number',
 		},
 		sort: {
+			type: 'string',
+		},
+		fields: {
 			type: 'string',
 		},
 	},


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Same defect as CORE-2644, on the sibling endpoint. `GET /api/v1/channels.list` returns HTTP 400 (`must NOT have additional properties`) whenever the `fields` query param is provided, even with `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=true`.

The typed-route migration in #41415 (b3eee9bf08) gave the endpoint a strict `ajvQuery` schema with `additionalProperties: false`, but `isChannelsListProps` never listed `fields` — while the handler still reads it:

```ts
const { sort, fields, query } = await this.parseJsonQuery();
```

So the param is rejected at validation before the handler can apply (or ignore) it.

This adds `fields` to `ChannelsListProps` — both the schema and the exported request type (annotated `/* deprecated */`, the way `PaginatedRequest` annotates `query`) — restoring the 8.7.x behavior until the param's scheduled removal in 9.0.0:

- flag disabled — HTTP 200, `fields` ignored;
- flag enabled — HTTP 200, `fields` applied as the projection, with the existing deprecation warning.

`additionalProperties: false` is kept, so genuinely unknown params still get a 400.

The shape follows the existing `isUsersListParamsGET` precedent, minus its `nullable: true`, since no other property in this schema uses it.

No changeset: this is a regression against unreleased 8.8.0 code, not a change end users saw in a released version.

## Issue(s)

https://rocketchat.atlassian.net/browse/CORE-2644 — the ticket reports `channels.list.joined`, fixed in #41979. This PR covers `channels.list`, which regressed the same way in the same migration.

Regression from #41415.

## Steps to test or reproduce

```sh
curl -i --get 'https://SERVER/api/v1/channels.list' \
  -H 'X-User-Id: USER_ID' \
  -H 'X-Auth-Token: AUTH_TOKEN' \
  --data-urlencode 'fields={"topic":0}'
```

Before: HTTP 400 `must NOT have additional properties`. After: HTTP 200.

Automated coverage added in `apps/meteor/tests/end-to-end/api/channels.ts` under `/channels.list`:

- `fields` alone is accepted (200 instead of 400);
- `fields` together with every other supported param (`_id`, `query`, `sort`, `count`, `offset`) is accepted, guarding the whole property list rather than the single key added;
- an unknown param still returns 400 `must NOT have additional properties`, proving the schema was not simply loosened.

The tests assert acceptance and response shape rather than the projection itself, since `parseJsonQuery` only honors `fields` when `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=TRUE`, which the e2e suite does not set.

## Further comments

`ChannelsListProps` is also the declared request type for `/v1/channels.list.joined`, so this change lines the client-facing type up with the server-side schema fix in #41979. The two PRs touch different files and won't conflict in either merge order, but they're worth reviewing together.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the optional `fields` parameter when listing channels.
  * The parameter can be combined with filtering, sorting, pagination, and channel ID options.

* **Bug Fixes**
  * Invalid or unknown query parameters now return a clear 400 validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2644]

[CORE-2644]: https://rocketchat.atlassian.net/browse/CORE-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ