### PR TITLE
fix: prevent recursive meteor build during Windows startup

### DIFF
--- a/apps/meteor/packages/rocketchat-livechat/plugin/build-livechat.js
+++ b/apps/meteor/packages/rocketchat-livechat/plugin/build-livechat.js
@@ -1,23 +1,49 @@
 import path from 'path';
-import { execSync } from 'child_process';
 import fs from 'fs';
-
 import UglifyJS from 'uglify-js';
 
 const livechatSource = path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocket-livechat.js');
 const livechatTarget = path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocketchat-livechat.min.js');
 
-fs.writeFileSync(livechatTarget, UglifyJS.minify(livechatSource).code);
-
-const packagePath = path.join(path.resolve('.'), 'packages', 'rocketchat-livechat');
-const pluginPath = path.join(packagePath, 'plugin');
-
-const options = {
-	env: process.env,
-};
-
-if (process.platform === 'win32') {
-	execSync(`${pluginPath}/build.bat`, options);
-} else {
-	execSync(`sh ${pluginPath}/build.sh`, options);
+try {
+	const sourceCode = fs.readFileSync(livechatSource, 'utf8');
+	const result = UglifyJS.minify(sourceCode);
+	if (result.error) {
+		throw result.error;
+	}
+	fs.writeFileSync(livechatTarget, result.code);
+} catch (e) {
+	console.error('Failed to minify livechat source:', e);
+	throw e;
 }
+
+const livechatDist = path.resolve('..', '..', 'packages', 'livechat', 'dist');
+const livechatDir = path.resolve('public', 'livechat');
+const livechatAssetsDir = path.resolve('private', 'livechat');
+
+if (fs.existsSync(livechatDist)) {
+	fs.rmSync(livechatDir, { recursive: true, force: true });
+	fs.mkdirSync(livechatDir, { recursive: true });
+
+	fs.rmSync(livechatAssetsDir, { recursive: true, force: true });
+	fs.mkdirSync(livechatAssetsDir, { recursive: true });
+
+	const files = fs.readdirSync(livechatDist);
+	const excludeMaps = (src) => !src.endsWith('.map');
+	for (const file of files) {
+		if (file.endsWith('.map')) continue;
+		const src = path.join(livechatDist, file);
+		const dest = path.join(livechatDir, file);
+		fs.cpSync(src, dest, { recursive: true, filter: excludeMaps });
+	}
+
+	const indexPath = path.join(livechatDir, 'index.html');
+	if (fs.existsSync(indexPath)) {
+		const content = fs.readFileSync(indexPath, 'utf8').replace('<!DOCTYPE', '<!doctype');
+		fs.writeFileSync(indexPath, content, 'utf8');
+		fs.writeFileSync(path.join(livechatAssetsDir, 'index.html'), content, 'utf8');
+	}
+} else {
+	console.warn(`[rocketchat:livechat] Livechat widget dist not found at ${livechatDist}. Skipping livechat asset bundling.`);
+}
+


### PR DESCRIPTION
## Description

This PR fixes a Windows development startup issue where Rocket.Chat hangs indefinitely while updating Livechat npm dependencies.

The issue causes the build process to recursively invoke `meteor build --headless`, resulting in runaway child processes and excessive CPU/memory usage. This fix prevents the recursive build execution and allows the application to start normally.

## Steps to reproduce

1. Set up the Rocket.Chat development environment on Windows.
2. Start the application using:
   `apps/meteor: meteor run --exclude-archs=web.browser.legacy,web.cordova`
3. Observe the startup process while Livechat dependencies are being updated.
4. Before the fix, the process hangs at the Livechat dependency update step.
5. Apply the fix and start the application again.
6. Verify that the application starts successfully at `http://localhost:3000`.

## Current behavior

Before the fix, the application hangs indefinitely while updating Livechat dependencies. `build.bat` fails to `cd` into the non-existent `packages/rocketchat-livechat/.app` directory, causing `meteor build --headless` to be executed recursively on `apps/meteor`.

This results in runaway child processes that continuously consume CPU and memory until the system becomes unresponsive.

### Before Fix — Terminal Output

<details>
<summary><b>Startup hangs indefinitely</b></summary>

```text
> apps/meteor: meteor run --exclude-archs=web.browser.legacy,web.cordova

modern.webArchOnly and --exclude-archs are both active. If both are set, --exclude-archs takes priority.
[[[[[ C:\Users\...\Rocket.Chat\apps\meteor ]]]]]

=> Started proxy.
Livechat: updating npm dependencies -- uglify-js...

# [PROCESS HANGS INDEFINITELY AT THIS STEP]
# `build.bat` fails to cd into non-existent `packages/rocketchat-livechat/.app`
# Executes `meteor build --headless` recursively on `apps/meteor` inside the build plugin.
# Runaway recursive child processes spawn in Task Manager, consuming CPU/RAM until freezing or crashing.

### After Fix — Terminal Output

> apps/meteor: meteor run --exclude-archs=web.browser.legacy,web.cordova

modern.webArchOnly and --exclude-archs are both active. If both are set, --exclude-archs takes priority.
[[[[[ C:\Users\...\Rocket.Chat\apps\meteor ]]]]]

=> Started proxy.
=> Meteor 3.5 is available. Check the changelog https://docs.meteor.com/history.html and update this project with 'meteor update'.
Processing file /app/utils/rocketchat-supported-versions.info
Processed file /app/utils/rocketchat-supported-versions.info
Processing file /app/utils/rocketchat.info
Processed file /app/utils/rocketchat.info
=> Linted your app. No linting errors.

[2026-09-02T14:56:42.372Z] INFO  TRANSPORTER: TCP Transporter started.
[2026-09-02T14:56:42.879Z] INFO  BROKER: ✔ ServiceBroker with 2 service(s) started successfully in 509ms.
{"level":30,"time":"2026-09-02T14:56:46.387Z","name":"homeserver","name":"EventService","msg":"Processing old staged events on startup"}
{"level":30,"time":"2026-09-02T14:56:46.395Z","name":"homeserver","name":"EventService","msg":"No old staged events found to process"}

=> App running at: http://localhost:3000/



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Livechat asset generation by reporting minification failures clearly.
  * Ensured generated Livechat assets are refreshed consistently while excluding source maps.
  * Standardized the HTML document declaration in the Livechat entry page.
  * Added safeguards and warnings when expected Livechat distribution assets are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->