### PR TITLE
fix: Clean up DDP publication close listeners

### DIFF
--- a/ee/apps/ddp-streamer/src/Publication.spec.ts
+++ b/ee/apps/ddp-streamer/src/Publication.spec.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events';
+
+import type { Client } from './Client';
+import { Publication } from './Publication';
+import type { Server } from './Server';
+import type { IPacket } from './types/IPacket';
+
+function makeClient(): Client {
+	return Object.assign(new EventEmitter(), {
+		subscriptions: new Map(),
+		userId: 'user1',
+		connection: {},
+	}) as unknown as Client;
+}
+
+function makeServer(): Server {
+	return {
+		nosub: jest.fn(),
+	} as unknown as Server;
+}
+
+function makePacket(id: string): IPacket {
+	return {
+		name: 'stream-notify-user',
+		id,
+		method: '',
+		msg: 'sub',
+		version: '',
+		support: [],
+		params: [],
+	};
+}
+
+describe('Publication', () => {
+	it('removes the client close listener when the publication stops', () => {
+		const client = makeClient();
+		const server = makeServer();
+		const publication = new Publication(client, makePacket('subscription'), server);
+
+		expect(client.listenerCount('close')).toBe(1);
+
+		publication.stop();
+
+		expect(client.listenerCount('close')).toBe(0);
+		expect(client.subscriptions.has('subscription')).toBe(false);
+	});
+
+	it('does not accumulate close listeners during subscription churn', () => {
+		const client = makeClient();
+		const server = makeServer();
+
+		for (let index = 0; index < 51; index++) {
+			new Publication(client, makePacket(`subscription-${index}`), server).stop();
+		}
+
+		expect(client.listenerCount('close')).toBe(0);
+		expect(client.subscriptions.size).toBe(0);
+	});
+
+	it('stops the publication when the client closes', () => {
+		const client = makeClient();
+		const packet = makePacket('subscription');
+		const publication = new Publication(client, packet, makeServer());
+		const onStop = jest.fn();
+		publication.onStop(onStop);
+
+		client.emit('close');
+
+		expect(onStop).toHaveBeenCalledWith(client, packet);
+		expect(client.listenerCount('close')).toBe(0);
+		expect(client.subscriptions.has('subscription')).toBe(false);
+	});
+});

--- a/ee/apps/ddp-streamer/src/Publication.ts
+++ b/ee/apps/ddp-streamer/src/Publication.ts
@@ -18,8 +18,13 @@ export class Publication extends EventEmitter implements IPublication {
 		super();
 		this.packet = packet;
 		client.subscriptions.set(packet.id, this);
-		client.once('close', () => this.emit('stop', this.client, this.packet));
-		this.once('stop', () => client.subscriptions.delete(packet.id));
+
+		const onClientClose = () => this.emit('stop', this.client, this.packet);
+		client.once('close', onClientClose);
+		this.once('stop', () => {
+			client.removeListener('close', onClientClose);
+			client.subscriptions.delete(packet.id);
+		});
 
 		this._session = {
 			sendAdded: this.added.bind(this),


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Remove a DDP publication's client `close` listener when the publication stops. Previously, stopped publications were removed from `client.subscriptions`, but their one-time listeners remained attached until the WebSocket closed.

This adds regression coverage for:

- explicit publication stop cleanup;
- more than 50 sequential subscribe/stop cycles;
- stopping active publications when the client closes.

## Issue(s)

Closes #42031

## Steps to test or reproduce

```shell
yarn workspace @rocket.chat/ddp-streamer test Publication.spec.ts
```

Without the fix, the explicit stop and subscription churn tests retain client `close` listeners. With the fix, the listener count returns to zero while the existing client-close behavior remains intact.

## Further comments

The runtime regression scenario was also verified with the repository's required Node.js 22.22.3. Full Jest and lint execution was not available in the local sparse checkout because Yarn validates workspace manifests outside the checked-out paths; the test is included for CI execution.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup when a client connection closes or a publication is manually stopped.
  - Prevented lingering close listeners and subscription entries during repeated start/stop activity.

- **Tests**
  - Added coverage for listener cleanup, subscription churn, and automatic stopping when the client disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->