### PR TITLE
test: cover the Markdown parser and syntax highlighting

### DIFF
--- a/apps/meteor/tests/unit/app/markdown/hljs.tests.ts
+++ b/apps/meteor/tests/unit/app/markdown/hljs.tests.ts
@@ -1,0 +1,212 @@
+import { expect } from 'chai';
+
+import { createRegister } from './markdown.mocks';
+
+const lazyLanguages: string[] = [
+	'onec',
+	'abnf',
+	'accesslog',
+	'actionscript',
+	'ada',
+	'apache',
+	'applescript',
+	'arduino',
+	'armasm',
+	'asciidoc',
+	'aspectj',
+	'autohotkey',
+	'autoit',
+	'avrasm',
+	'awk',
+	'axapta',
+	'bash',
+	'basic',
+	'bnf',
+	'brainfuck',
+	'cal',
+	'capnproto',
+	'ceylon',
+	'clean',
+	'clojure',
+	'clojure-repl',
+	'cmake',
+	'coffeescript',
+	'coq',
+	'cos',
+	'cpp',
+	'crmsh',
+	'crystal',
+	'csp',
+	'css',
+	'd',
+	'dart',
+	'delphi',
+	'diff',
+	'django',
+	'dns',
+	'dockerfile',
+	'dos',
+	'dsconfig',
+	'dts',
+	'dust',
+	'ebnf',
+	'elixir',
+	'elm',
+	'erb',
+	'erlang',
+	'excel',
+	'fix',
+	'flix',
+	'fortran',
+	'fsharp',
+	'gams',
+	'gauss',
+	'gcode',
+	'gherkin',
+	'glsl',
+	'go',
+	'golo',
+	'gradle',
+	'groovy',
+	'haml',
+	'handlebars',
+	'haskell',
+	'haxe',
+	'hsp',
+	'http',
+	'hy',
+	'inform7',
+	'ini',
+	'irpf90',
+	'java',
+	'javascript',
+	'jboss-cli',
+	'json',
+	'julia',
+	'julia-repl',
+	'kotlin',
+	'lasso',
+	'ldif',
+	'leaf',
+	'less',
+	'lisp',
+	'livecodeserver',
+	'livescript',
+	'llvm',
+	'lsl',
+	'lua',
+	'makefile',
+	'markdown',
+	'mathematica',
+	'matlab',
+	'maxima',
+	'mel',
+	'mercury',
+	'mipsasm',
+	'mizar',
+	'perl',
+	'mojolicious',
+	'monkey',
+	'moonscript',
+	'n1ql',
+	'nginx',
+	'nix',
+	'nsis',
+	'objectivec',
+	'ocaml',
+	'openscad',
+	'oxygene',
+	'parser3',
+	'pf',
+	'php',
+	'pony',
+	'powershell',
+	'processing',
+	'profile',
+	'prolog',
+	'protobuf',
+	'puppet',
+	'purebasic',
+	'python',
+	'q',
+	'qml',
+	'r',
+	'rib',
+	'roboconf',
+	'rsl',
+	'ruleslanguage',
+	'rust',
+	'scala',
+	'scheme',
+	'scilab',
+	'scss',
+	'shell',
+	'smali',
+	'smalltalk',
+	'sml',
+	'sqf',
+	'sql',
+	'stan',
+	'stata',
+	'step21',
+	'stylus',
+	'subunit',
+	'swift',
+	'taggerscript',
+	'yaml',
+	'tap',
+	'tcl',
+	'thrift',
+	'tp',
+	'twig',
+	'typescript',
+	'vala',
+	'vbnet',
+	'vbscript',
+	'verilog',
+	'vhdl',
+	'vim',
+	'x86asm',
+	'xl',
+	'xquery',
+	'zephir',
+];
+
+describe('hljs', () => {
+	describe('eagerly registered languages', () => {
+		it('should register markdown, clean and javascript when the module is loaded', () => {
+			const { registered } = createRegister();
+
+			expect(registered.map(({ name }) => name)).to.deep.equal(['markdown', 'clean', 'javascript']);
+			registered.forEach(({ definition }) => expect(definition).to.be.a('function'));
+		});
+	});
+
+	describe('register', () => {
+		lazyLanguages.forEach((lang) => {
+			it(`should register a syntax definition for '${lang}'`, async () => {
+				const { register, registered } = createRegister();
+				const eager = registered.length;
+
+				await register(lang);
+
+				expect(registered.slice(eager)).to.have.lengthOf(1);
+				expect(registered[eager].name).to.equal(lang);
+				expect(registered[eager].definition).to.be.a('function');
+			});
+		});
+
+		['', 'not-a-language'].forEach((lang) => {
+			it(`should fall back to plaintext for '${lang}'`, async () => {
+				const { register, registered } = createRegister();
+				const eager = registered.length;
+
+				await register(lang);
+
+				expect(registered.slice(eager)).to.have.lengthOf(1);
+				expect(registered[eager].name).to.equal('plaintext');
+				expect(registered[eager].definition).to.be.a('function');
+			});
+		});
+	});
+});

--- a/apps/meteor/tests/unit/app/markdown/hljs.tests.ts
+++ b/apps/meteor/tests/unit/app/markdown/hljs.tests.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { createRegister } from './markdown.mocks';
+import hljs, { register } from '../../../../app/markdown/lib/hljs';
 
 const lazyLanguages: string[] = [
 	'onec',
@@ -172,40 +172,40 @@ const lazyLanguages: string[] = [
 	'zephir',
 ];
 
+const eagerLanguages = ['markdown', 'clean', 'javascript'];
+
 describe('hljs', () => {
 	describe('eagerly registered languages', () => {
-		it('should register markdown, clean and javascript when the module is loaded', () => {
-			const { registered } = createRegister();
-
-			expect(registered.map(({ name }) => name)).to.deep.equal(['markdown', 'clean', 'javascript']);
-			registered.forEach(({ definition }) => expect(definition).to.be.a('function'));
+		eagerLanguages.forEach((lang) => {
+			it(`should register '${lang}' when the module is loaded`, () => {
+				expect(hljs.getLanguage(lang)).to.be.an('object');
+			});
 		});
 	});
 
 	describe('register', () => {
+		afterEach(() => {
+			hljs
+				.listLanguages()
+				.filter((lang) => !eagerLanguages.includes(lang))
+				.forEach((lang) => hljs.unregisterLanguage(lang));
+		});
+
 		lazyLanguages.forEach((lang) => {
 			it(`should register a syntax definition for '${lang}'`, async () => {
-				const { register, registered } = createRegister();
-				const eager = registered.length;
+				hljs.unregisterLanguage(lang);
 
 				await register(lang);
 
-				expect(registered.slice(eager)).to.have.lengthOf(1);
-				expect(registered[eager].name).to.equal(lang);
-				expect(registered[eager].definition).to.be.a('function');
+				expect(hljs.listLanguages()).to.include(lang);
 			});
 		});
 
 		['', 'not-a-language'].forEach((lang) => {
 			it(`should fall back to plaintext for '${lang}'`, async () => {
-				const { register, registered } = createRegister();
-				const eager = registered.length;
-
 				await register(lang);
 
-				expect(registered.slice(eager)).to.have.lengthOf(1);
-				expect(registered[eager].name).to.equal('plaintext');
-				expect(registered[eager].definition).to.be.a('function');
+				expect(hljs.listLanguages()).to.include('plaintext');
 			});
 		});
 	});

--- a/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
+++ b/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
@@ -1,0 +1,111 @@
+import proxyquire from 'proxyquire';
+
+export type MarkdownToken = { token: string; type?: string; text: string; noHtml?: string };
+
+export type ParsedMessage = { html?: string; msg?: string; tokens?: MarkdownToken[] };
+
+export type MarkdownOptions = { supportSchemesForLink?: string; headers?: boolean; rootUrl?: string };
+
+type MarkdownModule = {
+	Markdown: {
+		parse(text: string): string;
+		parseNotEscaped(text: string): string;
+		parseMessageNotEscaped(message: ParsedMessage): ParsedMessage;
+		mountTokensBack(message: ParsedMessage, useHtml?: boolean): ParsedMessage;
+		code(message: ParsedMessage): ParsedMessage;
+		filterMarkdownFromMessage(message: string): string;
+	};
+	filterMarkdown(message: string): string;
+	createMarkdownMessageRenderer(options: MarkdownOptions): (message?: ParsedMessage) => ParsedMessage | undefined;
+	createMarkdownNotificationRenderer(): (message: string) => string;
+};
+
+type CodeParser = (message: ParsedMessage) => ParsedMessage;
+
+let sequence = 0;
+
+export const resetTokenIds = (): void => {
+	sequence = 0;
+};
+
+const mocks = {
+	'meteor/meteor': {
+		'Meteor': {
+			absoluteUrl() {
+				return 'http://localhost:3000/';
+			},
+		},
+		'@global': true,
+	},
+	'@rocket.chat/random': {
+		'Random': {
+			id() {
+				sequence += 1;
+				return `id${String(sequence).padStart(15, '0')}`;
+			},
+		},
+		'@global': true,
+	},
+};
+
+export const { Markdown, filterMarkdown, createMarkdownMessageRenderer, createMarkdownNotificationRenderer } = proxyquire
+	.noCallThru()
+	.load('../../../../app/markdown/lib/markdown', mocks) as MarkdownModule;
+
+export const { original } = proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/original', mocks) as {
+	original: (message: ParsedMessage, options?: MarkdownOptions) => ParsedMessage;
+};
+
+export const { code } = proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/code', mocks) as {
+	code: CodeParser;
+};
+
+type LanguageDefinition = (...args: unknown[]) => unknown;
+
+type Registration = { name: string; definition: LanguageDefinition };
+
+export const createRegister = (): { register: (lang: string) => Promise<void>; registered: Registration[] } => {
+	const registered: Registration[] = [];
+
+	const hljsStub = {
+		registerLanguage: (name: string, definition: LanguageDefinition) => registered.push({ name, definition }),
+		listLanguages: () => registered.map(({ name }) => name),
+	};
+
+	const { register } = proxyquire.noCallThru().load('../../../../app/markdown/lib/hljs', {
+		'highlight.js/lib/core': { '__esModule': true, 'default': hljsStub, '@noCallThru': true },
+	});
+
+	return { register, registered };
+};
+
+export const createCodeParserWithFailingHighlighter = (): CodeParser => {
+	const hljsStub = {
+		listLanguages: () => ['javascript'],
+		highlight: () => {
+			throw new Error('highlighting failed');
+		},
+		highlightAuto: (value: string) => ({ language: 'plaintext', value }),
+	};
+
+	return (
+		proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/code', {
+			...mocks,
+			'../../hljs': { '__esModule': true, 'default': hljsStub, 'register': async () => undefined, '@noCallThru': true },
+		}) as { code: CodeParser }
+	).code;
+};
+
+const copyonly = (text: string, marker: string) => `<span class="copyonly">${marker}</span>${text}<span class="copyonly">${marker}</span>`;
+
+export const markup = {
+	bold: (text: string) => copyonly(`<strong>${text}</strong>`, '*'),
+	inlineCode: (text: string) => copyonly(`<span><code class="code-colors inline">${text}</code></span>`, '`'),
+	anchor: (url: string, title: string, target = '_blank') =>
+		`<a data-title="${url}" href="${url}" target="${target}" rel="noopener noreferrer">${title}</a>`,
+	image: (url: string, title: string, target = '_blank') =>
+		`<a data-title="${url}" href="${url}" title="${title}" target="${target}" rel="noopener noreferrer">` +
+		`<div class="inline-image" style="background-image: url(${url});"></div></a>`,
+	blockquote: (text: string, marker = '&gt;') =>
+		`<blockquote class="background-transparent-darker-before"><span class="copyonly">${marker}</span>${text}</blockquote>`,
+};

--- a/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
+++ b/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
@@ -60,25 +60,6 @@ export const { code } = proxyquire.noCallThru().load('../../../../app/markdown/l
 	code: CodeParser;
 };
 
-type LanguageDefinition = (...args: unknown[]) => unknown;
-
-type Registration = { name: string; definition: LanguageDefinition };
-
-export const createRegister = (): { register: (lang: string) => Promise<void>; registered: Registration[] } => {
-	const registered: Registration[] = [];
-
-	const hljsStub = {
-		registerLanguage: (name: string, definition: LanguageDefinition) => registered.push({ name, definition }),
-		listLanguages: () => registered.map(({ name }) => name),
-	};
-
-	const { register } = proxyquire.noCallThru().load('../../../../app/markdown/lib/hljs', {
-		'highlight.js/lib/core': { '__esModule': true, 'default': hljsStub, '@noCallThru': true },
-	});
-
-	return { register, registered };
-};
-
 export const createCodeParserWithFailingHighlighter = (): CodeParser => {
 	const hljsStub = {
 		listLanguages: () => ['javascript'],

--- a/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
+++ b/apps/meteor/tests/unit/app/markdown/markdown.mocks.ts
@@ -6,76 +6,27 @@ export type ParsedMessage = { html?: string; msg?: string; tokens?: MarkdownToke
 
 export type MarkdownOptions = { supportSchemesForLink?: string; headers?: boolean; rootUrl?: string };
 
-type MarkdownModule = {
-	Markdown: {
-		parse(text: string): string;
-		parseNotEscaped(text: string): string;
-		parseMessageNotEscaped(message: ParsedMessage): ParsedMessage;
-		mountTokensBack(message: ParsedMessage, useHtml?: boolean): ParsedMessage;
-		code(message: ParsedMessage): ParsedMessage;
-		filterMarkdownFromMessage(message: string): string;
-	};
-	filterMarkdown(message: string): string;
-	createMarkdownMessageRenderer(options: MarkdownOptions): (message?: ParsedMessage) => ParsedMessage | undefined;
-	createMarkdownNotificationRenderer(): (message: string) => string;
-};
-
-type CodeParser = (message: ParsedMessage) => ParsedMessage;
-
-let sequence = 0;
-
-export const resetTokenIds = (): void => {
-	sequence = 0;
-};
-
 const mocks = {
 	'meteor/meteor': {
-		'Meteor': {
+		Meteor: {
 			absoluteUrl() {
 				return 'http://localhost:3000/';
 			},
 		},
-		'@global': true,
-	},
-	'@rocket.chat/random': {
-		'Random': {
-			id() {
-				sequence += 1;
-				return `id${String(sequence).padStart(15, '0')}`;
-			},
-		},
-		'@global': true,
 	},
 };
 
 export const { Markdown, filterMarkdown, createMarkdownMessageRenderer, createMarkdownNotificationRenderer } = proxyquire
 	.noCallThru()
-	.load('../../../../app/markdown/lib/markdown', mocks) as MarkdownModule;
+	.load('../../../../app/markdown/lib/markdown', mocks) as typeof import('../../../../app/markdown/lib/markdown');
 
 export const { original } = proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/original', mocks) as {
 	original: (message: ParsedMessage, options?: MarkdownOptions) => ParsedMessage;
 };
 
-export const { code } = proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/code', mocks) as {
-	code: CodeParser;
-};
-
-export const createCodeParserWithFailingHighlighter = (): CodeParser => {
-	const hljsStub = {
-		listLanguages: () => ['javascript'],
-		highlight: () => {
-			throw new Error('highlighting failed');
-		},
-		highlightAuto: (value: string) => ({ language: 'plaintext', value }),
-	};
-
-	return (
-		proxyquire.noCallThru().load('../../../../app/markdown/lib/parser/original/code', {
-			...mocks,
-			'../../hljs': { '__esModule': true, 'default': hljsStub, 'register': async () => undefined, '@noCallThru': true },
-		}) as { code: CodeParser }
-	).code;
-};
+export const { code } = proxyquire
+	.noCallThru()
+	.load('../../../../app/markdown/lib/parser/original/code', mocks) as typeof import('../../../../app/markdown/lib/parser/original/code');
 
 const copyonly = (text: string, marker: string) => `<span class="copyonly">${marker}</span>${text}<span class="copyonly">${marker}</span>`;
 

--- a/apps/meteor/tests/unit/app/markdown/markdown.tests.ts
+++ b/apps/meteor/tests/unit/app/markdown/markdown.tests.ts
@@ -1,0 +1,242 @@
+import { escapeHTML } from '@rocket.chat/tools';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import type { MarkdownOptions, ParsedMessage } from './markdown.mocks';
+import {
+	Markdown,
+	original,
+	code,
+	filterMarkdown,
+	createMarkdownMessageRenderer,
+	createMarkdownNotificationRenderer,
+	createCodeParserWithFailingHighlighter,
+	resetTokenIds,
+	markup,
+} from './markdown.mocks';
+
+const { bold, inlineCode, anchor, image, blockquote } = markup;
+
+const rootUrl = 'http://localhost:3000/';
+const defaultOptions = { supportSchemesForLink: 'http,https', headers: true, rootUrl };
+
+const render = (text: string, options: MarkdownOptions = defaultOptions) =>
+	Markdown.mountTokensBack(original({ html: text }, options)).html;
+const renderEscaped = (text: string, options: MarkdownOptions = defaultOptions) => render(escapeHTML(text), options);
+
+describe('Markdown entry points', () => {
+	beforeEach(resetTokenIds);
+
+	it('should escape HTML before parsing', () => {
+		expect(Markdown.parse('<img src=x onerror=alert(1)> *Hello*')).to.equal(`&lt;img src=x onerror=alert(1)&gt; ${bold('Hello')}`);
+	});
+
+	it('should keep HTML when parsing unescaped input', () => {
+		expect(Markdown.parseNotEscaped('<b>x</b> *Hello*')).to.equal(`<b>x</b> ${bold('Hello')}`);
+	});
+
+	it('should leave the tokens unmounted when parsing a message', () => {
+		const message = Markdown.parseMessageNotEscaped({ html: '`code`' });
+
+		expect(message.tokens).to.have.lengthOf(1);
+		expect(message.tokens?.[0].type).to.equal('inlinecode');
+		expect(message.html).to.equal(message.tokens?.[0].token);
+	});
+
+	it('should expose the code parser', () => {
+		const message = Markdown.code({ html: '`code`' });
+
+		expect(Markdown.mountTokensBack(message).html).to.equal(inlineCode('code'));
+	});
+
+	it('should strip the markdown syntax when filtering', () => {
+		expect(Markdown.filterMarkdownFromMessage('*Hello* `there`')).to.equal('Hello there');
+		expect(filterMarkdown('*Hello* `there`')).to.equal('Hello there');
+	});
+});
+
+describe('Markdown token restoration', () => {
+	beforeEach(resetTokenIds);
+
+	it('should return the message untouched when it has no tokens', () => {
+		const message = { html: 'plain text' };
+
+		expect(Markdown.mountTokensBack(message)).to.equal(message);
+		expect(message.html).to.equal('plain text');
+	});
+
+	it('should restore the plain text representation when useHtml is false', () => {
+		const message = Markdown.parseMessageNotEscaped({ html: 'see `code`' });
+
+		expect(Markdown.mountTokensBack(message, false).html).to.equal('see `code`');
+	});
+
+	it('should restore tokens that are only revealed by another token', () => {
+		const message = {
+			html: 'start =!=outer=!=',
+			tokens: [
+				{ token: '=!=inner=!=', text: '<em>inner</em>' },
+				{ token: '=!=outer=!=', text: '<b>=!=inner=!=</b>' },
+			],
+		};
+
+		expect(Markdown.mountTokensBack(message).html).to.equal('start <b><em>inner</em></b>');
+	});
+
+	it('should leave tokens that never appear in the message', () => {
+		const message = {
+			html: 'start =!=present=!=',
+			tokens: [
+				{ token: '=!=absent=!=', text: '<em>absent</em>' },
+				{ token: '=!=present=!=', text: '<b>present</b>' },
+			],
+		};
+
+		expect(Markdown.mountTokensBack(message).html).to.equal('start <b>present</b>');
+	});
+
+	it('should not treat $ sequences in the token text as replacement patterns', () => {
+		const message = { html: '=!=t=!=', tokens: [{ token: '=!=t=!=', text: '$& $1 $$' }] };
+
+		expect(Markdown.mountTokensBack(message).html).to.equal('$& $1 $$');
+	});
+});
+
+describe('Markdown renderers', () => {
+	beforeEach(resetTokenIds);
+
+	const renderMessage = createMarkdownMessageRenderer({
+		rootUrl: 'http://localhost:3000/',
+		supportSchemesForLink: 'http,https',
+		headers: true,
+	});
+
+	it('should render markdown of a non-empty message', () => {
+		expect(renderMessage({ html: '# Hello' })?.html).to.equal('<h1>Hello</h1>');
+	});
+
+	const emptyMessages: (ParsedMessage | undefined)[] = [undefined, { html: '' }, { html: '   \n\t ' }];
+
+	emptyMessages.forEach((message, index) => {
+		it(`should return the message as-is when there is nothing to render (case ${index})`, () => {
+			expect(renderMessage(message)).to.equal(message);
+		});
+	});
+
+	it('should strip the markdown syntax when rendering a notification', () => {
+		expect(createMarkdownNotificationRenderer()('*Hello* there')).to.equal('Hello there');
+	});
+});
+
+describe('Original parser', () => {
+	beforeEach(resetTokenIds);
+
+	it('should convert every new line to a <br>', () => {
+		expect(render('a\nb\nc')).to.equal('a<br>b<br>c');
+	});
+
+	it('should not render headings when the option is disabled', () => {
+		expect(render('# Hello', { ...defaultOptions, headers: false })).to.equal('# Hello');
+	});
+
+	describe('blockquotes', () => {
+		it('should render consecutive single-line blockquotes without a line break in between', () => {
+			expect(renderEscaped('>a\n>b')).to.equal(`${blockquote('a')}${blockquote('b')}`);
+		});
+
+		it('should render a multiline blockquote delimited by >>> and <<<', () => {
+			expect(renderEscaped('>>>\nline1\nline2\n<<<')).to.equal(
+				blockquote('line1<br>line2<span class="copyonly">&lt;&lt;&lt;</span>', '&gt;&gt;&gt;'),
+			);
+		});
+	});
+
+	describe('links', () => {
+		it('should render an internal link without a target', () => {
+			expect(render(`[Home](${rootUrl}channel/general)`)).to.equal(anchor(`${rootUrl}channel/general`, 'Home', ''));
+			expect(render(`<${rootUrl}channel/general|Home>`)).to.equal(anchor(`${rootUrl}channel/general`, 'Home', ''));
+		});
+
+		it('should not render a link whose URL is not parseable', () => {
+			expect(render('[Text](http://[)')).to.equal('[Text](http://[)');
+			expect(render('<http://[|Text>')).to.equal('<http://[|Text>');
+		});
+
+		it('should not render a link whose URL contains another token', () => {
+			expect(render('[Text](http://example.com/`code`)')).to.equal(`[Text](http://example.com/${inlineCode('code')})`);
+		});
+
+		it('should not render a link whose title holds a disallowed token', () => {
+			expect(render('[`code`](http://example.com/)')).to.equal(`[${inlineCode('code')}](http://example.com/)`);
+			expect(render('<http://example.com/|`code`>')).to.equal(`<http://example.com/|${inlineCode('code')}>`);
+		});
+
+		it('should render a link whose title only looks like a token', () => {
+			expect(render('[=!=abcdefghijklmnopq=!=](http://example.com/)')).to.equal(anchor('http://example.com/', '=!=abcdefghijklmnopq=!='));
+		});
+
+		it('should only render the schemes it was configured with', () => {
+			expect(render('[Text](ftp://example.com/)', { ...defaultOptions, supportSchemesForLink: 'ftp' })).to.equal(
+				anchor('ftp://example.com/', 'Text'),
+			);
+			expect(render('[Text](http://example.com/)', { ...defaultOptions, supportSchemesForLink: 'ftp' })).to.equal(
+				'[Text](http://example.com/)',
+			);
+		});
+	});
+
+	describe('images', () => {
+		it('should render an external image with target _blank', () => {
+			expect(render('![alt](http://example.com/a.png)')).to.equal(image('http://example.com/a.png', 'alt'));
+		});
+
+		it('should render an internal image without a target', () => {
+			expect(render(`![alt](${rootUrl}a.png)`)).to.equal(image(`${rootUrl}a.png`, 'alt', ''));
+		});
+
+		it('should not render an image whose URL is not parseable', () => {
+			expect(render('![alt](http://[)')).to.equal('![alt](http://[)');
+		});
+
+		it('should not render an image whose title holds a disallowed token', () => {
+			expect(render('![`code`](http://example.com/a.png)')).to.equal(`![${inlineCode('code')}](http://example.com/a.png)`);
+		});
+	});
+});
+
+describe('Code parser', () => {
+	beforeEach(resetTokenIds);
+
+	it('should leave a message without code untouched', () => {
+		expect(code({ html: 'no code here' }).tokens).to.be.undefined;
+		expect(code({}).html).to.be.undefined;
+	});
+
+	it('should close an unclosed code block in both html and msg', () => {
+		const message: ParsedMessage = { html: '```code', msg: '```code' };
+
+		code(message);
+
+		expect(message.msg).to.equal('```code\n```');
+		expect(message.html).to.equal(message.tokens?.[0].token);
+	});
+
+	it('should restore the original fenced block when tokens are mounted back as text', () => {
+		const message = original({ html: '```\ncode\n```' }, defaultOptions);
+
+		expect(Markdown.mountTokensBack(message, false).html).to.equal('```\ncode\n```');
+	});
+
+	it('should fall back to automatic highlighting when highlighting the explicit language fails', () => {
+		const consoleError = sinon.stub(console, 'error');
+
+		try {
+			const message = createCodeParserWithFailingHighlighter()({ html: '```javascript\nvar a;\n```' });
+
+			expect(message.tokens?.[0].text).to.contain("code-colors hljs plaintext'");
+			expect(consoleError.calledOnce).to.be.true;
+		} finally {
+			consoleError.restore();
+		}
+	});
+});

--- a/apps/meteor/tests/unit/app/markdown/markdown.tests.ts
+++ b/apps/meteor/tests/unit/app/markdown/markdown.tests.ts
@@ -10,10 +10,9 @@ import {
 	filterMarkdown,
 	createMarkdownMessageRenderer,
 	createMarkdownNotificationRenderer,
-	createCodeParserWithFailingHighlighter,
-	resetTokenIds,
 	markup,
 } from './markdown.mocks';
+import hljs from '../../../../app/markdown/lib/hljs';
 
 const { bold, inlineCode, anchor, image, blockquote } = markup;
 
@@ -25,8 +24,6 @@ const render = (text: string, options: MarkdownOptions = defaultOptions) =>
 const renderEscaped = (text: string, options: MarkdownOptions = defaultOptions) => render(escapeHTML(text), options);
 
 describe('Markdown entry points', () => {
-	beforeEach(resetTokenIds);
-
 	it('should escape HTML before parsing', () => {
 		expect(Markdown.parse('<img src=x onerror=alert(1)> *Hello*')).to.equal(`&lt;img src=x onerror=alert(1)&gt; ${bold('Hello')}`);
 	});
@@ -56,8 +53,6 @@ describe('Markdown entry points', () => {
 });
 
 describe('Markdown token restoration', () => {
-	beforeEach(resetTokenIds);
-
 	it('should return the message untouched when it has no tokens', () => {
 		const message = { html: 'plain text' };
 
@@ -103,8 +98,6 @@ describe('Markdown token restoration', () => {
 });
 
 describe('Markdown renderers', () => {
-	beforeEach(resetTokenIds);
-
 	const renderMessage = createMarkdownMessageRenderer({
 		rootUrl: 'http://localhost:3000/',
 		supportSchemesForLink: 'http,https',
@@ -129,8 +122,6 @@ describe('Markdown renderers', () => {
 });
 
 describe('Original parser', () => {
-	beforeEach(resetTokenIds);
-
 	it('should convert every new line to a <br>', () => {
 		expect(render('a\nb\nc')).to.equal('a<br>b<br>c');
 	});
@@ -205,8 +196,6 @@ describe('Original parser', () => {
 });
 
 describe('Code parser', () => {
-	beforeEach(resetTokenIds);
-
 	it('should leave a message without code untouched', () => {
 		expect(code({ html: 'no code here' }).tokens).to.be.undefined;
 		expect(code({}).html).to.be.undefined;
@@ -229,14 +218,18 @@ describe('Code parser', () => {
 
 	it('should fall back to automatic highlighting when highlighting the explicit language fails', () => {
 		const consoleError = sinon.stub(console, 'error');
+		const highlight = sinon.stub(hljs, 'highlight').throws(new Error('highlighting failed'));
+		const highlightAuto = sinon.spy(hljs, 'highlightAuto');
 
 		try {
-			const message = createCodeParserWithFailingHighlighter()({ html: '```javascript\nvar a;\n```' });
+			const message = code({ html: '```javascript\nvar a;\n```' });
 
-			expect(message.tokens?.[0].text).to.contain("code-colors hljs plaintext'");
+			expect(highlight.args).to.deep.equal([['javascript', 'var a;\n']]);
+			expect(highlightAuto.calledOnce).to.be.true;
+			expect(message.tokens?.[0].text).to.contain(`code-colors hljs ${highlightAuto.firstCall.returnValue.language}'`);
 			expect(consoleError.calledOnce).to.be.true;
 		} finally {
-			consoleError.restore();
+			sinon.restore();
 		}
 	});
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Unit tests for `apps/meteor/app/markdown`, the legacy Markdown library — still the renderer behind email notification bodies, push/desktop notification text, thread titles and message previews. No production code touched.

Covers what the existing `client.tests.js` does not reach: the lazy syntax-language registration (167 mappings, parameterized), the `MarkdownClass` entry points and renderer factories, token restoration, blockquotes, links and images (internal, invalid URL, disallowed embedded token), URL schemes, unclosed code blocks and the highlighting-failure fallback.

`markdown.mocks.ts` stubs `highlight.js/lib/core` when exercising the language registration — the real core is a process-wide singleton, and registering into it would change what `highlightAuto` picks in the existing tests. The dynamic `import()` of each language module stays real.

| File | Lines before | Lines after |
|---|---:|---:|
| **all `app/markdown`** | **46.93%** | **99.73%** |
| `lib/hljs.js` | 6.14% | 99.44% |
| `lib/markdown.js` | 58.33% | 100% |
| `lib/parser/original/markdown.js` | 85.54% | 100% |

## Issue(s)

- [CORE-2605](https://rocketchat.atlassian.net/browse/CORE-2605)

## Steps to test or reproduce

```bash
cd apps/meteor && yarn .testunit:server
```

2470 passing, 0 failing (2265 before — 205 tests added).

## Further comments

Pre-existing defects found while writing the tests, none fixed here:

1. `server/lib/messaging/markdown.ts` builds its parser options as `{ rootUrl }` only, dropping `supportSchemesForLink` and `headers`. That renderer is the one wired to `renderMessage`, consumed only by `notifications/message/email.js` — so **email notification bodies render neither headings nor links**. The only finding with visible user impact.
2. `hljs.js` registers `vbscript-html` under the name `vbscript-html(`, so it never resolves. It is the single entry excluded from the parameterized table.
3. `markdown.js` dereferences `parsers.marked`, which no longer exists; `useMarkedParser = true` would throw. No caller passes it.

[CORE-2605]: https://rocketchat.atlassian.net/browse/CORE-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for Markdown rendering, including headings, links, images, blockquotes, notifications, and message content.
  * Added validation for token restoration, code-block handling, fallback highlighting, and unclosed code blocks.
  * Added coverage for eager and lazy syntax-highlighting language registration, including plaintext fallback behavior.
  * Improved test isolation by resetting language registration state between cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
