### PR TITLE
feat: add `aroundId` param to `rooms.history` endpoint

### DIFF
--- a/.changeset/ddp-migrate-surrounding-messages-caller.md
+++ b/.changeset/ddp-migrate-surrounding-messages-caller.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Deprecates the `loadSurroundingMessages` real-time API method in favor of the `aroundId` parameter of `GET /v1/rooms.history`. The method keeps working until it is removed in 9.0.0.

--- a/.changeset/rest-rooms-history-around.md
+++ b/.changeset/rest-rooms-history-around.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/rest-typings': minor
+'@rocket.chat/meteor': minor
+---
+
+Adds an `aroundId` parameter to `GET /v1/rooms.history`, returning a window of messages centered on a given message instead of a page from one end of the room. This is what jumping to a quoted message, a search result or a thread message uses to load the surrounding conversation.

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -342,6 +342,16 @@ class RoomHistoryManagerClass extends Emitter {
 		// Rebuilds the window around the target, so the store does not grow monotonically here.
 		this.clear(message.rid);
 
+		// `clear` drops the cursors and clears `isLoading`, so restore both before the upsert yields:
+		// a `getMore` landing in that window has no cursor and would page from the newest end instead.
+		this.updateRoom(message.rid, {
+			isLoading: true,
+			cursorPrevious: result.cursor.previous,
+			cursorNext: result.cursor.next,
+			hasMore: result.cursor.previous !== null,
+			hasMoreNext: result.cursor.next !== null,
+		});
+
 		const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 
 		await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
@@ -353,13 +363,7 @@ class RoomHistoryManagerClass extends Emitter {
 		}
 		room.loaded += messages.length;
 
-		this.updateRoom(message.rid, {
-			isLoading: false,
-			cursorPrevious: result.cursor.previous,
-			cursorNext: result.cursor.next,
-			hasMore: result.cursor.previous !== null,
-			hasMoreNext: result.cursor.next !== null,
-		});
+		this.updateRoom(message.rid, { isLoading: false });
 	}
 }
 

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -230,15 +230,19 @@ class RoomHistoryManagerClass extends Emitter {
 			return;
 		}
 
-		await this.queue();
+		try {
+			this.updateRoom(rid, { isLoading: true });
 
-		this.updateRoom(rid, { isLoading: true });
+			await this.queue();
 
-		const subscription = Subscriptions.state.find((record) => record.rid === rid);
+			// `clear` may have run while queued (jump to message, jump to recent):
+			// the window this cursor belonged to is gone, so there is nothing to page from.
+			const { cursorNext: next } = room;
+			if (!next) {
+				return;
+			}
 
-		const { cursorNext: next } = room;
-
-		if (next) {
+			const subscription = Subscriptions.state.find((record) => record.rid === rid);
 			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
 
 			const result = await sdk.rest.get('/v1/rooms.history', {
@@ -258,7 +262,6 @@ class RoomHistoryManagerClass extends Emitter {
 			this.emit('loaded-messages');
 
 			this.updateRoom(rid, {
-				isLoading: false,
 				cursorNext: result.cursor.next,
 				hasMoreNext: result.cursor.next !== null,
 			});
@@ -267,8 +270,10 @@ class RoomHistoryManagerClass extends Emitter {
 			}
 
 			room.loaded += messages.length;
+		} finally {
+			this.updateRoom(rid, { isLoading: false });
+			this.unqueue();
 		}
-		this.unqueue();
 	}
 
 	public hasMore(rid: IRoom['_id']) {

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -4,6 +4,7 @@ import { differenceInMilliseconds } from 'date-fns';
 import { useCallback, useSyncExternalStore } from 'react';
 
 import { getUserPreference } from './getUserPreference';
+import { dispatchToastMessage } from './toast';
 import { Messages, Subscriptions } from '../stores';
 import { sdk } from './SDKClient';
 import { onClientMessageReceived } from './onClientMessageReceived';
@@ -333,38 +334,46 @@ class RoomHistoryManagerClass extends Emitter {
 
 		const subscription = Subscriptions.state.find((record) => record.rid === message.rid);
 
-		const result = await sdk.rest.get('/v1/rooms.history', {
-			roomId: message.rid,
-			aroundId: message._id,
-			count: defaultLimit,
-			showThreadMessages,
-		});
+		try {
+			const result = await sdk.rest.get('/v1/rooms.history', {
+				roomId: message.rid,
+				aroundId: message._id,
+				count: defaultLimit,
+				showThreadMessages,
+			});
 
-		// Rebuilds the window around the target, so the store does not grow monotonically here.
-		this.clear(message.rid);
+			// Rebuilds the window around the target, so the store does not grow monotonically here.
+			this.clear(message.rid);
 
-		// `clear` drops the cursors and clears `isLoading`, so restore both before the upsert yields:
-		// a `getMore` landing in that window has no cursor and would page from the newest end instead.
-		this.updateRoom(message.rid, {
-			isLoading: true,
-			cursorPrevious: result.cursor.previous,
-			cursorNext: result.cursor.next,
-			hasMore: result.cursor.previous !== null,
-			hasMoreNext: result.cursor.next !== null,
-		});
+			// `clear` drops the cursors and clears `isLoading`, so restore both before the upsert yields:
+			// a `getMore` landing in that window has no cursor and would page from the newest end instead.
+			this.updateRoom(message.rid, {
+				isLoading: true,
+				cursorPrevious: result.cursor.previous,
+				cursorNext: result.cursor.next,
+				hasMore: result.cursor.previous !== null,
+				hasMoreNext: result.cursor.next !== null,
+			});
 
-		const messages = result.messages.map((msg) => mapMessageFromApi(msg));
+			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 
-		await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
+			await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
 
-		this.emit('loaded-messages');
+			this.emit('loaded-messages');
 
-		if (!room.loaded) {
-			room.loaded = 0;
+			if (!room.loaded) {
+				room.loaded = 0;
+			}
+			room.loaded += messages.length;
+		} catch (error) {
+			// The target may have been deleted since the link was created; no window to build then.
+			if (error instanceof Response && error.status === 404) {
+				return;
+			}
+			dispatchToastMessage({ type: 'error', message: error });
+		} finally {
+			this.updateRoom(message.rid, { isLoading: false });
 		}
-		room.loaded += messages.length;
-
-		this.updateRoom(message.rid, { isLoading: false });
 	}
 }
 

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -350,19 +350,25 @@ class RoomHistoryManagerClass extends Emitter {
 			// Rebuilds the window around the target, so the store does not grow monotonically here.
 			this.clear(message.rid);
 
-			// `clear` drops the cursors and clears `isLoading`, so restore both before the upsert yields:
-			// a `getMore` landing in that window has no cursor and would page from the newest end instead.
+			// `clear` drops the cursors and clears `isLoading`, so restore the previous side before the
+			// upsert yields: a `getMore` landing in that window has no cursor and would page from the
+			// newest end instead.
 			this.updateRoom(message.rid, {
 				isLoading: true,
 				cursorPrevious: result.cursor.previous,
-				cursorNext: result.cursor.next,
 				hasMore: result.cursor.previous !== null,
-				hasMoreNext: result.cursor.next !== null,
 			});
 
 			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 
 			await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
+
+			// The next side only lands after the upsert: `hasMoreNext` arms jump-to-recent
+			// (useHasNewMessages), which would clear the store while the upsert is still pending.
+			this.updateRoom(message.rid, {
+				cursorNext: result.cursor.next,
+				hasMoreNext: result.cursor.next !== null,
+			});
 
 			this.emit('loaded-messages');
 

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -386,6 +386,12 @@ class RoomHistoryManagerClass extends Emitter {
 				showThreadMessages,
 			});
 
+			// A `clear`/`close` that landed while the fetch was on the wire superseded this jump;
+			// clearing here would wipe the newer window and rebuild a stale one over it.
+			if (generation !== this.generation(message.rid)) {
+				return;
+			}
+
 			// Rebuilds the window around the target, so the store does not grow monotonically here.
 			this.clear(message.rid);
 

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -65,7 +65,15 @@ class RoomHistoryManagerClass extends Emitter {
 
 	private histories: Record<IRoom['_id'], RoomHistoryState> = {};
 
+	// Bumped by `clear`/`close`. In-flight requests capture it at entry and discard their
+	// response if it changed, so a page from a dead window can't touch the rebuilt one.
+	private generations: Record<IRoom['_id'], number> = {};
+
 	private requestsList: string[] = [];
+
+	private generation(rid: IRoom['_id']): number {
+		return this.generations[rid] ?? 0;
+	}
 
 	public getRoom(rid: IRoom['_id']): RoomHistoryState {
 		if (!this.histories[rid]) {
@@ -139,6 +147,8 @@ class RoomHistoryManagerClass extends Emitter {
 			return;
 		}
 
+		const generation = this.generation(rid);
+
 		try {
 			this.updateRoom(rid, { isLoading: true });
 
@@ -165,6 +175,10 @@ class RoomHistoryManagerClass extends Emitter {
 
 			this.unqueue();
 
+			if (generation !== this.generation(rid)) {
+				return;
+			}
+
 			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 			this.updateRoom(rid, {
 				unreadNotLoaded: result.unreadNotLoaded ?? 0,
@@ -186,6 +200,10 @@ class RoomHistoryManagerClass extends Emitter {
 				subscription,
 			});
 
+			if (generation !== this.generation(rid)) {
+				return;
+			}
+
 			this.emit('loaded-messages');
 
 			if (!room.loaded) {
@@ -203,7 +221,10 @@ class RoomHistoryManagerClass extends Emitter {
 
 			this.emit('loaded-messages');
 		} finally {
-			this.updateRoom(rid, { isLoading: false });
+			// When stale, `clear` already reset the flag and the rebuild owns it now.
+			if (generation === this.generation(rid)) {
+				this.updateRoom(rid, { isLoading: false });
+			}
 		}
 	}
 
@@ -230,6 +251,8 @@ class RoomHistoryManagerClass extends Emitter {
 			return;
 		}
 
+		const generation = this.generation(rid);
+
 		try {
 			this.updateRoom(rid, { isLoading: true });
 
@@ -252,12 +275,22 @@ class RoomHistoryManagerClass extends Emitter {
 				showThreadMessages: showThreadsInMainChannel,
 			});
 
+			// The queued-cursor check above only covers a `clear` that ran before dispatch;
+			// this one covers a `clear` that landed while the request was on the wire.
+			if (generation !== this.generation(rid)) {
+				return;
+			}
+
 			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 
 			await upsertMessageBulk({
 				msgs: messages.filter((msg) => msg.t !== 'command'),
 				subscription,
 			});
+
+			if (generation !== this.generation(rid)) {
+				return;
+			}
 
 			this.emit('loaded-messages');
 
@@ -271,7 +304,9 @@ class RoomHistoryManagerClass extends Emitter {
 
 			room.loaded += messages.length;
 		} finally {
-			this.updateRoom(rid, { isLoading: false });
+			if (generation === this.generation(rid)) {
+				this.updateRoom(rid, { isLoading: false });
+			}
 			this.unqueue();
 		}
 	}
@@ -297,11 +332,13 @@ class RoomHistoryManagerClass extends Emitter {
 	}
 
 	public close(rid: IRoom['_id']) {
+		this.generations[rid] = this.generation(rid) + 1;
 		Messages.state.remove((record) => record.rid === rid);
 		delete this.histories[rid];
 	}
 
 	public clear(rid: IRoom['_id']) {
+		this.generations[rid] = this.generation(rid) + 1;
 		const room = this.getRoom(rid);
 		Messages.state.remove((record) => record.rid === rid);
 		room.loaded = undefined;
@@ -339,6 +376,8 @@ class RoomHistoryManagerClass extends Emitter {
 
 		const subscription = Subscriptions.state.find((record) => record.rid === message.rid);
 
+		let generation = this.generation(message.rid);
+
 		try {
 			const result = await sdk.rest.get('/v1/rooms.history', {
 				roomId: message.rid,
@@ -349,6 +388,10 @@ class RoomHistoryManagerClass extends Emitter {
 
 			// Rebuilds the window around the target, so the store does not grow monotonically here.
 			this.clear(message.rid);
+
+			// This rebuild owns the window created by its own `clear`; a later `clear`
+			// (jump to recent, messagesImported) makes the rest of this flow stale.
+			generation = this.generation(message.rid);
 
 			// `clear` drops the cursors and clears `isLoading`, so restore the previous side before the
 			// upsert yields: a `getMore` landing in that window has no cursor and would page from the
@@ -362,6 +405,10 @@ class RoomHistoryManagerClass extends Emitter {
 			const messages = result.messages.map((msg) => mapMessageFromApi(msg));
 
 			await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
+
+			if (generation !== this.generation(message.rid)) {
+				return;
+			}
 
 			// The next side only lands after the upsert: `hasMoreNext` arms jump-to-recent
 			// (useHasNewMessages), which would clear the store while the upsert is still pending.
@@ -383,7 +430,9 @@ class RoomHistoryManagerClass extends Emitter {
 			}
 			dispatchToastMessage({ type: 'error', message: error });
 		} finally {
-			this.updateRoom(message.rid, { isLoading: false });
+			if (generation === this.generation(message.rid)) {
+				this.updateRoom(message.rid, { isLoading: false });
+			}
 		}
 	}
 }

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -306,6 +306,7 @@ class RoomHistoryManagerClass extends Emitter {
 			cursorPrevious: undefined,
 			cursorNext: undefined,
 		});
+		this.emit('room-cleared', rid);
 	}
 
 	public async getSurroundingMessages(message?: Pick<IMessage, '_id' | 'rid'> & { ts?: Date }) {

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -154,6 +154,12 @@ class RoomHistoryManagerClass extends Emitter {
 
 			await this.queue();
 
+			// A `clear` may have run while queued (jump to message, jump to recent): the window this
+			// cursor belonged to is gone, and a rebuild may already have installed a different one.
+			if (generation !== this.generation(rid)) {
+				return;
+			}
+
 			let ls = undefined;
 
 			const subscription = Subscriptions.state.find((record) => record.rid === rid);
@@ -258,8 +264,12 @@ class RoomHistoryManagerClass extends Emitter {
 
 			await this.queue();
 
-			// `clear` may have run while queued (jump to message, jump to recent):
-			// the window this cursor belonged to is gone, so there is nothing to page from.
+			// A `clear` may have run while queued (jump to message, jump to recent): the window this
+			// cursor belonged to is gone, and a rebuild may already have installed a different one.
+			if (generation !== this.generation(rid)) {
+				return;
+			}
+
 			const { cursorNext: next } = room;
 			if (!next) {
 				return;
@@ -275,8 +285,7 @@ class RoomHistoryManagerClass extends Emitter {
 				showThreadMessages: showThreadsInMainChannel,
 			});
 
-			// The queued-cursor check above only covers a `clear` that ran before dispatch;
-			// this one covers a `clear` that landed while the request was on the wire.
+			// Covers a `clear` that landed while the request was on the wire.
 			if (generation !== this.generation(rid)) {
 				return;
 			}

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -442,6 +442,10 @@ class RoomHistoryManagerClass extends Emitter {
 			}
 			room.loaded += messages.length;
 		} catch (error) {
+			if (generation !== this.generation(message.rid)) {
+				return;
+			}
+
 			// The target may have been deleted since the link was created; no window to build then.
 			if (!(error instanceof Response && error.status === 404)) {
 				dispatchToastMessage({ type: 'error', message: error });

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -348,6 +348,9 @@ class RoomHistoryManagerClass extends Emitter {
 			hasMoreNext: false,
 			cursorPrevious: undefined,
 			cursorNext: undefined,
+			// The snapshot describes the DOM of the window being discarded; a stale restoreScroll
+			// resuming after this clear must no-op instead of applying it to the rebuilt window.
+			scroll: undefined,
 		});
 		this.emit('room-cleared', rid);
 	}

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -8,7 +8,6 @@ import { Messages, Subscriptions } from '../stores';
 import { sdk } from './SDKClient';
 import { onClientMessageReceived } from './onClientMessageReceived';
 import { getUserId } from './user';
-import { callWithErrorHandling } from './utils/callWithErrorHandling';
 import { getConfig } from './utils/getConfig';
 import { mapMessageFromApi } from './utils/mapMessageFromApi';
 
@@ -50,7 +49,6 @@ export type RoomHistoryState = {
 	unreadNotLoaded: number;
 	firstUnread: IMessage | undefined;
 	loaded: number | undefined;
-	oldestTs?: Date;
 	cursorPrevious?: string | null;
 	cursorNext?: string | null;
 	scroll?: {
@@ -58,9 +56,6 @@ export type RoomHistoryState = {
 		scrollTop: number;
 	};
 };
-
-// Bridge until `loadSurroundingMessages` migrates: a jump rebuilds the window without cursors.
-const cursorFromMessageTs = (ts: Date): string => `${ts.getTime()}`;
 
 const roomStateEvent = (rid: IRoom['_id']) => `state:${rid}` as const;
 
@@ -157,8 +152,7 @@ class RoomHistoryManagerClass extends Emitter {
 
 			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
 
-			// Not `??`: a null cursor means exhausted and must not fall back to a stale `oldestTs`.
-			const previous = room.cursorPrevious !== undefined ? room.cursorPrevious : room.oldestTs && cursorFromMessageTs(room.oldestTs);
+			const { cursorPrevious: previous } = room;
 
 			const result = await sdk.rest.get('/v1/rooms.history', {
 				roomId: rid,
@@ -177,10 +171,6 @@ class RoomHistoryManagerClass extends Emitter {
 				cursorPrevious: result.cursor.previous,
 				hasMore: result.cursor.previous !== null,
 			});
-
-			if (messages.length > 0) {
-				room.oldestTs = messages[messages.length - 1].ts;
-			}
 
 			const wrapper = document.querySelector<HTMLElement>('.messages-box .wrapper [data-overlayscrollbars-viewport]');
 			if (wrapper) {
@@ -243,15 +233,9 @@ class RoomHistoryManagerClass extends Emitter {
 
 		this.updateRoom(rid, { isLoading: true });
 
-		const lastMessage = Messages.state.findFirst(
-			(record) => record.rid === rid && record._hidden !== true,
-			(a, b) => b.ts.getTime() - a.ts.getTime(),
-		);
-
 		const subscription = Subscriptions.state.find((record) => record.rid === rid);
 
-		// Not `??`: a null cursor means exhausted and must not fall back to the newest loaded message.
-		const next = room.cursorNext !== undefined ? room.cursorNext : lastMessage?.ts && cursorFromMessageTs(lastMessage.ts);
+		const { cursorNext: next } = room;
 
 		if (next) {
 			const showThreadsInMainChannel = getUserPreference(getUserId(), 'showThreadsInMainChannel', false);
@@ -314,7 +298,6 @@ class RoomHistoryManagerClass extends Emitter {
 	public clear(rid: IRoom['_id']) {
 		const room = this.getRoom(rid);
 		Messages.state.remove((record) => record.rid === rid);
-		room.oldestTs = undefined;
 		room.loaded = undefined;
 		this.updateRoom(rid, {
 			isLoading: false,
@@ -348,29 +331,34 @@ class RoomHistoryManagerClass extends Emitter {
 		this.updateRoom(message.rid, { isLoading: true });
 
 		const subscription = Subscriptions.state.find((record) => record.rid === message.rid);
-		const result = await callWithErrorHandling('loadSurroundingMessages', message, defaultLimit, showThreadMessages);
 
-		if (!result) {
-			this.updateRoom(message.rid, { isLoading: false });
-			if (!this.isLoaded(message.rid)) {
-				await this.getMore(message.rid);
-			}
-			return;
-		}
+		const result = await sdk.rest.get('/v1/rooms.history', {
+			roomId: message.rid,
+			aroundId: message._id,
+			count: defaultLimit,
+			showThreadMessages,
+		});
 
+		// Rebuilds the window around the target, so the store does not grow monotonically here.
 		this.clear(message.rid);
-		this.updateRoom(message.rid, { isLoading: true });
 
-		await upsertMessageBulk({ msgs: Array.from(result.messages).filter((msg) => msg.t !== 'command'), subscription });
+		const messages = result.messages.map((msg) => mapMessageFromApi(msg));
+
+		await upsertMessageBulk({ msgs: messages.filter((msg) => msg.t !== 'command'), subscription });
 
 		this.emit('loaded-messages');
 
+		if (!room.loaded) {
+			room.loaded = 0;
+		}
+		room.loaded += messages.length;
+
 		this.updateRoom(message.rid, {
 			isLoading: false,
-			oldestTs: result.messages.at(-1)?.ts,
-			loaded: (room.loaded ?? 0) + result.messages.length,
-			hasMore: result.moreBefore,
-			hasMoreNext: result.moreAfter,
+			cursorPrevious: result.cursor.previous,
+			cursorNext: result.cursor.next,
+			hasMore: result.cursor.previous !== null,
+			hasMoreNext: result.cursor.next !== null,
 		});
 	}
 }

--- a/apps/meteor/client/lib/RoomHistoryManager.ts
+++ b/apps/meteor/client/lib/RoomHistoryManager.ts
@@ -443,10 +443,13 @@ class RoomHistoryManagerClass extends Emitter {
 			room.loaded += messages.length;
 		} catch (error) {
 			// The target may have been deleted since the link was created; no window to build then.
-			if (error instanceof Response && error.status === 404) {
-				return;
+			if (!(error instanceof Response && error.status === 404)) {
+				dispatchToastMessage({ type: 'error', message: error });
 			}
-			dispatchToastMessage({ type: 'error', message: error });
+
+			if (!this.isLoaded(message.rid)) {
+				await this.getMore(message.rid);
+			}
 		} finally {
 			if (generation === this.generation(message.rid)) {
 				this.updateRoom(message.rid, { isLoading: false });

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.spec.tsx
@@ -15,6 +15,7 @@ jest.mock('../../../../lib/RoomHistoryManager', () => ({
 		getMore: jest.fn(),
 		getMoreNext: jest.fn(),
 		restoreScroll: jest.fn(),
+		on: jest.fn(() => () => undefined),
 	},
 }));
 

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -21,15 +21,6 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 				// flip this flag.
 				let userInteracted = false;
 
-				// A window rebuild (jump to a message, jump to recent) re-enters that same cascade
-				// mid-session: messages reinsert and the pending programmatic scroll hasn't run, so an
-				// observer pass would page off a stale scrollTop of 0. Require fresh input after each one.
-				const offRoomCleared = RoomHistoryManager.on('room-cleared', (clearedRid: string) => {
-					if (clearedRid === rid) {
-						userInteracted = false;
-					}
-				});
-
 				const checkPositionAndGetMore = withThrottling({ wait: 100 })(async () => {
 					if (!element.isConnected) {
 						return;
@@ -75,6 +66,17 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 						});
 					} else if (hasMoreNext === true && Math.ceil(lastScrollTopRef) >= scrollHeight - height) {
 						await RoomHistoryManager.getMoreNext(rid);
+					}
+				});
+
+				// A window rebuild (jump to a message, jump to recent) re-enters that same cascade
+				// mid-session: messages reinsert and the pending programmatic scroll hasn't run, so an
+				// observer pass would page off a stale scrollTop of 0. Require fresh input after each
+				// one, and drop any trailing invocation already scheduled against the dead window.
+				const offRoomCleared = RoomHistoryManager.on('room-cleared', (clearedRid: string) => {
+					if (clearedRid === rid) {
+						userInteracted = false;
+						checkPositionAndGetMore.cancel();
 					}
 				});
 

--- a/apps/meteor/client/views/room/body/hooks/useGetMore.ts
+++ b/apps/meteor/client/views/room/body/hooks/useGetMore.ts
@@ -21,6 +21,15 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 				// flip this flag.
 				let userInteracted = false;
 
+				// A window rebuild (jump to a message, jump to recent) re-enters that same cascade
+				// mid-session: messages reinsert and the pending programmatic scroll hasn't run, so an
+				// observer pass would page off a stale scrollTop of 0. Require fresh input after each one.
+				const offRoomCleared = RoomHistoryManager.on('room-cleared', (clearedRid: string) => {
+					if (clearedRid === rid) {
+						userInteracted = false;
+					}
+				});
+
 				const checkPositionAndGetMore = withThrottling({ wait: 100 })(async () => {
 					if (!element.isConnected) {
 						return;
@@ -117,6 +126,7 @@ export const useGetMore = (rid: string, isJumpingToMessage: boolean) => {
 				element.addEventListener('scroll', handleScroll, { passive: true });
 
 				return () => {
+					offRoomCleared();
 					observer.disconnect();
 					mutationObserver.disconnect();
 					checkPositionAndGetMore.cancel();

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1769,7 +1769,7 @@ export const roomEndpoints = API.v1
 			},
 		},
 		async function action() {
-			const { roomId, next, previous, lastSeen, showThreadMessages = true } = this.queryParams;
+			const { roomId, next, previous, aroundId, lastSeen, showThreadMessages = true } = this.queryParams;
 			// Defaults to 20 (matching the replaced DDP method) instead of API_Default_Count, but still
 			// honors the API_Upper_Count_Limit cap.
 			const { count } = await getPaginationItems({ count: this.queryParams.count ?? 20 });
@@ -1794,10 +1794,17 @@ export const roomEndpoints = API.v1
 				return API.v1.forbidden();
 			}
 
+			const around = aroundId ? await Messages.findOneById(aroundId) : undefined;
+
+			if (aroundId && around?.rid !== roomId) {
+				return API.v1.notFound();
+			}
+
 			const result = await loadRoomHistory({
 				userId: this.userId,
 				next,
 				previous,
+				around: around ?? undefined,
 				lastSeen: lastSeen ? new Date(lastSeen) : undefined,
 				count,
 				showThreadMessages,

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1770,6 +1770,13 @@ export const roomEndpoints = API.v1
 		},
 		async function action() {
 			const { roomId, next, previous, aroundId, lastSeen, showThreadMessages = true } = this.queryParams;
+
+			// Malformed request shape must be rejected before any data resolution, so the response
+			// does not flip to 404 when `aroundId` happens to point at a missing message.
+			if ([next, previous, aroundId].filter(Boolean).length > 1) {
+				throw new MeteorError('error-cursor-conflict', 'Only one of "next", "previous" and "aroundId" can be provided');
+			}
+
 			// Defaults to 20 (matching the replaced DDP method) instead of API_Default_Count, but still
 			// honors the API_Upper_Count_Limit cap.
 			const { count } = await getPaginationItems({ count: this.queryParams.count ?? 20 });

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1794,17 +1794,21 @@ export const roomEndpoints = API.v1
 				return API.v1.forbidden();
 			}
 
-			const around = aroundId ? await Messages.findOneById(aroundId) : undefined;
-
-			if (aroundId && around?.rid !== roomId) {
-				return API.v1.notFound();
+			let around: IMessage | undefined;
+			if (aroundId) {
+				const message = await Messages.findOneById(aroundId);
+				// Hidden messages (e.g. deleted with Message_KeepHistory) must not resurface as the anchor.
+				if (!message || message.rid !== roomId || message._hidden) {
+					return API.v1.notFound();
+				}
+				around = message;
 			}
 
 			const result = await loadRoomHistory({
 				userId: this.userId,
 				next,
 				previous,
-				around: around ?? undefined,
+				around,
 				lastSeen: lastSeen ? new Date(lastSeen) : undefined,
 				count,
 				showThreadMessages,

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1771,8 +1771,6 @@ export const roomEndpoints = API.v1
 		async function action() {
 			const { roomId, next, previous, aroundId, lastSeen, showThreadMessages = true } = this.queryParams;
 
-			// Malformed request shape must be rejected before any data resolution, so the response
-			// does not flip to 404 when `aroundId` happens to point at a missing message.
 			if ([next, previous, aroundId].filter(Boolean).length > 1) {
 				throw new MeteorError('error-cursor-conflict', 'Only one of "next", "previous" and "aroundId" can be provided');
 			}
@@ -1803,7 +1801,6 @@ export const roomEndpoints = API.v1
 
 			let around: IMessage | undefined;
 			if (aroundId) {
-				// Hidden messages (e.g. deleted with Message_KeepHistory) must not resurface as the anchor.
 				const message = await Messages.findOneVisibleByRoomIdAndMessageId(roomId, aroundId);
 				if (!message) {
 					return API.v1.notFound();

--- a/apps/meteor/server/api/v1/rooms.ts
+++ b/apps/meteor/server/api/v1/rooms.ts
@@ -1803,9 +1803,9 @@ export const roomEndpoints = API.v1
 
 			let around: IMessage | undefined;
 			if (aroundId) {
-				const message = await Messages.findOneById(aroundId);
 				// Hidden messages (e.g. deleted with Message_KeepHistory) must not resurface as the anchor.
-				if (!message || message.rid !== roomId || message._hidden) {
+				const message = await Messages.findOneVisibleByRoomIdAndMessageId(roomId, aroundId);
+				if (!message) {
 					return API.v1.notFound();
 				}
 				around = message;

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -49,6 +49,7 @@ export async function loadRoomHistory({
 	userId,
 	next,
 	previous,
+	around,
 	lastSeen,
 	count = 20,
 	showThreadMessages = true,
@@ -57,12 +58,13 @@ export async function loadRoomHistory({
 	userId?: string;
 	next?: string;
 	previous?: string;
+	around?: IMessage;
 	lastSeen?: Date;
 	count?: number;
 	showThreadMessages?: boolean;
 	room: IRoom;
 }): Promise<RoomHistoryResult> {
-	if (next && previous) {
+	if ([next, previous, around].filter(Boolean).length > 1) {
 		throw new Error('error-cursor-conflict');
 	}
 
@@ -70,6 +72,49 @@ export async function loadRoomHistory({
 
 	const hiddenMessageTypes = getHiddenSystemMessages(room, settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 
+	const { records, hasNewer, hasOlder } = around
+		? await loadAround({ rid, around, count, hiddenMessageTypes, showThreadMessages })
+		: await loadPage({ rid, next, previous, count, hiddenMessageTypes, showThreadMessages });
+
+	const newest = records[0];
+	const oldest = records[records.length - 1];
+
+	const cursor: RoomHistoryCursor = {
+		next: newest && hasNewer ? encodeHistoryCursor(newest.ts) : null,
+		previous: oldest && hasOlder ? encodeHistoryCursor(oldest.ts) : null,
+	};
+
+	const [messages, unread] = await Promise.all([
+		normalizeMessagesForUser(records, userId),
+		computeUnread({ rid, userId, lastSeen, oldest, hiddenMessageTypes, showThreadMessages }),
+	]);
+
+	return { messages, cursor, ...unread };
+}
+
+// In-memory `_id` tie-break for equal `ts`: the `{ rid, ts, _updatedAt }` index cannot back a
+// `{ ts, _id }` sort, and without it MongoDB's order among equal timestamps is unspecified.
+function sortByTs(records: IMessage[], direction: 1 | -1): IMessage[] {
+	return records.sort((a, b) => (a.ts.getTime() - b.ts.getTime() || (a._id < b._id ? -1 : 1)) * direction);
+}
+
+type Window = { records: IMessage[]; hasNewer: boolean; hasOlder: boolean };
+
+async function loadPage({
+	rid,
+	next,
+	previous,
+	count,
+	hiddenMessageTypes,
+	showThreadMessages,
+}: {
+	rid: IRoom['_id'];
+	next?: string;
+	previous?: string;
+	count: number;
+	hiddenMessageTypes: MessageTypesValues[];
+	showThreadMessages: boolean;
+}): Promise<Window> {
 	// One extra document reveals whether a further page exists.
 	const options: FindOptions<IMessage> = { sort: { ts: next ? 1 : -1 }, limit: count + 1 };
 
@@ -90,10 +135,7 @@ export async function loadRoomHistory({
 				showThreadMessages,
 			).toArray();
 
-	// In-memory `_id` tie-break for equal `ts`: the `{ rid, ts, _updatedAt }` index cannot back a
-	// `{ ts, _id }` sort, and without it MongoDB's order among equal timestamps is unspecified.
-	const direction = next ? 1 : -1;
-	records.sort((a, b) => (a.ts.getTime() - b.ts.getTime() || (a._id < b._id ? -1 : 1)) * direction);
+	sortByTs(records, next ? 1 : -1);
 
 	const hasMoreInPagingDirection = records.length > count;
 
@@ -105,25 +147,66 @@ export async function loadRoomHistory({
 		records.reverse();
 	}
 
-	const newest = records[0];
-	const oldest = records[records.length - 1];
-
 	// Null means no more in that direction. The side we came from always has more — except the first
 	// page, which starts at the newest end.
-	const hasNewer = next ? hasMoreInPagingDirection : Boolean(previous);
-	const hasOlder = next ? true : hasMoreInPagingDirection;
-
-	const cursor: RoomHistoryCursor = {
-		next: newest && hasNewer ? encodeHistoryCursor(newest.ts) : null,
-		previous: oldest && hasOlder ? encodeHistoryCursor(oldest.ts) : null,
+	return {
+		records,
+		hasNewer: next ? hasMoreInPagingDirection : Boolean(previous),
+		hasOlder: next ? true : hasMoreInPagingDirection,
 	};
+}
 
-	const [messages, unread] = await Promise.all([
-		normalizeMessagesForUser(records, userId),
-		computeUnread({ rid, userId, lastSeen, oldest, hiddenMessageTypes, showThreadMessages }),
+async function loadAround({
+	rid,
+	around,
+	count,
+	hiddenMessageTypes,
+	showThreadMessages,
+}: {
+	rid: IRoom['_id'];
+	around: IMessage;
+	count: number;
+	hiddenMessageTypes: MessageTypesValues[];
+	showThreadMessages: boolean;
+}): Promise<Window> {
+	const remaining = count - 1;
+	const olderLimit = Math.ceil(remaining / 2);
+	const newerLimit = Math.floor(remaining / 2);
+
+	const [older, newer] = await Promise.all([
+		Messages.findVisibleByRoomIdBeforeTimestampNotContainingTypes(
+			rid,
+			around.ts,
+			hiddenMessageTypes,
+			{ sort: { ts: -1 }, limit: olderLimit + 1 },
+			showThreadMessages,
+		).toArray(),
+		Messages.findVisibleByRoomIdBetweenTimestampsNotContainingTypes(
+			rid,
+			around.ts,
+			FAR_FUTURE,
+			hiddenMessageTypes,
+			{ sort: { ts: 1 }, limit: newerLimit + 1 },
+			showThreadMessages,
+		).toArray(),
 	]);
 
-	return { messages, cursor, ...unread };
+	sortByTs(older, -1);
+	sortByTs(newer, 1);
+
+	const hasOlder = older.length > olderLimit;
+	const hasNewer = newer.length > newerLimit;
+
+	if (hasOlder) {
+		older.pop();
+	}
+
+	if (hasNewer) {
+		newer.pop();
+	}
+
+	// The anchor is included whatever its type, so a jump always lands on its target.
+	return { records: [...newer.reverse(), around, ...older], hasNewer, hasOlder };
 }
 
 async function computeUnread({

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -1,3 +1,4 @@
+import { MeteorError } from '@rocket.chat/core-services';
 import type { IMessage, IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
 import { Messages } from '@rocket.chat/models';
 import type { FindOptions } from 'mongodb';
@@ -27,13 +28,13 @@ export function encodeHistoryCursor(ts: Date): string {
 
 export function decodeHistoryCursor(cursor: string): Date {
 	if (!/^\d+$/.test(cursor)) {
-		throw new Error('error-invalid-cursor');
+		throw new MeteorError('error-invalid-cursor', 'Invalid pagination cursor');
 	}
 
 	const date = new Date(parseInt(cursor, 10));
 
 	if (date.toString() === 'Invalid Date') {
-		throw new Error('error-invalid-cursor');
+		throw new MeteorError('error-invalid-cursor', 'Invalid pagination cursor');
 	}
 
 	return date;
@@ -65,7 +66,7 @@ export async function loadRoomHistory({
 	room: IRoom;
 }): Promise<RoomHistoryResult> {
 	if ([next, previous, around].filter(Boolean).length > 1) {
-		throw new Error('error-cursor-conflict');
+		throw new MeteorError('error-cursor-conflict', 'Only one of "next", "previous" and "aroundId" can be provided');
 	}
 
 	const rid = room._id;

--- a/apps/meteor/server/lib/messages/loadRoomHistory.ts
+++ b/apps/meteor/server/lib/messages/loadRoomHistory.ts
@@ -170,7 +170,8 @@ async function loadAround({
 	hiddenMessageTypes: MessageTypesValues[];
 	showThreadMessages: boolean;
 }): Promise<Window> {
-	const remaining = count - 1;
+	// A non-positive count would produce a Mongo `limit: 0`, which means "no limit".
+	const remaining = Math.max(count, 1) - 1;
 	const olderLimit = Math.ceil(remaining / 2);
 	const newerLimit = Math.floor(remaining / 2);
 

--- a/apps/meteor/server/meteor-methods/messages/loadSurroundingMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/loadSurroundingMessages.ts
@@ -6,6 +6,7 @@ import { Meteor } from 'meteor/meteor';
 import type { FindOptions } from 'mongodb';
 
 import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 import { normalizeMessagesForUser } from '../../lib/utils/lib/normalizeMessagesForUser';
 import { settings } from '../../settings';
 
@@ -28,6 +29,7 @@ declare module '@rocket.chat/ddp-client' {
 
 Meteor.methods<ServerMethods>({
 	async loadSurroundingMessages(message, limit = 50, showThreadMessages = true) {
+		methodDeprecationLogger.method('loadSurroundingMessages', '9.0.0', '/v1/rooms.history');
 		check(message, Object);
 		check(limit, Number);
 		check(showThreadMessages, Boolean);

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5561,6 +5561,17 @@ describe('[/rooms.history]', () => {
 		expect(res.body).to.have.property('errorType', 'error-cursor-conflict');
 	});
 
+	it('should report the cursor conflict even when `aroundId` does not resolve', async () => {
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: 'does-not-exist', previous: '1' })
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('errorType', 'error-cursor-conflict');
+	});
+
 	it('should not find a message that belongs to another room', async () => {
 		const other = (await createRoom({ type: 'c', name: `rooms-history-other-${Date.now()}` })).body.channel;
 		const stray = await sendMessage({ message: { rid: other._id, msg: 'stray message' } });

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5559,6 +5559,23 @@ describe('[/rooms.history]', () => {
 		await deleteRoom({ type: 'c', roomId: other._id });
 	});
 
+	it('should not find a hidden message', async () => {
+		// Message_KeepHistory without Message_ShowDeletedStatus hides the deleted message instead of removing it
+		await updateSetting('Message_KeepHistory', true);
+		try {
+			const hidden = await sendMessage({ message: { rid: testChannel._id, msg: 'to be hidden' } });
+			await deleteMessage({ roomId: testChannel._id, msgId: hidden.body.message._id });
+
+			await request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, aroundId: hidden.body.message._id })
+				.expect(404);
+		} finally {
+			await updateSetting('Message_KeepHistory', false);
+		}
+	});
+
 	it('should fail when both cursors are provided', async () => {
 		const res = await request
 			.get(api('rooms.history'))

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5490,23 +5490,35 @@ describe('[/rooms.history]', () => {
 	});
 
 	it('should close the cursors at the edges of the room', async () => {
-		const newest = await request
-			.get(api('rooms.history'))
-			.set(credentials)
-			.query({ roomId: testChannel._id, aroundId: messageIds[messageCount - 1], count: 5 })
-			.expect(200);
+		// A dedicated room keeps the edges unambiguous: other tests keep appending to testChannel,
+		// so its newest message is whatever the previous test happened to send.
+		const edgeChannel = (await createRoom({ type: 'c', name: `rooms-history-edges-${Date.now()}` })).body.channel;
+		const ids: IMessage['_id'][] = [];
+		for (let i = 0; i < 6; i++) {
+			ids.push((await sendMessage({ message: { rid: edgeChannel._id, msg: `edge-${i}` } })).body.message._id);
+		}
 
-		expect(newest.body.cursor.next).to.be.null;
-		expect(newest.body.cursor.previous).to.be.a('string');
+		try {
+			const newest = await request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: edgeChannel._id, aroundId: ids[ids.length - 1], count: 5 })
+				.expect(200);
 
-		const oldest = await request
-			.get(api('rooms.history'))
-			.set(credentials)
-			.query({ roomId: testChannel._id, aroundId: messageIds[0], count: 5 })
-			.expect(200);
+			expect(newest.body.cursor.next).to.be.null;
+			expect(newest.body.cursor.previous).to.be.a('string');
 
-		expect(oldest.body.cursor.previous).to.be.null;
-		expect(oldest.body.cursor.next).to.be.a('string');
+			const oldest = await request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: edgeChannel._id, aroundId: ids[0], count: 5 })
+				.expect(200);
+
+			expect(oldest.body.cursor.previous).to.be.null;
+			expect(oldest.body.cursor.next).to.be.a('string');
+		} finally {
+			await deleteRoom({ type: 'c', roomId: edgeChannel._id });
+		}
 	});
 
 	it('should page in both directions from a window built by `aroundId`', async () => {

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5467,6 +5467,98 @@ describe('[/rooms.history]', () => {
 		await deleteRoom({ type: 'c', roomId: discussion.body.discussion._id });
 	});
 
+	it('should build a window around `aroundId` and expose both cursors', async () => {
+		const target = messageIds[Math.floor(messageCount / 2)];
+
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: target, count: 5 })
+			.expect('Content-Type', 'application/json')
+			.expect(200);
+
+		expect(res.body).to.have.property('success', true);
+		expect(res.body.messages).to.have.lengthOf(5);
+		expect(res.body.messages.map((m: IMessage) => m._id)).to.include(target);
+
+		// the only request shape that can report more in both directions at once
+		expect(res.body.cursor.previous).to.be.a('string');
+		expect(res.body.cursor.next).to.be.a('string');
+
+		const timestamps = res.body.messages.map((m: IMessage) => new Date(m.ts).getTime());
+		expect(timestamps).to.deep.equal([...timestamps].sort((a, b) => b - a));
+	});
+
+	it('should close the cursors at the edges of the room', async () => {
+		const newest = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: messageIds[messageCount - 1], count: 5 })
+			.expect(200);
+
+		expect(newest.body.cursor.next).to.be.null;
+		expect(newest.body.cursor.previous).to.be.a('string');
+
+		const oldest = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: messageIds[0], count: 5 })
+			.expect(200);
+
+		expect(oldest.body.cursor.previous).to.be.null;
+		expect(oldest.body.cursor.next).to.be.a('string');
+	});
+
+	it('should page in both directions from a window built by `aroundId`', async () => {
+		const around = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: messageIds[Math.floor(messageCount / 2)], count: 5 })
+			.expect(200);
+
+		const windowIds = around.body.messages.map((m: IMessage) => m._id);
+
+		const [older, newer] = await Promise.all([
+			request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, previous: around.body.cursor.previous, count: 5 })
+				.expect(200),
+			request
+				.get(api('rooms.history'))
+				.set(credentials)
+				.query({ roomId: testChannel._id, next: around.body.cursor.next, count: 5 })
+				.expect(200),
+		]);
+
+		const olderIds = older.body.messages.map((m: IMessage) => m._id);
+		const newerIds = newer.body.messages.map((m: IMessage) => m._id);
+
+		expect(olderIds.filter((id: string) => windowIds.includes(id))).to.be.empty;
+		expect(newerIds.filter((id: string) => windowIds.includes(id))).to.be.empty;
+	});
+
+	it('should fail when `aroundId` is combined with a cursor', async () => {
+		await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: messageIds[0], previous: '1' })
+			.expect(400);
+	});
+
+	it('should not find a message that belongs to another room', async () => {
+		const other = (await createRoom({ type: 'c', name: `rooms-history-other-${Date.now()}` })).body.channel;
+		const stray = await sendMessage({ message: { rid: other._id, msg: 'stray message' } });
+
+		await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, aroundId: stray.body.message._id })
+			.expect(404);
+
+		await deleteRoom({ type: 'c', roomId: other._id });
+	});
+
 	it('should fail when both cursors are provided', async () => {
 		const res = await request
 			.get(api('rooms.history'))

--- a/apps/meteor/tests/end-to-end/api/rooms.ts
+++ b/apps/meteor/tests/end-to-end/api/rooms.ts
@@ -5539,11 +5539,14 @@ describe('[/rooms.history]', () => {
 	});
 
 	it('should fail when `aroundId` is combined with a cursor', async () => {
-		await request
+		const res = await request
 			.get(api('rooms.history'))
 			.set(credentials)
 			.query({ roomId: testChannel._id, aroundId: messageIds[0], previous: '1' })
 			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('errorType', 'error-cursor-conflict');
 	});
 
 	it('should not find a message that belongs to another room', async () => {
@@ -5584,6 +5587,18 @@ describe('[/rooms.history]', () => {
 			.expect(400);
 
 		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('errorType', 'error-cursor-conflict');
+	});
+
+	it('should fail when a cursor is not parseable', async () => {
+		const res = await request
+			.get(api('rooms.history'))
+			.set(credentials)
+			.query({ roomId: testChannel._id, previous: 'not-a-cursor' })
+			.expect(400);
+
+		expect(res.body).to.have.property('success', false);
+		expect(res.body).to.have.property('errorType', 'error-invalid-cursor');
 	});
 
 	it('should fail for a room that does not exist', async () => {

--- a/apps/meteor/tests/unit/server/meteor-methods/messages/loadSurroundingMessages.spec.ts
+++ b/apps/meteor/tests/unit/server/meteor-methods/messages/loadSurroundingMessages.spec.ts
@@ -37,6 +37,9 @@ p.noCallThru().load('../../../../../server/meteor-methods/messages/loadSurroundi
 	'../../lib/authorization/canAccessRoom': {
 		canAccessRoomIdAsync: canAccessRoomIdMock,
 	},
+	'../../lib/deprecationWarningLogger': {
+		methodDeprecationLogger: { method: sinon.stub() },
+	},
 	'../../lib/utils/lib/normalizeMessagesForUser': {
 		normalizeMessagesForUser: normalizeMessagesForUserMock,
 	},

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -290,6 +290,11 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 		messageId: string,
 		options?: O,
 	): Promise<DocumentWithProjection<T, O> | null>;
+	findOneVisibleByRoomIdAndMessageId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 
 	updateUserStarById(_id: string, userId: string, starred?: boolean): Promise<UpdateResult>;
 	updateUsernameAndMessageOfMentionByIdAndOldUsername(

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1047,6 +1047,22 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.findOne<T, O>(query, options);
 	}
 
+	findOneVisibleByRoomIdAndMessageId<T extends Document = IMessage, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		messageId: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		const query = {
+			rid,
+			_id: messageId,
+			_hidden: {
+				$ne: true,
+			},
+		};
+
+		return this.findOne<T, O>(query, options);
+	}
+
 	getLastVisibleUserMessageSentByRoomId(rid: string, messageId?: string): Promise<IMessage | null> {
 		const query: Filter<IMessage> = {
 			rid,

--- a/packages/rest-typings/src/v1/rooms.ts
+++ b/packages/rest-typings/src/v1/rooms.ts
@@ -1064,6 +1064,7 @@ export type RoomsHistoryProps = {
 	roomId: IRoom['_id'];
 	next?: string;
 	previous?: string;
+	aroundId?: IMessage['_id'];
 	lastSeen?: string;
 	count?: number;
 	showThreadMessages?: boolean;
@@ -1082,6 +1083,11 @@ const RoomsHistorySchema = {
 		},
 		previous: {
 			type: 'string',
+			nullable: true,
+		},
+		aroundId: {
+			type: 'string',
+			minLength: 1,
 			nullable: true,
 		},
 		lastSeen: {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

Adds an `aroundId` param to `/v1/rooms.history` and migrates the client's "jump to message" flow (`RoomHistoryManager.loadSurroundingMessages`) from the deprecated `loadSurroundingMessages` DDP method to this endpoint. The method keeps working and now logs a deprecation warning; removal is scheduled for 9.0.0.

`aroundId` inherits the ordering and filtering `rooms.history` already applies to `next`/`previous`, which gives two behavior differences vs the DDP method:

- The window is newest-first; the method returned `[older desc, anchor, newer asc]`.
- Hidden system message types are filtered out of the surrounding messages. The anchor itself is always returned whatever its type, so a jump still lands on its target.

An anchor that can't be resolved — unknown id, a message in another room, or one flagged `_hidden` — returns 404. A cursor conflict (`aroundId` plus `next`/`previous`) is reported before the anchor is resolved. Jump windows now go through `getPaginationItems`, so `API_Upper_Count_Limit` caps them; the client asks for 50 (`roomListLimit`).

Also affects existing `next`/`previous` callers: cursor errors are now `MeteorError`s, so `error-invalid-cursor` / `error-cursor-conflict` surface as `errorType` and the `error` string changed from the bare code to `"<reason> [<code>]"`.

### Client-side window ownership

A jump rebuilds the room window, and the old code had no way to tell a page belonging to the discarded window from one belonging to the rebuilt one. `RoomHistoryManager` now keeps a per-room generation counter, bumped by `clear`/`close`; in-flight requests capture it at entry and discard their response — and leave `isLoading` to the current owner — if it changed. The `oldestTs` fallback is gone, so cursors are the only pagination source and `getMoreNext` no-ops without one.

### Unrelated fix included

Fixes a pre-existing race where, after a window rebuild (jump to a message / "jump to recent messages"), an observer pass paged off a stale `scrollTop` of 0 before the programmatic scroll ran, issuing a duplicate `rooms.history` request. `clear` now emits `room-cleared`; `useGetMore` resets its user-interaction gate and cancels any trailing throttled check on it, and `clear` drops the scroll snapshot describing the discarded DOM. Latent on develop; this migration's timing made it fire deterministically.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `aroundId` option to room history requests to load messages surrounding a specific message.
  * Improved navigation to quoted messages, search results, and thread messages with balanced surrounding history.
  * Added cursor-based navigation in both directions around the selected message.

* **Bug Fixes**
  * Improved handling of cleared rooms, deleted messages, invalid cursors, hidden messages, and messages from other rooms.
  * Prevented history loading for containers that are not yet visible.

* **Deprecations**
  * Deprecated the `loadSurroundingMessages` real-time API. Use `aroundId` with `GET /v1/rooms.history` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
