### PR TITLE
chore(perf): update discussion message count incrementally instead of recounting on every message

### DIFF
--- a/.changeset/discussion-message-count-increment.md
+++ b/.changeset/discussion-message-count-increment.md
@@ -1,0 +1,7 @@
+---
+'@rocket.chat/model-typings': patch
+'@rocket.chat/models': patch
+'@rocket.chat/meteor': patch
+---
+
+Improves the performance of sending and deleting messages in discussions by updating the discussion's message counter incrementally instead of recounting hidden system messages on every message

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -154,21 +154,19 @@ settings.onReady(() => {
 	hiddenSystemMessageTypes = expandHiddenSystemMessageTypes(settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 });
 
-settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
-	const previousTypes = hiddenSystemMessageTypes;
-	const currentTypes = expandHiddenSystemMessageTypes(value);
+// sweeps are serialized so each one diffs against the baseline left by the previous one;
+// a failed sweep keeps the baseline, so the next change re-sweeps the missed diff
+let pendingSweep = Promise.resolve();
 
-	const changedTypes = previousTypes && [...previousTypes.symmetricDifference(currentTypes)];
-	if (!changedTypes?.length) {
+settings.change<MessageTypesValues[]>('Hide_System_Messages', (value) => {
+	pendingSweep = pendingSweep.then(async () => {
+		const currentTypes = expandHiddenSystemMessageTypes(value);
+		const changedTypes = hiddenSystemMessageTypes && [...hiddenSystemMessageTypes.symmetricDifference(currentTypes)];
+
+		if (changedTypes?.length && !(await refreshDiscussionsContainingTypes(changedTypes))) {
+			return;
+		}
+
 		hiddenSystemMessageTypes = currentTypes;
-		return;
-	}
-
-	const refreshed = await refreshDiscussionsContainingTypes(changedTypes);
-
-	// the baseline only advances when the refresh fully succeeded and no newer change already moved it,
-	// so the next change retries any missed diff instead of computing against a wrong baseline
-	if (refreshed && hiddenSystemMessageTypes === previousTypes) {
-		hiddenSystemMessageTypes = currentTypes;
-	}
+	});
 });

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -124,6 +124,30 @@ callbacks.add(
 	'CleanDiscussionMessage',
 );
 
+const refreshDiscussionsContainingTypes = async (types: MessageTypesValues[]): Promise<boolean> => {
+	try {
+		const rids = await Messages.findDiscussionRoomIdsContainingTypes(types);
+		const results = [];
+
+		for await (const room of Rooms.findDiscussionsByIds(rids, { projection: { msgs: 1, lm: 1, sysMes: 1 } })) {
+			results.push(
+				await updateAndNotifyParentRoomWithParentMessage(room).then(
+					() => true,
+					(err) => {
+						SystemLogger.error({ msg: 'Failed to refresh the message count of a discussion', err, rid: room._id });
+						return false;
+					},
+				),
+			);
+		}
+
+		return results.every(Boolean);
+	} catch (err) {
+		SystemLogger.error({ msg: 'Failed to refresh discussion message counts after hidden system messages change', err });
+		return false;
+	}
+};
+
 let hiddenSystemMessageTypes: Set<MessageTypesValues> | undefined;
 
 settings.onReady(() => {
@@ -140,15 +164,11 @@ settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
 		return;
 	}
 
-	try {
-		const rids = await Messages.findDiscussionRoomIdsContainingTypes(changedTypes);
+	const refreshed = await refreshDiscussionsContainingTypes(changedTypes);
 
-		for await (const room of Rooms.findDiscussionsByIds(rids, { projection: { msgs: 1, lm: 1, sysMes: 1 } })) {
-			await updateAndNotifyParentRoomWithParentMessage(room);
-		}
-
+	// the baseline only advances when the refresh fully succeeded and no newer change already moved it,
+	// so the next change retries any missed diff instead of computing against a wrong baseline
+	if (refreshed && hiddenSystemMessageTypes === previousTypes) {
 		hiddenSystemMessageTypes = currentTypes;
-	} catch (err) {
-		SystemLogger.error({ msg: 'Failed to refresh discussion message counts after hidden system messages change', err });
 	}
 });

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -130,10 +130,6 @@ settings.onReady(() => {
 	hiddenSystemMessageTypes = expandHiddenSystemMessageTypes(settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 });
 
-/**
- * The globally hidden system message types are an input of the incrementally maintained
- * discussion message counts, so changing them requires refreshing the stored counts.
- */
 settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
 	const previousTypes = hiddenSystemMessageTypes;
 	const currentTypes = expandHiddenSystemMessageTypes(value);
@@ -151,7 +147,6 @@ settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
 			await updateAndNotifyParentRoomWithParentMessage(room);
 		}
 
-		// only committed after a successful refresh so the next change retries any failed diff
 		hiddenSystemMessageTypes = currentTypes;
 	} catch (err) {
 		SystemLogger.error({ msg: 'Failed to refresh discussion message counts after hidden system messages change', err });

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -1,35 +1,23 @@
-import type { IRoom } from '@rocket.chat/core-typings';
+import type { MessageTypesValues } from '@rocket.chat/core-typings';
 import { Messages, Rooms, VideoConference } from '@rocket.chat/models';
-import type { Updater } from '@rocket.chat/models';
 
 import { callbacks } from '../../lib/callbacks';
-import { updateAndNotifyParentRoomWithParentMessage } from '../../lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage';
+import {
+	expandHiddenSystemMessageTypes,
+	incrementAndNotifyParentRoomWithParentMessage,
+	updateAndNotifyParentRoomWithParentMessage,
+} from '../../lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage';
 import { deleteRoom } from '../../lib/rooms/deleteRoom';
-
-/**
- * The messages count and the last message timestamp of the room are only written to the database
- * once every `afterSaveMessage` callback ran, so the changes staged for the message being saved
- * have to be applied on top of the stored room, otherwise the discussion metadata would always
- * be left one message behind.
- */
-const withPendingRoomChanges = (
-	room: Pick<IRoom, '_id' | 'msgs' | 'lm'>,
-	roomUpdater?: Updater<IRoom>,
-): Pick<IRoom, '_id' | 'msgs' | 'lm'> => {
-	const { $inc, $set } = roomUpdater?.getRawUpdateFilter() ?? {};
-	const pendingMsgs = typeof $inc?.msgs === 'number' ? $inc.msgs : 0;
-	const pendingLm = $set?.lm instanceof Date ? $set.lm : undefined;
-
-	return {
-		...room,
-		msgs: room.msgs + pendingMsgs,
-		lm: pendingLm ?? room.lm,
-	};
-};
+import { settings } from '../../settings/cached';
 
 /**
  * We need to propagate the writing of new message in a discussion to the linking
- * system message
+ * system message.
+ *
+ * The messages count and the last message timestamp of the room are only written to the database
+ * once every `afterSaveMessage` callback ran, so the changes staged for the message being saved
+ * have to be read from the updater, otherwise the discussion metadata would always be left one
+ * message behind.
  */
 callbacks.add(
 	'afterSaveMessage',
@@ -40,7 +28,6 @@ callbacks.add(
 
 		const room = await Rooms.findOneById(_id, {
 			projection: {
-				msgs: 1,
 				lm: 1,
 				sysMes: 1,
 			},
@@ -50,7 +37,11 @@ callbacks.add(
 			return message;
 		}
 
-		await updateAndNotifyParentRoomWithParentMessage(withPendingRoomChanges(room, roomUpdater));
+		const { $inc, $set } = roomUpdater?.getRawUpdateFilter() ?? {};
+		const countDelta = typeof $inc?.msgs === 'number' ? $inc.msgs : 0;
+		const lm = $set?.lm instanceof Date ? $set.lm : room.lm;
+
+		await incrementAndNotifyParentRoomWithParentMessage({ ...room, lm }, message.t, countDelta);
 
 		return message;
 	},
@@ -64,14 +55,13 @@ callbacks.add(
 		if (prid) {
 			const room = await Rooms.findOneById(_id, {
 				projection: {
-					msgs: 1,
 					lm: 1,
 					sysMes: 1,
 				},
 			});
 
 			if (room) {
-				await updateAndNotifyParentRoomWithParentMessage(room);
+				await incrementAndNotifyParentRoomWithParentMessage(room, message.t, -1);
 			}
 		}
 		if (message.drid) {
@@ -132,3 +122,35 @@ callbacks.add(
 	callbacks.priority.LOW,
 	'CleanDiscussionMessage',
 );
+
+let hiddenSystemMessageTypes: Set<MessageTypesValues> | undefined;
+
+settings.onReady(() => {
+	hiddenSystemMessageTypes = expandHiddenSystemMessageTypes(settings.get<MessageTypesValues[]>('Hide_System_Messages'));
+});
+
+/**
+ * The set of globally hidden system message types is an input of the incrementally maintained
+ * discussion messages counts, so when it changes the stored counts have to be refreshed. Only
+ * the discussions containing messages of the types whose visibility actually changed need a
+ * recount.
+ */
+settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
+	const previousTypes = hiddenSystemMessageTypes;
+	const currentTypes = expandHiddenSystemMessageTypes(value);
+	hiddenSystemMessageTypes = currentTypes;
+
+	const changedTypes = previousTypes && [...previousTypes.symmetricDifference(currentTypes)];
+	if (!changedTypes?.length) {
+		return;
+	}
+
+	const rids = await Messages.findDiscussionRoomIdsContainingTypes(changedTypes);
+	if (!rids.length) {
+		return;
+	}
+
+	for await (const room of Rooms.findDiscussionsByIds(rids, { projection: { msgs: 1, lm: 1, sysMes: 1 } })) {
+		await updateAndNotifyParentRoomWithParentMessage(room);
+	}
+});

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -130,10 +130,8 @@ settings.onReady(() => {
 });
 
 /**
- * The set of globally hidden system message types is an input of the incrementally maintained
- * discussion messages counts, so when it changes the stored counts have to be refreshed. Only
- * the discussions containing messages of the types whose visibility actually changed need a
- * recount.
+ * The globally hidden system message types are an input of the incrementally maintained
+ * discussion message counts, so changing them requires refreshing the stored counts.
  */
 settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
 	const previousTypes = hiddenSystemMessageTypes;

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -155,18 +155,22 @@ settings.onReady(() => {
 });
 
 // sweeps are serialized so each one diffs against the baseline left by the previous one;
-// a failed sweep keeps the baseline, so the next change re-sweeps the missed diff
+// types whose sweep failed stay pending and join the next diff, so they are retried even
+// if the setting rolls back to the previous value in the meantime
 let pendingSweep = Promise.resolve();
+let typesPendingRefresh = new Set<MessageTypesValues>();
 
 settings.change<MessageTypesValues[]>('Hide_System_Messages', (value) => {
 	pendingSweep = pendingSweep.then(async () => {
+		const previousTypes = hiddenSystemMessageTypes;
 		const currentTypes = expandHiddenSystemMessageTypes(value);
-		const changedTypes = hiddenSystemMessageTypes && [...hiddenSystemMessageTypes.symmetricDifference(currentTypes)];
+		hiddenSystemMessageTypes = currentTypes;
 
-		if (changedTypes?.length && !(await refreshDiscussionsContainingTypes(changedTypes))) {
+		const changedTypes = previousTypes?.symmetricDifference(currentTypes).union(typesPendingRefresh);
+		if (!changedTypes?.size) {
 			return;
 		}
 
-		hiddenSystemMessageTypes = currentTypes;
+		typesPendingRefresh = (await refreshDiscussionsContainingTypes([...changedTypes])) ? new Set() : changedTypes;
 	});
 });

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -154,9 +154,7 @@ settings.onReady(() => {
 	hiddenSystemMessageTypes = expandHiddenSystemMessageTypes(settings.get<MessageTypesValues[]>('Hide_System_Messages'));
 });
 
-// sweeps are serialized so each one diffs against the baseline left by the previous one;
-// types whose sweep failed stay pending and join the next diff, so they are retried even
-// if the setting rolls back to the previous value in the meantime
+// failed types stay pending because a rollback to the previous value alone diffs to empty and would never retry them
 let pendingSweep = Promise.resolve();
 let typesPendingRefresh = new Set<MessageTypesValues>();
 

--- a/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
+++ b/apps/meteor/server/hooks/messages/propagateDiscussionMetadata.ts
@@ -2,6 +2,7 @@ import type { MessageTypesValues } from '@rocket.chat/core-typings';
 import { Messages, Rooms, VideoConference } from '@rocket.chat/models';
 
 import { callbacks } from '../../lib/callbacks';
+import { SystemLogger } from '../../lib/logger/system';
 import {
 	expandHiddenSystemMessageTypes,
 	incrementAndNotifyParentRoomWithParentMessage,
@@ -136,19 +137,23 @@ settings.onReady(() => {
 settings.change<MessageTypesValues[]>('Hide_System_Messages', async (value) => {
 	const previousTypes = hiddenSystemMessageTypes;
 	const currentTypes = expandHiddenSystemMessageTypes(value);
-	hiddenSystemMessageTypes = currentTypes;
 
 	const changedTypes = previousTypes && [...previousTypes.symmetricDifference(currentTypes)];
 	if (!changedTypes?.length) {
+		hiddenSystemMessageTypes = currentTypes;
 		return;
 	}
 
-	const rids = await Messages.findDiscussionRoomIdsContainingTypes(changedTypes);
-	if (!rids.length) {
-		return;
-	}
+	try {
+		const rids = await Messages.findDiscussionRoomIdsContainingTypes(changedTypes);
 
-	for await (const room of Rooms.findDiscussionsByIds(rids, { projection: { msgs: 1, lm: 1, sysMes: 1 } })) {
-		await updateAndNotifyParentRoomWithParentMessage(room);
+		for await (const room of Rooms.findDiscussionsByIds(rids, { projection: { msgs: 1, lm: 1, sysMes: 1 } })) {
+			await updateAndNotifyParentRoomWithParentMessage(room);
+		}
+
+		// only committed after a successful refresh so the next change retries any failed diff
+		hiddenSystemMessageTypes = currentTypes;
+	} catch (err) {
+		SystemLogger.error({ msg: 'Failed to refresh discussion message counts after hidden system messages change', err });
 	}
 });

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -3,33 +3,32 @@ import { Messages } from '@rocket.chat/models';
 
 import { settings } from '../../../settings/cached';
 import { notifyOnMessageChange } from '../../notifyListener';
+import { expandSystemMessageOptions, shouldHideSystemMessage } from '../../systemMessage/hideSystemMessage';
 
 type DiscussionRoom = Pick<IRoom, '_id' | 'msgs' | 'lm' | 'sysMes'>;
 
 /**
- * `mute_unmute` is a single option covering two different message types, and `rm` is filtered
- * out because it's already discounted when the message is deleted.
+ * `rm` is excluded from the discount because it's already discounted when the message is deleted.
  */
-export const expandHiddenSystemMessageTypes = (types: unknown): Set<MessageTypesValues> =>
-	new Set(
-		(Array.isArray(types) ? (types as MessageTypesValues[]) : [])
-			.flatMap<MessageTypesValues>((type) => (type === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [type]))
-			.filter((type) => type !== 'rm'),
-	);
+export const expandHiddenSystemMessageTypes = (types: unknown): Set<MessageTypesValues> => {
+	const expanded = expandSystemMessageOptions(Array.isArray(types) ? (types as MessageTypesValues[]) : []);
+	expanded.delete('rm');
+
+	return expanded;
+};
 
 /**
  * Both the system messages hidden globally and the ones hidden on the room itself are
  * filtered out from the room history, so the count has to consider both of them.
  */
-const getHiddenTypesToDiscount = (room: Pick<IRoom, 'sysMes'>): MessageTypesValues[] => {
+const getRawHiddenTypes = (room: Pick<IRoom, 'sysMes'>): MessageTypesValues[] => {
 	const globalHiddenTypes = settings.get<MessageTypesValues[]>('Hide_System_Messages');
-	const roomHiddenTypes = Array.isArray(room.sysMes) ? room.sysMes : [];
 
-	return [...expandHiddenSystemMessageTypes([...(Array.isArray(globalHiddenTypes) ? globalHiddenTypes : []), ...roomHiddenTypes])];
+	return [...(Array.isArray(globalHiddenTypes) ? globalHiddenTypes : []), ...(Array.isArray(room.sysMes) ? room.sysMes : [])];
 };
 
 const getDiscussionMessagesCount = async (room: DiscussionRoom): Promise<number> => {
-	const hiddenMessageTypes = getHiddenTypesToDiscount(room);
+	const hiddenMessageTypes = [...expandHiddenSystemMessageTypes(getRawHiddenTypes(room))];
 
 	if (!hiddenMessageTypes.length) {
 		return room.msgs;
@@ -66,7 +65,7 @@ export const incrementAndNotifyParentRoomWithParentMessage = async (
 	messageType: IMessage['t'],
 	countDelta: number,
 ): Promise<void> => {
-	const isHidden = !!messageType && getHiddenTypesToDiscount(room).includes(messageType);
+	const isHidden = !!messageType && shouldHideSystemMessage(messageType, getRawHiddenTypes(room));
 
 	notifyParentMessage(await Messages.incDiscussionMetadata(room, isHidden ? 0 : countDelta));
 };

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -66,6 +66,11 @@ export const incrementAndNotifyParentRoomWithParentMessage = async (
 	countDelta: number,
 ): Promise<void> => {
 	const isHidden = !!messageType && shouldHideSystemMessage(messageType, getRawHiddenTypes(room));
+	const dcountInc = isHidden ? 0 : countDelta;
 
-	notifyParentMessage(await Messages.incDiscussionMetadata(room, isHidden ? 0 : countDelta));
+	if (!dcountInc && !room.lm) {
+		return;
+	}
+
+	notifyParentMessage(await Messages.incDiscussionMetadata(room, dcountInc));
 };

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -17,10 +17,6 @@ export const expandHiddenSystemMessageTypes = (types: unknown): Set<MessageTypes
 	return expanded;
 };
 
-/**
- * Both the system messages hidden globally and the ones hidden on the room itself are
- * filtered out from the room history, so the count has to consider both of them.
- */
 const getRawHiddenTypes = (room: Pick<IRoom, 'sysMes'>): MessageTypesValues[] => {
 	const globalHiddenTypes = settings.get<MessageTypesValues[]>('Hide_System_Messages');
 
@@ -50,10 +46,6 @@ const notifyParentMessage = (parentMessage: IMessage | null): void => {
 	});
 };
 
-/**
- * Only meant for when the set of hidden system message types changes; regular message activity
- * goes through `incrementAndNotifyParentRoomWithParentMessage` instead.
- */
 export const updateAndNotifyParentRoomWithParentMessage = async (room: DiscussionRoom): Promise<void> => {
 	const msgs = await getDiscussionMessagesCount(room);
 

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -1,4 +1,4 @@
-import type { IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
+import type { IMessage, IRoom, MessageTypesValues } from '@rocket.chat/core-typings';
 import { Messages } from '@rocket.chat/models';
 
 import { settings } from '../../../settings/cached';
@@ -7,21 +7,26 @@ import { notifyOnMessageChange } from '../../notifyListener';
 type DiscussionRoom = Pick<IRoom, '_id' | 'msgs' | 'lm' | 'sysMes'>;
 
 /**
+ * Resolves a hidden system messages setting value into the set of message types it discounts.
+ * `mute_unmute` is a single option covering two different message types, and `rm` is filtered
+ * out because it's already discounted when the message is deleted.
+ */
+export const expandHiddenSystemMessageTypes = (types: unknown): Set<MessageTypesValues> =>
+	new Set(
+		(Array.isArray(types) ? (types as MessageTypesValues[]) : [])
+			.flatMap<MessageTypesValues>((type) => (type === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [type]))
+			.filter((type) => type !== 'rm'),
+	);
+
+/**
  * Both the system messages hidden globally and the ones hidden on the room itself are
  * filtered out from the room history, so the count has to consider both of them.
- * Type `rm` is filtered out because it's already discounted when the message is deleted.
  */
-const getHiddenTypesToDiscount = (room: DiscussionRoom): MessageTypesValues[] => {
+const getHiddenTypesToDiscount = (room: Pick<IRoom, 'sysMes'>): MessageTypesValues[] => {
 	const globalHiddenTypes = settings.get<MessageTypesValues[]>('Hide_System_Messages');
-	const globallyHiddenTypes = Array.isArray(globalHiddenTypes) ? globalHiddenTypes : [];
 	const roomHiddenTypes = Array.isArray(room.sysMes) ? room.sysMes : [];
 
-	return [...new Set([...globallyHiddenTypes, ...roomHiddenTypes])]
-		.flatMap<MessageTypesValues>((type) =>
-			// `mute_unmute` is a single option covering two different message types
-			type === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [type],
-		)
-		.filter((type) => type !== 'rm');
+	return [...expandHiddenSystemMessageTypes([...(Array.isArray(globalHiddenTypes) ? globalHiddenTypes : []), ...roomHiddenTypes])];
 };
 
 const getDiscussionMessagesCount = async (room: DiscussionRoom): Promise<number> => {
@@ -36,14 +41,7 @@ const getDiscussionMessagesCount = async (room: DiscussionRoom): Promise<number>
 	return Math.max(room.msgs - hiddenMessagesCount, 0);
 };
 
-/**
- * Copies the current metadata of a discussion (messages count and last message timestamp) to the
- *  message which links to it on the parent room, and notifies the change to the clients.
- */
-export const updateAndNotifyParentRoomWithParentMessage = async (room: DiscussionRoom): Promise<void> => {
-	room.msgs = await getDiscussionMessagesCount(room);
-
-	const parentMessage = await Messages.refreshDiscussionMetadata(room);
+const notifyParentMessage = (parentMessage: IMessage | null): void => {
 	if (!parentMessage) {
 		return;
 	}
@@ -52,4 +50,31 @@ export const updateAndNotifyParentRoomWithParentMessage = async (room: Discussio
 		id: parentMessage._id,
 		data: parentMessage,
 	});
+};
+
+/**
+ * Recounts the messages of a discussion from scratch, copies its metadata (messages count and
+ * last message timestamp) to the message which links to it on the parent room, and notifies the
+ * change to the clients. Only meant for when the set of hidden system message types changes;
+ * on regular message activity use `incrementAndNotifyParentRoomWithParentMessage` instead.
+ */
+export const updateAndNotifyParentRoomWithParentMessage = async (room: DiscussionRoom): Promise<void> => {
+	const msgs = await getDiscussionMessagesCount(room);
+
+	notifyParentMessage(await Messages.refreshDiscussionMetadata({ ...room, msgs }));
+};
+
+/**
+ * Applies the metadata changes of a single discussion message (sent, edited or deleted) to the
+ * message which links to it on the parent room, and notifies the change to the clients. The
+ * count only moves if the message is visible, so hidden system messages never enter it.
+ */
+export const incrementAndNotifyParentRoomWithParentMessage = async (
+	room: Pick<IRoom, '_id' | 'lm' | 'sysMes'>,
+	messageType: IMessage['t'],
+	countDelta: number,
+): Promise<void> => {
+	const isHidden = !!messageType && getHiddenTypesToDiscount(room).includes(messageType);
+
+	notifyParentMessage(await Messages.incDiscussionMetadata(room, isHidden ? 0 : countDelta));
 };

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -7,7 +7,6 @@ import { notifyOnMessageChange } from '../../notifyListener';
 type DiscussionRoom = Pick<IRoom, '_id' | 'msgs' | 'lm' | 'sysMes'>;
 
 /**
- * Resolves a hidden system messages setting value into the set of message types it discounts.
  * `mute_unmute` is a single option covering two different message types, and `rm` is filtered
  * out because it's already discounted when the message is deleted.
  */
@@ -53,10 +52,8 @@ const notifyParentMessage = (parentMessage: IMessage | null): void => {
 };
 
 /**
- * Recounts the messages of a discussion from scratch, copies its metadata (messages count and
- * last message timestamp) to the message which links to it on the parent room, and notifies the
- * change to the clients. Only meant for when the set of hidden system message types changes;
- * on regular message activity use `incrementAndNotifyParentRoomWithParentMessage` instead.
+ * Only meant for when the set of hidden system message types changes; regular message activity
+ * goes through `incrementAndNotifyParentRoomWithParentMessage` instead.
  */
 export const updateAndNotifyParentRoomWithParentMessage = async (room: DiscussionRoom): Promise<void> => {
 	const msgs = await getDiscussionMessagesCount(room);
@@ -64,11 +61,6 @@ export const updateAndNotifyParentRoomWithParentMessage = async (room: Discussio
 	notifyParentMessage(await Messages.refreshDiscussionMetadata({ ...room, msgs }));
 };
 
-/**
- * Applies the metadata changes of a single discussion message (sent, edited or deleted) to the
- * message which links to it on the parent room, and notifies the change to the clients. The
- * count only moves if the message is visible, so hidden system messages never enter it.
- */
 export const incrementAndNotifyParentRoomWithParentMessage = async (
 	room: Pick<IRoom, '_id' | 'lm' | 'sysMes'>,
 	messageType: IMessage['t'],

--- a/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
+++ b/apps/meteor/server/lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage.ts
@@ -66,11 +66,6 @@ export const incrementAndNotifyParentRoomWithParentMessage = async (
 	countDelta: number,
 ): Promise<void> => {
 	const isHidden = !!messageType && shouldHideSystemMessage(messageType, getRawHiddenTypes(room));
-	const dcountInc = isHidden ? 0 : countDelta;
 
-	if (!dcountInc && !room.lm) {
-		return;
-	}
-
-	notifyParentMessage(await Messages.incDiscussionMetadata(room, dcountInc));
+	notifyParentMessage(await Messages.incDiscussionMetadata(room, isHidden ? 0 : countDelta));
 };

--- a/apps/meteor/server/lib/messaging/getHiddenSystemMessages.ts
+++ b/apps/meteor/server/lib/messaging/getHiddenSystemMessages.ts
@@ -1,10 +1,7 @@
 import type { MessageTypesValues, IRoom } from '@rocket.chat/core-typings';
 
-export const getHiddenSystemMessages = (room: Pick<IRoom, 'sysMes'>, hiddenSystemMessages: MessageTypesValues[]): MessageTypesValues[] => {
-	const hiddenTypes = hiddenSystemMessages.reduce((array, value): MessageTypesValues[] => {
-		const newValue: MessageTypesValues[] = value === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [value];
-		return [...array, ...newValue];
-	}, [] as MessageTypesValues[]);
+import { expandSystemMessageOptions } from '../systemMessage/hideSystemMessage';
 
-	return Array.isArray(room?.sysMes) ? room.sysMes : hiddenTypes;
+export const getHiddenSystemMessages = (room: Pick<IRoom, 'sysMes'>, hiddenSystemMessages: MessageTypesValues[]): MessageTypesValues[] => {
+	return Array.isArray(room?.sysMes) ? room.sysMes : [...expandSystemMessageOptions(hiddenSystemMessages)];
 };

--- a/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
+++ b/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
@@ -5,10 +5,25 @@ import { Messages, Rooms, Subscriptions, ReadReceipts, ReadReceiptsArchive } fro
 import { deleteRoom } from './deleteRoom';
 import { NOTIFICATION_ATTACHMENT_COLOR } from '../../../lib/constants';
 import { i18n } from '../i18n';
+import { SystemLogger } from '../logger/system';
 import { FileUpload } from '../media/file-upload';
+import { updateAndNotifyParentRoomWithParentMessage } from '../messaging/discussions/updateAndNotifyParentRoomWithParentMessage';
 import { notifyOnRoomChangedById, notifyOnSubscriptionChangedById } from '../notifyListener';
 
 const FILE_CLEANUP_BATCH_SIZE = 1000;
+
+async function refreshDiscussionMetadataOnParentRoom(rid: IRoom['_id']): Promise<void> {
+	const room = await Rooms.findOneById(rid, { projection: { prid: 1, msgs: 1, lm: 1, sysMes: 1 } });
+	if (!room?.prid) {
+		return;
+	}
+
+	try {
+		await updateAndNotifyParentRoomWithParentMessage(room);
+	} catch (err) {
+		SystemLogger.error({ msg: 'Failed to propagate discussion metadata', err, rid });
+	}
+}
 
 export async function cleanRoomHistory({
 	rid = '',
@@ -152,6 +167,8 @@ export async function cleanRoomHistory({
 		const lastMessage = await Messages.getLastVisibleUserMessageSentByRoomId(rid);
 
 		await Rooms.resetLastMessageById(rid, lastMessage, -count);
+
+		await refreshDiscussionMetadataOnParentRoom(rid);
 
 		void notifyOnRoomChangedById(rid);
 

--- a/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
+++ b/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
@@ -13,12 +13,12 @@ import { notifyOnRoomChangedById, notifyOnSubscriptionChangedById } from '../not
 const FILE_CLEANUP_BATCH_SIZE = 1000;
 
 async function refreshDiscussionMetadataOnParentRoom(rid: IRoom['_id']): Promise<void> {
-	const room = await Rooms.findOneDiscussionById(rid, { projection: { msgs: 1, lm: 1, sysMes: 1 } });
-	if (!room) {
-		return;
-	}
-
 	try {
+		const room = await Rooms.findOneDiscussionById(rid, { projection: { msgs: 1, lm: 1, sysMes: 1 } });
+		if (!room) {
+			return;
+		}
+
 		await updateAndNotifyParentRoomWithParentMessage(room);
 	} catch (err) {
 		SystemLogger.error({ msg: 'Failed to propagate discussion metadata', err, rid });

--- a/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
+++ b/apps/meteor/server/lib/rooms/cleanRoomHistory.ts
@@ -13,8 +13,8 @@ import { notifyOnRoomChangedById, notifyOnSubscriptionChangedById } from '../not
 const FILE_CLEANUP_BATCH_SIZE = 1000;
 
 async function refreshDiscussionMetadataOnParentRoom(rid: IRoom['_id']): Promise<void> {
-	const room = await Rooms.findOneById(rid, { projection: { prid: 1, msgs: 1, lm: 1, sysMes: 1 } });
-	if (!room?.prid) {
+	const room = await Rooms.findOneDiscussionById(rid, { projection: { msgs: 1, lm: 1, sysMes: 1 } });
+	if (!room) {
 		return;
 	}
 

--- a/apps/meteor/server/lib/systemMessage/hideSystemMessage.ts
+++ b/apps/meteor/server/lib/systemMessage/hideSystemMessage.ts
@@ -13,3 +13,7 @@ export const shouldHideSystemMessage = (messageType: MessageTypesValues, hideSys
 
 	return hideSystemMessage.includes(messageType) || (isMutedUnmuted(messageType) && hideSystemMessage.includes('mute_unmute'));
 };
+
+/** `mute_unmute` is a single setting option covering two different message types */
+export const expandSystemMessageOptions = (types: MessageTypesValues[]): Set<MessageTypesValues> =>
+	new Set(types.flatMap<MessageTypesValues>((type) => (type === 'mute_unmute' ? ['user-muted', 'user-unmuted'] : [type])));

--- a/apps/meteor/server/services/messages/service.ts
+++ b/apps/meteor/server/services/messages/service.ts
@@ -23,7 +23,7 @@ import { deleteMessage } from '../../lib/messages/deleteMessage';
 import { parseUrlsInMessage } from '../../lib/messages/parseUrlsInMessage';
 import { sendMessage } from '../../lib/messages/sendMessage';
 import { updateMessage } from '../../lib/messages/updateMessage';
-import { updateAndNotifyParentRoomWithParentMessage } from '../../lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage';
+import { incrementAndNotifyParentRoomWithParentMessage } from '../../lib/messaging/discussions/updateAndNotifyParentRoomWithParentMessage';
 import { executeSetReaction } from '../../lib/messaging/reactions/setReaction';
 import { notifyOnRoomChangedById, notifyOnMessageChange } from '../../lib/notifyListener';
 import { shouldBreakInVersion } from '../../lib/shouldBreakInVersion';
@@ -196,7 +196,7 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 				settings.get('Message_Read_Receipt_Enabled'),
 				extraData,
 			),
-			Rooms.findOneAndIncMsgCountById(rid, 1, { projection: { prid: 1, msgs: 1, lm: 1, sysMes: 1 } }),
+			Rooms.findOneAndIncMsgCountById(rid, 1, { projection: { prid: 1, lm: 1, sysMes: 1 } }),
 		]);
 
 		if (!insertedId) {
@@ -217,7 +217,7 @@ export class MessageService extends ServiceClassInternal implements IMessageServ
 
 		if (room?.prid) {
 			try {
-				await updateAndNotifyParentRoomWithParentMessage(room);
+				await incrementAndNotifyParentRoomWithParentMessage(room, type, 1);
 			} catch (err) {
 				SystemLogger.error({ msg: 'Failed to propagate discussion metadata', err, rid });
 			}

--- a/packages/model-typings/src/models/IMessagesModel.ts
+++ b/packages/model-typings/src/models/IMessagesModel.ts
@@ -181,6 +181,7 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 		options?: O,
 		showThreadMessages?: boolean,
 	): FindCursor<DocumentWithProjection<T, O>>;
+	findDiscussionRoomIdsContainingTypes(types: MessageTypesValues[]): Promise<IRoom['_id'][]>;
 	countVisibleByRoomIdContainingTypes(roomId: string, types: MessageTypesValues[]): Promise<number>;
 	findFilesByRoomIdPinnedTimestampAndUsers<
 		T extends Document = IMessage,
@@ -340,6 +341,7 @@ export interface IMessagesModel extends IBaseModel<IMessage> {
 	setThreadMessagesAsRead(rid: string, tmid: string, until: Date): Promise<UpdateResult | Document>;
 	updateRepliesByThreadId(tmid: string, replies: string[], ts: Date): Promise<UpdateResult>;
 	refreshDiscussionMetadata(room: Pick<IRoom, '_id' | 'msgs' | 'lm'>): Promise<null | WithId<IMessage>>;
+	incDiscussionMetadata(room: Pick<IRoom, '_id' | 'lm'>, dcountInc: number): Promise<null | WithId<IMessage>>;
 	findUnreadThreadMessagesByDate(
 		rid: string,
 		tmid: string,

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -297,6 +297,10 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		rids: string[],
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
+	findDiscussionsByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rids: string[],
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>>;
 	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		type: IRoom['t'],
 		options?: O,

--- a/packages/model-typings/src/models/IRoomsModel.ts
+++ b/packages/model-typings/src/models/IRoomsModel.ts
@@ -301,6 +301,10 @@ export interface IRoomsModel extends IBaseModel<IRoom> {
 		rids: string[],
 		options?: O,
 	): FindCursor<DocumentWithProjection<T, O>>;
+	findOneDiscussionById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		rid: string,
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null>;
 	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		type: IRoom['t'],
 		options?: O,

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -798,6 +798,26 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 		return this.find<T, O>(query, options);
 	}
 
+	findDiscussionRoomIdsContainingTypes(types: MessageTypesValues[]): Promise<IRoom['_id'][]> {
+		return this.col
+			.aggregate<{ _id: IRoom['_id'] }>([
+				{ $match: { t: { $in: types } } },
+				{ $group: { _id: '$rid' } },
+				{
+					$lookup: {
+						from: 'rocketchat_room',
+						localField: '_id',
+						foreignField: '_id',
+						pipeline: [{ $match: { prid: { $exists: true } } }, { $project: { _id: 1 } }],
+						as: 'discussion',
+					},
+				},
+				{ $match: { discussion: { $ne: [] } } },
+			])
+			.map(({ _id }) => _id)
+			.toArray();
+	}
+
 	countVisibleByRoomIdContainingTypes(roomId: string, types: MessageTypesValues[]): Promise<number> {
 		const query: Filter<IMessage> = {
 			_hidden: {
@@ -1648,6 +1668,28 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 					dcount,
 					...(dlm && { dlm }),
 				},
+			},
+			{ returnDocument: 'after' },
+		);
+	}
+
+	async incDiscussionMetadata(room: Pick<IRoom, '_id' | 'lm'>, dcountInc: number): Promise<null | WithId<IMessage>> {
+		const { _id: drid, lm: dlm } = room;
+
+		if (!dcountInc && !dlm) {
+			return null;
+		}
+
+		const query = {
+			drid,
+			$or: [{ dlm: { $exists: false } }, ...(dlm ? [{ dlm: { $lte: dlm } }] : [])],
+		};
+
+		return this.findOneAndUpdate(
+			query,
+			{
+				...(dcountInc && { $inc: { dcount: dcountInc } }),
+				...(dlm && { $set: { dlm } }),
 			},
 			{ returnDocument: 'after' },
 		);

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1676,10 +1676,6 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 	async incDiscussionMetadata(room: Pick<IRoom, '_id' | 'lm'>, dcountInc: number): Promise<null | WithId<IMessage>> {
 		const { _id: drid, lm: dlm } = room;
 
-		if (!dcountInc && !dlm) {
-			return null;
-		}
-
 		// dlm stays monotonic via $max instead of a query guard — a non-matching guard would silently drop the count delta
 		return this.findOneAndUpdate(
 			{ drid },

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1680,17 +1680,17 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 			return null;
 		}
 
-		const query = {
-			drid,
-			$or: [{ dlm: { $exists: false } }, ...(dlm ? [{ dlm: { $lte: dlm } }] : [])],
-		};
-
+		// dlm stays monotonic via $max instead of a query guard — a non-matching guard would silently drop the count delta
 		return this.findOneAndUpdate(
-			query,
-			{
-				...(dcountInc && { $inc: { dcount: dcountInc } }),
-				...(dlm && { $set: { dlm } }),
-			},
+			{ drid },
+			[
+				{
+					$set: {
+						dcount: { $max: [0, { $add: [{ $ifNull: ['$dcount', 0] }, dcountInc] }] },
+						...(dlm && { dlm: { $max: ['$dlm', dlm] } }),
+					},
+				},
+			],
 			{ returnDocument: 'after' },
 		);
 	}

--- a/packages/models/src/models/Messages.ts
+++ b/packages/models/src/models/Messages.ts
@@ -1676,7 +1676,6 @@ export class MessagesRaw extends BaseRaw<IMessage> implements IMessagesModel {
 	async incDiscussionMetadata(room: Pick<IRoom, '_id' | 'lm'>, dcountInc: number): Promise<null | WithId<IMessage>> {
 		const { _id: drid, lm: dlm } = room;
 
-		// dlm stays monotonic via $max instead of a query guard — a non-matching guard would silently drop the count delta
 		return this.findOneAndUpdate(
 			{ drid },
 			[

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1165,6 +1165,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>({ _id: { $in: roomIds }, prid: { $exists: true } }, options);
 	}
 
+	findOneDiscussionById<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		_id: IRoom['_id'],
+		options?: O,
+	): Promise<DocumentWithProjection<T, O> | null> {
+		return this.findOne<T, O>({ _id, prid: { $exists: true } }, options);
+	}
+
 	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		type: IRoom['t'],
 		options?: O,

--- a/packages/models/src/models/Rooms.ts
+++ b/packages/models/src/models/Rooms.ts
@@ -1158,6 +1158,13 @@ export class RoomsRaw extends BaseRaw<IRoom> implements IRoomsModel {
 		return this.find<T, O>({ _id: { $in: roomIds } }, options);
 	}
 
+	findDiscussionsByIds<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
+		roomIds: Array<IRoom['_id']>,
+		options?: O,
+	): FindCursor<DocumentWithProjection<T, O>> {
+		return this.find<T, O>({ _id: { $in: roomIds }, prid: { $exists: true } }, options);
+	}
+
 	findByType<T extends Document = IRoom, O extends FindOptionsWithProjection<T> = FindOptionsWithProjection<T>>(
 		type: IRoom['t'],
 		options?: O,


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Follow-up to #41673.

Since #41673, every message saved or deleted in a discussion triggered `Messages.countVisibleByRoomIdContainingTypes()` — a full `countDocuments` over the discussion's messages to subtract hidden system messages — even though only one message changed.

This PR makes the per-message path incremental and moves the full recount to the only moments the set of hidden types can actually change:

- **On message save/delete** (`propagateDiscussionMetadata.ts`, `MessageService.saveSystemMessage`): the parent message's `dcount` now moves by the same amount staged for the room's `msgs` (0 for edits, ±1 for new/deleted messages), and only when the message type is not hidden for that room. New `Messages.incDiscussionMetadata()` applies the delta through an aggregation-pipeline update that clamps `dcount` at 0 and keeps `dlm` monotonic via `$max` — no query guard, so concurrent out-of-order callbacks can never drop a delta.
- **On bulk deletions** (`cleanRoomHistory` — prune API and retention-policy cron): those paths decrement `room.msgs` without firing per-message delete callbacks, so pruning a discussion now triggers one full recount of it.
- **On the room's `systemMessages` setting save** (`saveRoomSettings.ts`): unchanged — still a full recount of that one discussion.
- **On the global `Hide_System_Messages` setting change**: a new `settings.change` watcher diffs the previous and new expanded type sets (`Set.prototype.symmetricDifference`; initial value recorded via `settings.onReady`) and recounts **only the discussions that contain messages of the types whose visibility actually changed**, resolved DB-side by the new `Messages.findDiscussionRoomIdsContainingTypes()` (`$match` + `$group` + `$lookup` on rooms' `prid`) and fetched via the new `Rooms.findDiscussionsByIds()`. Verified against mongod 7.0 with production indexes: the aggregation examines the same docs/keys as the previous `distinct()` call while returning only discussion ids.

Also removes the in-place mutation of the `room` argument in `updateAndNotifyParentRoomWithParentMessage()`.

## Issue(s)

[CORE-2616](https://rocketchat.atlassian.net/browse/CORE-2616)

Follow-up to #41673

## Steps to test or reproduce

Covered by the existing `discussion messages count` API tests from #41673 (`apps/meteor/tests/end-to-end/api/rooms.ts`): messages sent/deleted in discussions update the counter shown on the parent channel, hidden system messages are not counted, and toggling the per-room or global hidden system messages settings refreshes the counts.

## Further comments

The incremental counter can only drift if a concurrent update wins the `dlm` guard (same window that already existed for the full refresh); any drift is corrected by the recount on the next hidden-types settings change.

### Benchmark

k6 (4 VUs × 60s) posting `chat.sendMessage` into a single seeded discussion, local dev server (Meteor 3.4) + mongod 7.0 replica set with production indexes; `Hide_System_Messages` set to 5 options (incl. `mute_unmute`), rate limiter off, zero failed requests in all runs. Seeds mix hidden-type (`uj`, `ul`, `ru`, `ut`, `user-muted`, `user-unmuted`), visible-type (`au`, `r`, `wm`, `discussion-created`) and plain messages.

Full methodology, scripts (seed + k6 scenario) and per-scale results: https://gist.github.com/KevLehman/a9f3d4d4de146a66c1ed85b1d2cebc50

1M messages seeded (750k hidden-type):

| Variant | med | avg | p95 | p99 | throughput |
|---|---|---|---|---|---|
| develop (recount per message) | 382.8ms | 385.0ms | 403.4ms | 416.6ms | 10.4 msg/s |
| this PR | 41.9ms | 42.1ms | 48.4ms | 55.7ms | 94.7 msg/s |

**9.1× lower send latency and 9.1× the throughput.** The recount cost on develop grows linearly with the discussion's hidden-message count (~0.5ms per 1k hidden messages, paid on every message sent or deleted), while this PR stays flat:

| Hidden msgs in discussion | develop med | this PR med |
|---|---|---|
| 30k | 54.3ms | 41.0ms |
| 150k | 114.1ms | 42.8ms |
| 750k | 382.8ms | 41.9ms |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




[CORE-2616]: https://rocketchat.atlassian.net/browse/CORE-2616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Discussion message counts now update incrementally when messages are sent or deleted, reducing unnecessary recounting.
  * Discussion metadata is recalculated when hidden system-message settings change.
  * Room history cleanup now refreshes related discussion metadata.

* **Bug Fixes**
  * Message counters remain accurate when system messages are hidden or restored, including discussions affected by those messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->