### PR TITLE
chore: add canAccessRoomIds to batch room access checks

### DIFF
--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -26,6 +26,7 @@ import {
 	isChatGetStarredMessagesProps,
 	isChatGetDiscussionsProps,
 	validateBadRequestErrorResponse,
+	validateNotFoundErrorResponse,
 	validateUnauthorizedErrorResponse,
 	validateForbiddenErrorResponse,
 } from '@rocket.chat/rest-typings';
@@ -1495,12 +1496,16 @@ const chatEndpoints = API.v1
 				400: validateBadRequestErrorResponse,
 				401: validateUnauthorizedErrorResponse,
 				403: validateForbiddenErrorResponse,
+				404: validateNotFoundErrorResponse,
 			},
 		},
 		async function action() {
 			const { messageIds } = this.bodyParams;
 
 			const messages = await Messages.findVisibleByIds(messageIds).toArray();
+			if (!messages.length) {
+				return API.v1.notFound();
+			}
 
 			const rids = [...new Set(messages.map(({ rid }) => rid))];
 

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -33,7 +33,7 @@ import { escapeRegExp } from '@rocket.chat/tools';
 import { Meteor } from 'meteor/meteor';
 
 import { roomAccessAttributes } from '../../lib/authorization';
-import { canAccessRoomAsync, canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { canAccessRoomAsync, canAccessRoomIdAsync, canAccessRoomIdsAsync } from '../../lib/authorization/canAccessRoom';
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
 import { callbacks } from '../../lib/callbacks';
 import { applyAirGappedRestrictionsValidation } from '../../lib/cloud/license/airGappedRestrictionsWrapper';
@@ -1503,10 +1503,9 @@ const chatEndpoints = API.v1
 			const messages = await Messages.findVisibleByIds(messageIds).toArray();
 
 			const rids = [...new Set(messages.map(({ rid }) => rid))];
-			const allowed = await Promise.all(rids.map((rid) => canAccessRoomIdAsync(rid, this.userId)));
 
 			// The batch spans rooms, so one unreadable room rejects the whole request.
-			if (!allowed.every(Boolean)) {
+			if (!(await canAccessRoomIdsAsync(rids, this.userId))) {
 				return API.v1.forbidden();
 			}
 

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -1505,7 +1505,7 @@ const chatEndpoints = API.v1
 			const rids = [...new Set(messages.map(({ rid }) => rid))];
 
 			// The batch spans rooms, so one unreadable room rejects the whole request.
-			if (!(await canAccessRoomIdsAsync(rids, this.userId))) {
+			if (!(await canAccessRoomIdsAsync(rids, this.user))) {
 				return API.v1.forbidden();
 			}
 

--- a/apps/meteor/server/lib/authorization/canAccessRoom.ts
+++ b/apps/meteor/server/lib/authorization/canAccessRoom.ts
@@ -2,6 +2,7 @@ import { Authorization } from '@rocket.chat/core-services';
 
 export const canAccessRoomAsync = Authorization.canAccessRoom;
 export const canAccessRoomIdAsync = Authorization.canAccessRoomId;
+export const canAccessRoomIdsAsync = Authorization.canAccessRoomIds;
 export const roomAccessAttributes = {
 	_id: 1,
 	t: 1,

--- a/apps/meteor/server/meteor-methods/messages/getMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getMessages.ts
@@ -27,6 +27,10 @@ Meteor.methods<ServerMethods>({
 
 		const msgs = await Messages.findVisibleByIds(messages).toArray();
 
+		if (!msgs.length) {
+			return msgs;
+		}
+
 		if (
 			!(await canAccessRoomIdsAsync(
 				msgs.map((m) => m.rid),

--- a/apps/meteor/server/meteor-methods/messages/getMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getMessages.ts
@@ -4,7 +4,7 @@ import { Messages } from '@rocket.chat/models';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
-import { canAccessRoomIdAsync } from '../../lib/authorization/canAccessRoom';
+import { canAccessRoomIdsAsync } from '../../lib/authorization/canAccessRoom';
 import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
@@ -25,9 +25,8 @@ Meteor.methods<ServerMethods>({
 		}
 
 		const msgs = await Messages.findVisibleByIds(messages).toArray();
-		const rids = await Promise.all([...new Set(msgs.map((m) => m.rid))].map((_id) => canAccessRoomIdAsync(_id, uid)));
 
-		if (!rids.every(Boolean)) {
+		if (!(await canAccessRoomIdsAsync([...new Set(msgs.map((m) => m.rid))], this.userId))) {
 			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'getSingleMessage' });
 		}
 

--- a/apps/meteor/server/meteor-methods/messages/getMessages.ts
+++ b/apps/meteor/server/meteor-methods/messages/getMessages.ts
@@ -18,16 +18,22 @@ Meteor.methods<ServerMethods>({
 	async getMessages(messages) {
 		methodDeprecationLogger.method('getMessages', '9.0.0', '/v1/chat.getMessages');
 		check(messages, [String]);
-		const uid = Meteor.userId();
 
-		if (!uid) {
+		const user = await Meteor.userAsync();
+
+		if (!user) {
 			throw new Meteor.Error('error-invalid-user', 'Invalid user', { method: 'getMessages' });
 		}
 
 		const msgs = await Messages.findVisibleByIds(messages).toArray();
 
-		if (!(await canAccessRoomIdsAsync([...new Set(msgs.map((m) => m.rid))], this.userId))) {
-			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'getSingleMessage' });
+		if (
+			!(await canAccessRoomIdsAsync(
+				msgs.map((m) => m.rid),
+				user,
+			))
+		) {
+			throw new Meteor.Error('error-not-allowed', 'Not allowed', { method: 'getMessages' });
 		}
 
 		return msgs;

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -106,6 +106,35 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return this.canAccessRoom(room, { _id: user });
 	}
 
+	async canAccessRoomIds(rids: IRoom['_id'][], uid: IUser['_id']): Promise<boolean> {
+		const uniqueRids = [...new Set(rids)];
+
+		if (!uniqueRids.length) {
+			return true;
+		}
+
+		const [user, rooms] = await Promise.all([
+			Users.findOneById(uid),
+			Rooms.findByIds<Pick<IRoom, '_id' | 't' | 'teamId' | 'prid' | 'abacAttributes'>>(uniqueRids, {
+				projection: {
+					_id: 1,
+					t: 1,
+					teamId: 1,
+					prid: 1,
+					abacAttributes: 1,
+				},
+			}).toArray(),
+		]);
+
+		if (!user || rooms.length !== uniqueRids.length) {
+			return false;
+		}
+
+		const allowed = await Promise.all(rooms.map((room) => this.canAccessRoom(room, user)));
+
+		return allowed.every(Boolean);
+	}
+
 	async getUsersFromPublicRoles(): Promise<
 		{
 			_id: string;

--- a/apps/meteor/server/services/authorization/service.ts
+++ b/apps/meteor/server/services/authorization/service.ts
@@ -106,27 +106,28 @@ export class Authorization extends ServiceClass implements IAuthorization {
 		return this.canAccessRoom(room, { _id: user });
 	}
 
-	async canAccessRoomIds(rids: IRoom['_id'][], uid: IUser['_id']): Promise<boolean> {
+	async canAccessRoomIds(rids: IRoom['_id'][], user: UserWithRoles): Promise<boolean> {
 		const uniqueRids = [...new Set(rids)];
 
 		if (!uniqueRids.length) {
-			return true;
+			return false;
 		}
 
-		const [user, rooms] = await Promise.all([
-			Users.findOneById(uid),
-			Rooms.findByIds<Pick<IRoom, '_id' | 't' | 'teamId' | 'prid' | 'abacAttributes'>>(uniqueRids, {
-				projection: {
-					_id: 1,
-					t: 1,
-					teamId: 1,
-					prid: 1,
-					abacAttributes: 1,
-				},
-			}).toArray(),
-		]);
+		if (!user) {
+			return false;
+		}
 
-		if (!user || rooms.length !== uniqueRids.length) {
+		const rooms = await Rooms.findByIds<Pick<IRoom, '_id' | 't' | 'teamId' | 'prid' | 'abacAttributes'>>(uniqueRids, {
+			projection: {
+				_id: 1,
+				t: 1,
+				teamId: 1,
+				prid: 1,
+				abacAttributes: 1,
+			},
+		}).toArray();
+
+		if (rooms.length !== uniqueRids.length) {
 			return false;
 		}
 

--- a/packages/core-services/src/types/IAuthorization.ts
+++ b/packages/core-services/src/types/IAuthorization.ts
@@ -16,7 +16,7 @@ export interface IAuthorization {
 	canAccessRoom: RoomAccessValidator;
 	canReadRoom: RoomAccessValidator;
 	canAccessRoomId(rid: IRoom['_id'], uid?: IUser['_id']): Promise<boolean>;
-	canAccessRoomIds(rids: IRoom['_id'][], uid: IUser['_id']): Promise<boolean>;
+	canAccessRoomIds(rids: IRoom['_id'][], user: UserWithRoles): Promise<boolean>;
 	getUsersFromPublicRoles(): Promise<Pick<Required<IUser>, '_id' | 'username' | 'roles'>[]>;
 	hasAnyRole(userId: IUser['_id'], roleIds: IRole['_id'][], scope?: IRoom['_id']): Promise<boolean>;
 }

--- a/packages/core-services/src/types/IAuthorization.ts
+++ b/packages/core-services/src/types/IAuthorization.ts
@@ -16,6 +16,7 @@ export interface IAuthorization {
 	canAccessRoom: RoomAccessValidator;
 	canReadRoom: RoomAccessValidator;
 	canAccessRoomId(rid: IRoom['_id'], uid?: IUser['_id']): Promise<boolean>;
+	canAccessRoomIds(rids: IRoom['_id'][], uid: IUser['_id']): Promise<boolean>;
 	getUsersFromPublicRoles(): Promise<Pick<Required<IUser>, '_id' | 'username' | 'roles'>[]>;
 	hasAnyRole(userId: IUser['_id'], roleIds: IRole['_id'][], scope?: IRoom['_id']): Promise<boolean>;
 }


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
- Follow-up of https://github.com/RocketChat/Rocket.Chat/pull/41961
- [ARCH-2303](https://rocketchat.atlassian.net/browse/ARCH-2303)

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved chat message retrieval when requests include messages from multiple rooms.
  * Reduced redundant access checks during message retrieval.

* **Bug Fixes**
  * Requests now correctly require access to every requested room.
  * Improved handling of unavailable or unauthorized messages, including appropriate not-found responses.
  * Improved validation for missing users and requests without matching messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ARCH-2303]: https://rocketchat.atlassian.net/browse/ARCH-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ