### PR TITLE
fix: custom emoji picker showing no emoji when unsafe query params are enabled

### DIFF
--- a/.changeset/curly-ravens-shout.md
+++ b/.changeset/curly-ravens-shout.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the custom emoji picker returning zero emoji on workspaces running with `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=true`, caused by the client sending an empty `query` string to `emoji-custom.list`

--- a/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.spec.ts
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.spec.ts
@@ -1,0 +1,62 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useCustomEmoji } from './useCustomEmoji';
+import { emoji } from '../../../../lib/emoji';
+
+jest.mock('../../../../lib/customEmoji', () => ({ customRender: jest.fn((html: string) => html) }));
+
+const createCustomEmoji = () => ({
+	_id: 'emojiId',
+	_updatedAt: new Date().toISOString(),
+	name: 'my-emoji',
+	aliases: ['my-alias'],
+	extension: 'png',
+});
+
+it('should call emoji-custom.list without a query parameter', async () => {
+	const getCustomEmojis = jest.fn().mockReturnValue({ emojis: { update: [], remove: [] } });
+
+	renderHook(() => useCustomEmoji(), {
+		wrapper: mockAppRoot().withEndpoint('GET', '/v1/emoji-custom.list', getCustomEmojis).build(),
+	});
+
+	await waitFor(() => expect(getCustomEmojis).toHaveBeenCalledWith({}));
+});
+
+it('should populate emoji.packages.emojiCustom with the emojis and aliases returned by the endpoint', async () => {
+	const customEmoji = createCustomEmoji();
+	const dispatchUpdateSpy = jest.spyOn(emoji, 'dispatchUpdate');
+
+	renderHook(() => useCustomEmoji(), {
+		wrapper: mockAppRoot()
+			.withEndpoint('GET', '/v1/emoji-custom.list', () => ({ emojis: { update: [customEmoji], remove: [] } }))
+			.build(),
+	});
+
+	await waitFor(() => expect(emoji.packages.emojiCustom.emojisByCategory.rocket).toContain('my-emoji'));
+
+	expect(emoji.packages.emojiCustom.list).toEqual(expect.arrayContaining([':my-emoji:', ':my-alias:']));
+	expect(emoji.list[':my-emoji:']).toMatchObject({ name: 'my-emoji', emojiPackage: 'emojiCustom' });
+	expect(emoji.list[':my-alias:']).toEqual({ emojiPackage: 'emojiCustom', aliasOf: 'my-emoji' });
+	expect(dispatchUpdateSpy).toHaveBeenCalled();
+});
+
+it('should reset emoji.packages.emojiCustom to an empty list when the request fails', async () => {
+	const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+	renderHook(() => useCustomEmoji(), {
+		wrapper: mockAppRoot()
+			.withEndpoint('GET', '/v1/emoji-custom.list', () => {
+				throw new Error('unexpected error');
+			})
+			.build(),
+	});
+
+	await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalledWith('Error getting custom emoji ', expect.any(Error)));
+
+	expect(emoji.packages.emojiCustom.list).toEqual([]);
+	expect(emoji.packages.emojiCustom.emojisByCategory.rocket).toEqual([]);
+
+	consoleErrorSpy.mockRestore();
+});

--- a/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.spec.ts
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.spec.ts
@@ -6,6 +6,17 @@ import { emoji } from '../../../../lib/emoji';
 
 jest.mock('../../../../lib/customEmoji', () => ({ customRender: jest.fn((html: string) => html) }));
 
+const pristinePackages = { ...emoji.packages };
+
+beforeEach(() => {
+	emoji.list = {};
+	emoji.packages = { ...pristinePackages };
+});
+
+afterEach(() => {
+	jest.restoreAllMocks();
+});
+
 const createCustomEmoji = () => ({
 	_id: 'emojiId',
 	_updatedAt: new Date().toISOString(),
@@ -57,6 +68,4 @@ it('should reset emoji.packages.emojiCustom to an empty list when the request fa
 
 	expect(emoji.packages.emojiCustom.list).toEqual([]);
 	expect(emoji.packages.emojiCustom.emojisByCategory.rocket).toEqual([]);
-
-	consoleErrorSpy.mockRestore();
 });

--- a/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.ts
+++ b/apps/meteor/client/views/root/hooks/loggedIn/useCustomEmoji.ts
@@ -9,7 +9,7 @@ export const useCustomEmoji = () => {
 	const getCustomEmojis = useEndpoint('GET', '/v1/emoji-custom.list');
 	const result = useQuery({
 		queryKey: ['emoji-custom.list'],
-		queryFn: () => getCustomEmojis({ query: '' }),
+		queryFn: () => getCustomEmojis({}),
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

`useCustomEmoji` was calling `emoji-custom.list` with `query: ''`, which always put an empty `query` string on the wire.

On workspaces running with `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=true`, `parseJsonQuery` takes the `typeof params.query === 'string'` branch for that empty string and hands it to `ejson.parse('')`, which throws. The handler converts that into `error-invalid-query` and the whole request fails, so the hook never populates `emoji.packages.emojiCustom` and the picker shows zero custom emoji. With the flag off the branch is skipped entirely, which is why the bug only reproduces with it enabled.

The `query` parameter is optional on this endpoint, so the client now omits it instead of sending an empty string. The server-side parsing was left untouched because the `query` parameter is already deprecated and slated for removal in the next major.

Also adds unit tests for the hook covering the request shape, the success path, and the error path.

## Issue(s)

Closes: https://rocketchat.atlassian.net/browse/SUP-1103

## Steps to test or reproduce

1. Start a workspace with `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS=true`
2. Add at least one custom emoji in Admin > Emoji
3. Open any channel and open the emoji picker
4. Expected: the Custom category lists the custom emoji, and `GET /api/v1/emoji-custom.list` returns 200 with no `query` parameter in the request URL

## Further comments

[SUP-1103](https://rocketchat.atlassian.net/browse/SUP-1103)


[SUP-1103]: https://rocketchat.atlassian.net/browse/SUP-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the custom emoji picker returning no emojis in workspaces using certain API query settings.
  * Custom emoji requests now load correctly without sending an empty search parameter.
  * Improved error handling so failed emoji requests reset the picker state appropriately.

* **Tests**
  * Added coverage for successful emoji loading, state updates, request failures, and request parameter handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->