### PR TITLE
fix: room info button exposes room name instead of a descriptive label as its accessible name

### DIFF
--- a/.changeset/quiet-rooms-listen.md
+++ b/.changeset/quiet-rooms-listen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed the room header button that opens the room info panel exposing the room's name as its accessible name instead of a stable, descriptive label

--- a/apps/meteor/client/views/room/Header/RoomTitle.tsx
+++ b/apps/meteor/client/views/room/Header/RoomTitle.tsx
@@ -37,7 +37,7 @@ const RoomTitle = ({ room }: RoomTitleProps) => {
 	const buttonProps = useButtonPattern(handleOpenRoomInfo);
 
 	return (
-		<HeaderTitleButton aria-label={`${room.name}${room.encrypted ? ` - ${t('encrypted')}` : ''}`} {...buttonProps} marginInlineEnd={4}>
+		<HeaderTitleButton aria-label={`${t('Room_Info')}${room.encrypted ? ` - ${t('Encrypted')}` : ''}`} {...buttonProps} marginInlineEnd={4}>
 			<HeaderIconWithRoom room={room} />
 			<HeaderTitle>{room.name}</HeaderTitle>
 		</HeaderTitleButton>

--- a/apps/meteor/tests/e2e/channel-management.spec.ts
+++ b/apps/meteor/tests/e2e/channel-management.spec.ts
@@ -148,8 +148,8 @@ test.describe.serial('channel-management', () => {
 
 	test('should open room info when clicking on roomName', async ({ page }) => {
 		await poHomeChannel.navbar.openChat(targetChannel);
-		await poHomeChannel.getBtnOpenRoomInfo(targetChannel).focus();
-		await expect(poHomeChannel.getBtnOpenRoomInfo(targetChannel)).toBeFocused();
+		await poHomeChannel.btnOpenRoomInfo.focus();
+		await expect(poHomeChannel.btnOpenRoomInfo).toBeFocused();
 		await page.keyboard.press('Space');
 		await page.getByRole('dialog').waitFor();
 

--- a/apps/meteor/tests/e2e/messaging.spec.ts
+++ b/apps/meteor/tests/e2e/messaging.spec.ts
@@ -145,8 +145,8 @@ test.describe('Messaging', () => {
 		});
 
 		test('should focus the latest message when moving the focus on the list and theres no previous focus', async ({ page }) => {
-			await channelPage.getBtnOpenRoomInfo(targetChannel).focus();
-			await expect(channelPage.getBtnOpenRoomInfo(targetChannel)).toBeFocused();
+			await channelPage.btnOpenRoomInfo.focus();
+			await expect(channelPage.btnOpenRoomInfo).toBeFocused();
 
 			await test.step('move focus to the list', async () => {
 				await page.keyboard.press('Tab');
@@ -155,8 +155,8 @@ test.describe('Messaging', () => {
 			});
 
 			await test.step('move focus to the list again', async () => {
-				await channelPage.getBtnOpenRoomInfo(targetChannel).focus();
-				await expect(channelPage.getBtnOpenRoomInfo(targetChannel)).toBeFocused();
+				await channelPage.btnOpenRoomInfo.focus();
+				await expect(channelPage.btnOpenRoomInfo).toBeFocused();
 				await page.keyboard.press('Tab');
 				await page.keyboard.press('Tab');
 				await expect(channelPage.content.lastUserMessage).toBeFocused();

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -128,7 +128,12 @@ export class HomeChannel {
 
 	get btnOpenRoomInfo(): Locator {
 		// Encrypted rooms append " - Encrypted" to the accessible name (see RoomTitle.tsx), so match either form.
-		return this.page.getByRole('main').getByRole('button', { name: /^Room Information( - Encrypted)?$/ });
+		// The room header toolbar has its own "Room Information" button (see fragments/toolbar.ts), so scope to
+		// the header title button specifically, which is the only one of the two wrapping a heading (RoomTitle renders an h1).
+		return this.page
+			.getByRole('main')
+			.getByRole('button', { name: /^Room Information( - Encrypted)?$/ })
+			.filter({ has: this.page.getByRole('heading') });
 	}
 
 	get roomHeaderToolbar(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -126,9 +126,8 @@ export class HomeChannel {
 		return this.page.getByRole('main').getByRole('button', { name: 'Move to', exact: true });
 	}
 
-	// TODO: this button should name open room info or something instead of the room name
-	getBtnOpenRoomInfo(roomName: string): Locator {
-		return this.page.getByRole('main').getByRole('button', { name: roomName, exact: true });
+	get btnOpenRoomInfo(): Locator {
+		return this.page.getByRole('main').getByRole('button', { name: 'Room Information', exact: true });
 	}
 
 	get roomHeaderToolbar(): Locator {

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -127,7 +127,8 @@ export class HomeChannel {
 	}
 
 	get btnOpenRoomInfo(): Locator {
-		return this.page.getByRole('main').getByRole('button', { name: 'Room Information', exact: true });
+		// Encrypted rooms append " - Encrypted" to the accessible name (see RoomTitle.tsx), so match either form.
+		return this.page.getByRole('main').getByRole('button', { name: /^Room Information( - Encrypted)?$/ });
 	}
 
 	get roomHeaderToolbar(): Locator {

--- a/apps/meteor/tests/e2e/team-management.spec.ts
+++ b/apps/meteor/tests/e2e/team-management.spec.ts
@@ -240,8 +240,8 @@ test.describe.serial('teams-management', () => {
 
 	test('should access team channel through targetTeam header', async ({ page }) => {
 		await poHomeTeam.navbar.openChat(targetChannel);
-		await poHomeTeam.getBtnOpenRoomInfo(targetChannel).focus();
-		await expect(poHomeTeam.getBtnOpenRoomInfo(targetChannel)).toBeFocused();
+		await poHomeTeam.btnOpenRoomInfo.focus();
+		await expect(poHomeTeam.btnOpenRoomInfo).toBeFocused();
 		await page.keyboard.press('Shift+Tab');
 		await page.keyboard.press('Shift+Tab');
 		await page.keyboard.press('Space');


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)
The header button that opens the room info panel used the room's own name as its accessible name (aria-label), so a screen reader announced e.g. "general" instead of what the button does. It now reads "Room Information" (reusing the string already used as the panel's own title), while the room name is still shown visually — no visual change. Also fixes the encrypted-room aria-label suffix using the wrong translation key case (`encrypted` -> `Encrypted`).

Updated the e2e page object/spec locators that depended on the old room-name-based accessible name.

## Issue(s)
Closes #41973

## Steps to test or reproduce
1. Open any channel.
2. Inspect the header title button (the room name next to the channel icon).
3. Confirm its accessible name (aria-label) is "Room Information" instead of the room name.
4. Click/focus + Enter it and confirm it still opens the room info panel as before.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved the room information button’s accessible labeling with translated text.
  * Localized the encrypted-room indicator for supported languages.
* **Tests**
  * Updated navigation and room-management checks to reliably identify and verify focus on the room information button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->