### PR TITLE
test: restore Jira flaky test comments

### DIFF
--- a/apps/meteor/reporters/jira.ts
+++ b/apps/meteor/reporters/jira.ts
@@ -5,12 +5,53 @@ const LOG = '[JIRA reporter]';
 
 const escapeJqlTextSearch = (value: string): string => value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
 
+export const createJiraSearchParams = (summary: string) =>
+	new URLSearchParams({
+		jql: `project = FLAKY AND summary ~ '"${escapeJqlTextSearch(summary)}"'`,
+		fields: 'summary',
+	});
+
 /** Jira REST API v3 expects `description` as Atlassian Document Format, not a plain string. */
 const EMPTY_ADF_DESCRIPTION = {
 	type: 'doc',
 	version: 1,
 	content: [] as const,
 };
+
+type JiraCommentDetails = {
+	run: number;
+	author: string;
+	pr: number;
+	testUrl: string;
+	runUrl: string;
+};
+
+export const createJiraCommentBody = ({ run, author, pr, testUrl, runUrl }: JiraCommentDetails) => ({
+	type: 'doc',
+	version: 1,
+	content: [
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: `Test run ${run} failed` }],
+		},
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: `author: ${author}` }],
+		},
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: `PR: ${pr}` }],
+		},
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: testUrl, marks: [{ type: 'link', attrs: { href: testUrl } }] }],
+		},
+		{
+			type: 'paragraph',
+			content: [{ type: 'text', text: runUrl, marks: [{ type: 'link', attrs: { href: runUrl } }] }],
+		},
+	],
+});
 
 class JIRAReporter implements Reporter {
 	private url: string;
@@ -62,6 +103,32 @@ class JIRAReporter implements Reporter {
 		throw new Error(`${LOG} ${context}: HTTP ${response.status} ${response.statusText}. Body: ${preview}`);
 	}
 
+	private async postComment(issue: string, test: TestCase, payload: { run: number; headSha: string }): Promise<void> {
+		const { location } = test;
+		const testUrl = `https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
+			'/home/runner/work/Rocket.Chat/Rocket.Chat',
+			'',
+		)}#L${location.line}:${location.column}`;
+
+		const commentRes = await fetch(`${this.url}/rest/api/3/issue/${issue}/comment`, {
+			method: 'POST',
+			body: JSON.stringify({
+				body: createJiraCommentBody({
+					run: payload.run,
+					author: this.author,
+					pr: this.pr,
+					testUrl,
+					runUrl: this.run_url,
+				}),
+			}),
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Basic ${this.apiKey}`,
+			},
+		});
+		await JIRAReporter.ensureJiraOk(commentRes, `comment on ${issue}`);
+	}
+
 	async onTestEnd(test: TestCase, result: TestResult) {
 		try {
 			await this._onTestEnd(test, result);
@@ -100,19 +167,13 @@ class JIRAReporter implements Reporter {
 		console.log(`${LOG} preparing notification for flaky/unexpected failure: ${JSON.stringify(payload)}`);
 
 		// first search and check if there is an existing issue
-		const summarySearch = escapeJqlTextSearch(payload.name);
-		const search = await fetch(
-			`${this.url}/rest/api/3/search/jql?${new URLSearchParams({
-				jql: `project = FLAKY AND summary ~ '"${summarySearch}"'`,
-			})}`,
-			{
-				method: 'GET',
-				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Basic ${this.apiKey}`,
-				},
+		const search = await fetch(`${this.url}/rest/api/3/search/jql?${createJiraSearchParams(payload.name)}`, {
+			method: 'GET',
+			headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Basic ${this.apiKey}`,
 			},
-		);
+		});
 
 		await JIRAReporter.ensureJiraOk(search, 'search for existing issue');
 
@@ -126,8 +187,6 @@ class JIRAReporter implements Reporter {
 
 		if (existing) {
 			console.log(`${LOG} exact summary match on ${existing.key}; no new issue will be created (comment / label only).`);
-
-			const { location } = test;
 
 			if (this.pr === 0) {
 				const labelRes = await fetch(`${this.url}/rest/api/3/issue/${existing.key}`, {
@@ -150,25 +209,7 @@ class JIRAReporter implements Reporter {
 				console.log(`${LOG} label update OK for ${existing.key}`);
 			}
 
-			const commentRes = await fetch(`${this.url}/rest/api/3/issue/${existing.key}/comment`, {
-				method: 'POST',
-				body: JSON.stringify({
-					body: `Test run ${payload.run} failed
-author: ${this.author}
-PR: ${this.pr}
-https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
-						'/home/runner/work/Rocket.Chat/Rocket.Chat',
-						'',
-					)}#L${location.line}:${location.column}
-${this.run_url}
-`,
-				}),
-				headers: {
-					'Content-Type': 'application/json',
-					'Authorization': `Basic ${this.apiKey}`,
-				},
-			});
-			await JIRAReporter.ensureJiraOk(commentRes, `comment on ${existing.key}`);
+			await this.postComment(existing.key, test, payload);
 			console.log(`${LOG} comment posted on ${existing.key} for run ${payload.run}.`);
 			return;
 		}
@@ -219,27 +260,7 @@ ${this.run_url}
 
 		console.log(`${LOG} created issue ${issue}.`);
 
-		const { location } = test;
-
-		const commentRes = await fetch(`${this.url}/rest/api/3/issue/${issue}/comment`, {
-			method: 'POST',
-			body: JSON.stringify({
-				body: `Test run ${payload.run} failed
-author: ${this.author}
-PR: ${this.pr}
-https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
-					'/home/runner/work/Rocket.Chat/Rocket.Chat',
-					'',
-				)}#L${location.line}:${location.column}
-${this.run_url}
-`,
-			}),
-			headers: {
-				'Content-Type': 'application/json',
-				'Authorization': `Basic ${this.apiKey}`,
-			},
-		});
-		await JIRAReporter.ensureJiraOk(commentRes, `comment on ${issue}`);
+		await this.postComment(issue, test, payload);
 		console.log(`${LOG} comment posted on ${issue}; done for run ${payload.run}.`);
 	}
 }

--- a/apps/meteor/reporters/jira.ts
+++ b/apps/meteor/reporters/jira.ts
@@ -105,10 +105,10 @@ class JIRAReporter implements Reporter {
 
 	private async postComment(issue: string, test: TestCase, payload: { run: number; headSha: string }): Promise<void> {
 		const { location } = test;
-		const testUrl = `https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}/${location.file.replace(
+		const testUrl = `https://github.com/RocketChat/Rocket.Chat/blob/${payload.headSha}${location.file.replace(
 			'/home/runner/work/Rocket.Chat/Rocket.Chat',
 			'',
-		)}#L${location.line}:${location.column}`;
+		)}#L${location.line}`;
 
 		const commentRes = await fetch(`${this.url}/rest/api/3/issue/${issue}/comment`, {
 			method: 'POST',


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Restores Jira comments from the Playwright flaky-test reporter after its migration to Jira REST API v3.

The enhanced JQL search endpoint was returning candidate issues without `fields.summary`, causing the reporter to throw before it could reuse an existing issue or post a comment. Jira REST API v3 also requires comment bodies to use Atlassian Document Format (ADF), while the reporter was still sending the plain-string payload accepted by v2.

This PR:

- requests the `summary` field explicitly when searching for existing flaky-test issues;
- builds Jira comments as ADF documents;
- preserves the test run, author, PR, source location, and CI run details;
- renders the source and CI URLs as clickable links;
- shares one comment-posting path for both existing and newly created issues.

## Issue(s)

[QA-137](https://rocketchat.atlassian.net/browse/QA-137)

## Steps to test or reproduce

1. Run an E2E test with the Jira reporter enabled and force an unexpected failure.
2. Verify that the reporter searches for an existing FLAKY issue without throwing while reading `fields.summary`.
3. Verify that either the existing issue is reused or a new issue is created.
4. Confirm that Jira receives a comment containing the run details and clickable source/CI links.

Validation performed:

- ESLint and formatting checks pass for the reporter.
- An equivalent ADF comment payload was posted successfully to FLAKY-1395; Jira returned HTTP `201`.

## Further comments

The missing `summary` field failure was reproduced in [this Actions job](https://github.com/RocketChat/Rocket.Chat/actions/runs/33438930373/job/99658085313), where the reporter logged one candidate issue and then failed while reading `issue.fields.summary`.

No changeset is required because this only affects CI reporting infrastructure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


[FLAKY-1395]: https://rocketchat.atlassian.net/browse/FLAKY-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[QA-137]: https://rocketchat.atlassian.net/browse/QA-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIRA issue comments with clearer, more consistent formatting.
  * Test and run links now appear as clickable links in comments.
  * Corrected test links to use supported line references.
  * JIRA issue searches now return the issue summary for more reliable issue handling.
  * Applied the updated comment formatting when reporting both new and existing JIRA issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->