### PR TITLE
fix: directory omitting local users with leftover federation data

### DIFF
--- a/.changeset/directory-leftover-federation-origin.md
+++ b/.changeset/directory-leftover-federation-origin.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the admin and search directory omitting local users whose documents still carried data from the removed legacy federation, making them unsearchable in Directory > Users while still visible in Spotlight and Administration > Users.

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -4,6 +4,7 @@ import { TeamType } from '@rocket.chat/core-typings';
 import type { IInstance } from '@rocket.chat/rest-typings';
 import { AssertionError, expect } from 'chai';
 import { after, before, describe, it } from 'mocha';
+import { MongoClient } from 'mongodb';
 
 import { getCredentials, api, request, credentials } from '../../data/api-data';
 import { updatePermission, updateSetting } from '../../data/permissions.helper';
@@ -12,7 +13,7 @@ import { createTeam, deleteTeam } from '../../data/teams.helper';
 import { adminEmail, adminUsername, adminPassword, password } from '../../data/user';
 import type { TestUser } from '../../data/users.helper';
 import { createUser, deleteUser, login as doLogin } from '../../data/users.helper';
-import { IS_EE } from '../../e2e/config/constants';
+import { IS_EE, URL_MONGODB } from '../../e2e/config/constants';
 
 describe('miscellaneous', () => {
 	before((done) => getCredentials(done));
@@ -268,6 +269,32 @@ describe('miscellaneous', () => {
 			expect(res.body.result[0]).to.not.have.property('emails');
 			expect(res.body.result[0]).to.have.property('name');
 		});
+		it('should find local users that still have leftover federation data', async () => {
+			const localUser = await createUser();
+			const connection = await MongoClient.connect(URL_MONGODB);
+			await connection
+				.db()
+				.collection('users')
+				.updateOne({ _id: localUser._id as any }, { $set: { federation: { origin: 'example.com' } } });
+			await connection.close();
+
+			const res = await request
+				.get(api('directory'))
+				.set(credentials)
+				.query({
+					text: localUser.username,
+					type: 'users',
+				})
+				.expect('Content-Type', 'application/json')
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.result).to.have.lengthOf(1);
+			expect(res.body.result[0]).to.have.property('_id', localUser._id);
+
+			await deleteUser(localUser);
+		});
+
 		it('should return an array(result) when search by channel and execute successfully', async () => {
 			const res = await request
 				.get(api('directory'))

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -216,11 +216,12 @@ describe('miscellaneous', () => {
 			]);
 
 			const connection = await MongoClient.connect(URL_MONGODB);
-			await connection
+			const updateResult = await connection
 				.db()
 				.collection('users')
 				.updateOne({ _id: userWithLeftoverFederationData._id as any }, { $set: { federation: { origin: 'example.com' } } });
 			await connection.close();
+			expect(updateResult.modifiedCount).to.equal(1);
 		});
 
 		after(async () => {

--- a/apps/meteor/tests/end-to-end/api/miscellaneous.ts
+++ b/apps/meteor/tests/end-to-end/api/miscellaneous.ts
@@ -197,6 +197,7 @@ describe('miscellaneous', () => {
 
 	describe('/directory', () => {
 		let user: TestUser<IUser>;
+		let userWithLeftoverFederationData: TestUser<IUser>;
 		let testChannel: IRoom;
 		let testGroup: IRoom;
 		let normalUserCredentials: Credentials;
@@ -206,18 +207,27 @@ describe('miscellaneous', () => {
 		before(async () => {
 			await updatePermission('create-team', ['admin', 'user']);
 			user = await createUser();
+			userWithLeftoverFederationData = await createUser();
 			normalUserCredentials = await doLogin(user.username, password);
 			[testChannel, testGroup, teamCreated] = await Promise.all([
 				createRoom({ name: `channel.test.${Date.now()}`, type: 'c' }).then((res) => res.body.channel),
 				createRoom({ name: `group.test.${Date.now()}`, type: 'p' }).then((res) => res.body.group),
 				createTeam(normalUserCredentials, teamName, TeamType.PUBLIC),
 			]);
+
+			const connection = await MongoClient.connect(URL_MONGODB);
+			await connection
+				.db()
+				.collection('users')
+				.updateOne({ _id: userWithLeftoverFederationData._id as any }, { $set: { federation: { origin: 'example.com' } } });
+			await connection.close();
 		});
 
 		after(async () => {
 			await Promise.all([
 				deleteTeam(normalUserCredentials, teamName),
 				deleteUser(user),
+				deleteUser(userWithLeftoverFederationData),
 				deleteRoom({ type: 'c', roomId: testChannel._id }),
 				deleteRoom({ type: 'p', roomId: testGroup._id }),
 				updatePermission('create-team', ['admin', 'user']),
@@ -270,19 +280,11 @@ describe('miscellaneous', () => {
 			expect(res.body.result[0]).to.have.property('name');
 		});
 		it('should find local users that still have leftover federation data', async () => {
-			const localUser = await createUser();
-			const connection = await MongoClient.connect(URL_MONGODB);
-			await connection
-				.db()
-				.collection('users')
-				.updateOne({ _id: localUser._id as any }, { $set: { federation: { origin: 'example.com' } } });
-			await connection.close();
-
 			const res = await request
 				.get(api('directory'))
 				.set(credentials)
 				.query({
-					text: localUser.username,
+					text: userWithLeftoverFederationData.username,
 					type: 'users',
 				})
 				.expect('Content-Type', 'application/json')
@@ -290,9 +292,7 @@ describe('miscellaneous', () => {
 
 			expect(res.body).to.have.property('success', true);
 			expect(res.body.result).to.have.lengthOf(1);
-			expect(res.body.result[0]).to.have.property('_id', localUser._id);
-
-			await deleteUser(localUser);
+			expect(res.body.result[0]).to.have.property('_id', userWithLeftoverFederationData._id);
 		});
 
 		it('should return an array(result) when search by channel and execute successfully', async () => {

--- a/packages/model-typings/src/models/IUsersModel.ts
+++ b/packages/model-typings/src/models/IUsersModel.ts
@@ -93,7 +93,6 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		exceptions?: string[],
 		options?: O,
 		forcedSearchFields?: string[],
-		localDomain?: string,
 	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	findPaginatedByActiveExternalUsersExcept<
@@ -104,7 +103,6 @@ export interface IUsersModel extends IBaseModel<IUser> {
 		exceptions?: string[],
 		options?: O,
 		forcedSearchFields?: string[],
-		localDomain?: string,
 	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>>;
 
 	findActive<T extends Document = IUser, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(

--- a/packages/models/src/models/Users.ts
+++ b/packages/models/src/models/Users.ts
@@ -469,13 +469,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		exceptions?: string[],
 		options?: O,
 		forcedSearchFields?: string[],
-		localDomain?: string,
 	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
-		const extraQuery = [
-			{
-				$or: [{ federation: { $exists: false } }, { 'federation.origin': localDomain }],
-			},
-		];
+		const extraQuery = [{ federated: { $ne: true } }];
 		return this.findPaginatedByActiveUsersExcept<T, O>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 
@@ -487,9 +482,8 @@ export class UsersRaw extends BaseRaw<IUser, DefaultFields<IUser>> implements IU
 		exceptions?: string[],
 		options?: O,
 		forcedSearchFields?: string[],
-		localDomain?: string,
 	): FindPaginated<FindCursor<DocumentWithProjection<T, O>>> {
-		const extraQuery = [{ federation: { $exists: true } }, { 'federation.origin': { $ne: localDomain } }];
+		const extraQuery = [{ federated: true }];
 		return this.findPaginatedByActiveUsersExcept<T, O>(searchTerm, exceptions, options, forcedSearchFields, extraQuery);
 	}
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Directory > Users (`workspace=local`, the only workspace the UI exposes) omits local, active users whose documents still carry a `federation.origin` string left behind by the removed legacy federation — while Spotlight and Administration > Users still find them.

Since the legacy federation removal (#37059), `browseChannels` no longer passes a domain into `Users.findPaginatedByActiveLocalUsersExcept`, so its filter `{ $or: [{ federation: { $exists: false } }, { 'federation.origin': undefined }] }` drops any user with a leftover origin value. Even restoring the argument wouldn't help: leftover origins (e.g. `bcs.ru`) don't match the workspace domain.

This PR replaces the legacy `federation` object checks with the `federated` flag — the marker actually set for federated users (and already used as the discriminator in usage statistics):

- `findPaginatedByActiveLocalUsersExcept` → `{ federated: { $ne: true } }`
- `findPaginatedByActiveExternalUsersExcept` → `{ federated: true }`
- dead `localDomain` parameters removed

Includes an API test that plants leftover `federation.origin` data on a local user and asserts `GET /api/v1/directory` still finds them (verified red before the fix, green after).

## Issue(s)

[SUP-1105](https://rocketchat.atlassian.net/browse/SUP-1105)

## Steps to test or reproduce

1. Create a local user.
2. Set `federation: { origin: 'example.com' }` on their user document directly in MongoDB (federation disabled).
3. Search Directory > Users for them: before this change `total: 0`; after, the user is listed — matching Spotlight and Administration > Users.

## Further comments

No migration: leftover data stays untouched; the query simply no longer keys off it. Data cleanup could ride a future major if ever desired.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




[SUP-1105]: https://rocketchat.atlassian.net/browse/SUP-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Directory and user search so local users remain discoverable when outdated federation information is present.
  * Improved classification of local and external users for more accurate search results.
* **Tests**
  * Added coverage confirming affected local users appear in directory searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->