### PR TITLE
fix: sync emoji history across clients

### DIFF
--- a/apps/meteor/client/lib/emoji/helpers.ts
+++ b/apps/meteor/client/lib/emoji/helpers.ts
@@ -24,17 +24,14 @@ export const createEmojiListByCategorySubscription = (
 	actualTone: number,
 	recentEmojis: string[],
 	setRecentEmojis: (emojis: string[]) => void,
-	setQuickReactions: () => void,
 ): [subscribe: (onStoreChange: () => void) => () => void, getSnapshot: () => ReturnType<typeof createPickerEmojis>] => {
 	let result: ReturnType<typeof createPickerEmojis> = [[], []];
 	updateRecent(recentEmojis);
 
 	const sub = (cb: () => void) => {
 		result = createPickerEmojis(customItemsLimit, actualTone, recentEmojis, setRecentEmojis);
-		setQuickReactions();
 		return emojiEmitter.on('updated', () => {
 			result = createPickerEmojis(customItemsLimit, actualTone, recentEmojis, setRecentEmojis);
-			setQuickReactions();
 			cb();
 		});
 	};

--- a/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.spec.tsx
+++ b/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.spec.tsx
@@ -15,6 +15,12 @@ jest.mock('@rocket.chat/fuselage-hooks', () => {
 	};
 });
 
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useEndpoint: () => jest.fn().mockResolvedValue(undefined),
+	useUser: () => ({ _id: 'user-id', settings: { preferences: {} } }),
+	useUserPreference: <T,>(_key: string, defaultValue: T) => defaultValue,
+}));
+
 jest.mock('../../lib/emoji', () => ({
 	emoji: { packages: { base: { emojisByCategory: { recent: [] } } } },
 	getFrequentEmoji: jest.fn(() => []),

--- a/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
+++ b/apps/meteor/client/providers/EmojiPickerProvider/EmojiPickerProvider.tsx
@@ -1,6 +1,7 @@
-import { useDebouncedState, useStableCallback, useLocalStorage } from '@rocket.chat/fuselage-hooks';
+import { useDebouncedState, useLocalStorage } from '@rocket.chat/fuselage-hooks';
+import { useEndpoint, useUser, useUserPreference } from '@rocket.chat/ui-contexts';
 import type { ReactNode, ContextType } from 'react';
-import { useState, useCallback, useMemo, useSyncExternalStore } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 
 import { useUpdateCustomEmoji } from './useUpdateCustomEmoji';
 import { EmojiPickerContext } from '../../contexts/EmojiPickerContext';
@@ -11,28 +12,71 @@ const DEFAULT_ITEMS_LIMIT = 90;
 
 // limit recent emojis to 27 (3 rows of 9)
 const RECENT_EMOJIS_LIMIT = 27;
+const EMPTY_RECENT_EMOJIS: string[] = [];
+const EMPTY_FREQUENT_EMOJIS: [string, number][] = [];
 
 export type EmojiPickerProviderProps = { children: ReactNode };
 
 const EmojiPickerProvider = ({ children }: EmojiPickerProviderProps) => {
 	const [emojiPicker, setEmojiPicker] = useState<ReactNode>(null);
 	const [emojiToPreview, setEmojiToPreview] = useDebouncedState<{ emoji: string; name: string } | null>(null, 100);
-	const [recentEmojis, setRecentEmojis] = useLocalStorage<string[]>('emoji.recent', []);
-	const [frequentEmojis, setFrequentEmojis] = useLocalStorage<[string, number][]>('emoji.frequent', []);
+	const user = useUser();
+	const saveUserPreferences = useEndpoint('POST', '/v1/users.setPreferences');
+	const recentEmojis = useUserPreference<string[]>('recentEmojis', EMPTY_RECENT_EMOJIS) ?? EMPTY_RECENT_EMOJIS;
+	const frequentEmojis = useUserPreference<[string, number][]>('frequentEmojis', EMPTY_FREQUENT_EMOJIS) ?? EMPTY_FREQUENT_EMOJIS;
+	const [storedRecentEmojis, setStoredRecentEmojis] = useLocalStorage<string[]>('emoji.recent', []);
+	const [storedFrequentEmojis, setStoredFrequentEmojis] = useLocalStorage<[string, number][]>('emoji.frequent', []);
+	const migratedUsers = useRef(new Set<string>());
+
+	const setRecentEmojis = useCallback(
+		(emojis: string[]) => {
+			void saveUserPreferences({ data: { recentEmojis: emojis } });
+		},
+		[saveUserPreferences],
+	);
+
+	useEffect(() => {
+		if (!user?._id || migratedUsers.current.has(user._id)) {
+			return;
+		}
+
+		migratedUsers.current.add(user._id);
+		const preferences = user.settings?.preferences;
+		const migration: { recentEmojis?: string[]; frequentEmojis?: [string, number][] } = {};
+		const hasRecentPreference = preferences?.hasOwnProperty('recentEmojis');
+		const hasFrequentPreference = preferences?.hasOwnProperty('frequentEmojis');
+
+		if (!hasRecentPreference && storedRecentEmojis?.length) {
+			migration.recentEmojis = storedRecentEmojis.slice(0, RECENT_EMOJIS_LIMIT);
+		}
+		if (!hasFrequentPreference && storedFrequentEmojis?.length) {
+			migration.frequentEmojis = storedFrequentEmojis;
+		}
+
+		if (Object.keys(migration).length) {
+			void saveUserPreferences({ data: migration }).then(() => {
+				setStoredRecentEmojis([]);
+				setStoredFrequentEmojis([]);
+			});
+		} else {
+			if (hasRecentPreference) {
+				setStoredRecentEmojis([]);
+			}
+			if (hasFrequentPreference) {
+				setStoredFrequentEmojis([]);
+			}
+		}
+	}, [saveUserPreferences, setStoredFrequentEmojis, setStoredRecentEmojis, storedFrequentEmojis, storedRecentEmojis, user]);
 
 	const [actualTone, setActualTone] = useLocalStorage('emoji.tone', 0);
 	const [currentCategory, setCurrentCategory] = useState('recent');
 
 	const [customItemsLimit, setCustomItemsLimit] = useState(DEFAULT_ITEMS_LIMIT);
 
-	const [quickReactions, _setQuickReactions] = useState<{ emoji: string; image: string }[]>(() =>
-		getFrequentEmoji(frequentEmojis.map(([emoji]) => emoji)),
-	);
-
-	const setQuickReactions = useStableCallback(() => _setQuickReactions(getFrequentEmoji(frequentEmojis.map(([emoji]) => emoji))));
+	const quickReactions = getFrequentEmoji(frequentEmojis.map(([emoji]) => emoji));
 	const [sub, getSnapshot] = useMemo(() => {
-		return createEmojiListByCategorySubscription(customItemsLimit, actualTone, recentEmojis, setRecentEmojis, setQuickReactions);
-	}, [customItemsLimit, actualTone, recentEmojis, setRecentEmojis, setQuickReactions]);
+		return createEmojiListByCategorySubscription(customItemsLimit, actualTone, recentEmojis, setRecentEmojis);
+	}, [customItemsLimit, actualTone, recentEmojis, setRecentEmojis]);
 
 	const [emojiListByCategory, categoriesIndexes] = useSyncExternalStore(sub, getSnapshot);
 
@@ -50,10 +94,9 @@ const EmojiPickerProvider = ({ children }: EmojiPickerProviderProps) => {
 				})
 				.sort(([, frequentA], [, frequentB]) => frequentB - frequentA);
 
-			setFrequentEmojis(sortedFrequent);
-			_setQuickReactions(getFrequentEmoji(sortedFrequent.map(([emoji]) => emoji)));
+			void saveUserPreferences({ data: { frequentEmojis: sortedFrequent } });
 		},
-		[frequentEmojis, setFrequentEmojis],
+			[frequentEmojis, saveUserPreferences],
 	);
 
 	const addRecentEmoji = useCallback(

--- a/apps/meteor/server/meteor-methods/users/saveUserPreferences.ts
+++ b/apps/meteor/server/meteor-methods/users/saveUserPreferences.ts
@@ -58,6 +58,8 @@ type UserPreferences = {
 	mentionsWithSymbol?: boolean;
 	utcOffset?: number;
 	statusVisibilityDenied?: string[];
+	recentEmojis?: string[];
+	frequentEmojis?: [string, number][];
 };
 
 declare module '@rocket.chat/ddp-client' {
@@ -166,6 +168,8 @@ export const saveUserPreferences = async (settings: Partial<UserPreferences>, us
 		mentionsWithSymbol: Match.Optional(Boolean),
 		utcOffset: Match.Optional(Number),
 		statusVisibilityDenied: Match.Optional([String]),
+		recentEmojis: Match.Optional([String]),
+		frequentEmojis: Match.Optional([[String, Number]]),
 	};
 	check(settings, Match.ObjectIncluding(keys));
 

--- a/packages/rest-typings/src/v1/users/UsersSetPreferenceParamsPOST.ts
+++ b/packages/rest-typings/src/v1/users/UsersSetPreferenceParamsPOST.ts
@@ -56,6 +56,8 @@ export type UsersSetPreferencesParamsPOST = {
 		mentionsWithSymbol?: boolean;
 		desktopNotificationVoiceCalls?: boolean;
 		utcOffset?: number;
+		recentEmojis?: string[];
+		frequentEmojis?: [string, number][];
 	};
 };
 
@@ -292,6 +294,21 @@ const UsersSetPreferencesParamsPostSchema = {
 				},
 				utcOffset: {
 					type: 'number',
+					nullable: true,
+				},
+				recentEmojis: {
+					type: 'array',
+					items: { type: 'string' },
+					nullable: true,
+				},
+				frequentEmojis: {
+					type: 'array',
+					items: {
+						type: 'array',
+						prefixItems: [{ type: 'string' }, { type: 'number' }],
+						minItems: 2,
+						maxItems: 2,
+					},
 					nullable: true,
 				},
 			},


### PR DESCRIPTION
## What does this PR do?

Fixes emoji history synchronization across Rocket.Chat clients.

The emoji picker previously stored its history only in browser `localStorage`. As a result, recently used emojis were client-local and were not synchronized between browsers or devices using the same Rocket.Chat account. The history could also be lost after logout or a hard refresh.

This PR stores emoji history in server-backed user preferences so it is associated with the user account and synchronized through Meteor's reactive user data.

## Changes

- Store `recentEmojis` in server-backed user preferences.
- Store `frequentEmojis` in server-backed user preferences.
- Synchronize emoji history across active client sessions.
- Preserve the existing 27-item limit for recent emojis.
- Migrate existing values from `emoji.recent` and `emoji.frequent` in localStorage.
- Clear legacy localStorage values after successful migration.
- Prevent the EmojiPickerProvider from causing React maximum update-depth errors.
- Add REST and Meteor preference validation.
- Update unit-test mocks and provider coverage.

The UI category is displayed as "Frequently Used" and is powered by both recent emoji ordering and frequency scores. This covers emoji selection from both the message composer and message reactions.

## Issue

Closes #41985

## How to test

1. Start the application locally.
2. Open `http://localhost:3000/`.
3. Log in with the same account in two separate browsers or browser profiles.
4. In browser A, open a room and use several different emojis:
   - Send messages containing emojis.
   - Add emoji reactions to messages.
5. Open the emoji picker again in browser A.
6. Open the "Frequently Used" category and confirm the emojis appear.
7. Open the same room in browser B.
8. Open the emoji picker and check the "Frequently Used" category.
9. Confirm the emojis used in browser A are also present in browser B.
10. Reload browser B and confirm the emoji history remains available.
11. Log out and log back in to browser A with the same account.
12. Confirm the emoji history persists after signing in again.

## Validation

- REST typings package typecheck passes.
- `EmojiPickerProvider` Jest test passes.
- Type diagnostics pass for the changed files.
- `git diff --check` passes.
- Manual cross-client testing completed locally.

## Implementation notes

The existing user-preference storage and synchronization mechanism is used. No separate synchronization service or collection was introduced.

Existing localStorage values are used only for one-time migration. After the server preferences are successfully saved, the legacy localStorage values are cleared so they cannot remain a stale or cross-account source of truth.

https://github.com/user-attachments/assets/76eba90e-6ab8-40d2-b807-3dcfe6f24e66


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent and frequently used emojis now sync with user preferences across sessions and devices.
  * Emoji preferences can be saved and validated through user settings APIs.
  * Existing locally stored emoji history is migrated automatically.

* **Bug Fixes**
  * Recent emoji history is limited to 27 items.
  * Quick reactions now stay synchronized with frequently used emojis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->