### PR TITLE
fix(tools): censorUrl redacts sensitive query parameters and handles relative URLs

### DIFF
--- a/.changeset/tools-censor-url-sensitive-params.md
+++ b/.changeset/tools-censor-url-sensitive-params.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/tools': patch
+---
+
+fix: Redact additional sensitive query parameters (`token`, `secret`, `password`, `apiKey`, `auth_token`, `authorization`, `code`) and sanitize relative URLs in `censorUrl`

--- a/packages/tools/src/censorUrl.spec.ts
+++ b/packages/tools/src/censorUrl.spec.ts
@@ -13,6 +13,24 @@ describe('censorUrl', () => {
 		expect(censorUrl(input)).toBe('/path/to/resource?query=*Redacted*&access_token=*Redacted*&foo=bar');
 	});
 
+	it('redacts path-relative URLs without a leading slash', () => {
+		expect(censorUrl('users?token=secret')).toBe('users?token=*Redacted*');
+		expect(censorUrl('next?token=secret')).toBe('next?token=*Redacted*');
+		expect(censorUrl('api/v1/users?token=secret&foo=bar')).toBe('api/v1/users?token=*Redacted*&foo=bar');
+	});
+
+	it('redacts and preserves protocol-relative URLs', () => {
+		expect(censorUrl('//example.com/path?token=secret')).toBe('//example.com/path?token=*Redacted*');
+		expect(censorUrl('//user:pass@example.com/path?token=secret')).toBe(
+			'//*Redacted*:*Redacted*@example.com/path?token=*Redacted*',
+		);
+	});
+
+	it('redacts and preserves dot-relative URLs', () => {
+		expect(censorUrl('./users?token=secret')).toBe('./users?token=*Redacted*');
+		expect(censorUrl('../../users?token=secret&foo=bar')).toBe('../../users?token=*Redacted*&foo=bar');
+	});
+
 	it('preserves non-sensitive relative URLs without modification', () => {
 		const input = '/path/to/resource?foo=bar&page=2';
 

--- a/packages/tools/src/censorUrl.spec.ts
+++ b/packages/tools/src/censorUrl.spec.ts
@@ -7,10 +7,28 @@ describe('censorUrl', () => {
 		expect(censorUrl(input)).toBe(input);
 	});
 
-	it('returns relative URLs unchanged when no base is provided', () => {
-		const input = '/path/to/resource?query=secret&access_token=token';
+	it('redacts sensitive query parameters in relative URLs', () => {
+		const input = '/path/to/resource?query=secret&access_token=token&foo=bar';
 
-		expect(censorUrl(input)).toBe(input);
+		expect(censorUrl(input)).toBe('/path/to/resource?query=*Redacted*&access_token=*Redacted*&foo=bar');
+	});
+
+	it('preserves non-sensitive relative URLs without modification', () => {
+		const input = '/path/to/resource?foo=bar&page=2';
+
+		expect(censorUrl(input)).toBe('/path/to/resource?foo=bar&page=2');
+	});
+
+	it('redacts query-only relative URLs', () => {
+		const input = '?token=secret123&foo=bar';
+
+		expect(censorUrl(input)).toBe('?token=*Redacted*&foo=bar');
+	});
+
+	it('preserves hash anchors in relative URLs while redacting parameters', () => {
+		const input = '/api/v1/users?token=secret123#profile';
+
+		expect(censorUrl(input)).toBe('/api/v1/users?token=*Redacted*#profile');
 	});
 
 	it('does not change URLs without sensitive parts', () => {
@@ -34,6 +52,22 @@ describe('censorUrl', () => {
 	it('redacts access_token even when query is absent', () => {
 		expect(censorUrl('https://example.com/path?access_token=token&foo=bar')).toBe(
 			'https://example.com/path?access_token=*Redacted*&foo=bar',
+		);
+	});
+
+	it('redacts additional sensitive parameters (token, secret, password, apiKey, auth_token, authorization, code)', () => {
+		expect(
+			censorUrl(
+				'https://example.com/api?token=tok123&secret=sec456&password=pass789&apiKey=key0&auth_token=auth1&authorization=Bearer123&code=oauthcode&userId=user1',
+			),
+		).toBe(
+			'https://example.com/api?token=*Redacted*&secret=*Redacted*&password=*Redacted*&apiKey=*Redacted*&auth_token=*Redacted*&authorization=*Redacted*&code=*Redacted*&userId=user1',
+		);
+	});
+
+	it('redacts sensitive query parameters case-insensitively', () => {
+		expect(censorUrl('https://example.com/api?TOKEN=tok123&PASSWORD=pass&ApiKey=key0&SECRET=sec')).toBe(
+			'https://example.com/api?TOKEN=*Redacted*&PASSWORD=*Redacted*&ApiKey=*Redacted*&SECRET=*Redacted*',
 		);
 	});
 

--- a/packages/tools/src/censorUrl.ts
+++ b/packages/tools/src/censorUrl.ts
@@ -1,3 +1,38 @@
+const SENSITIVE_QUERY_PARAMS = new Set([
+	'query',
+	'access_token',
+	'token',
+	'auth_token',
+	'authtoken',
+	'secret',
+	'password',
+	'apikey',
+	'api_key',
+	'authorization',
+	'code',
+]);
+
+const redactUrlParams = (parsedUrl: URL): void => {
+	if (parsedUrl.username) {
+		parsedUrl.username = '*Redacted*';
+	}
+
+	if (parsedUrl.password) {
+		parsedUrl.password = '*Redacted*';
+	}
+
+	const keysToRedact: string[] = [];
+	for (const key of parsedUrl.searchParams.keys()) {
+		if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+			keysToRedact.push(key);
+		}
+	}
+
+	for (const key of keysToRedact) {
+		parsedUrl.searchParams.set(key, '*Redacted*');
+	}
+};
+
 /**
  * Redacts sensitive information from a URL string.
  *
@@ -5,7 +40,7 @@
  * It redacts the following URL components:
  * - Username in the authentication section
  * - Password in the authentication section
- * - Query parameters named: 'query', 'access_token'
+ * - Sensitive query parameters: 'query', 'access_token', 'token', 'auth_token', 'authtoken', 'secret', 'password', 'apikey', 'api_key', 'authorization', 'code'
  *
  * Note: We use `*Redacted*` instead of `[Redacted]` for legibility, as `[` and `]` would be encoded by toString()
  *
@@ -21,25 +56,22 @@
 export function censorUrl(url: string | URL): string {
 	try {
 		const parsedUrl = new URL(url);
-
-		if (parsedUrl.username) {
-			parsedUrl.username = '*Redacted*';
-		}
-
-		if (parsedUrl.password) {
-			parsedUrl.password = '*Redacted*';
-		}
-
-		if (parsedUrl.searchParams.has('query')) {
-			parsedUrl.searchParams.set('query', '*Redacted*');
-		}
-
-		if (parsedUrl.searchParams.has('access_token')) {
-			parsedUrl.searchParams.set('access_token', '*Redacted*');
-		}
-
+		redactUrlParams(parsedUrl);
 		return parsedUrl.toString();
 	} catch {
+		if (typeof url === 'string' && (url.startsWith('/') || url.startsWith('?') || url.startsWith('./') || url.startsWith('../'))) {
+			try {
+				const dummyBase = 'http://localhost';
+				const parsed = new URL(url, dummyBase);
+				redactUrlParams(parsed);
+				if (url.startsWith('?')) {
+					return parsed.search + parsed.hash;
+				}
+				return parsed.pathname + parsed.search + parsed.hash;
+			} catch {
+				return url.toString();
+			}
+		}
 		return url.toString();
 	}
 }

--- a/packages/tools/src/censorUrl.ts
+++ b/packages/tools/src/censorUrl.ts
@@ -54,24 +54,56 @@ const redactUrlParams = (parsedUrl: URL): void => {
  * ```
  */
 export function censorUrl(url: string | URL): string {
+	if (url instanceof URL) {
+		const parsedUrl = new URL(url.toString());
+		redactUrlParams(parsedUrl);
+		return parsedUrl.toString();
+	}
+
+	if (typeof url !== 'string') {
+		return String(url);
+	}
+
+	// 1. Protocol-relative URL: //user:pass@host/path?token=secret
+	if (url.startsWith('//')) {
+		try {
+			const parsed = new URL(`http:${url}`);
+			redactUrlParams(parsed);
+			return parsed.toString().slice(5); // remove 'http:'
+		} catch {
+			return url;
+		}
+	}
+
+	// 2. Absolute URL with scheme: https://user:pass@example.com/path?token=secret
 	try {
 		const parsedUrl = new URL(url);
 		redactUrlParams(parsedUrl);
 		return parsedUrl.toString();
 	} catch {
-		if (typeof url === 'string' && (url.startsWith('/') || url.startsWith('?') || url.startsWith('./') || url.startsWith('../'))) {
-			try {
-				const dummyBase = 'http://localhost';
-				const parsed = new URL(url, dummyBase);
-				redactUrlParams(parsed);
-				if (url.startsWith('?')) {
-					return parsed.search + parsed.hash;
-				}
-				return parsed.pathname + parsed.search + parsed.hash;
-			} catch {
-				return url.toString();
+		// 3. Relative URL (path-relative, dot-relative, root-relative, or query-only)
+		try {
+			const dummyBase = 'http://localhost';
+			const parsed = new URL(url, dummyBase);
+			redactUrlParams(parsed);
+
+			const queryIndex = url.indexOf('?');
+			const hashIndex = url.indexOf('#');
+			const splitIndex =
+				queryIndex !== -1 && hashIndex !== -1
+					? Math.min(queryIndex, hashIndex)
+					: queryIndex !== -1
+						? queryIndex
+						: hashIndex;
+
+			if (splitIndex === -1) {
+				return url;
 			}
+
+			const pathPrefix = url.slice(0, splitIndex);
+			return pathPrefix + parsed.search + parsed.hash;
+		} catch {
+			return url;
 		}
-		return url.toString();
 	}
 }

--- a/packages/tools/src/censorUrl.ts
+++ b/packages/tools/src/censorUrl.ts
@@ -54,14 +54,14 @@ const redactUrlParams = (parsedUrl: URL): void => {
  * ```
  */
 export function censorUrl(url: string | URL): string {
-	if (url instanceof URL) {
-		const parsedUrl = new URL(url.toString());
-		redactUrlParams(parsedUrl);
-		return parsedUrl.toString();
-	}
-
 	if (typeof url !== 'string') {
-		return String(url);
+		try {
+			const parsedUrl = new URL(String(url));
+			redactUrlParams(parsedUrl);
+			return parsedUrl.toString();
+		} catch {
+			return String(url);
+		}
 	}
 
 	// 1. Protocol-relative URL: //user:pass@host/path?token=secret


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes 

- Enhanced `censorUrl` in `@rocket.chat/tools` to redact additional sensitive query parameters (`token`, `secret`, `password`, `apiKey`, `api_key`, `auth_token`, `authorization`, `code`) in addition to `query` and `access_token`.
- Added case-insensitive matching for query parameters (e.g., `TOKEN`, `Password`, `ApiKey`).
- Added support for relative URLs (e.g., `/api/v1/users.getAvatar?token=secret123`, `?token=abc`, `/path?secret=xyz#profile`), preventing `new URL()` TypeErrors from bypassing redaction and leaking sensitive query tokens to server logs.
- Added comprehensive unit tests in `packages/tools/src/censorUrl.spec.ts` covering all new sensitive parameters, relative URLs, hash anchors, and edge cases.
- Added changeset patch file for `@rocket.chat/tools`.

## Issue(s)

Closes #42026

## Steps to test or reproduce

Run the unit test suite for `@rocket.chat/tools`:

```bash
yarn workspace @rocket.chat/tools test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL sanitization by redacting a broader range of sensitive query parameters, including tokens, secrets, passwords, API keys, authorization values, and codes.
  - Sensitive parameter matching is now case-insensitive.
  - Relative, protocol-relative, query-only, and hash-containing URLs are sanitized correctly while preserving their structure.
  - Usernames and passwords embedded in URLs remain protected.
  - Unparseable URLs are handled safely without disrupting the original value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->