### PR TITLE
test: fix broken dummy data and unskip marketplace sorting tests

### DIFF
--- a/apps/meteor/client/views/marketplace/helpers/sortAppsByAlphabeticalOrInverseOrder.spec.ts
+++ b/apps/meteor/client/views/marketplace/helpers/sortAppsByAlphabeticalOrInverseOrder.spec.ts
@@ -1,18 +1,18 @@
 import { sortAppsByAlphabeticalOrInverseOrder } from './sortAppsByAlphabeticalOrInverseOrder';
 
 describe('sortAppsByAlphabeticalOrder', () => {
-	it.skip('should return a positive number if first word is, alphabetically, after second word', () => {
-		const firstWord = 'Alfa';
-		const secondWord = 'Bravo';
+	it('should return a positive number if first word is, alphabetically, after second word', () => {
+		const firstWord = 'Bravo';
+		const secondWord = 'Alfa';
 
 		const result = sortAppsByAlphabeticalOrInverseOrder(firstWord, secondWord);
 
 		expect(result).toBeGreaterThan(0);
 	});
 
-	it.skip('should return a negative number if first word is, alphabetically, before second word', () => {
-		const firstWord = 'Bravo';
-		const secondWord = 'Alfa';
+	it('should return a negative number if first word is, alphabetically, before second word', () => {
+		const firstWord = 'Alfa';
+		const secondWord = 'Bravo';
 
 		const result = sortAppsByAlphabeticalOrInverseOrder(firstWord, secondWord);
 

--- a/apps/meteor/client/views/marketplace/helpers/sortAppsByClosestOrFarthestModificationDate.spec.ts
+++ b/apps/meteor/client/views/marketplace/helpers/sortAppsByClosestOrFarthestModificationDate.spec.ts
@@ -19,12 +19,12 @@ describe('sortAppsByClosestOrFarthestModificationDate', () => {
 		expect(result).toBeLessThan(0);
 	});
 
-	it.skip('should return zero if firstDate and secondDate are equivalent', () => {
+	it('should return zero if firstDate and secondDate are equivalent', () => {
 		const firstDate = '2000-04-01T07:00:00';
 		const secondDate = '2000-04-01T07:00:00';
 
 		const result = sortAppsByClosestOrFarthestModificationDate(firstDate, secondDate);
 
-		expect(result).toBeLessThan(0);
+		expect(result).toBe(0);
 	});
 });


### PR DESCRIPTION
## Description
While reading the codebase, I noticed that several marketplace sorting helper tests were skipped (`it.skip`). Upon inspection, the tests were skipped because the dummy data or assertions were mathematically incorrect, causing them to fail.

This PR fixes the dummy data so the assertions are logically sound, and removes the `it.skip` flags so these tests are executed in CI again.

### Changes:
- `sortAppsByClosestOrFarthestModificationDate`: Changed the assertion for identical dates from `toBeLessThan(0)` to `toBe(0)`.
- `sortAppsByAlphabeticalOrInverseOrder`: Swapped the dummy data strings (`Alfa` and `Bravo`) in the positive and negative tests to actually match the test description.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled coverage for alphabetical sorting in both ascending and descending order.
  * Added validation for modification-date sorting when dates are identical, ensuring it returns an exact neutral result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->