### PR TITLE
fix(server): Enforce dot notation boundary for wildcard attribute query validation

### DIFF
--- a/.changeset/fix-query-validation-wildcard-prefix.md
+++ b/.changeset/fix-query-validation-wildcard-prefix.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+fix: Enforce exact root and dot notation boundary for wildcard attribute matching in query validation

--- a/apps/meteor/server/api/lib/isValidQuery.ts
+++ b/apps/meteor/server/api/lib/isValidQuery.ts
@@ -46,7 +46,8 @@ const verifyQuery = (query: Query, allowedAttributes: string[], allowedOperation
 		if (
 			!allowedAttributes.some((allowedAttribute) => {
 				if (allowedAttribute.endsWith('.*')) {
-					return path.startsWith(allowedAttribute.replace('.*', ''));
+					const root = allowedAttribute.slice(0, -2);
+					return path === root || path.startsWith(`${root}.`);
 				}
 				if (allowedAttribute.endsWith('*') && !allowedAttribute.endsWith('.*')) {
 					return true;

--- a/apps/meteor/tests/unit/server/api/lib/isValidQuery.spec.ts
+++ b/apps/meteor/tests/unit/server/api/lib/isValidQuery.spec.ts
@@ -139,6 +139,24 @@ describe('isValidQuery', () => {
 			expect(isValidQuery(query, props, [])).to.be.true;
 			expect(isValidQuery.errors.length).to.be.equals(0);
 		});
+
+		it('should return false if the query contains an attribute sharing the prefix without dot notation', () => {
+			const props = ['user.*'];
+			const query = {
+				username: '123',
+			};
+			expect(isValidQuery(query, props, [])).to.be.false;
+			expect(isValidQuery.errors.length).to.be.equals(1);
+		});
+
+		it('should return false if the query contains nested attribute sharing prefix without dot boundary', () => {
+			const props = ['email.address.*'];
+			const query = {
+				'email.address_confirmed': true,
+			};
+			expect(isValidQuery(query, props, [])).to.be.false;
+			expect(isValidQuery.errors.length).to.be.equals(1);
+		});
 	});
 
 	describe('using * for match keys', () => {


### PR DESCRIPTION
## Proposed changes
When validating query attributes in `isValidQuery`, allowed wildcard patterns such as `user.*` previously used `path.startsWith(allowedAttribute.replace('.*', ''))`.

Because `replace('.*', '')` resulted in the prefix `'user'`, string path checks like `path.startsWith('user')` would unintentionally match any unrelated attributes that share the same string prefix without dot notation (e.g. `username` or `user_roles`).

### Solution
1. Changed the prefix matching logic in `isValidQuery.ts` to verify that the path either equals the exact root object property (e.g. `user`) or begins with the dot notation prefix (e.g. `user.`).
2. Added unit test cases in `apps/meteor/tests/unit/server/api/lib/isValidQuery.spec.ts` ensuring that attributes sharing prefixes without dot notation boundary are rejected.
3. Included changeset for `@rocket.chat/meteor`.

## Issue(s)
Closes #42005

## Steps to test or reproduce
1. Run unit tests:
```bash
yarn test:unit apps/meteor/tests/unit/server/api/lib/isValidQuery.spec.ts
```
2. Verify that queries with allowed properties like `['user.*']` reject attributes such as `username` or `user_roles` while correctly accepting nested keys like `user.name`.

## Further comments
- No breaking changes introduced.
- Ensures strict attribute allowlist enforcement across all API query validator handlers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query validation for wildcard attributes.
  * Wildcard rules now correctly match the specified root path and its descendants while rejecting similar but invalid prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->