### PR TITLE
fix: wrap omnichannel transfer comment to multiple lines

### DIFF
--- a/.changeset/fix-omnichannel-transfer-comment-wrap.md
+++ b/.changeset/fix-omnichannel-transfer-comment-wrap.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixed omnichannel transfer comment text being truncated on a single line instead of wrapping to multiple lines

--- a/apps/meteor/app/theme/client/imports/general/base.css
+++ b/apps/meteor/app/theme/client/imports/general/base.css
@@ -110,3 +110,12 @@ button {
 	max-width: 100%;
 	cursor: pointer;
 }
+
+/* Override fuselage's truncated-text on system message body so that
+   long text (e.g. omnichannel transfer comments) wraps instead of
+   being clipped with an ellipsis.  See #26723. */
+.rcx-message-system__body {
+	white-space: normal;
+	overflow-wrap: break-word;
+	word-break: break-word;
+}

--- a/apps/meteor/app/theme/client/imports/general/base.css
+++ b/apps/meteor/app/theme/client/imports/general/base.css
@@ -114,8 +114,9 @@ button {
 /* Override fuselage's truncated-text on system message body so that
    long text (e.g. omnichannel transfer comments) wraps instead of
    being clipped with an ellipsis.  See #26723. */
+.rcx-message-system .rcx-message-system__body,
 .rcx-message-system__body {
-	white-space: normal;
+	white-space: normal !important;
 	overflow-wrap: break-word;
 	word-break: break-word;
 }


### PR DESCRIPTION
## Proposed changes

Overrides the fuselage library's `use-with-truncated-text` mixin on `.rcx-message-system__body` so that long omnichannel transfer comments wrap to multiple lines instead of being truncated with an ellipsis.

The upstream `MessageSystem.styles.scss` applies `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` to the system message body via the `use-with-truncated-text` mixin. This CSS override in the application's `base.css` resets `white-space` to `normal` and adds `overflow-wrap: break-word` and `word-break: break-word` so text wraps naturally.

This is a pure CSS fix — no component logic changes.

## Issue(s)

Closes #26723

## Steps to test or reproduce

1. Agent A receives an omnichannel conversation.
2. Agent A transfers it to Agent B with a long text comment (100+ characters).
3. Agent B views the chat — the transfer comment now wraps to multiple lines instead of being clipped with "...".

## Previous attempts

- PR #27080 (closed) used inline `style` props on `MessageSystemBlock` and `MessageSystemBody`.
- PR #37385 (closed) added the same override in `base.css` but included `pre-wrap` which preserves whitespace sequences unnecessarily.
- PR #37530 (open) uses inline `style` props, which the project's [building-components guidelines](https://github.com/RocketChat/Rocket.Chat/blob/develop/docs/frontend/building-components.md) discourage ("Don't write CSS styles in JS files").

This PR uses a targeted CSS class override in the application's existing `base.css`, consistent with project conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/41999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Omnichannel transfer comments now wrap across multiple lines instead of being truncated with an ellipsis.
  * Long system messages are displayed more completely and remain readable within the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->