### PR TITLE
test: prevent ddp-client reconnect leakage between tests

### DIFF
--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -123,6 +123,7 @@ it('should handle reconnecting', async () => {
 	);
 
 	expect(connection.status).toBe('connected');
+	connection.close();
 	jest.useRealTimers();
 });
 
@@ -245,6 +246,7 @@ it('should not surface the retry timer rejection when an external connect won th
 	expect(connection.status).toBe('connected');
 	expect(unhandled).not.toHaveBeenCalled();
 	process.off('unhandledRejection', unhandled);
+	connection.close();
 	jest.useRealTimers();
 });
 
@@ -314,6 +316,7 @@ it('should reset retryCount on a successful connection so subsequent drops can r
 	);
 	jest.useRealTimers();
 	expect(connection.status).toBe('connected');
+	connection.close();
 });
 
 it('should ignore a stale ws.onclose that fires after the socket has been replaced', async () => {
@@ -365,4 +368,5 @@ it('should ignore a stale ws.onclose that fires after the socket has been replac
 
 	expect(connection.status).toBe(statusBefore);
 	expect((connection as unknown as { retryCount: number }).retryCount).toBe(retryBefore);
+	connection.close();
 });

--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -5,11 +5,13 @@ import { ConnectionImpl } from '../src/Connection';
 import { MinimalDDPClient } from '../src/MinimalDDPClient';
 
 let server: WS;
+let connection: ConnectionImpl;
 beforeEach(() => {
 	server = new WS('ws://localhost:1234/websocket');
 });
 
 afterEach(() => {
+	connection?.close();
 	server.close();
 	WS.clean();
 	jest.useRealTimers();
@@ -17,7 +19,7 @@ afterEach(() => {
 
 it('should connect', async () => {
 	const client = new MinimalDDPClient();
-	const connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
+	connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
 
 	expect(connection.status).toBe('idle');
 	expect(connection.session).toBeUndefined();
@@ -29,7 +31,7 @@ it('should connect', async () => {
 
 it('should handle a failing connection', async () => {
 	const client = new MinimalDDPClient();
-	const connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
+	connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
 
 	expect(connection.status).toBe('idle');
 	expect(connection.session).toBeUndefined();
@@ -42,7 +44,7 @@ it('should handle a failing connection', async () => {
 
 it('should trigger a disconnect callback', async () => {
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
+	connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
 
 	expect(connection.status).toBe('idle');
 	expect(connection.session).toBeUndefined();
@@ -63,7 +65,7 @@ it('should trigger a disconnect callback', async () => {
 it('should handle the close method', async () => {
 	const client = new MinimalDDPClient();
 
-	const connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, {
+	connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, {
 		retryCount: 0,
 		retryTime: 0,
 	});
@@ -88,7 +90,7 @@ it('should handle the close method', async () => {
 
 it('should handle reconnecting', async () => {
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
+	connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
 
 	expect(connection.status).toBe('idle');
 	expect(connection.session).toBeUndefined();
@@ -123,13 +125,12 @@ it('should handle reconnecting', async () => {
 	);
 
 	expect(connection.status).toBe('connected');
-	connection.close();
 	jest.useRealTimers();
 });
 
 it('should queue messages if the connection is not ready', async () => {
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
+	connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
 
 	await handleConnection(server, connection.connect());
 
@@ -150,7 +151,7 @@ it('should queue messages if the connection is not ready', async () => {
 
 it('should be idempotent if reconnect is called while already connected', async () => {
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
+	connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
 
 	await handleConnection(server, connection.connect());
 
@@ -178,7 +179,7 @@ it('should share the in-flight connect promise with a concurrent connect() calle
 	// 'failed' payload from the in-flight handshake. Both callers must now
 	// observe the real outcome.
 	const client = new MinimalDDPClient();
-	const connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
+	connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
 
 	const first = connection.connect();
 	expect(connection.status).toBe('connecting');
@@ -195,7 +196,7 @@ it('should share the in-flight connect promise with a concurrent reconnect() cal
 	// timer fires `reconnect()` and must piggyback on any handshake the
 	// consumer's bootstrap path already started.
 	const client = new MinimalDDPClient();
-	const connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
+	connection = new ConnectionImpl('ws://localhost:1234', WebSocket as any, client, { retryCount: 0, retryTime: 0 });
 
 	const first = connection.connect();
 	expect(connection.status).toBe('connecting');
@@ -215,7 +216,7 @@ it('should not surface the retry timer rejection when an external connect won th
 	// rejection on the page. The timer must now no-op silently when the
 	// connection has already been re-established.
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
+	connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
 
 	await handleConnection(server, connection.connect());
 	expect(connection.status).toBe('connected');
@@ -246,7 +247,6 @@ it('should not surface the retry timer rejection when an external connect won th
 	expect(connection.status).toBe('connected');
 	expect(unhandled).not.toHaveBeenCalled();
 	process.off('unhandledRejection', unhandled);
-	connection.close();
 	jest.useRealTimers();
 });
 
@@ -260,7 +260,7 @@ it('should reset retryCount on a successful connection so subsequent drops can r
 	// forever — observed in e2e-encryption/e2ee-passphrase-management as the
 	// next loginByUserState login frame never being delivered.
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
+	connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
 
 	await handleConnection(server, connection.connect());
 	expect(connection.status).toBe('connected');
@@ -316,7 +316,6 @@ it('should reset retryCount on a successful connection so subsequent drops can r
 	);
 	jest.useRealTimers();
 	expect(connection.status).toBe('connected');
-	connection.close();
 });
 
 it('should ignore a stale ws.onclose that fires after the socket has been replaced', async () => {
@@ -326,7 +325,7 @@ it('should ignore a stale ws.onclose that fires after the socket has been replac
 	// handler would flip status back to 'disconnected' and schedule another
 	// retry timer.
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
+	connection = ConnectionImpl.create('ws://localhost:1234', WebSocket, client, { retryCount: 1, retryTime: 100 });
 
 	await handleConnection(server, connection.connect());
 	const firstWs = (connection as unknown as { ws: WebSocket }).ws;
@@ -368,5 +367,4 @@ it('should ignore a stale ws.onclose that fires after the socket has been replac
 
 	expect(connection.status).toBe(statusBefore);
 	expect((connection as unknown as { retryCount: number }).retryCount).toBe(retryBefore);
-	connection.close();
 });

--- a/packages/ddp-client/__tests__/Connection.spec.ts
+++ b/packages/ddp-client/__tests__/Connection.spec.ts
@@ -165,7 +165,7 @@ it('should be idempotent if reconnect is called while already connected', async 
 
 it('should be idempotent if connect is called while already connected', async () => {
 	const client = new MinimalDDPClient();
-	const connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
+	connection = ConnectionImpl.create('ws://localhost:1234', globalThis.WebSocket, client, { retryCount: 0, retryTime: 0 });
 
 	await handleConnection(server, connection.connect());
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes flaky `@rocket.chat/ddp-client` unit tests by centralizing `ConnectionImpl` cleanup in `afterEach`.

Mock server teardown fires the client `onclose` handler. Retry-enabled connections interpreted that teardown as a real disconnect and scheduled reconnect timers, which could leak into the following test and consume its mock WebSocket handshake. Closing the client connection before the mock server marks it as intentionally closed and prevents the retry from being scheduled.

## Issue(s)

[FLAKY-2485](https://rocketchat.atlassian.net/browse/FLAKY-2485)

## Steps to test or reproduce

Run the focused suite:

```sh
yarn workspace @rocket.chat/ddp-client testunit Connection.spec.ts --runInBand
```

Run the complete package suite and typecheck:

```sh
yarn workspace @rocket.chat/ddp-client testunit --runInBand
yarn workspace @rocket.chat/ddp-client typecheck
```

The focused suite was also run 30 consecutive times to verify that reconnect work no longer leaks between tests.

## Further comments

This only changes test teardown. Production connection and retry behavior is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved test connection cleanup by consistently closing connections after each test.
  * Test coverage and assertions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[FLAKY-2485]: https://rocketchat.atlassian.net/browse/FLAKY-2485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ