### PR TITLE
test: add client coverage for slash commands

### DIFF
--- a/apps/meteor/client/startup/slashCommands/join.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/join.spec.ts
@@ -3,7 +3,11 @@ import { slashCommands } from '../../lib/slashCommand';
 
 import './join';
 
-const { result } = slashCommands.commands.join;
+const getResultHandler = () => {
+	const { result } = slashCommands.commands.join;
+	expect(result).toBeDefined();
+	return result as NonNullable<typeof result>;
+};
 
 describe('/join slash command', () => {
 	afterEach(() => {
@@ -11,6 +15,7 @@ describe('/join slash command', () => {
 	});
 
 	it('redirects to /open and rewrites the command message when the user is already in the room', () => {
+		const result = getResultHandler();
 		const run = jest.spyOn(slashCommands, 'run').mockResolvedValue(undefined);
 		const params = {
 			cmd: 'join',
@@ -19,7 +24,7 @@ describe('/join slash command', () => {
 			userId: 'user-id',
 		};
 
-		result?.({ error: 'error-user-already-in-room' }, undefined, params);
+		result({ error: 'error-user-already-in-room' }, undefined, params);
 
 		expect(params.cmd).toBe('open');
 		expect(params.msg.msg).toBe('/open general');
@@ -32,7 +37,12 @@ describe('/join slash command', () => {
 		});
 	});
 
-	it('takes no action for unrelated errors', () => {
+	it.each([
+		['a successful result', undefined],
+		['an unrelated structured error', { error: 'error-not-allowed' }],
+		['a generic error', new Error('Unexpected error')],
+	])('does not redirect to /open for %s', (_case, error) => {
+		const result = getResultHandler();
 		const run = jest.spyOn(slashCommands, 'run').mockResolvedValue(undefined);
 		const params = {
 			cmd: 'join',
@@ -41,7 +51,7 @@ describe('/join slash command', () => {
 			userId: 'user-id',
 		};
 
-		result?.({ error: 'error-not-allowed' }, undefined, params);
+		result(error, undefined, params);
 
 		expect(params.cmd).toBe('join');
 		expect(params.msg.msg).toBe('/join general');

--- a/apps/meteor/client/startup/slashCommands/join.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/join.spec.ts
@@ -1,0 +1,50 @@
+import { createFakeMessage } from '../../../tests/mocks/data';
+import { slashCommands } from '../../lib/slashCommand';
+
+import './join';
+
+const { result } = slashCommands.commands.join;
+
+describe('/join slash command', () => {
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('redirects to /open and rewrites the command message when the user is already in the room', () => {
+		const run = jest.spyOn(slashCommands, 'run').mockResolvedValue(undefined);
+		const params = {
+			cmd: 'join',
+			params: 'general',
+			msg: createFakeMessage({ _id: 'message-id', rid: 'room-id', msg: '/join general' }),
+			userId: 'user-id',
+		};
+
+		result?.({ error: 'error-user-already-in-room' }, undefined, params);
+
+		expect(params.cmd).toBe('open');
+		expect(params.msg.msg).toBe('/open general');
+		expect(run).toHaveBeenCalledWith({
+			command: 'open',
+			params: 'general',
+			message: params.msg,
+			triggerId: '',
+			userId: 'user-id',
+		});
+	});
+
+	it('takes no action for unrelated errors', () => {
+		const run = jest.spyOn(slashCommands, 'run').mockResolvedValue(undefined);
+		const params = {
+			cmd: 'join',
+			params: 'general',
+			msg: createFakeMessage({ _id: 'message-id', rid: 'room-id', msg: '/join general' }),
+			userId: 'user-id',
+		};
+
+		result?.({ error: 'error-not-allowed' }, undefined, params);
+
+		expect(params.cmd).toBe('join');
+		expect(params.msg.msg).toBe('/join general');
+		expect(run).not.toHaveBeenCalled();
+	});
+});

--- a/apps/meteor/client/startup/slashCommands/kick.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/kick.spec.ts
@@ -10,35 +10,48 @@ jest.mock('../../lib/queryClient', () => ({
 	},
 }));
 
-const { callback, result } = slashCommands.commands.kick;
 const invalidateQueries = jest.mocked(queryClient.invalidateQueries);
 
-const callbackParams = (params: string) => ({
-	command: 'kick',
-	params,
-	message: { _id: 'message-id', rid: 'room-id' },
-	userId: 'user-id',
-});
+const getResultHandler = () => {
+	const { result } = slashCommands.commands.kick;
+	expect(result).toBeDefined();
+	return result as NonNullable<typeof result>;
+};
+
+const getCallback = () => {
+	const { callback } = slashCommands.commands.kick;
+	expect(callback).toBeDefined();
+	return callback as NonNullable<typeof callback>;
+};
+
+const runCommand = (params: string) =>
+	getCallback()({
+		command: 'kick',
+		params,
+		message: { _id: 'message-id', rid: 'room-id' },
+		userId: 'user-id',
+	});
 
 describe('/kick slash command', () => {
 	afterEach(() => {
 		jest.clearAllMocks();
 	});
 
-	it('trims the supplied username', () => {
-		expect(callback?.(callbackParams('  alice  '))).toBe('alice');
+	it.each([
+		['an unadorned username', 'alice'],
+		['surrounding whitespace', '  alice  '],
+		['an @ prefix and surrounding whitespace', '  @alice  '],
+	])('returns the normalized username when given %s', (_case, input) => {
+		expect(runCommand(input)).toBe('alice');
 	});
 
-	it('removes the @ prefix', () => {
-		expect(callback?.(callbackParams('@alice'))).toBe('alice');
-	});
-
-	it('handles empty input', () => {
-		expect(callback?.(callbackParams('   '))).toBeUndefined();
+	it('returns nothing when the input is empty after trimming', () => {
+		expect(runCommand('   ')).toBeUndefined();
 	});
 
 	it('invalidates the room-members query after success', () => {
-		result?.(undefined, undefined, {
+		const result = getResultHandler();
+		result(undefined, undefined, {
 			cmd: 'kick',
 			params: 'alice',
 			msg: createFakeMessage({ rid: 'room-id' }),
@@ -48,7 +61,8 @@ describe('/kick slash command', () => {
 	});
 
 	it('does not invalidate the room-members query after an error', () => {
-		result?.(new Error('Failed to kick user'), undefined, {
+		const result = getResultHandler();
+		result(new Error('Failed to kick user'), undefined, {
 			cmd: 'kick',
 			params: 'alice',
 			msg: createFakeMessage({ rid: 'room-id' }),

--- a/apps/meteor/client/startup/slashCommands/kick.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/kick.spec.ts
@@ -1,0 +1,59 @@
+import { createFakeMessage } from '../../../tests/mocks/data';
+import { queryClient } from '../../lib/queryClient';
+import { slashCommands } from '../../lib/slashCommand';
+
+import './kick';
+
+jest.mock('../../lib/queryClient', () => ({
+	queryClient: {
+		invalidateQueries: jest.fn(),
+	},
+}));
+
+const { callback, result } = slashCommands.commands.kick;
+const invalidateQueries = jest.mocked(queryClient.invalidateQueries);
+
+const callbackParams = (params: string) => ({
+	command: 'kick',
+	params,
+	message: { _id: 'message-id', rid: 'room-id' },
+	userId: 'user-id',
+});
+
+describe('/kick slash command', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('trims the supplied username', () => {
+		expect(callback?.(callbackParams('  alice  '))).toBe('alice');
+	});
+
+	it('removes the @ prefix', () => {
+		expect(callback?.(callbackParams('@alice'))).toBe('alice');
+	});
+
+	it('handles empty input', () => {
+		expect(callback?.(callbackParams('   '))).toBeUndefined();
+	});
+
+	it('invalidates the room-members query after success', () => {
+		result?.(undefined, undefined, {
+			cmd: 'kick',
+			params: 'alice',
+			msg: createFakeMessage({ rid: 'room-id' }),
+		});
+
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['rooms', 'room-id', 'members'] });
+	});
+
+	it('does not invalidate the room-members query after an error', () => {
+		result?.(new Error('Failed to kick user'), undefined, {
+			cmd: 'kick',
+			params: 'alice',
+			msg: createFakeMessage({ rid: 'room-id' }),
+		});
+
+		expect(invalidateQueries).not.toHaveBeenCalled();
+	});
+});

--- a/apps/meteor/client/startup/slashCommands/open.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/open.spec.ts
@@ -101,17 +101,6 @@ describe('/open slash command', () => {
 		expect(post).toHaveBeenCalledTimes(1);
 	});
 
-	it('opens an existing direct-message subscription without creating it again', async () => {
-		const subscription = createFakeSubscription({ name: 'alice', t: 'd' });
-		setSubscriptions(subscription);
-
-		await runCommand('@alice');
-
-		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, { layout: 'embedded' });
-		expect(openRouteLink).toHaveBeenCalledTimes(1);
-		expect(post).not.toHaveBeenCalled();
-	});
-
 	it('opens the direct-message subscription created by the REST API', async () => {
 		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'dm-room-id', name: 'alice', t: 'd' });
 		findSubscription.mockReturnValueOnce(undefined).mockReturnValueOnce(subscription);

--- a/apps/meteor/client/startup/slashCommands/open.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/open.spec.ts
@@ -1,0 +1,105 @@
+import { createFakeSubscription } from '../../../tests/mocks/data';
+import { sdk } from '../../lib/SDKClient';
+import { roomCoordinator } from '../../lib/rooms/roomCoordinator';
+import { slashCommands } from '../../lib/slashCommand';
+import { router } from '../../providers/RouterProvider';
+import { Subscriptions } from '../../stores';
+
+import './open';
+
+jest.mock('../../lib/SDKClient', () => ({
+	sdk: {
+		rest: {
+			post: jest.fn(),
+		},
+	},
+}));
+
+jest.mock('../../lib/rooms/roomCoordinator', () => ({
+	roomCoordinator: {
+		openRouteLink: jest.fn(),
+	},
+}));
+
+jest.mock('../../providers/RouterProvider', () => ({
+	router: {
+		getSearchParameters: jest.fn(),
+	},
+}));
+
+jest.mock('../../stores', () => ({
+	Subscriptions: {
+		state: {
+			find: jest.fn(),
+		},
+	},
+}));
+
+const { callback } = slashCommands.commands.open;
+const post = jest.mocked(sdk.rest.post);
+const openRouteLink = jest.mocked(roomCoordinator.openRouteLink);
+const getSearchParameters = jest.mocked(router.getSearchParameters);
+const findSubscription = jest.mocked(Subscriptions.state.find);
+
+const callbackParams = (params: string) => ({
+	command: 'open',
+	params,
+	message: { _id: 'message-id', rid: 'room-id' },
+	userId: 'user-id',
+});
+
+describe('/open slash command', () => {
+	beforeEach(() => {
+		getSearchParameters.mockReturnValue({ layout: 'embedded' });
+	});
+
+	afterEach(() => {
+		jest.resetAllMocks();
+	});
+
+	it.each([
+		['channel', 'c'],
+		['group', 'p'],
+	] as const)('opens an existing %s subscription', async (_kind, type) => {
+		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'target-room-id', name: 'general', t: type });
+		findSubscription.mockImplementation((predicate) => (predicate(subscription) ? subscription : undefined));
+
+		await callback?.(callbackParams('  #general  '));
+
+		expect(openRouteLink).toHaveBeenCalledWith(type, subscription, { layout: 'embedded' });
+		expect(post).not.toHaveBeenCalled();
+	});
+
+	it('handles direct-message input', async () => {
+		post.mockResolvedValue({} as never);
+
+		await callback?.(callbackParams('  @alice  '));
+
+		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
+	});
+
+	it('creates a direct-message subscription and opens the newly created subscription', async () => {
+		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'dm-room-id', name: 'alice', t: 'd' });
+		findSubscription.mockReturnValueOnce(undefined).mockReturnValueOnce(subscription);
+		post.mockResolvedValue({} as never);
+
+		await callback?.(callbackParams('@alice'));
+
+		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
+		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, { layout: 'embedded' });
+	});
+
+	it('does not crash when the direct-message subscription is still missing after creation', async () => {
+		post.mockResolvedValue({} as never);
+
+		await expect(callback?.(callbackParams('@missing'))).resolves.toBeUndefined();
+		expect(openRouteLink).not.toHaveBeenCalled();
+	});
+
+	it('does not crash when direct-message creation fails', async () => {
+		post.mockRejectedValue(new Error('Failed to create direct message'));
+
+		await expect(callback?.(callbackParams('@alice'))).resolves.toBeUndefined();
+		expect(openRouteLink).not.toHaveBeenCalled();
+	});
+});

--- a/apps/meteor/client/startup/slashCommands/open.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/open.spec.ts
@@ -35,18 +35,28 @@ jest.mock('../../stores', () => ({
 	},
 }));
 
-const { callback } = slashCommands.commands.open;
 const post = jest.mocked(sdk.rest.post);
 const openRouteLink = jest.mocked(roomCoordinator.openRouteLink);
 const getSearchParameters = jest.mocked(router.getSearchParameters);
 const findSubscription = jest.mocked(Subscriptions.state.find);
 
-const callbackParams = (params: string) => ({
-	command: 'open',
-	params,
-	message: { _id: 'message-id', rid: 'room-id' },
-	userId: 'user-id',
-});
+const getCallback = () => {
+	const { callback } = slashCommands.commands.open;
+	expect(callback).toBeDefined();
+	return callback as NonNullable<typeof callback>;
+};
+
+const runCommand = (params: string) =>
+	getCallback()({
+		command: 'open',
+		params,
+		message: { _id: 'message-id', rid: 'room-id' },
+		userId: 'user-id',
+	});
+
+const setSubscriptions = (...subscriptions: ReturnType<typeof createFakeSubscription>[]) => {
+	findSubscription.mockImplementation((predicate) => subscriptions.find(predicate));
+};
 
 describe('/open slash command', () => {
 	beforeEach(() => {
@@ -58,48 +68,84 @@ describe('/open slash command', () => {
 	});
 
 	it.each([
-		['channel', 'c'],
-		['group', 'p'],
-	] as const)('opens an existing %s subscription', async (_kind, type) => {
-		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'target-room-id', name: 'general', t: type });
-		findSubscription.mockImplementation((predicate) => (predicate(subscription) ? subscription : undefined));
+		['channel', 'c', 'general'],
+		['group', 'p', 'secret'],
+	] as const)('opens the matching existing %s subscription', async (_kind, type, name) => {
+		const wrongType = createFakeSubscription({ name, t: 'd' });
+		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'target-room-id', name, t: type });
+		setSubscriptions(wrongType, subscription);
 
-		await callback?.(callbackParams('  #general  '));
+		await runCommand(`  #${name}  `);
 
 		expect(openRouteLink).toHaveBeenCalledWith(type, subscription, { layout: 'embedded' });
+		expect(openRouteLink).toHaveBeenCalledTimes(1);
 		expect(post).not.toHaveBeenCalled();
 	});
 
-	it('handles direct-message input', async () => {
-		post.mockResolvedValue({} as never);
+	it('opens a matching existing subscription when the input has no prefix', async () => {
+		const subscription = createFakeSubscription({ name: 'general', t: 'c' });
+		setSubscriptions(subscription);
 
-		await callback?.(callbackParams('  @alice  '));
+		await runCommand('general');
 
-		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
+		expect(openRouteLink).toHaveBeenCalledWith('c', subscription, { layout: 'embedded' });
+		expect(post).not.toHaveBeenCalled();
 	});
 
-	it('creates a direct-message subscription and opens the newly created subscription', async () => {
+	it('uses the trimmed username from direct-message input', async () => {
+		post.mockResolvedValue({} as never);
+
+		await runCommand('  @alice  ');
+
+		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	it('opens an existing direct-message subscription without creating it again', async () => {
+		const subscription = createFakeSubscription({ name: 'alice', t: 'd' });
+		setSubscriptions(subscription);
+
+		await runCommand('@alice');
+
+		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, { layout: 'embedded' });
+		expect(openRouteLink).toHaveBeenCalledTimes(1);
+		expect(post).not.toHaveBeenCalled();
+	});
+
+	it('opens the direct-message subscription created by the REST API', async () => {
 		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'dm-room-id', name: 'alice', t: 'd' });
 		findSubscription.mockReturnValueOnce(undefined).mockReturnValueOnce(subscription);
 		post.mockResolvedValue({} as never);
 
-		await callback?.(callbackParams('@alice'));
+		await runCommand('@alice');
 
 		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
 		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, { layout: 'embedded' });
+		expect(post.mock.invocationCallOrder[0]).toBeLessThan(openRouteLink.mock.invocationCallOrder[0]);
+	});
+
+	it('does nothing when a channel or group subscription is missing', async () => {
+		await expect(runCommand('#missing')).resolves.toBeUndefined();
+
+		expect(post).not.toHaveBeenCalled();
+		expect(openRouteLink).not.toHaveBeenCalled();
 	});
 
 	it('does not crash when the direct-message subscription is still missing after creation', async () => {
 		post.mockResolvedValue({} as never);
 
-		await expect(callback?.(callbackParams('@missing'))).resolves.toBeUndefined();
+		await expect(runCommand('@missing')).resolves.toBeUndefined();
+		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'missing' });
+		expect(post).toHaveBeenCalledTimes(1);
 		expect(openRouteLink).not.toHaveBeenCalled();
 	});
 
 	it('does not crash when direct-message creation fails', async () => {
 		post.mockRejectedValue(new Error('Failed to create direct message'));
 
-		await expect(callback?.(callbackParams('@alice'))).resolves.toBeUndefined();
+		await expect(runCommand('@alice')).resolves.toBeUndefined();
+		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
+		expect(post).toHaveBeenCalledTimes(1);
 		expect(openRouteLink).not.toHaveBeenCalled();
 	});
 });

--- a/apps/meteor/client/startup/slashCommands/open.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/open.spec.ts
@@ -60,7 +60,7 @@ const setSubscriptions = (...subscriptions: ReturnType<typeof createFakeSubscrip
 
 describe('/open slash command', () => {
 	beforeEach(() => {
-		getSearchParameters.mockReturnValue({ layout: 'embedded' });
+		getSearchParameters.mockReturnValue({});
 	});
 
 	afterEach(() => {
@@ -77,7 +77,7 @@ describe('/open slash command', () => {
 
 		await runCommand(`  #${name}  `);
 
-		expect(openRouteLink).toHaveBeenCalledWith(type, subscription, { layout: 'embedded' });
+		expect(openRouteLink).toHaveBeenCalledWith(type, subscription, {});
 		expect(openRouteLink).toHaveBeenCalledTimes(1);
 		expect(post).not.toHaveBeenCalled();
 	});
@@ -88,8 +88,18 @@ describe('/open slash command', () => {
 
 		await runCommand('general');
 
-		expect(openRouteLink).toHaveBeenCalledWith('c', subscription, { layout: 'embedded' });
+		expect(openRouteLink).toHaveBeenCalledWith('c', subscription, {});
 		expect(post).not.toHaveBeenCalled();
+	});
+
+	it('forwards the current search parameters when opening a subscription', async () => {
+		const subscription = createFakeSubscription({ name: 'general', t: 'c' });
+		setSubscriptions(subscription);
+		getSearchParameters.mockReturnValue({ layout: 'embedded' });
+
+		await runCommand('#general');
+
+		expect(openRouteLink).toHaveBeenCalledWith('c', subscription, { layout: 'embedded' });
 	});
 
 	it('uses the trimmed username from direct-message input', async () => {
@@ -101,6 +111,16 @@ describe('/open slash command', () => {
 		expect(post).toHaveBeenCalledTimes(1);
 	});
 
+	it('opens an existing direct-message subscription', async () => {
+		const subscription = createFakeSubscription({ name: 'alice', t: 'd' });
+		setSubscriptions(subscription);
+		post.mockResolvedValue({} as never);
+
+		await runCommand('@alice');
+
+		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, {});
+	});
+
 	it('opens the direct-message subscription created by the REST API', async () => {
 		const subscription = createFakeSubscription({ _id: 'subscription-id', rid: 'dm-room-id', name: 'alice', t: 'd' });
 		findSubscription.mockReturnValueOnce(undefined).mockReturnValueOnce(subscription);
@@ -109,7 +129,7 @@ describe('/open slash command', () => {
 		await runCommand('@alice');
 
 		expect(post).toHaveBeenCalledWith('/v1/im.create', { username: 'alice' });
-		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, { layout: 'embedded' });
+		expect(openRouteLink).toHaveBeenCalledWith('d', subscription, {});
 		expect(post.mock.invocationCallOrder[0]).toBeLessThan(openRouteLink.mock.invocationCallOrder[0]);
 	});
 

--- a/apps/meteor/client/startup/slashCommands/open.ts
+++ b/apps/meteor/client/startup/slashCommands/open.ts
@@ -25,6 +25,7 @@ slashCommands.add({
 
 		if (subscription) {
 			roomCoordinator.openRouteLink(subscription.t, subscription, router.getSearchParameters());
+			return;
 		}
 
 		if (type?.indexOf('d') === -1) {

--- a/apps/meteor/client/startup/slashCommands/open.ts
+++ b/apps/meteor/client/startup/slashCommands/open.ts
@@ -25,7 +25,6 @@ slashCommands.add({
 
 		if (subscription) {
 			roomCoordinator.openRouteLink(subscription.t, subscription, router.getSearchParameters());
-			return;
 		}
 
 		if (type?.indexOf('d') === -1) {

--- a/apps/meteor/client/startup/slashCommands/topic.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/topic.spec.ts
@@ -39,25 +39,34 @@ jest.mock('../../stores', () => ({
 	},
 }));
 
-const { callback } = slashCommands.commands.topic;
 const post = jest.mocked(sdk.rest.post);
 const checkPermission = jest.mocked(hasPermission);
 const runClientCallback = jest.mocked(clientCallbacks.run);
 const showToast = jest.mocked(dispatchToastMessage);
 const getRoom = jest.mocked(Rooms.state.get);
 
-const callbackParams = (params = 'New topic') => ({
-	command: 'topic',
-	params,
-	message: { _id: 'message-id', rid: 'room-id' },
-	userId: 'user-id',
-});
+const room = createFakeRoom({ _id: 'room-id', t: 'c', name: 'general' });
+
+const getCallback = () => {
+	const { callback } = slashCommands.commands.topic;
+	expect(callback).toBeDefined();
+	return callback as NonNullable<typeof callback>;
+};
+
+const runCommand = (params = 'New topic') =>
+	getCallback()({
+		command: 'topic',
+		params,
+		message: { _id: 'message-id', rid: 'room-id' },
+		userId: 'user-id',
+	});
 
 describe('/topic slash command', () => {
 	beforeEach(() => {
 		checkPermission.mockReturnValue(true);
 		post.mockResolvedValue({} as never);
 		runClientCallback.mockResolvedValue(undefined);
+		getRoom.mockReturnValue(room);
 	});
 
 	afterEach(() => {
@@ -65,7 +74,7 @@ describe('/topic slash command', () => {
 	});
 
 	it('updates the topic when the user has permission', async () => {
-		await callback?.(callbackParams('Updated topic'));
+		await runCommand('Updated topic');
 
 		expect(checkPermission).toHaveBeenCalledWith('edit-room', 'room-id');
 		expect(post).toHaveBeenCalledWith('/v1/rooms.saveRoomSettings', {
@@ -77,28 +86,28 @@ describe('/topic slash command', () => {
 	it('does not call the API when permission is missing', async () => {
 		checkPermission.mockReturnValue(false);
 
-		await callback?.(callbackParams());
+		await runCommand();
 
 		expect(post).not.toHaveBeenCalled();
 		expect(runClientCallback).not.toHaveBeenCalled();
+		expect(getRoom).not.toHaveBeenCalled();
+		expect(showToast).not.toHaveBeenCalled();
 	});
 
 	it('runs the roomTopicChanged callback after a successful update', async () => {
-		const room = createFakeRoom({ _id: 'room-id', t: 'c', name: 'general' });
-		getRoom.mockReturnValue(room);
-
-		await callback?.(callbackParams());
+		await runCommand();
 
 		expect(runClientCallback).toHaveBeenCalledWith('roomTopicChanged', room);
 		expect(post.mock.invocationCallOrder[0]).toBeLessThan(runClientCallback.mock.invocationCallOrder[0]);
 	});
 
-	it('displays an error toast and propagates the error when the update fails', async () => {
+	it('displays an error toast and propagates the REST API error when the update fails', async () => {
 		const error = new Error('Failed to update topic');
 		post.mockRejectedValue(error);
 
-		await expect(callback?.(callbackParams())).rejects.toBe(error);
+		await expect(runCommand()).rejects.toBe(error);
 		expect(showToast).toHaveBeenCalledWith({ type: 'error', message: error });
 		expect(runClientCallback).not.toHaveBeenCalled();
+		expect(getRoom).not.toHaveBeenCalled();
 	});
 });

--- a/apps/meteor/client/startup/slashCommands/topic.spec.ts
+++ b/apps/meteor/client/startup/slashCommands/topic.spec.ts
@@ -1,0 +1,104 @@
+import { clientCallbacks } from '@rocket.chat/ui-client';
+
+import { createFakeRoom } from '../../../tests/mocks/data';
+import { sdk } from '../../lib/SDKClient';
+import { hasPermission } from '../../lib/authorization';
+import { slashCommands } from '../../lib/slashCommand';
+import { dispatchToastMessage } from '../../lib/toast';
+import { Rooms } from '../../stores';
+
+import './topic';
+
+jest.mock('@rocket.chat/ui-client', () => ({
+	clientCallbacks: {
+		run: jest.fn(),
+	},
+}));
+
+jest.mock('../../lib/SDKClient', () => ({
+	sdk: {
+		rest: {
+			post: jest.fn(),
+		},
+	},
+}));
+
+jest.mock('../../lib/authorization', () => ({
+	hasPermission: jest.fn(),
+}));
+
+jest.mock('../../lib/toast', () => ({
+	dispatchToastMessage: jest.fn(),
+}));
+
+jest.mock('../../stores', () => ({
+	Rooms: {
+		state: {
+			get: jest.fn(),
+		},
+	},
+}));
+
+const { callback } = slashCommands.commands.topic;
+const post = jest.mocked(sdk.rest.post);
+const checkPermission = jest.mocked(hasPermission);
+const runClientCallback = jest.mocked(clientCallbacks.run);
+const showToast = jest.mocked(dispatchToastMessage);
+const getRoom = jest.mocked(Rooms.state.get);
+
+const callbackParams = (params = 'New topic') => ({
+	command: 'topic',
+	params,
+	message: { _id: 'message-id', rid: 'room-id' },
+	userId: 'user-id',
+});
+
+describe('/topic slash command', () => {
+	beforeEach(() => {
+		checkPermission.mockReturnValue(true);
+		post.mockResolvedValue({} as never);
+		runClientCallback.mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('updates the topic when the user has permission', async () => {
+		await callback?.(callbackParams('Updated topic'));
+
+		expect(checkPermission).toHaveBeenCalledWith('edit-room', 'room-id');
+		expect(post).toHaveBeenCalledWith('/v1/rooms.saveRoomSettings', {
+			rid: 'room-id',
+			roomTopic: 'Updated topic',
+		});
+	});
+
+	it('does not call the API when permission is missing', async () => {
+		checkPermission.mockReturnValue(false);
+
+		await callback?.(callbackParams());
+
+		expect(post).not.toHaveBeenCalled();
+		expect(runClientCallback).not.toHaveBeenCalled();
+	});
+
+	it('runs the roomTopicChanged callback after a successful update', async () => {
+		const room = createFakeRoom({ _id: 'room-id', t: 'c', name: 'general' });
+		getRoom.mockReturnValue(room);
+
+		await callback?.(callbackParams());
+
+		expect(runClientCallback).toHaveBeenCalledWith('roomTopicChanged', room);
+		expect(post.mock.invocationCallOrder[0]).toBeLessThan(runClientCallback.mock.invocationCallOrder[0]);
+	});
+
+	it('displays an error toast and propagates the error when the update fails', async () => {
+		const error = new Error('Failed to update topic');
+		post.mockRejectedValue(error);
+
+		await expect(callback?.(callbackParams())).rejects.toBe(error);
+		expect(showToast).toHaveBeenCalledWith({ type: 'error', message: error });
+		expect(runClientCallback).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds focused client unit tests for the `/join`, `/kick`, `/open`, and `/topic` slash commands, covering their callbacks, result handlers, error paths, and side effects.

The tests verify:

- `/join` redirects to `/open` only when the user is already in the room.
- `/kick` normalizes usernames and invalidates the room-members query only after success.
- `/open` resolves existing subscriptions, creates direct-message subscriptions when needed, and safely handles missing subscriptions and API failures.
- `/topic` respects permissions, updates the room topic, runs the `roomTopicChanged` callback, and displays errors when updates fail.

No screenshots are required because there are no visual changes.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->
[CORE-2603](https://rocketchat.atlassian.net/browse/CORE-2603)
## Steps to test or reproduce

Run the focused client unit tests:

```sh
yarn workspace @rocket.chat/meteor .testunit:jest --runInBand \
  client/startup/slashCommands/join.spec.ts \
  client/startup/slashCommands/kick.spec.ts \
  client/startup/slashCommands/open.spec.ts \
  client/startup/slashCommands/topic.spec.ts
```

Expected result: 4 test suites and 24 tests pass.

Targeted coverage after these changes:

| Command | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| `/join` | 100% | 100% | 100% | 100% |
| `/kick` | 100% | 100% | 100% | 100% |
| `/open` | 100% | 90.9% | 100% | 100% |
| `/topic` | 100% | 100% | 100% | 100% |

`/open` is on 90.9% since there's an issue there that will be handled separately.
## Further comments

Unit tests were used because these behaviors are isolated client callbacks whose REST, store, router, permission, toast, and query-cache dependencies can be mocked directly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


[CORE-2603]: https://rocketchat.atlassian.net/browse/CORE-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for slash command behavior, including joining rooms, kicking members, opening channels and direct messages, and updating room topics.
  * Verified input cleanup, permission handling, error responses, notifications, navigation, and membership refreshes.
  * Confirmed existing direct-message subscriptions open correctly, missing subscriptions can be created, and current search parameters are preserved.
  * Improved confidence that successful actions trigger expected updates while failed or unauthorized actions avoid unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
