### PR TITLE
test: add coverage for AutoTranslate client logic

### DIFF
--- a/apps/meteor/client/lib/autotranslate/autotranslate.spec.ts
+++ b/apps/meteor/client/lib/autotranslate/autotranslate.spec.ts
@@ -1,0 +1,350 @@
+import type { IMessage, ISupportedLanguage, ITranslatedMessage, MessageAttachmentDefault } from '@rocket.chat/core-typings';
+import mem from 'mem';
+
+import { AutoTranslate, createAutoTranslateMessageStreamHandler } from './autotranslate';
+import { createFakeMessage, createFakeSubscription, createFakeUser } from '../../../tests/mocks/data';
+import { Messages, Subscriptions, Users } from '../../stores';
+import { sdk } from '../SDKClient';
+import { hasPermission } from '../authorization';
+import { settings } from '../settings';
+import { userIdStore } from '../user';
+
+jest.mock('../SDKClient', () => ({
+	sdk: {
+		call: jest.fn(),
+		rest: { get: jest.fn() },
+	},
+}));
+
+jest.mock('../authorization', () => ({
+	hasPermission: jest.fn(),
+}));
+
+jest.mock('../settings', () => ({
+	settings: {
+		peek: jest.fn(),
+		observe: jest.fn(() => jest.fn()),
+	},
+}));
+
+jest.mock('../../cachedStores', () => ({
+	PermissionsCachedStore: {
+		useReady: { subscribe: jest.fn(() => jest.fn()) },
+	},
+}));
+
+const USER_ID = 'userId';
+const USERNAME = 'john.doe';
+const ROOM_ID = 'roomId';
+
+const asMock = (fn: unknown) => fn as jest.Mock;
+
+const flushPromises = async () => {
+	await Promise.resolve();
+	await Promise.resolve();
+};
+
+const signInAs = ({ language }: { language?: string } = {}) => {
+	Users.state.store(createFakeUser({ _id: USER_ID, username: USERNAME, language }));
+	userIdStore.setState(USER_ID);
+};
+
+describe('AutoTranslate', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		asMock(settings.observe).mockReturnValue(jest.fn());
+		asMock(sdk.call).mockResolvedValue({});
+		asMock(sdk.rest.get).mockResolvedValue({ languages: [] });
+
+		Messages.state.replaceAll([]);
+		Subscriptions.state.replaceAll([]);
+		Users.state.replaceAll([]);
+		userIdStore.setState(undefined);
+
+		mem.clear(AutoTranslate.findSubscriptionByRid);
+
+		AutoTranslate.initialized = false;
+		AutoTranslate.providersMetadata = {};
+		AutoTranslate.messageIdsToWait = {};
+		AutoTranslate.supportedLanguages = [];
+	});
+
+	describe('getLanguage', () => {
+		it('should prefer the language configured on the subscription', () => {
+			signInAs({ language: 'en' });
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslateLanguage: 'fr' }));
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('fr');
+		});
+
+		it('should fall back to the user language when the subscription has none', () => {
+			signInAs({ language: 'de' });
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslateLanguage: undefined }));
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('de');
+		});
+
+		it('should fall back to the user language when the room has no subscription', () => {
+			signInAs({ language: 'de' });
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('de');
+		});
+
+		it('should keep a regional code that is supported', () => {
+			signInAs();
+			AutoTranslate.supportedLanguages = [{ language: 'zh-HK', name: 'Chinese (Hong Kong)' }] as ISupportedLanguage[];
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslateLanguage: 'zh-HK' }));
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('zh-HK');
+		});
+
+		it('should fall back to the base language when the regional code is not supported', () => {
+			signInAs();
+			AutoTranslate.supportedLanguages = [{ language: 'pt', name: 'Portuguese' }] as ISupportedLanguage[];
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslateLanguage: 'pt-BR' }));
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('pt');
+		});
+
+		it('should fall back to the base language when the supported list has not loaded yet', () => {
+			signInAs();
+			AutoTranslate.supportedLanguages = undefined;
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslateLanguage: 'pt-BR' }));
+
+			expect(AutoTranslate.getLanguage(ROOM_ID)).toBe('pt');
+		});
+	});
+
+	describe('translateAttachments', () => {
+		beforeEach(() => {
+			signInAs();
+		});
+
+		it('should return attachments untouched when they are not translatable', () => {
+			const attachments = [{ text: 'hello' }] as MessageAttachmentDefault[];
+
+			expect(AutoTranslate.translateAttachments(attachments, 'fr', false)).toBe(attachments);
+			expect(attachments[0].text).toBe('hello');
+		});
+
+		it('should replace the text with the translation and keep the original', () => {
+			const attachments = [
+				{ author_name: 'someone', text: 'hello', translations: { fr: 'bonjour' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', false);
+
+			expect(attachments[0].text).toBe('bonjour');
+			expect((attachments[0] as any).translations.original).toBe('hello');
+		});
+
+		it('should keep the original text when showing the inverse translation', () => {
+			const attachments = [
+				{ author_name: 'someone', text: 'hello', translations: { fr: 'bonjour' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', true);
+
+			expect(attachments[0].text).toBe('hello');
+		});
+
+		it('should replace the description with the translation for the given language', () => {
+			const attachments = [
+				{ author_name: 'someone', description: 'a picture', translations: { fr: 'une image' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', false);
+
+			expect(attachments[0].description).toBe('une image');
+		});
+
+		it('should keep the original description when showing the inverse translation', () => {
+			const attachments = [
+				{ author_name: 'someone', description: 'a picture', translations: { fr: 'une image' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', true);
+
+			expect(attachments[0].description).toBe('a picture');
+		});
+
+		it('should not translate attachments authored by the current user', () => {
+			const attachments = [
+				{ author_name: USERNAME, text: 'hello', translations: { fr: 'bonjour' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', false);
+
+			expect(attachments[0].text).toBe('hello');
+		});
+
+		it('should leave the text alone when there is no translation for the language', () => {
+			const attachments = [
+				{ author_name: 'someone', text: 'hello', translations: { de: 'hallo' } },
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', false);
+
+			expect(attachments[0].text).toBe('hello');
+		});
+
+		it('should translate nested attachments', () => {
+			const attachments = [
+				{
+					author_name: 'someone',
+					text: 'outer',
+					translations: { fr: 'exterieur' },
+					attachments: [{ author_name: 'someone', text: 'inner', translations: { fr: 'interieur' } }],
+				},
+			] as unknown as MessageAttachmentDefault[];
+
+			AutoTranslate.translateAttachments(attachments, 'fr', false);
+
+			expect((attachments[0] as any).attachments[0].text).toBe('interieur');
+		});
+	});
+
+	describe('init', () => {
+		const enableAutoTranslate = () => {
+			asMock(settings.peek).mockReturnValue(true);
+			asMock(hasPermission).mockReturnValue(true);
+			userIdStore.setState(USER_ID);
+		};
+
+		it('should load provider metadata and supported languages when enabled, signed in and permitted', async () => {
+			enableAutoTranslate();
+			asMock(sdk.call).mockResolvedValue({ google: { name: 'google', displayName: 'Google' } });
+			asMock(sdk.rest.get).mockResolvedValue({ languages: [{ language: 'fr', name: 'French' }] });
+
+			AutoTranslate.init();
+			await flushPromises();
+
+			expect(AutoTranslate.providersMetadata).toEqual({ google: { name: 'google', displayName: 'Google' } });
+			expect(AutoTranslate.supportedLanguages).toEqual([{ language: 'fr', name: 'French' }]);
+			expect(AutoTranslate.initialized).toBe(true);
+		});
+
+		it('should not subscribe again when already initialized', () => {
+			AutoTranslate.initialized = true;
+
+			AutoTranslate.init();
+
+			expect(settings.observe).not.toHaveBeenCalled();
+		});
+
+		it('should not request providers when the setting is disabled', () => {
+			asMock(settings.peek).mockReturnValue(false);
+			asMock(hasPermission).mockReturnValue(true);
+			userIdStore.setState(USER_ID);
+
+			AutoTranslate.init();
+
+			expect(sdk.call).not.toHaveBeenCalled();
+		});
+
+		it('should not request providers when there is no signed-in user', () => {
+			asMock(settings.peek).mockReturnValue(true);
+			asMock(hasPermission).mockReturnValue(true);
+			userIdStore.setState(undefined);
+
+			AutoTranslate.init();
+
+			expect(sdk.call).not.toHaveBeenCalled();
+		});
+
+		it('should not request providers when the user lacks the auto-translate permission', () => {
+			asMock(settings.peek).mockReturnValue(true);
+			asMock(hasPermission).mockReturnValue(false);
+			userIdStore.setState(USER_ID);
+
+			AutoTranslate.init();
+
+			expect(sdk.call).not.toHaveBeenCalled();
+		});
+
+		it('should not throw and should keep defaults when loading providers fails', async () => {
+			enableAutoTranslate();
+			asMock(sdk.call).mockRejectedValue(new Error('autotranslate disabled'));
+			asMock(sdk.rest.get).mockRejectedValue(new Error('autotranslate disabled'));
+			const consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+			AutoTranslate.init();
+			await flushPromises();
+
+			expect(AutoTranslate.providersMetadata).toEqual({});
+			expect(consoleError).toHaveBeenCalledWith('autotranslate disabled');
+
+			consoleError.mockRestore();
+		});
+	});
+
+	describe('createAutoTranslateMessageStreamHandler', () => {
+		beforeEach(() => {
+			signInAs();
+			asMock(settings.peek).mockReturnValue(false);
+			asMock(hasPermission).mockReturnValue(false);
+			userIdStore.setState(USER_ID);
+		});
+
+		const storeMessage = (overrides: Partial<ITranslatedMessage> = {}) => {
+			const message = {
+				...createFakeMessage<IMessage>({ rid: ROOM_ID, msg: 'hello', u: { _id: 'anotherUserId', username: 'someone' } }),
+				...overrides,
+			} as ITranslatedMessage;
+			Messages.state.store(message);
+			return message;
+		};
+
+		it('should ignore messages authored by the current user', () => {
+			const handler = createAutoTranslateMessageStreamHandler();
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslate: true }));
+			const message = storeMessage({ u: { _id: USER_ID, username: USERNAME } });
+
+			handler(message);
+
+			expect(Messages.state.get(message._id)?.autoTranslateFetching).toBeUndefined();
+		});
+
+		it('should flag an untranslated message as fetching when the subscription auto-translates', () => {
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslate: true, autoTranslateLanguage: 'fr' }));
+			const handler = createAutoTranslateMessageStreamHandler();
+			const message = storeMessage();
+
+			handler(message);
+
+			expect(Messages.state.get(message._id)?.autoTranslateFetching).toBe(true);
+		});
+
+		it('should not flag a message that already carries the translation', () => {
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslate: true, autoTranslateLanguage: 'fr' }));
+			const handler = createAutoTranslateMessageStreamHandler();
+			const message = storeMessage({ translations: { fr: 'bonjour' } });
+
+			handler(message);
+
+			expect(Messages.state.get(message._id)?.autoTranslateFetching).toBeUndefined();
+		});
+
+		it('should clear the fetching flag when auto-translate was turned off while waiting', () => {
+			Subscriptions.state.store(createFakeSubscription({ rid: ROOM_ID, autoTranslate: false }));
+			const handler = createAutoTranslateMessageStreamHandler();
+			const message = storeMessage({ autoTranslateFetching: true });
+			AutoTranslate.messageIdsToWait[message._id] = true;
+
+			handler(message);
+
+			expect(Messages.state.get(message._id)?.autoTranslateFetching).toBeUndefined();
+			expect(AutoTranslate.messageIdsToWait[message._id]).toBeUndefined();
+		});
+
+		it('should clear a stale fetching flag when the room has no auto-translating subscription', () => {
+			const handler = createAutoTranslateMessageStreamHandler();
+			const message = storeMessage({ autoTranslateFetching: true });
+
+			handler(message);
+
+			expect(Messages.state.get(message._id)?.autoTranslateFetching).toBeUndefined();
+		});
+	});
+});

--- a/apps/meteor/tests/e2e/auto-translate.spec.ts
+++ b/apps/meteor/tests/e2e/auto-translate.spec.ts
@@ -1,0 +1,73 @@
+import { Users } from './fixtures/userStates';
+import { HomeChannel } from './page-objects';
+import { createTargetChannel, deleteChannel } from './utils';
+import { preserveSettings } from './utils/preserveSettings';
+import { setSettingValueById } from './utils/setSettingValueById';
+import { expect, test } from './utils/test';
+
+test.use({ storageState: Users.admin.state });
+
+test.describe.serial('auto-translate', () => {
+	let poHomeChannel: HomeChannel;
+	let targetChannel: string;
+
+	preserveSettings(['AutoTranslate_Enabled']);
+
+	test.beforeAll(async ({ api }) => {
+		targetChannel = await createTargetChannel(api);
+	});
+
+	test.afterAll(async ({ api }) => {
+		await deleteChannel(api, targetChannel);
+	});
+
+	test.beforeEach(async ({ page }) => {
+		poHomeChannel = new HomeChannel(page);
+	});
+
+	test.describe('with the setting disabled', () => {
+		test.beforeAll(async ({ api }) => {
+			await setSettingValueById(api, 'AutoTranslate_Enabled', false);
+		});
+
+		test('should not offer auto-translate in the room options', async () => {
+			await poHomeChannel.gotoChannel(targetChannel);
+			await poHomeChannel.roomToolbar.openMoreOptions();
+
+			await expect(poHomeChannel.roomToolbar.menuItemAutoTranslate).not.toBeVisible();
+		});
+	});
+
+	test.describe('with the setting enabled', () => {
+		test.beforeAll(async ({ api }) => {
+			await setSettingValueById(api, 'AutoTranslate_Enabled', true);
+		});
+
+		test('should keep translation enabled after reopening the room', async () => {
+			await poHomeChannel.gotoChannel(targetChannel);
+			await poHomeChannel.roomToolbar.openMoreOptions();
+			await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
+			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+			await poHomeChannel.tabs.autoTranslate.setAutomaticTranslation(true);
+
+			await poHomeChannel.page.reload();
+			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+
+			await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeChecked();
+		});
+
+		test('should warn and block the toggle in an encrypted room', async ({ api }) => {
+			const encryptedChannel = await createTargetChannel(api, { extraData: { encrypted: true } });
+
+			await poHomeChannel.gotoChannel(encryptedChannel);
+			await poHomeChannel.roomToolbar.openMoreOptions();
+			await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
+			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+
+			await expect(poHomeChannel.tabs.autoTranslate.calloutEncryptedRoom).toBeVisible();
+			await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeDisabled();
+
+			await deleteChannel(api, encryptedChannel);
+		});
+	});
+});

--- a/apps/meteor/tests/e2e/auto-translate.spec.ts
+++ b/apps/meteor/tests/e2e/auto-translate.spec.ts
@@ -1,81 +1,65 @@
+import type { MongoClient } from 'mongodb';
+import { MongoClient as Mongo } from 'mongodb';
+
+import { URL_MONGODB } from './config/constants';
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
-import { createTargetChannel, deleteChannel } from './utils';
+import { createTargetChannelAndReturnFullRoom, deleteChannel, sendTargetChannelMessage } from './utils';
 import { preserveSettings } from './utils/preserveSettings';
 import { setSettingValueById } from './utils/setSettingValueById';
 import { expect, test } from './utils/test';
 
 test.use({ storageState: Users.admin.state });
 
+const ORIGINAL_MESSAGE = 'Good morning everyone';
+const TRANSLATED_MESSAGE = 'Guten Morgen zusammen';
+
 test.describe.serial('auto-translate', () => {
 	let poHomeChannel: HomeChannel;
 	let targetChannel: string;
+	let connection: MongoClient;
 
 	preserveSettings(['AutoTranslate_Enabled']);
 
 	test.beforeAll(async ({ api }) => {
-		targetChannel = await createTargetChannel(api);
+		connection = await Mongo.connect(URL_MONGODB);
+
+		await setSettingValueById(api, 'AutoTranslate_Enabled', true);
+
+		const { channel } = await createTargetChannelAndReturnFullRoom(api);
+		targetChannel = channel.name as string;
+
+		await sendTargetChannelMessage(api, targetChannel, { msg: ORIGINAL_MESSAGE });
+
+		await connection
+			.db()
+			.collection('rocketchat_message')
+			.updateOne({ rid: channel._id, msg: ORIGINAL_MESSAGE }, { $set: { u: Users.user1.data, translations: { de: TRANSLATED_MESSAGE } } });
+
+		await api.post('/autotranslate.saveSettings', { roomId: channel._id, field: 'autoTranslateLanguage', value: 'de' });
 	});
 
 	test.afterAll(async ({ api }) => {
 		await deleteChannel(api, targetChannel);
+		await connection.close();
 	});
 
 	test.beforeEach(async ({ page }) => {
 		poHomeChannel = new HomeChannel(page);
 	});
 
-	test.describe('with the setting disabled', () => {
-		test.beforeAll(async ({ api }) => {
-			await setSettingValueById(api, 'AutoTranslate_Enabled', false);
-		});
+	test('should render the translated message once the user enables automatic translation', async () => {
+		await poHomeChannel.gotoChannel(targetChannel);
 
-		test('should not offer auto-translate in the room options', async () => {
-			await poHomeChannel.gotoChannel(targetChannel);
-			await poHomeChannel.roomToolbar.openMoreOptions();
+		await expect(poHomeChannel.content.lastUserMessage).toContainText(ORIGINAL_MESSAGE);
 
-			await expect(poHomeChannel.roomToolbar.menuItemAutoTranslate).not.toBeVisible();
-		});
-	});
+		await poHomeChannel.roomToolbar.openMoreOptions();
+		await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
+		await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+		await poHomeChannel.tabs.autoTranslate.setAutomaticTranslation(true);
+		await poHomeChannel.toastMessage.waitForDisplay({ type: 'success' });
 
-	test.describe('with the setting enabled', () => {
-		test.beforeAll(async ({ api }) => {
-			await setSettingValueById(api, 'AutoTranslate_Enabled', true);
-		});
-
-		test('should keep translation enabled after reloading the page', async () => {
-			await poHomeChannel.gotoChannel(targetChannel);
-			await poHomeChannel.roomToolbar.openMoreOptions();
-			await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
-			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
-			await poHomeChannel.tabs.autoTranslate.setAutomaticTranslation(true);
-
-			await poHomeChannel.page.reload();
-			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
-
-			await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeChecked();
-		});
-
-		test.describe('in an encrypted room', () => {
-			let encryptedChannel: string;
-
-			test.beforeAll(async ({ api }) => {
-				encryptedChannel = await createTargetChannel(api, { extraData: { encrypted: true } });
-			});
-
-			test.afterAll(async ({ api }) => {
-				await deleteChannel(api, encryptedChannel);
-			});
-
-			test('should warn and block the toggle', async () => {
-				await poHomeChannel.gotoChannel(encryptedChannel);
-				await poHomeChannel.roomToolbar.openMoreOptions();
-				await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
-				await poHomeChannel.tabs.autoTranslate.waitForDisplay();
-
-				await expect(poHomeChannel.tabs.autoTranslate.calloutEncryptedRoom).toBeVisible();
-				await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeDisabled();
-			});
-		});
+		await expect(poHomeChannel.content.lastUserMessage).toContainText(TRANSLATED_MESSAGE);
+		await expect(poHomeChannel.content.lastUserMessage).not.toContainText(ORIGINAL_MESSAGE);
 	});
 });

--- a/apps/meteor/tests/e2e/auto-translate.spec.ts
+++ b/apps/meteor/tests/e2e/auto-translate.spec.ts
@@ -34,7 +34,10 @@ test.describe.serial('auto-translate', () => {
 		await connection
 			.db()
 			.collection('rocketchat_message')
-			.updateOne({ rid: channel._id, msg: ORIGINAL_MESSAGE }, { $set: { u: Users.user1.data, translations: { de: TRANSLATED_MESSAGE } } });
+			.updateOne(
+				{ rid: channel._id, msg: ORIGINAL_MESSAGE },
+				{ $set: { u: { _id: Users.user1.data._id, username: Users.user1.data.username }, translations: { de: TRANSLATED_MESSAGE } } },
+			);
 
 		await api.post('/autotranslate.saveSettings', { roomId: channel._id, field: 'autoTranslateLanguage', value: 'de' });
 	});

--- a/apps/meteor/tests/e2e/auto-translate.spec.ts
+++ b/apps/meteor/tests/e2e/auto-translate.spec.ts
@@ -43,7 +43,7 @@ test.describe.serial('auto-translate', () => {
 			await setSettingValueById(api, 'AutoTranslate_Enabled', true);
 		});
 
-		test('should keep translation enabled after reopening the room', async () => {
+		test('should keep translation enabled after reloading the page', async () => {
 			await poHomeChannel.gotoChannel(targetChannel);
 			await poHomeChannel.roomToolbar.openMoreOptions();
 			await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
@@ -56,18 +56,26 @@ test.describe.serial('auto-translate', () => {
 			await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeChecked();
 		});
 
-		test('should warn and block the toggle in an encrypted room', async ({ api }) => {
-			const encryptedChannel = await createTargetChannel(api, { extraData: { encrypted: true } });
+		test.describe('in an encrypted room', () => {
+			let encryptedChannel: string;
 
-			await poHomeChannel.gotoChannel(encryptedChannel);
-			await poHomeChannel.roomToolbar.openMoreOptions();
-			await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
-			await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+			test.beforeAll(async ({ api }) => {
+				encryptedChannel = await createTargetChannel(api, { extraData: { encrypted: true } });
+			});
 
-			await expect(poHomeChannel.tabs.autoTranslate.calloutEncryptedRoom).toBeVisible();
-			await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeDisabled();
+			test.afterAll(async ({ api }) => {
+				await deleteChannel(api, encryptedChannel);
+			});
 
-			await deleteChannel(api, encryptedChannel);
+			test('should warn and block the toggle', async () => {
+				await poHomeChannel.gotoChannel(encryptedChannel);
+				await poHomeChannel.roomToolbar.openMoreOptions();
+				await poHomeChannel.roomToolbar.menuItemAutoTranslate.click();
+				await poHomeChannel.tabs.autoTranslate.waitForDisplay();
+
+				await expect(poHomeChannel.tabs.autoTranslate.calloutEncryptedRoom).toBeVisible();
+				await expect(poHomeChannel.tabs.autoTranslate.checkboxAutomaticTranslation).toBeDisabled();
+			});
 		});
 	});
 });

--- a/apps/meteor/tests/e2e/auto-translate.spec.ts
+++ b/apps/meteor/tests/e2e/auto-translate.spec.ts
@@ -1,11 +1,8 @@
-import type { MongoClient } from 'mongodb';
-import { MongoClient as Mongo } from 'mongodb';
-
-import { URL_MONGODB } from './config/constants';
 import { Users } from './fixtures/userStates';
 import { HomeChannel } from './page-objects';
 import { createTargetChannelAndReturnFullRoom, deleteChannel, sendTargetChannelMessage } from './utils';
 import { preserveSettings } from './utils/preserveSettings';
+import { seedTranslatedMessage } from './utils/seedTranslatedMessage';
 import { setSettingValueById } from './utils/setSettingValueById';
 import { expect, test } from './utils/test';
 
@@ -17,13 +14,10 @@ const TRANSLATED_MESSAGE = 'Guten Morgen zusammen';
 test.describe.serial('auto-translate', () => {
 	let poHomeChannel: HomeChannel;
 	let targetChannel: string;
-	let connection: MongoClient;
 
 	preserveSettings(['AutoTranslate_Enabled']);
 
 	test.beforeAll(async ({ api }) => {
-		connection = await Mongo.connect(URL_MONGODB);
-
 		await setSettingValueById(api, 'AutoTranslate_Enabled', true);
 
 		const { channel } = await createTargetChannelAndReturnFullRoom(api);
@@ -31,20 +25,18 @@ test.describe.serial('auto-translate', () => {
 
 		await sendTargetChannelMessage(api, targetChannel, { msg: ORIGINAL_MESSAGE });
 
-		await connection
-			.db()
-			.collection('rocketchat_message')
-			.updateOne(
-				{ rid: channel._id, msg: ORIGINAL_MESSAGE },
-				{ $set: { u: { _id: Users.user1.data._id, username: Users.user1.data.username }, translations: { de: TRANSLATED_MESSAGE } } },
-			);
+		await seedTranslatedMessage({
+			rid: channel._id,
+			msg: ORIGINAL_MESSAGE,
+			author: Users.user1,
+			translations: { de: TRANSLATED_MESSAGE },
+		});
 
 		await api.post('/autotranslate.saveSettings', { roomId: channel._id, field: 'autoTranslateLanguage', value: 'de' });
 	});
 
 	test.afterAll(async ({ api }) => {
 		await deleteChannel(api, targetChannel);
-		await connection.close();
 	});
 
 	test.beforeEach(async ({ page }) => {

--- a/apps/meteor/tests/e2e/page-objects/fragments/flextabs/auto-translate-flextab.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/flextabs/auto-translate-flextab.ts
@@ -11,11 +11,11 @@ export class AutoTranslateFlexTab extends FlexTab {
 		return this.root.getByRole('checkbox', { name: 'Automatic Translation' });
 	}
 
-	get toggleAutomaticTranslation(): Locator {
-		return this.root.locator('label[for="automatic-translation"]');
+	get textAutomaticTranslation(): Locator {
+		return this.root.getByText('Automatic Translation', { exact: true });
 	}
 
-	get calloutEncryptedRoom(): Locator {
+	get textEncryptedRoomCallout(): Locator {
 		return this.root.getByText('Automatic translation not available');
 	}
 
@@ -23,6 +23,6 @@ export class AutoTranslateFlexTab extends FlexTab {
 		if ((await this.checkboxAutomaticTranslation.isChecked()) === enabled) {
 			return;
 		}
-		await this.toggleAutomaticTranslation.click();
+		await this.textAutomaticTranslation.click();
 	}
 }

--- a/apps/meteor/tests/e2e/page-objects/fragments/flextabs/auto-translate-flextab.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/flextabs/auto-translate-flextab.ts
@@ -1,0 +1,28 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { FlexTab } from './flextab';
+
+export class AutoTranslateFlexTab extends FlexTab {
+	constructor(page: Page) {
+		super(page.getByRole('dialog', { name: 'Auto-Translate' }));
+	}
+
+	get checkboxAutomaticTranslation(): Locator {
+		return this.root.getByRole('checkbox', { name: 'Automatic Translation' });
+	}
+
+	get toggleAutomaticTranslation(): Locator {
+		return this.root.locator('label[for="automatic-translation"]');
+	}
+
+	get calloutEncryptedRoom(): Locator {
+		return this.root.getByText('Automatic translation not available');
+	}
+
+	async setAutomaticTranslation(enabled: boolean): Promise<void> {
+		if ((await this.checkboxAutomaticTranslation.isChecked()) === enabled) {
+			return;
+		}
+		await this.toggleAutomaticTranslation.click();
+	}
+}

--- a/apps/meteor/tests/e2e/page-objects/fragments/flextabs/index.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/flextabs/index.ts
@@ -1,3 +1,4 @@
+export * from './auto-translate-flextab';
 export * from './admin-flextab-emoji';
 export * from './admin-edit-room-flextab';
 export * from './channels-flextab';

--- a/apps/meteor/tests/e2e/page-objects/fragments/toolbar.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/toolbar.ts
@@ -83,6 +83,10 @@ export class RoomToolbar extends Toolbar {
 		return this.menu.getMenuItem('Prune Messages');
 	}
 
+	get menuItemAutoTranslate(): Locator {
+		return this.menu.getMenuItem('Auto-Translate');
+	}
+
 	get menuItemNotificationsPreferences(): Locator {
 		return this.menu.getMenuItem('Notifications Preferences');
 	}

--- a/apps/meteor/tests/e2e/page-objects/home-channel.ts
+++ b/apps/meteor/tests/e2e/page-objects/home-channel.ts
@@ -11,6 +11,7 @@ import {
 	MembersFlexTab,
 	ChannelsFlexTab,
 	NotificationPreferencesFlexTab,
+	AutoTranslateFlexTab,
 	ExportMessagesFlexTab,
 	PruneMessagesFlexTab,
 	SearchMessagesFlexTab,
@@ -44,6 +45,7 @@ export class HomeChannel {
 		editRoom: EditRoomFlexTab;
 		channels: ChannelsFlexTab;
 		notificationPreferences: NotificationPreferencesFlexTab;
+		autoTranslate: AutoTranslateFlexTab;
 		exportMessages: ExportMessagesFlexTab;
 		pruneMessages: PruneMessagesFlexTab;
 		searchMessages: SearchMessagesFlexTab;
@@ -75,6 +77,7 @@ export class HomeChannel {
 			editRoom: new EditRoomFlexTab(page.getByRole('dialog', { name: 'Edit channel' })),
 			channels: new ChannelsFlexTab(page),
 			notificationPreferences: new NotificationPreferencesFlexTab(page),
+			autoTranslate: new AutoTranslateFlexTab(page),
 			exportMessages: new ExportMessagesFlexTab(page),
 			pruneMessages: new PruneMessagesFlexTab(page),
 			searchMessages: new SearchMessagesFlexTab(page),

--- a/apps/meteor/tests/e2e/utils/seedTranslatedMessage.ts
+++ b/apps/meteor/tests/e2e/utils/seedTranslatedMessage.ts
@@ -1,0 +1,26 @@
+import { MongoClient } from 'mongodb';
+
+import { URL_MONGODB } from '../config/constants';
+import type { IUserState } from '../fixtures/userStates';
+
+type SeedTranslatedMessageParams = {
+	rid: string;
+	msg: string;
+	author: IUserState;
+	translations: Record<string, string>;
+};
+
+// No translation provider is reachable from CI, so translations are seeded straight into the message.
+// The author is reassigned as well because auto-translate skips messages sent by the user reading them.
+export const seedTranslatedMessage = async ({ rid, msg, author, translations }: SeedTranslatedMessageParams): Promise<void> => {
+	const connection = await MongoClient.connect(URL_MONGODB);
+
+	try {
+		await connection
+			.db()
+			.collection('rocketchat_message')
+			.updateOne({ rid, msg }, { $set: { u: { _id: author.data._id, username: author.data.username }, translations } });
+	} finally {
+		await connection.close();
+	}
+};


### PR DESCRIPTION
# test: add coverage for AutoTranslate client logic

## Proposed changes (including videos or screenshots)

`apps/meteor/client/lib/autotranslate/autotranslate.ts` had no tests targeting it.

| | Statements | Branches | Functions | Lines |
| --- | ---: | ---: | ---: | ---: |
| Before | — | — | — | 19.75% |
| After | 100% | 94.2% | 100% | 100% |

**25 unit tests** covering language resolution, attachment translation, initialization and provider loading, and the message stream handler.

**1 E2E test** plus an `AutoTranslateFlexTab` page object, covering the full journey: a message arrives in the room, the user turns automatic translation on, and the message is re-rendered in the target language.

No production code is changed.

## Issue(s)

- [CORE-2604](https://rocketchat.atlassian.net/browse/CORE-2604)

## Steps to test or reproduce

```bash
cd apps/meteor
yarn .testunit:jest client/lib/autotranslate   # unit
yarn test:e2e tests/e2e/auto-translate.spec.ts # E2E, needs a running instance
```

## Further comments

The E2E seeds `translations` on the message instead of configuring a translation provider — the four providers are external services and none is available in CI. That keeps the assertion on the real render path (`showAutoTranslate` → text replacement → message body) rather than on UI state.

Two pre-existing issues found while testing, neither changed here:

1. `translateAttachments` has no callers anywhere in the repo — it is dead code, and its recursive call also drops the `autoTranslateShowInverse` argument. 8 of the 25 unit tests here cover it, because the issue asks for attachment coverage, so part of the reported gain protects code nothing invokes. Worth deciding whether to fix or delete.
2. In `AutoTranslate.tsx` the label's `htmlFor` points at a non-existent id, leaving the language select without an accessible name.

[CORE-2604]: https://rocketchat.atlassian.net/browse/CORE-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added unit test coverage for automatic translation language selection, attachment handling, initialization, and message-stream behavior.
  - Expanded end-to-end coverage to verify that automatic translation replaces an original message with its translated version.
  - Added reusable test support for translated messages and automatic translation interface interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->