### PR TITLE
fix: prevent recursive meteor build during Windows startup

### DIFF
--- a/apps/meteor/packages/rocketchat-livechat/plugin/build-livechat.js
+++ b/apps/meteor/packages/rocketchat-livechat/plugin/build-livechat.js
@@ -1,23 +1,49 @@
 import path from 'path';
-import { execSync } from 'child_process';
 import fs from 'fs';
-
 import UglifyJS from 'uglify-js';
 
 const livechatSource = path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocket-livechat.js');
 const livechatTarget = path.resolve('packages', 'rocketchat-livechat', 'assets', 'rocketchat-livechat.min.js');
 
-fs.writeFileSync(livechatTarget, UglifyJS.minify(livechatSource).code);
-
-const packagePath = path.join(path.resolve('.'), 'packages', 'rocketchat-livechat');
-const pluginPath = path.join(packagePath, 'plugin');
-
-const options = {
-	env: process.env,
-};
-
-if (process.platform === 'win32') {
-	execSync(`${pluginPath}/build.bat`, options);
-} else {
-	execSync(`sh ${pluginPath}/build.sh`, options);
+try {
+	const sourceCode = fs.readFileSync(livechatSource, 'utf8');
+	const result = UglifyJS.minify(sourceCode, { fromString: true });
+	if (result.error) {
+		throw result.error;
+	}
+	fs.writeFileSync(livechatTarget, result.code);
+} catch (e) {
+	console.error('Failed to minify livechat source:', e);
+	throw e;
 }
+
+const livechatDist = path.resolve('..', '..', 'packages', 'livechat', 'dist');
+const livechatDir = path.resolve('public', 'livechat');
+const livechatAssetsDir = path.resolve('private', 'livechat');
+
+if (fs.existsSync(livechatDist)) {
+	fs.rmSync(livechatDir, { recursive: true, force: true });
+	fs.mkdirSync(livechatDir, { recursive: true });
+
+	fs.rmSync(livechatAssetsDir, { recursive: true, force: true });
+	fs.mkdirSync(livechatAssetsDir, { recursive: true });
+
+	const files = fs.readdirSync(livechatDist);
+	const excludeMaps = (src) => !src.endsWith('.map');
+	for (const file of files) {
+		if (file.endsWith('.map')) continue;
+		const src = path.join(livechatDist, file);
+		const dest = path.join(livechatDir, file);
+		fs.cpSync(src, dest, { recursive: true, filter: excludeMaps });
+	}
+
+	const indexPath = path.join(livechatDir, 'index.html');
+	if (fs.existsSync(indexPath)) {
+		const content = fs.readFileSync(indexPath, 'utf8').replace('<!DOCTYPE', '<!doctype');
+		fs.writeFileSync(indexPath, content, 'utf8');
+		fs.writeFileSync(path.join(livechatAssetsDir, 'index.html'), content, 'utf8');
+	}
+} else {
+	console.warn(`[rocketchat:livechat] Livechat widget dist not found at ${livechatDist}. Skipping livechat asset bundling.`);
+}
+


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

This PR fixes a Windows development startup issue where the Rocket.Chat application could hang indefinitely during the Livechat dependency update phase.

The issue was caused by the build process recursively triggering `meteor build --headless`, resulting in runaway child processes and preventing the application from completing startup.

The build flow has been updated to prevent this recursive execution and allow the development server to start normally.

## Issue(s)

Closes #ISSUE_NUMBER

## Steps to test or reproduce

1. Set up the Rocket.Chat development environment on Windows.
2. Start the application using the development startup command.
3. Observe the startup process during the Livechat dependency update.
4. Verify that the application completes startup and is available at `http://localhost:3000`.

## Current behavior

Before the fix, the startup process gets stuck while updating the Livechat dependencies:

```text
=> Started proxy.

Livechat: updating npm dependencies -- uglify-js...
```

At this point, the process can hang indefinitely and recursively spawn additional Meteor/build processes, resulting in increasing CPU and memory usage.

## Expected behavior

The application should complete the startup process without recursively spawning build processes and should become available at:

```text
http://localhost:3000
```

## Proposed fix

The build flow has been changed to prevent the recursive `meteor build --headless` execution responsible for the startup hang.

### Before Fix

<details>
<summary><b>Application hangs during startup</b></summary>

```text
=> apps/meteor: meteor run --exclude-archs=web.browser.legacy,web.browser.cordova

modern.webArchOnly and --exclude-archs are both active. If both are set,
--exclude-archs takes priority.

[[[[[ C:\Users\...\Rocket.Chat\apps\meteor ]]]]]

=> Started proxy.

Livechat: updating npm dependencies -- uglify-js...

# Process hangs indefinitely at this step.
# Recursive Meteor/build processes are spawned.
```

</details>

### After Fix

<details>
<summary><b>Application starts successfully</b></summary>

```text
Processing file /app/utils/rocketchat-supported-versions.info
Processed file /app/utils/rocketchat-supported-versions.info
Processing file /app/utils/rocketchat.info
Processed file /app/utils/rocketchat.info

=> Linted your app. No linting errors.

[INFO] TRANSPORTER: TCP Transporter started.
[INFO] BROKER: ✔ ServiceBroker with 2 service(s) started successfully.

{"level":30,"name":"homeserver","name":"EventService",
"msg":"Processing old staged events on startup"}

=> App running at http://localhost:3000

Started your app.
```

</details>

### Verification

The startup behavior was verified after applying the fix:

- The application no longer hangs during the startup process.
- No recursive build loop is triggered.
- Linting completes successfully with no errors.
- Required services start successfully.
- The Rocket.Chat application starts and becomes available at `http://localhost:3000`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Livechat asset packaging to produce more reliable builds and deployments.
  - Added clearer handling for build failures and unavailable Livechat distribution files.
  - Ensured generated Livechat assets are copied consistently across supported environments.
  - Source map files are excluded from packaged Livechat assets, and the Livechat entry page receives consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->