### PR TITLE
regression: slash command replies show HTML entities in names

### DIFF
--- a/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
+++ b/apps/meteor/server/lib/dataExport/exportRoomMessagesToFile.ts
@@ -148,7 +148,7 @@ export const getMessageData = (
 			});
 			break;
 		case 'wm':
-			messageObject.msg = i18n.t('Welcome', { user: username });
+			messageObject.msg = i18n.t('Welcome', { interpolation: { escapeValue: false }, user: username });
 			break;
 		case 'livechat-close':
 			messageObject.msg = i18n.t('Conversation_finished');

--- a/apps/meteor/server/meteor-methods/rooms/addUsersToRoom.ts
+++ b/apps/meteor/server/meteor-methods/rooms/addUsersToRoom.ts
@@ -110,6 +110,7 @@ export const addUsersToRoomMethod = async (userId: string, data: { rid: string; 
 			}
 			void api.broadcast('notify.ephemeralMessage', userId, data.rid, {
 				msg: i18n.t('Username_is_already_in_here', {
+					interpolation: { escapeValue: false },
 					username: newUser.username,
 					lng: user?.language,
 				}),

--- a/apps/meteor/server/slashcommands/archiveroom/server.ts
+++ b/apps/meteor/server/slashcommands/archiveroom/server.ts
@@ -41,6 +41,7 @@ slashCommands.add({
 		if (!room) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng: settings.get('Language') || 'en',
 				}),
@@ -59,6 +60,7 @@ slashCommands.add({
 		if (room.archived) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Duplicate_archived_channel_name', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng: settings.get('Language') || 'en',
 				}),
@@ -70,6 +72,7 @@ slashCommands.add({
 
 		void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 			msg: i18n.t('Channel_Archived', {
+				interpolation: { escapeValue: false },
 				channelName: channel,
 				lng: settings.get('Language') || 'en',
 			}),

--- a/apps/meteor/server/slashcommands/ban/ban.ts
+++ b/apps/meteor/server/slashcommands/ban/ban.ts
@@ -21,6 +21,7 @@ slashCommands.add({
 		if (!user) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/ban/unban.ts
+++ b/apps/meteor/server/slashcommands/ban/unban.ts
@@ -21,6 +21,7 @@ slashCommands.add({
 		if (!user) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/create/server.ts
+++ b/apps/meteor/server/slashcommands/create/server.ts
@@ -41,6 +41,7 @@ slashCommands.add({
 		if (room != null) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_already_exist', {
+					interpolation: { escapeValue: false },
 					channelName: channelStr,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/help/server.ts
+++ b/apps/meteor/server/slashcommands/help/server.ts
@@ -58,6 +58,7 @@ slashCommands.add({
 		let msg = '';
 		keys.forEach((key) => {
 			msg = `${msg}\n${i18n.t(key.key, {
+				interpolation: { escapeValue: false },
 				shortcut: key.command,
 				lng: user?.language || settings.get('language') || 'en',
 			})}`;

--- a/apps/meteor/server/slashcommands/hide/hide.ts
+++ b/apps/meteor/server/slashcommands/hide/hide.ts
@@ -45,6 +45,7 @@ slashCommands.add({
 			if (!roomObject) {
 				void api.broadcast('notify.ephemeralMessage', user._id, message.rid, {
 					msg: i18n.t('Channel_doesnt_exist', {
+						interpolation: { escapeValue: false },
 						channelName: strippedRoom,
 						lng,
 					}),
@@ -53,6 +54,7 @@ slashCommands.add({
 			if (!(await Subscriptions.findOneByRoomIdAndUserId(roomObject ? roomObject._id : '', user._id, { projection: { _id: 1 } }))) {
 				void api.broadcast('notify.ephemeralMessage', user._id, message.rid, {
 					msg: i18n.t('error-logged-user-not-in-room', {
+						interpolation: { escapeValue: false },
 						roomName: room,
 						lng,
 					}),

--- a/apps/meteor/server/slashcommands/invite/server.ts
+++ b/apps/meteor/server/slashcommands/invite/server.ts
@@ -63,6 +63,7 @@ slashCommands.add({
 		if (users.length === 0) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('User_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username: usernames.join(' @'),
 					lng: settings.get('Language') || 'en',
 				}),
@@ -83,6 +84,7 @@ slashCommands.add({
 			const usernameStr = user.username as string;
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_is_already_in_here', {
+					interpolation: { escapeValue: false },
 					username: usernameStr,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/inviteall/server.ts
+++ b/apps/meteor/server/slashcommands/inviteall/server.ts
@@ -49,6 +49,7 @@ function inviteAll<T extends string>(type: T): SlashCommand<T>['callback'] {
 		if (!baseChannel) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng,
 				}),
@@ -83,6 +84,7 @@ function inviteAll<T extends string>(type: T): SlashCommand<T>['callback'] {
 				baseChannel.t === 'c' ? await createChannelMethod(userId, channel, users) : await createPrivateGroupMethod(user, channel, users);
 				void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 					msg: i18n.t('Channel_created', {
+						interpolation: { escapeValue: false },
 						channelName: channel,
 						lng,
 					}),

--- a/apps/meteor/server/slashcommands/join/server.ts
+++ b/apps/meteor/server/slashcommands/join/server.ts
@@ -25,6 +25,7 @@ slashCommands.add({
 		if (!room) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/kick/server.ts
+++ b/apps/meteor/server/slashcommands/kick/server.ts
@@ -24,6 +24,7 @@ slashCommands.add({
 		if (kickedUser == null) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username,
 					lng,
 				}),

--- a/apps/meteor/server/slashcommands/msg/server.ts
+++ b/apps/meteor/server/slashcommands/msg/server.ts
@@ -32,6 +32,7 @@ slashCommands.add({
 			const user = await Users.findOneById(userId, { projection: { language: 1 } });
 			void api.broadcast('notify.ephemeralMessage', userId, item.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username: targetUsernameOrig,
 					lng: user?.language || settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/mute/mute.ts
+++ b/apps/meteor/server/slashcommands/mute/mute.ts
@@ -23,6 +23,7 @@ slashCommands.add({
 		if (mutedUser == null) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/mute/unmute.ts
+++ b/apps/meteor/server/slashcommands/mute/unmute.ts
@@ -22,6 +22,7 @@ slashCommands.add({
 		if (unmutedUser == null) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Username_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					username,
 					lng: settings.get('Language') || 'en',
 				}),

--- a/apps/meteor/server/slashcommands/unarchiveroom/server.ts
+++ b/apps/meteor/server/slashcommands/unarchiveroom/server.ts
@@ -40,6 +40,7 @@ slashCommands.add({
 		if (!room) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_doesnt_exist', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng: settings.get('Language') || 'en',
 				}),
@@ -58,6 +59,7 @@ slashCommands.add({
 		if (!room.archived) {
 			void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 				msg: i18n.t('Channel_already_Unarchived', {
+					interpolation: { escapeValue: false },
 					channelName: channel,
 					lng: settings.get('Language') || 'en',
 				}),
@@ -69,6 +71,7 @@ slashCommands.add({
 
 		void api.broadcast('notify.ephemeralMessage', userId, message.rid, {
 			msg: i18n.t('Channel_Unarchived', {
+				interpolation: { escapeValue: false },
 				channelName: channel,
 				lng: settings.get('Language') || 'en',
 			}),


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

#41667 and #41736 replaced the `i18next-sprintf-postprocessor` (which never escaped) with i18next's native named interpolation (which escapes by default).

The server i18n instance never sets `interpolation.escapeValue`, so it falls back to the i18next default of `true`, while the client provider explicitly sets `false`:

| Instance | `interpolation.escapeValue` | Escapes? |
|---|---|---|
| `apps/meteor/server/lib/i18n.ts` | never set → i18next default `true` | **yes** |
| `apps/meteor/client/providers/TranslationProvider.tsx` | `false` | no |
| `packages/livechat/src/i18next.ts` | `false` | no |

The regression is therefore confined to server-side calls. Because these strings are delivered as ordinary chat message bodies, nothing decodes the entities and the user reads them literally:

```
/join #a&b
  before: The channel `#a&b` does not exist.
  after : The channel `#a&amp;b` does not exist.

/kick @o'brien&co
  before: The username `o'brien&co` doesn't exist.
  after : The username `o&#39;brien&co` doesn't exist.
```

### Scope

40 translation keys moved from `%s` to `{{...}}` across the two PRs, spanning 67 call sites. 33 are client-side and unaffected. Of the 34 server-side sites, 4 (SlackBridge) were already opted out in #41736 itself, leaving **23 call sites** patched here with `interpolation: { escapeValue: false }`.

This is deliberately scoped to sites whose behaviour actually changed. A global `escapeValue: false` on the server instance would be the tidier fix, but it is a workspace-wide policy change and does not belong on a release branch — see Further comments.

### Escaping is not load bearing at any patched site

- **21 sites** broadcast via `notify.ephemeralMessage`. `listeners.module.ts` parses the string into a message-parser AST which gazzodown renders as React elements (`PlainSpan` emits `{text}`), so React escapes it. No `dangerouslySetInnerHTML` anywhere on that path.
- **1 site** (`exportRoomMessagesToFile`, the `wm` case) flows into `exportMessageObject`, which already calls `escapeHTML()` at the sink. That control was added by #40802 and is untouched here; at the time it landed `Welcome` still used `%s` and was not escaped by i18n, so this restores exactly the input it was written to receive. The site had been double escaping only since #41736.
- **8 `help` sites** interpolate hardcoded keyboard shortcuts such as `Shift (or Ctrl) + ESC`, which contain no HTML-special characters. They are a no-op either way and are included only so the rule stays uniform and greppable.

I also confirmed the two client call sites that *do* reach `dangerouslySetInnerHTML` (`UrlChangeModal.tsx`, `OAuthGroupPage.tsx`) both wrap in `DOMPurify.sanitize()`, and are on the client instance where `escapeValue` was already `false` before and after the migration. Untouched, unaffected.

### Verification

Rendered every patched key through the real pre-migration stack (`i18next` + `i18next-sprintf-postprocessor`) and the post-patch stack, across values including `a&b`, `o'brien&co`, `<b>x</b>` and `a"b`:

```
fixed output == pre-migration sprintf output:  72 pass, 0 fail
cases that were broken before the patch:       60
```

`tsc --noEmit --skipLibCheck` exits clean, prettier passes, eslint reports 0 errors on the changed files.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

Closes: [CORE-2645](https://rocketchat.atlassian.net/browse/CORE-2645)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

No admin configuration change is required:

1. Open any channel.
2. Run `/join #a&b` (any non-existent name containing `&`, `<`, `>`, `"` or `'`).
3. Before: the ephemeral reply reads ``The channel `#a&amp;b` does not exist.`` After: ``The channel `#a&b` does not exist.``

For the case reported in CORE-2645, which needs a widened validation setting:

1. Admin → Workspace → Settings → General → UTF8, set `UTF8_Channel_Names_Validation` to `[0-9a-zA-Z&_.-]+` and save.
2. Create a public channel named `a&b`.
3. Run `/create a&b` in any room.
4. Before: ``The channel `#a&amp;b` already exists.`` After: ``The channel `#a&b` already exists.``

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

**No changeset.** Both migration PRs are unreleased, so this is a regression fixed within the same cycle.

**Why not a global `escapeValue: false` on the server instance?** It would fix all 23 at once and prevent recurrence, and I audited the blast radius: only 65 of the 212 server-side `i18n.t` calls actually interpolate, and just one key genuinely depends on escaping (`UserDataDownload_EmailBody`, whose `<a href="{{download_link}}">` receives `Site_Url` + a `Random.id()`, so admin-controlled only). That makes it a good change for `develop`, but it is a workspace-wide behaviour change and too broad for a release branch. Worth a follow-up ticket.

Three adjacent issues found while tracing this, all pre-existing and deliberately left alone:

- `i18n.cloneInstance({ interpolation: { escapeValue: false } })` silently ignores the override in i18next 23.4.9, making the opt-out at `sendTranscript.ts:113` dead code. The per-call form used in this PR does work.
- `notifications/message/email.js` runs `escapeHTML()` on `userName`/`roomName` before handing them to i18n, which escapes again, so offline notification emails render `Tom &amp; Jerry` for any real name containing `&`. The same shape exists in `mention.module.ts` and in the other 11 cases of the `exportRoomMessagesToFile` switch. Unlike the `wm` case, those keys already used `{{...}}` before both migration PRs, so they are not regressions from this cycle and a fix for them would need its own changeset.
- `help/server.ts` reads `settings.get('language')` with a lowercase id; the setting is `Language`.

[CORE-2645](https://rocketchat.atlassian.net/browse/CORE-2645)


[CORE-2645]: https://rocketchat.atlassian.net/browse/CORE-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ