### PR TITLE
fix: use correct MIME type for audio messages

### DIFF
--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
@@ -24,8 +24,8 @@ export const useAudioMessageAction = (disabled: boolean, isMicrophoneDenied: boo
 					!isMicrophoneDenied &&
 					isFileUploadEnabled &&
 					isAudioRecorderEnabled &&
-					!fileUploadMediaTypeBlackList?.match(/audio\/mp3|audio\/\*/i) &&
-					(!fileUploadMediaTypeWhiteList || fileUploadMediaTypeWhiteList.match(/audio\/mp3|audio\/\*/i)),
+					!fileUploadMediaTypeBlackList?.match(/audio\/mpeg|audio\/\*/i) &&
+					(!fileUploadMediaTypeWhiteList || fileUploadMediaTypeWhiteList.match(/audio\/mpeg|audio\/\*/i)),
 			),
 		[fileUploadMediaTypeBlackList, fileUploadMediaTypeWhiteList, isAudioRecorderEnabled, isFileUploadEnabled, isMicrophoneDenied],
 	);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Updates the audio message action to check for `audio/mpeg` instead of `audio/mp3` in the file upload media type allow/block settings.

The audio recorder produces and uploads voice messages with the `audio/mpeg` MIME type, so checking for `audio/mp3` could incorrectly disable the voice message button when `audio/mpeg` was explicitly allowed.

<!-- Attach before/after screenshots here if available -->

## Issue(s)

Closes #42003

## Steps to test or reproduce

1. Go to **Administration → File Upload**.
2. Set **Accepted Media Types** to `audio/mpeg`.
3. Open a room and verify that the voice message button is enabled.
4. Set **Accepted Media Types** to `audio/*` and verify that the voice message button remains enabled.
5. Clear **Accepted Media Types** and set **Blocked Media Types** to `audio/mpeg`.
6. Verify that the voice message button is disabled.
7. Set **Blocked Media Types** to `audio/*` and verify that the voice message button remains disabled.

### Demo

The recording below demonstrates the media type setting and the voice message button behavior before/after the fix.

https://github.com/user-attachments/assets/3dabbc59-1fd6-4795-b9e6-f5a0d29f8446


## Further comments

The audio recorder creates voice message files using the `audio/mpeg` MIME type. This change aligns the media type checks in `useAudioMessageAction` with the MIME type actually used by the recorder.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio message recording availability by correctly recognizing the standard MPEG audio format.
  * Continued support for devices and configurations using the broader `audio/*` format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->