### PR TITLE
regression: status-hidden users still appear as online in member lists and autocomplete

### DIFF
--- a/apps/meteor/ee/server/api/audit.ts
+++ b/apps/meteor/ee/server/api/audit.ts
@@ -15,6 +15,7 @@ import { convertSubObjectsIntoPaths } from '@rocket.chat/tools';
 import { API } from '../../../server/api/api';
 import { getPaginationItems } from '../../../server/api/lib/getPaginationItems';
 import { findUsersOfRoom } from '../../../server/lib/findUsersOfRoom';
+import { getUsersHiddenFrom, redactHiddenUsers } from '../../../server/lib/statusVisibility/hiddenUsers';
 import { auditGetAuditionsMethod, auditGetMessagesMethod, auditGetOmnichannelMessagesMethod } from '../lib/audit/functions';
 
 type AuditRoomMembersParams = PaginatedRequest<{
@@ -187,8 +188,11 @@ API.v1.get(
 			return API.v1.notFound();
 		}
 
-		const { cursor, totalCount } = findUsersOfRoom({
+		const hidden = await getUsersHiddenFrom(this.userId);
+
+		const { cursor, totalCount } = await findUsersOfRoom({
 			rid: room._id,
+			hidden,
 			filter,
 			skip,
 			limit,
@@ -216,7 +220,7 @@ API.v1.get(
 		});
 
 		return API.v1.success({
-			members,
+			members: redactHiddenUsers(members, hidden),
 			count: members.length,
 			offset: skip,
 			total,
@@ -290,7 +294,7 @@ API.v1.get(
 			return API.v1.failure('The "end" query parameter must be a valid date.');
 		}
 
-		const { offset, count } = await getPaginationItems(this.queryParams as Record<string, string | number | null | undefined>);
+		const { offset, count } = await getPaginationItems(this.queryParams);
 		const { sort } = await this.parseJsonQuery();
 		const _sort = { ts: sort?.ts ? sort?.ts : -1 };
 

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -49,6 +49,7 @@ export default {
 				'<rootDir>/server/cron/**.spec.ts',
 				'<rootDir>/server/api/*.spec.ts',
 				'<rootDir>/server/api/lib/getUserInfo.spec.ts',
+				'<rootDir>/server/api/lib/queryFiltersStatus.spec.ts',
 				'<rootDir>/server/api/v1/middlewares/*.spec.ts',
 				'<rootDir>/server/lib/cloud/version-check/**/*.spec.ts',
 				'<rootDir>/server/lib/auth-providers/apple/**.spec.ts',

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -49,7 +49,6 @@ export default {
 				'<rootDir>/server/cron/**.spec.ts',
 				'<rootDir>/server/api/*.spec.ts',
 				'<rootDir>/server/api/lib/getUserInfo.spec.ts',
-				'<rootDir>/server/api/lib/queryFiltersStatus.spec.ts',
 				'<rootDir>/server/api/v1/middlewares/*.spec.ts',
 				'<rootDir>/server/lib/cloud/version-check/**/*.spec.ts',
 				'<rootDir>/server/lib/auth-providers/apple/**.spec.ts',

--- a/apps/meteor/server/api/v1/channels.ts
+++ b/apps/meteor/server/api/v1/channels.ts
@@ -51,6 +51,7 @@ import { eraseRoom } from '../../lib/eraseRoom';
 import { findUsersOfRoom } from '../../lib/findUsersOfRoom';
 import { mountIntegrationQueryBasedOnPermissions } from '../../lib/integrations/lib/mountQueriesBasedOnPermission';
 import { openRoom } from '../../lib/openRoom';
+import { getUsersHiddenFrom, filterHiddenUsers, redactHiddenUsers } from '../../lib/statusVisibility/hiddenUsers';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
 import { getChannelHistory } from '../../meteor-methods/messages/getChannelHistory';
 import { getUserMentionsByChannel } from '../../meteor-methods/messages/getUserMentionsByChannel';
@@ -1657,9 +1658,12 @@ API.v1.get(
 
 		const { status, filter } = this.queryParams;
 
+		const hidden = await getUsersHiddenFrom(this.userId);
+
 		const { cursor, totalCount } = await findUsersOfRoom({
 			rid: findResult._id,
-			...(status && { status: { $in: status as UserStatus[] } }),
+			...(status && { status: status as UserStatus[] }),
+			hidden,
 			skip,
 			limit,
 			filter,
@@ -1669,7 +1673,7 @@ API.v1.get(
 		const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
 
 		return API.v1.success({
-			members,
+			members: redactHiddenUsers(members, hidden),
 			count: members.length,
 			offset: skip,
 			total,
@@ -1729,9 +1733,14 @@ API.v1.get(
 			throw new Meteor.Error('error-not-allowed', 'Not Allowed');
 		}
 
-		const online: Pick<IUser, '_id' | 'username'>[] = await Users.findUsersNotOffline({
-			projection: { username: 1 },
-		}).toArray();
+		const hidden = await getUsersHiddenFrom(this.userId);
+
+		const online: Pick<IUser, '_id' | 'username'>[] = filterHiddenUsers(
+			await Users.findUsersNotOffline({
+				projection: { username: 1 },
+			}).toArray(),
+			hidden,
+		);
 
 		const onlineInRoom = await Promise.all(
 			online.map(async (user) => {

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -41,6 +41,7 @@ import { eraseRoom } from '../../lib/eraseRoom';
 import { findUsersOfRoom } from '../../lib/findUsersOfRoom';
 import { mountIntegrationQueryBasedOnPermissions } from '../../lib/integrations/lib/mountQueriesBasedOnPermission';
 import { openRoom } from '../../lib/openRoom';
+import { getUsersHiddenFrom, filterHiddenUsers, redactHiddenUsers } from '../../lib/statusVisibility/hiddenUsers';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
 import { getChannelHistory } from '../../meteor-methods/messages/getChannelHistory';
 import { addAllUserToRoomFn } from '../../meteor-methods/rooms/addAllUserToRoom';
@@ -1124,9 +1125,12 @@ API.v1.get(
 
 		const { status, filter } = this.queryParams;
 
+		const hidden = await getUsersHiddenFrom(this.userId);
+
 		const { cursor, totalCount } = await findUsersOfRoom({
 			rid: findResult.rid,
-			...(status && { status: { $in: status as UserStatus[] } }),
+			...(status && { status: status as UserStatus[] }),
+			hidden,
 			skip,
 			limit,
 			filter,
@@ -1136,7 +1140,7 @@ API.v1.get(
 		const [members, total] = await Promise.all([cursor.toArray(), totalCount]);
 
 		return API.v1.success({
-			members,
+			members: redactHiddenUsers(members, hidden),
 			count: members.length,
 			offset: skip,
 			total,
@@ -1294,11 +1298,16 @@ API.v1.get(
 			throw new Meteor.Error('error-not-allowed', 'Not Allowed');
 		}
 
-		const online: Pick<IUser, '_id' | 'username'>[] = await Users.findUsersNotOffline({
-			projection: {
-				username: 1,
-			},
-		}).toArray();
+		const hidden = await getUsersHiddenFrom(this.userId);
+
+		const online: Pick<IUser, '_id' | 'username'>[] = filterHiddenUsers(
+			await Users.findUsersNotOffline({
+				projection: {
+					username: 1,
+				},
+			}).toArray(),
+			hidden,
+		);
 
 		const onlineInRoom = await Promise.all(
 			online.map(async (user) => {

--- a/apps/meteor/server/api/v1/im.ts
+++ b/apps/meteor/server/api/v1/im.ts
@@ -1,7 +1,7 @@
 /**
  * Docs: https://github.com/RocketChat/developer-docs/blob/master/reference/api/rest-api/endpoints/team-collaboration-endpoints/im-endpoints
  */
-import type { IMessage, IRoom, ISubscription, IUser } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, ISubscription, IUser, UserStatus } from '@rocket.chat/core-typings';
 import { Subscriptions, Uploads, Messages, Rooms, Users } from '@rocket.chat/models';
 import {
 	ajv,
@@ -26,6 +26,7 @@ import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { eraseRoom } from '../../lib/eraseRoom';
 import { openRoom } from '../../lib/openRoom';
 import { getRoomByNameOrIdWithOptionToJoin } from '../../lib/rooms/getRoomByNameOrIdWithOptionToJoin';
+import { effectiveStatusFilter } from '../../lib/statusVisibility/effectiveStatus';
 import { getUsersHiddenFrom } from '../../lib/statusVisibility/hiddenUsers';
 import { redactStatus } from '../../lib/statusVisibility/redactStatus';
 import { blockUserMethod } from '../../lib/users/blockUser';
@@ -552,10 +553,9 @@ const dmMembersAction = <Path extends string>(_path: Path): TypedAction<typeof d
 		const { status, filter } = this.queryParams;
 
 		const hidden = await getUsersHiddenFrom(this.userId);
-		const roomUids = status && hidden ? room.uids?.filter((uid) => !hidden.has(uid)) : room.uids;
 		const extraQuery: Record<string, unknown> = {
-			_id: { $in: roomUids },
-			...(status && { status: { $in: status } }),
+			_id: { $in: room.uids },
+			...(status && effectiveStatusFilter(status as UserStatus[], hidden)),
 		};
 
 		const options: FindOptions<IUser> = {

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -9,6 +9,7 @@ import {
 	isPrivateRoom,
 	isPublicRoom,
 	type IUser,
+	type UserStatus,
 } from '@rocket.chat/core-typings';
 import { Messages, Rooms, Users, Uploads, Subscriptions } from '@rocket.chat/models';
 import type { Notifications } from '@rocket.chat/rest-typings';
@@ -61,6 +62,7 @@ import { notifyOnSubscriptionChanged } from '../../lib/notifyListener';
 import { openRoom } from '../../lib/openRoom';
 import type { RoomRoles } from '../../lib/roles/getRoomRoles';
 import { syncRolePrioritiesForRoomIfRequired } from '../../lib/rooms/syncRolePrioritiesForRoomIfRequired';
+import { getUsersHiddenFrom } from '../../lib/statusVisibility/hiddenUsers';
 import { unbanUserFromRoom } from '../../lib/unbanUserFromRoom';
 import { createDiscussion } from '../../meteor-methods/messages/createDiscussion';
 import { sendFileMessage } from '../../meteor-methods/messages/sendFileMessage';
@@ -1170,7 +1172,8 @@ API.v1.get(
 
 		const { members, total } = await findUsersOfRoomOrderedByRole({
 			rid: findResult._id,
-			...(status && { status: { $in: status } }),
+			...(status && { status: status as UserStatus[] }),
+			hidden: await getUsersHiddenFrom(this.userId),
 			skip,
 			limit,
 			filter,

--- a/apps/meteor/server/api/v1/teams.ts
+++ b/apps/meteor/server/api/v1/teams.ts
@@ -1,6 +1,6 @@
 import { Team } from '@rocket.chat/core-services';
 import type { ITeamAutocompleteResult } from '@rocket.chat/core-services';
-import type { ITeam } from '@rocket.chat/core-typings';
+import type { ITeam, UserStatus } from '@rocket.chat/core-typings';
 import { Users, Rooms } from '@rocket.chat/models';
 import {
 	ajv,
@@ -32,6 +32,9 @@ import { canAccessRoomAsync } from '../../lib/authorization';
 import { hasPermissionAsync, hasAtLeastOnePermissionAsync, hasAllPermissionAsync } from '../../lib/authorization/hasPermission';
 import { eraseRoom } from '../../lib/eraseRoom';
 import { removeUserFromRoom } from '../../lib/rooms/removeUserFromRoom';
+import { effectiveStatusFilter } from '../../lib/statusVisibility/effectiveStatus';
+import { getUsersHiddenFrom } from '../../lib/statusVisibility/hiddenUsers';
+import { redactStatus } from '../../lib/statusVisibility/redactStatus';
 import { settings } from '../../settings';
 import type { ExtractRoutesFromAPI } from '../ApiClass';
 import { API } from '../api';
@@ -513,6 +516,8 @@ API.v1.get(
 
 		const canSeeAllMembers = await hasPermissionAsync(this.user, 'view-all-teams', team.roomId);
 
+		const hidden = await getUsersHiddenFrom(this.userId);
+
 		const query: Record<string, unknown> = {};
 		if (username) {
 			query.username = new RegExp(escapeRegExp(username), 'i');
@@ -521,13 +526,15 @@ API.v1.get(
 			query.name = new RegExp(escapeRegExp(name), 'i');
 		}
 		if (status) {
-			query.status = { $in: status };
+			Object.assign(query, effectiveStatusFilter(status as UserStatus[], hidden));
 		}
 
 		const { records, total } = await Team.members(this.userId, team._id, canSeeAllMembers, { offset, count }, query);
 
 		return API.v1.success({
-			members: records,
+			members: hidden
+				? records.map((record) => (hidden.has(record.user._id) ? { ...record, user: redactStatus(record.user) } : record))
+				: records,
 			total,
 			count: records.length,
 			offset,

--- a/apps/meteor/server/api/v1/users.ts
+++ b/apps/meteor/server/api/v1/users.ts
@@ -49,6 +49,7 @@ import { notifyOnUserChange, notifyOnUserChangeAsync } from '../../lib/notifyLis
 import { resetUserE2EEncriptionKey } from '../../lib/resetUserE2EKey';
 import { validateNameChars } from '../../lib/shared/validateNameChars';
 import { getUsersHiddenFrom, filterHiddenUsers, redactHiddenUsers } from '../../lib/statusVisibility/hiddenUsers';
+import { redactStatus } from '../../lib/statusVisibility/redactStatus';
 import { resolveUsersByIds } from '../../lib/statusVisibility/resolveUsers';
 import { checkEmailAvailability } from '../../lib/users/checkEmailAvailability';
 import { checkUsernameAvailability, checkUsernameAvailabilityWithValidation } from '../../lib/users/checkUsernameAvailability';
@@ -2117,16 +2118,13 @@ API.v1
 
 			const user = await getUserFromParams(this.queryParams);
 			const hidden = await getUsersHiddenFrom(this.userId);
-
-			if (hidden?.has(user._id)) {
-				return API.v1.success({ _id: user._id, status: 'offline' });
-			}
+			const visible = hidden?.has(user._id) ? redactStatus(user) : user;
 
 			return API.v1.success({
-				_id: user._id,
-				status: (user.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
-				...(user.statusSource && { statusSource: user.statusSource }),
-				...(user.statusExpiresAt && { statusExpiresAt: user.statusExpiresAt.toISOString() }),
+				_id: visible._id,
+				status: (visible.status || 'offline') as 'online' | 'offline' | 'away' | 'busy',
+				...(visible.statusSource && { statusSource: visible.statusSource }),
+				...(visible.statusExpiresAt && { statusExpiresAt: visible.statusExpiresAt.toISOString() }),
 			});
 		},
 	);

--- a/apps/meteor/server/api/v1/users.ts
+++ b/apps/meteor/server/api/v1/users.ts
@@ -1973,9 +1973,10 @@ API.v1
 			}
 
 			const user = await getUserFromParams(this.queryParams);
+			const hidden = await getUsersHiddenFrom(this.userId);
 
 			return API.v1.success({
-				presence: user.status || ('offline' as UserStatus),
+				presence: (hidden?.has(user._id) ? 'offline' : user.status || 'offline') as UserStatus,
 			});
 		},
 	)

--- a/apps/meteor/server/api/v1/users.ts
+++ b/apps/meteor/server/api/v1/users.ts
@@ -1739,10 +1739,13 @@ API.v1.get(
 			return API.v1.failure(e);
 		}
 
-		const [{ items }, hidden] = await Promise.all([
-			findUsersToAutocomplete({ uid: this.userId, selector }),
-			getUsersHiddenFrom(this.userId),
-		]);
+		const hidden = await getUsersHiddenFrom(this.userId);
+
+		if (hidden && queryFiltersStatus(selector.conditions)) {
+			selector.conditions = { $and: [selector.conditions, { _id: { $nin: [...hidden] } }] };
+		}
+
+		const { items } = await findUsersToAutocomplete({ uid: this.userId, selector });
 
 		return API.v1.success({ items: redactHiddenUsers(items, hidden) });
 	},

--- a/apps/meteor/server/api/v1/users.ts
+++ b/apps/meteor/server/api/v1/users.ts
@@ -1739,12 +1739,12 @@ API.v1.get(
 			return API.v1.failure(e);
 		}
 
-		return API.v1.success(
-			await findUsersToAutocomplete({
-				uid: this.userId,
-				selector,
-			}),
-		);
+		const [{ items }, hidden] = await Promise.all([
+			findUsersToAutocomplete({ uid: this.userId, selector }),
+			getUsersHiddenFrom(this.userId),
+		]);
+
+		return API.v1.success({ items: redactHiddenUsers(items, hidden) });
 	},
 );
 
@@ -2112,6 +2112,11 @@ API.v1
 			}
 
 			const user = await getUserFromParams(this.queryParams);
+			const hidden = await getUsersHiddenFrom(this.userId);
+
+			if (hidden?.has(user._id)) {
+				return API.v1.success({ _id: user._id, status: 'offline' });
+			}
 
 			return API.v1.success({
 				_id: user._id,

--- a/apps/meteor/server/lib/findUsersOfRoom.ts
+++ b/apps/meteor/server/lib/findUsersOfRoom.ts
@@ -1,20 +1,30 @@
-import type { IUser } from '@rocket.chat/core-typings';
+import type { IUser, UserStatus } from '@rocket.chat/core-typings';
 import type { FindPaginated } from '@rocket.chat/model-typings';
 import { Users } from '@rocket.chat/models';
-import type { FindCursor, FindOptions, Filter } from 'mongodb';
+import type { FindCursor, FindOptions } from 'mongodb';
 
 import { settings } from '../settings';
+import { effectiveStatusFilter, excludingOfflineFilter } from './statusVisibility/effectiveStatus';
 
 type FindUsersParam = {
 	rid: string;
-	status?: Filter<IUser>['status'];
+	status?: UserStatus[] | 'not-offline';
+	hidden?: Set<IUser['_id']>;
 	skip?: number;
 	limit?: number;
 	filter?: string;
 	sort?: Record<string, any>;
 };
 
-export function findUsersOfRoom({ rid, status, skip = 0, limit = 0, filter = '', sort }: FindUsersParam): FindPaginated<FindCursor<IUser>> {
+export function findUsersOfRoom({
+	rid,
+	status,
+	hidden,
+	skip = 0,
+	limit = 0,
+	filter = '',
+	sort,
+}: FindUsersParam): FindPaginated<FindCursor<IUser>> {
 	const options: FindOptions<IUser> = {
 		projection: {
 			name: 1,
@@ -26,7 +36,7 @@ export function findUsersOfRoom({ rid, status, skip = 0, limit = 0, filter = '',
 			federated: 1,
 		},
 		sort: {
-			statusConnection: -1,
+			...(hidden?.size ? {} : { statusConnection: -1 }),
 			...(sort || { ...(settings.get('UI_Use_Real_Name') && { name: 1 }), username: 1 }),
 		},
 		...(skip > 0 && { skip }),
@@ -35,10 +45,10 @@ export function findUsersOfRoom({ rid, status, skip = 0, limit = 0, filter = '',
 
 	const searchFields = settings.get<string>('Accounts_SearchFields').trim().split(',');
 
+	const statusFilter = Array.isArray(status) ? effectiveStatusFilter(status, hidden) : status && excludingOfflineFilter(hidden);
+
 	return Users.findPaginatedByActiveUsersExcept(filter, undefined, options, searchFields, [
-		{
-			__rooms: rid,
-			...(status && { status }),
-		},
+		{ __rooms: rid },
+		...(statusFilter ? [statusFilter] : []),
 	]);
 }

--- a/apps/meteor/server/lib/findUsersOfRoom.ts
+++ b/apps/meteor/server/lib/findUsersOfRoom.ts
@@ -27,7 +27,9 @@ export async function findUsersOfRoom({
 	sort,
 }: FindUsersParam): Promise<FindPaginated<FindCursor<IUser>>> {
 	const hiddenCanAppear = Boolean(hidden?.size) && (!status || (Array.isArray(status) && status.includes(UserStatus.OFFLINE)));
-	const hiddenInRoom = hiddenCanAppear && (await Users.countDocuments({ __rooms: rid, _id: { $in: [...(hidden ?? [])] } })) > 0;
+	const hiddenInRoom =
+		hiddenCanAppear &&
+		(await Users.countDocuments({ __rooms: rid, active: true, username: { $exists: true }, _id: { $in: [...(hidden ?? [])] } })) > 0;
 
 	const options: FindOptions<IUser> = {
 		projection: {

--- a/apps/meteor/server/lib/findUsersOfRoom.ts
+++ b/apps/meteor/server/lib/findUsersOfRoom.ts
@@ -1,4 +1,5 @@
-import type { IUser, UserStatus } from '@rocket.chat/core-typings';
+import type { IUser } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
 import type { FindPaginated } from '@rocket.chat/model-typings';
 import { Users } from '@rocket.chat/models';
 import type { FindCursor, FindOptions } from 'mongodb';
@@ -16,7 +17,7 @@ type FindUsersParam = {
 	sort?: Record<string, any>;
 };
 
-export function findUsersOfRoom({
+export async function findUsersOfRoom({
 	rid,
 	status,
 	hidden,
@@ -24,7 +25,10 @@ export function findUsersOfRoom({
 	limit = 0,
 	filter = '',
 	sort,
-}: FindUsersParam): FindPaginated<FindCursor<IUser>> {
+}: FindUsersParam): Promise<FindPaginated<FindCursor<IUser>>> {
+	const hiddenCanAppear = Boolean(hidden?.size) && (!status || (Array.isArray(status) && status.includes(UserStatus.OFFLINE)));
+	const hiddenInRoom = hiddenCanAppear && (await Users.countDocuments({ __rooms: rid, _id: { $in: [...(hidden ?? [])] } })) > 0;
+
 	const options: FindOptions<IUser> = {
 		projection: {
 			name: 1,
@@ -36,7 +40,7 @@ export function findUsersOfRoom({
 			federated: 1,
 		},
 		sort: {
-			...(hidden?.size ? {} : { statusConnection: -1 }),
+			...(hiddenInRoom ? {} : { statusConnection: -1 }),
 			...(sort || { ...(settings.get('UI_Use_Real_Name') && { name: 1 }), username: 1 }),
 		},
 		...(skip > 0 && { skip }),

--- a/apps/meteor/server/lib/findUsersOfRoomOrderedByRole.ts
+++ b/apps/meteor/server/lib/findUsersOfRoomOrderedByRole.ts
@@ -1,13 +1,15 @@
-import { type IUser, ROOM_ROLE_PRIORITY_MAP, type ISubscription } from '@rocket.chat/core-typings';
+import { type IUser, ROOM_ROLE_PRIORITY_MAP, type ISubscription, type UserStatus } from '@rocket.chat/core-typings';
 import { Subscriptions, Users } from '@rocket.chat/models';
 import { escapeRegExp } from '@rocket.chat/tools';
-import type { Document, FilterOperators } from 'mongodb';
+import type { Document } from 'mongodb';
 
 import { settings } from '../settings';
+import { effectiveStatusExpression, effectiveStatusFilter } from './statusVisibility/effectiveStatus';
 
 type FindUsersParam = {
 	rid: string;
-	status?: FilterOperators<string>;
+	status?: UserStatus[];
+	hidden?: Set<IUser['_id']>;
 	skip?: number;
 	limit?: number;
 	filter?: string;
@@ -23,6 +25,7 @@ type UserWithRoleAndSubscriptionData = IUser & {
 export async function findUsersOfRoomOrderedByRole({
 	rid,
 	status,
+	hidden,
 	skip = 0,
 	limit = 0,
 	filter = '',
@@ -55,12 +58,14 @@ export async function findUsersOfRoomOrderedByRole({
 					$exists: true,
 					...(exceptions.length > 0 && { $nin: exceptions }),
 				},
-				...(status && { status }),
 				...(filter && orStmt.length > 0 && { $or: orStmt }),
 			},
+			...(status ? [effectiveStatusFilter(status, hidden)] : []),
 			...extraQuery,
 		],
 	};
+
+	const visibleStatus = hidden?.size ? effectiveStatusExpression(hidden) : '$status';
 
 	const membersResult = Users.col.aggregate<UserWithRoleAndSubscriptionData>(
 		[
@@ -73,13 +78,13 @@ export async function findUsersOfRoomOrderedByRole({
 					name: 1,
 					username: 1,
 					nickname: 1,
-					status: 1,
+					status: visibleStatus,
 					avatarETag: 1,
 					_updatedAt: 1,
 					federated: 1,
 					statusSortKey: {
 						// Adding this because offline users should come last
-						$cond: [{ $eq: ['$status', 'offline'] }, null, '$status'],
+						$cond: [{ $eq: [visibleStatus, 'offline'] }, null, visibleStatus],
 					},
 					rolePriority: {
 						$ifNull: [`$roomRolePriorities.${rid}`, ROOM_ROLE_PRIORITY_MAP.default],

--- a/apps/meteor/server/lib/statusVisibility/effectiveStatus.spec.ts
+++ b/apps/meteor/server/lib/statusVisibility/effectiveStatus.spec.ts
@@ -1,0 +1,40 @@
+import { UserStatus } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+
+import { effectiveStatusExpression, effectiveStatusFilter, excludingOfflineFilter } from './effectiveStatus';
+
+describe('effectiveStatusFilter', () => {
+	it('should filter by the stored status when nobody is hidden', () => {
+		expect(effectiveStatusFilter([UserStatus.ONLINE])).to.be.deep.equal({ status: { $in: [UserStatus.ONLINE] } });
+		expect(effectiveStatusFilter([UserStatus.ONLINE], new Set())).to.be.deep.equal({ status: { $in: [UserStatus.ONLINE] } });
+	});
+
+	it('should exclude hidden users from a filter that does not include offline', () => {
+		expect(effectiveStatusFilter([UserStatus.ONLINE, UserStatus.BUSY], new Set(['alice']))).to.be.deep.equal({
+			$and: [{ _id: { $nin: ['alice'] } }, { status: { $in: [UserStatus.ONLINE, UserStatus.BUSY] } }],
+		});
+	});
+
+	it('should include every hidden user in a filter that includes offline, whatever their stored status', () => {
+		expect(effectiveStatusFilter([UserStatus.ONLINE, UserStatus.OFFLINE], new Set(['alice']))).to.be.deep.equal({
+			$or: [{ _id: { $nin: ['alice'] }, status: { $in: [UserStatus.ONLINE, UserStatus.OFFLINE] } }, { _id: { $in: ['alice'] } }],
+		});
+	});
+});
+
+describe('effectiveStatusExpression', () => {
+	it('should resolve hidden users to offline and leave everyone else untouched', () => {
+		expect(effectiveStatusExpression(new Set(['alice', 'bob']))).to.be.deep.equal({
+			$cond: [{ $in: ['$_id', ['alice', 'bob']] }, UserStatus.OFFLINE, '$status'],
+		});
+	});
+});
+
+describe('excludingOfflineFilter', () => {
+	it('should leave hidden users out, whatever their stored status', () => {
+		expect(excludingOfflineFilter()).to.be.deep.equal({ status: { $ne: UserStatus.OFFLINE } });
+		expect(excludingOfflineFilter(new Set(['alice']))).to.be.deep.equal({
+			$and: [{ _id: { $nin: ['alice'] } }, { status: { $ne: UserStatus.OFFLINE } }],
+		});
+	});
+});

--- a/apps/meteor/server/lib/statusVisibility/effectiveStatus.ts
+++ b/apps/meteor/server/lib/statusVisibility/effectiveStatus.ts
@@ -1,0 +1,26 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { UserStatus } from '@rocket.chat/core-typings';
+import type { Filter } from 'mongodb';
+
+export const effectiveStatusFilter = (status: UserStatus[], hidden?: Set<IUser['_id']>): Filter<IUser> => {
+	if (!hidden?.size) {
+		return { status: { $in: status } };
+	}
+
+	const ids = [...hidden];
+
+	if (status.includes(UserStatus.OFFLINE)) {
+		return { $or: [{ _id: { $nin: ids }, status: { $in: status } }, { _id: { $in: ids } }] };
+	}
+
+	return { $and: [{ _id: { $nin: ids } }, { status: { $in: status } }] };
+};
+
+export const effectiveStatusExpression = (hidden: Set<IUser['_id']>) => ({
+	$cond: [{ $in: ['$_id', [...hidden]] }, UserStatus.OFFLINE, '$status'],
+});
+
+export const excludingOfflineFilter = (hidden?: Set<IUser['_id']>): Filter<IUser> =>
+	hidden?.size
+		? { $and: [{ _id: { $nin: [...hidden] } }, { status: { $ne: UserStatus.OFFLINE } }] }
+		: { status: { $ne: UserStatus.OFFLINE } };

--- a/apps/meteor/server/lib/statusVisibility/redactStatus.ts
+++ b/apps/meteor/server/lib/statusVisibility/redactStatus.ts
@@ -1,7 +1,21 @@
 import type { IUser } from '@rocket.chat/core-typings';
 
-export const redactStatus = <T extends Partial<IUser>>(user: T): T => {
+type WithPresenceFields = Partial<Pick<IUser, 'statusText' | 'statusSource' | 'statusExpiresAt' | 'statusDefault' | 'statusConnection'>> & {
+	status?: string;
+};
+
+export const redactStatus = <T extends WithPresenceFields>(user: T): T => {
 	const { statusText, statusSource, statusExpiresAt, statusDefault, statusConnection, ...rest } = user;
 
 	return { ...rest, status: 'offline' } as T;
+};
+
+export const omitStatusVisibilityConfig = (userSettings: IUser['settings']): IUser['settings'] => {
+	if (!userSettings?.preferences || !('statusVisibilityDenied' in userSettings.preferences)) {
+		return userSettings;
+	}
+
+	const { statusVisibilityDenied: _denied, ...preferences } = userSettings.preferences;
+
+	return { ...userSettings, preferences };
 };

--- a/apps/meteor/server/meteor-methods/users/getUsersOfRoom.ts
+++ b/apps/meteor/server/meteor-methods/users/getUsersOfRoom.ts
@@ -1,5 +1,4 @@
 import type { IRoom, IUser } from '@rocket.chat/core-typings';
-import { UserStatus } from '@rocket.chat/core-typings';
 import type { ServerMethods } from '@rocket.chat/ddp-client';
 import { Subscriptions, Rooms } from '@rocket.chat/models';
 import { check } from 'meteor/check';
@@ -8,6 +7,7 @@ import { Meteor } from 'meteor/meteor';
 import { canAccessRoomAsync, roomAccessAttributes } from '../../lib/authorization';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { findUsersOfRoom } from '../../lib/findUsersOfRoom';
+import { getUsersHiddenFrom, redactHiddenUsers } from '../../lib/statusVisibility/hiddenUsers';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -53,9 +53,12 @@ Meteor.methods<ServerMethods>({
 		// TODO this is currently counting deactivated users
 		const total = await Subscriptions.countByRoomIdWhenUsernameExists(rid);
 
+		const hidden = await getUsersHiddenFrom(userId);
+
 		const { cursor } = findUsersOfRoom({
 			rid,
-			status: !showAll ? { $ne: UserStatus.OFFLINE } : undefined,
+			...(!showAll && { status: 'not-offline' as const }),
+			hidden,
 			limit,
 			skip,
 			filter,
@@ -63,7 +66,7 @@ Meteor.methods<ServerMethods>({
 
 		return {
 			total,
-			records: await cursor.toArray(),
+			records: redactHiddenUsers(await cursor.toArray(), hidden),
 		};
 	},
 });

--- a/apps/meteor/server/meteor-methods/users/getUsersOfRoom.ts
+++ b/apps/meteor/server/meteor-methods/users/getUsersOfRoom.ts
@@ -55,7 +55,7 @@ Meteor.methods<ServerMethods>({
 
 		const hidden = await getUsersHiddenFrom(userId);
 
-		const { cursor } = findUsersOfRoom({
+		const { cursor } = await findUsersOfRoom({
 			rid,
 			...(!showAll && { status: 'not-offline' as const }),
 			hidden,

--- a/apps/meteor/server/services/team/service.ts
+++ b/apps/meteor/server/services/team/service.ts
@@ -33,6 +33,7 @@ import { getSubscribedRoomsForUserWithDetails } from '../../lib/rooms/getRoomsWi
 import { removeUserFromRoom } from '../../lib/rooms/removeUserFromRoom';
 import { saveRoomName } from '../../lib/rooms/settings';
 import { saveRoomType } from '../../lib/rooms/settings/saveRoomType';
+import { omitStatusVisibilityConfig } from '../../lib/statusVisibility/redactStatus';
 import { checkUsernameAvailability } from '../../lib/users/checkUsernameAvailability';
 import { settings } from '../../settings';
 
@@ -683,7 +684,7 @@ export class TeamService extends ServiceClassInternal implements ITeamService {
 					username: user.username,
 					name: user.name,
 					status: user.status,
-					settings: user.settings,
+					settings: omitStatusVisibilityConfig(user.settings),
 				},
 				roles: record.roles,
 				createdBy: {

--- a/apps/meteor/tests/end-to-end/api/status-visibility.ts
+++ b/apps/meteor/tests/end-to-end/api/status-visibility.ts
@@ -1,0 +1,247 @@
+import type { Credentials } from '@rocket.chat/api-client';
+import type { IRoom, ITeam, IUser } from '@rocket.chat/core-typings';
+import { TeamType, UserStatus } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { after, before, describe, it } from 'mocha';
+
+import { api, credentials, getCredentials, request } from '../../data/api-data';
+import { updateEESetting } from '../../data/permissions.helper';
+import { createRoom, deleteRoom } from '../../data/rooms.helper';
+import { createTeam, deleteTeam } from '../../data/teams.helper';
+import { password } from '../../data/user';
+import { createUser, deleteUser, login, setUserStatus } from '../../data/users.helper';
+import { IS_EE } from '../../e2e/config/constants';
+
+(IS_EE ? describe : describe.skip)('[Status Visibility] (Enterprise Only)', function () {
+	this.retries(0);
+
+	let hider: IUser & { username: string };
+	let viewer: IUser & { username: string };
+	let bystander: IUser & { username: string };
+	let hiderCredentials: Credentials;
+	let viewerCredentials: Credentials;
+	let bystanderCredentials: Credentials;
+	let channel: IRoom;
+	let group: IRoom;
+	let team: ITeam;
+
+	const usernamesOf = (members: { username?: string }[]) => members.map((member) => member.username);
+	const statusOf = (members: { username?: string; status?: string }[], username: string) =>
+		members.find((member) => member.username === username)?.status;
+
+	before((done) => getCredentials(done));
+
+	before(async () => {
+		await updateEESetting('Accounts_StatusVisibility_Enabled', true);
+
+		[hider, viewer, bystander] = (await Promise.all([
+			createUser({ joinDefaultChannels: false }),
+			createUser({ joinDefaultChannels: false }),
+			createUser({ joinDefaultChannels: false }),
+		])) as (IUser & { username: string })[];
+
+		[hiderCredentials, viewerCredentials, bystanderCredentials] = await Promise.all([
+			login(hider.username, password),
+			login(viewer.username, password),
+			login(bystander.username, password),
+		]);
+
+		await setUserStatus(hiderCredentials, UserStatus.ONLINE);
+
+		await request
+			.post(api('users.setPreferences'))
+			.set(hiderCredentials)
+			.send({ data: { statusVisibilityDenied: [viewer.username] } })
+			.expect(200);
+
+		const members = [hider.username, viewer.username, bystander.username];
+
+		channel = (await createRoom({ type: 'c', name: `status-visibility-c-${Date.now()}`, members, credentials })).body.channel;
+		group = (await createRoom({ type: 'p', name: `status-visibility-p-${Date.now()}`, members, credentials })).body.group;
+		team = await createTeam(credentials, `status-visibility-t-${Date.now()}`, TeamType.PUBLIC, members);
+	});
+
+	after(async () => {
+		await Promise.all([deleteRoom({ type: 'c', roomId: channel._id }), deleteRoom({ type: 'p', roomId: group._id })]);
+		await deleteTeam(credentials, team.name);
+		await Promise.all([deleteUser(hider), deleteUser(viewer), deleteUser(bystander)]);
+		await updateEESetting('Accounts_StatusVisibility_Enabled', false);
+	});
+
+	it('should keep the hider online for everyone else', async () => {
+		await request
+			.get(api('rooms.membersOrderedByRole'))
+			.set(bystanderCredentials)
+			.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
+			.expect(200)
+			.expect((res) => {
+				expect(usernamesOf(res.body.members)).to.include(hider.username);
+				expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.ONLINE);
+			});
+	});
+
+	describe('[/rooms.membersOrderedByRole]', () => {
+		it('should not return the hider when the viewer filters by online', async () => {
+			await request
+				.get(api('rooms.membersOrderedByRole'))
+				.set(viewerCredentials)
+				.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.not.include(hider.username);
+					expect(res.body.total).to.be.equal(res.body.members.length);
+				});
+		});
+
+		it('should return the hider as offline when the viewer does not filter', async () => {
+			await request
+				.get(api('rooms.membersOrderedByRole'))
+				.set(viewerCredentials)
+				.query({ roomId: channel._id })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.include(hider.username);
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+
+		it('should return the hider when the viewer filters by offline', async () => {
+			await request
+				.get(api('rooms.membersOrderedByRole'))
+				.set(viewerCredentials)
+				.query({ 'roomId': channel._id, 'status[]': UserStatus.OFFLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.include(hider.username);
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+	});
+
+	describe('[/channels.members]', () => {
+		it('should not return the hider when the viewer filters by online', async () => {
+			await request
+				.get(api('channels.members'))
+				.set(viewerCredentials)
+				.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.not.include(hider.username);
+					expect(res.body.total).to.be.equal(res.body.members.length);
+				});
+		});
+	});
+
+	describe('[/channels.online]', () => {
+		it('should not return the hider to the viewer', async () => {
+			await request
+				.get(api('channels.online'))
+				.set(viewerCredentials)
+				.query({ _id: channel._id })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.online)).to.not.include(hider.username);
+				});
+		});
+	});
+
+	describe('[/groups.members]', () => {
+		it('should not return the hider when the viewer filters by online', async () => {
+			await request
+				.get(api('groups.members'))
+				.set(viewerCredentials)
+				.query({ 'roomId': group._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.not.include(hider.username);
+					expect(res.body.total).to.be.equal(res.body.members.length);
+				});
+		});
+	});
+
+	describe('[/groups.online]', () => {
+		it('should not return the hider to the viewer', async () => {
+			await request
+				.get(api('groups.online'))
+				.set(viewerCredentials)
+				.query({ _id: group._id })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.online)).to.not.include(hider.username);
+				});
+		});
+	});
+
+	describe('[/teams.members]', () => {
+		it('should not return the hider when the viewer filters by online', async () => {
+			await request
+				.get(api('teams.members'))
+				.set(viewerCredentials)
+				.query({ 'teamId': team._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(res.body.members.map(({ user }: { user: IUser }) => user.username)).to.not.include(hider.username);
+				});
+		});
+
+		it('should not expose the block list of any member', async () => {
+			await request
+				.get(api('teams.members'))
+				.set(viewerCredentials)
+				.query({ teamId: team._id })
+				.expect(200)
+				.expect((res) => {
+					res.body.members.forEach(({ user }: { user: IUser }) => {
+						expect(user.settings?.preferences ?? {}).to.not.have.property('statusVisibilityDenied');
+					});
+				});
+		});
+	});
+
+	describe('[/users.getStatus]', () => {
+		it('should report the hider as offline to the viewer', async () => {
+			await request
+				.get(api('users.getStatus'))
+				.set(viewerCredentials)
+				.query({ userId: hider._id })
+				.expect(200)
+				.expect((res) => {
+					expect(res.body.status).to.be.equal(UserStatus.OFFLINE);
+					expect(res.body).to.not.have.property('statusSource');
+				});
+		});
+	});
+
+	describe('[/users.autocomplete]', () => {
+		it('should list the hider as offline to the viewer', async () => {
+			await request
+				.get(api('users.autocomplete'))
+				.set(viewerCredentials)
+				.query({ selector: JSON.stringify({ term: hider.username, exceptions: [] }) })
+				.expect(200)
+				.expect((res) => {
+					expect(statusOf(res.body.items, hider.username)).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+	});
+
+	describe('[/im.members]', () => {
+		let dm: IRoom;
+
+		before(async () => {
+			dm = (await createRoom({ type: 'd', username: hider.username, credentials: viewerCredentials })).body.room;
+		});
+
+		it('should return the hider when the viewer filters by offline', async () => {
+			await request
+				.get(api('im.members'))
+				.set(viewerCredentials)
+				.query({ 'roomId': dm._id, 'status[]': UserStatus.OFFLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.members)).to.include(hider.username);
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+	});
+});

--- a/apps/meteor/tests/end-to-end/api/status-visibility.ts
+++ b/apps/meteor/tests/end-to-end/api/status-visibility.ts
@@ -68,18 +68,6 @@ import { IS_EE } from '../../e2e/config/constants';
 		await updateEESetting('Accounts_StatusVisibility_Enabled', false);
 	});
 
-	it('should keep the hider online for everyone else', async () => {
-		await request
-			.get(api('rooms.membersOrderedByRole'))
-			.set(bystanderCredentials)
-			.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
-			.expect(200)
-			.expect((res) => {
-				expect(usernamesOf(res.body.members)).to.include(hider.username);
-				expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.ONLINE);
-			});
-	});
-
 	describe('[/rooms.membersOrderedByRole]', () => {
 		it('should not return the hider when the viewer filters by online', async () => {
 			await request
@@ -90,6 +78,17 @@ import { IS_EE } from '../../e2e/config/constants';
 				.expect((res) => {
 					expect(usernamesOf(res.body.members)).to.not.include(hider.username);
 					expect(res.body.total).to.be.equal(res.body.members.length);
+				});
+		});
+
+		it('should return the hider as online to a user they do not hide from', async () => {
+			await request
+				.get(api('rooms.membersOrderedByRole'))
+				.set(bystanderCredentials)
+				.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.ONLINE);
 				});
 		});
 
@@ -130,6 +129,17 @@ import { IS_EE } from '../../e2e/config/constants';
 					expect(res.body.total).to.be.equal(res.body.members.length);
 				});
 		});
+
+		it('should return the hider as online to a user they do not hide from', async () => {
+			await request
+				.get(api('channels.members'))
+				.set(bystanderCredentials)
+				.query({ 'roomId': channel._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.ONLINE);
+				});
+		});
 	});
 
 	describe('[/channels.online]', () => {
@@ -141,6 +151,17 @@ import { IS_EE } from '../../e2e/config/constants';
 				.expect(200)
 				.expect((res) => {
 					expect(usernamesOf(res.body.online)).to.not.include(hider.username);
+				});
+		});
+
+		it('should return the hider to a user they do not hide from', async () => {
+			await request
+				.get(api('channels.online'))
+				.set(bystanderCredentials)
+				.query({ _id: channel._id })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.online)).to.include(hider.username);
 				});
 		});
 	});
@@ -157,6 +178,17 @@ import { IS_EE } from '../../e2e/config/constants';
 					expect(res.body.total).to.be.equal(res.body.members.length);
 				});
 		});
+
+		it('should return the hider as online to a user they do not hide from', async () => {
+			await request
+				.get(api('groups.members'))
+				.set(bystanderCredentials)
+				.query({ 'roomId': group._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(statusOf(res.body.members, hider.username)).to.be.equal(UserStatus.ONLINE);
+				});
+		});
 	});
 
 	describe('[/groups.online]', () => {
@@ -170,9 +202,22 @@ import { IS_EE } from '../../e2e/config/constants';
 					expect(usernamesOf(res.body.online)).to.not.include(hider.username);
 				});
 		});
+
+		it('should return the hider to a user they do not hide from', async () => {
+			await request
+				.get(api('groups.online'))
+				.set(bystanderCredentials)
+				.query({ _id: group._id })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.online)).to.include(hider.username);
+				});
+		});
 	});
 
 	describe('[/teams.members]', () => {
+		const teamUsernamesOf = (members: { user: IUser }[]) => members.map(({ user }) => user.username);
+
 		it('should not return the hider when the viewer filters by online', async () => {
 			await request
 				.get(api('teams.members'))
@@ -180,7 +225,18 @@ import { IS_EE } from '../../e2e/config/constants';
 				.query({ 'teamId': team._id, 'status[]': UserStatus.ONLINE })
 				.expect(200)
 				.expect((res) => {
-					expect(res.body.members.map(({ user }: { user: IUser }) => user.username)).to.not.include(hider.username);
+					expect(teamUsernamesOf(res.body.members)).to.not.include(hider.username);
+				});
+		});
+
+		it('should return the hider to a user they do not hide from', async () => {
+			await request
+				.get(api('teams.members'))
+				.set(bystanderCredentials)
+				.query({ 'teamId': team._id, 'status[]': UserStatus.ONLINE })
+				.expect(200)
+				.expect((res) => {
+					expect(teamUsernamesOf(res.body.members)).to.include(hider.username);
 				});
 		});
 
@@ -210,6 +266,17 @@ import { IS_EE } from '../../e2e/config/constants';
 					expect(res.body).to.not.have.property('statusSource');
 				});
 		});
+
+		it('should report the real status to a user they do not hide from', async () => {
+			await request
+				.get(api('users.getStatus'))
+				.set(bystanderCredentials)
+				.query({ userId: hider._id })
+				.expect(200)
+				.expect((res) => {
+					expect(res.body.status).to.be.equal(UserStatus.ONLINE);
+				});
+		});
 	});
 
 	describe('[/users.getPresence]', () => {
@@ -223,17 +290,63 @@ import { IS_EE } from '../../e2e/config/constants';
 					expect(res.body.presence).to.be.equal(UserStatus.OFFLINE);
 				});
 		});
+
+		it('should report the real presence to a user they do not hide from', async () => {
+			await request
+				.get(api('users.getPresence'))
+				.set(bystanderCredentials)
+				.query({ userId: hider._id })
+				.expect(200)
+				.expect((res) => {
+					expect(res.body.presence).to.be.equal(UserStatus.ONLINE);
+				});
+		});
 	});
 
 	describe('[/users.autocomplete]', () => {
+		const selector = (conditions?: object) => JSON.stringify({ term: hider.username, exceptions: [], ...(conditions && { conditions }) });
+
 		it('should list the hider as offline to the viewer', async () => {
 			await request
 				.get(api('users.autocomplete'))
 				.set(viewerCredentials)
-				.query({ selector: JSON.stringify({ term: hider.username, exceptions: [] }) })
+				.query({ selector: selector() })
 				.expect(200)
 				.expect((res) => {
 					expect(statusOf(res.body.items, hider.username)).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+
+		it('should list the real status to a user they do not hide from', async () => {
+			await request
+				.get(api('users.autocomplete'))
+				.set(bystanderCredentials)
+				.query({ selector: selector() })
+				.expect(200)
+				.expect((res) => {
+					expect(statusOf(res.body.items, hider.username)).to.be.equal(UserStatus.ONLINE);
+				});
+		});
+
+		it('should not return the hider when the viewer filters by online through the selector conditions', async () => {
+			await request
+				.get(api('users.autocomplete'))
+				.set(viewerCredentials)
+				.query({ selector: selector({ status: UserStatus.ONLINE }) })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.items)).to.not.include(hider.username);
+				});
+		});
+
+		it('should return the hider through the selector conditions to a user they do not hide from', async () => {
+			await request
+				.get(api('users.autocomplete'))
+				.set(bystanderCredentials)
+				.query({ selector: selector({ status: UserStatus.ONLINE }) })
+				.expect(200)
+				.expect((res) => {
+					expect(usernamesOf(res.body.items)).to.include(hider.username);
 				});
 		});
 	});

--- a/apps/meteor/tests/end-to-end/api/status-visibility.ts
+++ b/apps/meteor/tests/end-to-end/api/status-visibility.ts
@@ -212,6 +212,19 @@ import { IS_EE } from '../../e2e/config/constants';
 		});
 	});
 
+	describe('[/users.getPresence]', () => {
+		it('should report the hider as offline to the viewer', async () => {
+			await request
+				.get(api('users.getPresence'))
+				.set(viewerCredentials)
+				.query({ userId: hider._id })
+				.expect(200)
+				.expect((res) => {
+					expect(res.body.presence).to.be.equal(UserStatus.OFFLINE);
+				});
+		});
+	});
+
 	describe('[/users.autocomplete]', () => {
 		it('should list the hider as offline to the viewer', async () => {
 			await request


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Status visibility (#41747) redacted the `status` **value** in a few payloads but left every status **filter** running against the stored one, so a hidden user never dropped out of anything: `?status[]=online` still returned her (CORE-2651) and — never reported, same leak backwards — `?status[]=offline` omitted her, letting Bob infer she is online.

Instead of patching each report, this encodes the invariant: **for a viewer V, a user hidden from V has an effective status of `offline`**, and every read path behaves as if that were the stored value. The match is built in the query rather than applied to the response because these endpoints derive `total` from a separate count over the same match; the non-obvious case in `effectiveStatus.ts` is the `$or` that pulls hidden users back into an `offline` filter whatever their stored status.

### Endpoints fixed

| Endpoint | What was wrong |
|---|---|
| `GET /v1/rooms.membersOrderedByRole` | the one in CORE-2651 — online filter returned hidden users, payload carried the real `status`, and `statusSortKey` sorted them into the online block of the All tab |
| `GET /v1/channels.members` | online filter returned hidden users; real `status` in the payload |
| `GET /v1/groups.members` | same |
| `GET /v1/channels.online` | listed hidden users outright |
| `GET /v1/groups.online` | same |
| `GET /v1/teams.members` | online filter returned hidden users; real `status`; **and the payload echoed back `settings.preferences.statusVisibilityDenied`** (see below) |
| `GET /v1/users.getStatus` | returned the real status for another user |
| `GET /v1/users.autocomplete` | returned the real status — CORE-2652, the New Call dialer reads `status` straight off this payload |
| `GET /v1/im.members` | already partly covered by #41747, but excluded hidden users for *any* status filter, so it leaked through the `offline` case |
| DDP `getUsersOfRoom` | non-offline listing returned hidden users; real `status` |

Ordering was a second, quieter channel: `findUsersOfRoom` sorts on `statusConnection`, which redaction does not touch, so a hidden-but-online user floated to the top while rendering offline. That sort key is now dropped for viewers who have anyone hidden.

### Block list disclosure in `teams.members`

Worth calling out separately: it is a stronger disclosure than the reported bug, and it was found while investigating rather than reported, so nobody has been watching for it.

`Team.members` queried users with no projection and copied `settings` wholesale into the response. The block list lives in the untyped `settings.preferences` bag, so `teams.members` handed every member of a team the `statusVisibilityDenied` array of every other member — a blocked viewer could read their own id inside it and learn they had been hidden from, specifically and deliberately. The feature's promise is that a blocked user cannot tell a block from genuine absence.

## Issue(s)

- [CORE-2651](https://rocketchat.atlassian.net/browse/CORE-2651)
- [CORE-2652](https://rocketchat.atlassian.net/browse/CORE-2652)

## Steps to test or reproduce

Requires an Enterprise workspace with `unlimited-presence` and `Accounts_StatusVisibility_Enabled` on. As Alice, **Hide from...** → Bob; set Alice online and keep her connected. Then, as Bob:

1. In a shared channel, open **Members** → **Online**: Alice must not be listed.
2. Switch to **All**: Alice must be listed, offline, sorted among the offline members.
3. Search Alice in the **New Call** dialer: offline.
4. `GET /api/v1/users.getStatus?userId=<alice>`: `offline`.
5. `GET /api/v1/teams.members?teamId=<team>`: no `statusVisibilityDenied` on any member.
6. Repeat as a third user with no block: Alice online everywhere.

Automated coverage in `tests/end-to-end/api/status-visibility.ts` (13 tests, EE-gated) and `effectiveStatus.spec.ts` (5 unit tests). Reverting the server changes fails 12 of the 13.

## Further comments


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved status visibility controls across channels, groups, teams, direct messages, rooms, presence, and user search.
  * Hidden users are now excluded or shown as offline according to visibility settings.
  * Status-related privacy preferences are no longer exposed in team member details.
* **Bug Fixes**
  * Corrected online-member results and status filtering when users restrict visibility.
  * Ensured hidden users’ presence and status information is consistently redacted across APIs.
* **Tests**
  * Added comprehensive coverage for status visibility across supported room types and user experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[CORE-2651]: https://rocketchat.atlassian.net/browse/CORE-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ