### PR TITLE
feat: flush stored drafts upon message send

### DIFF
--- a/.changeset/large-spies-raise.md
+++ b/.changeset/large-spies-raise.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Improves draft handling by discarding the stored draft as soon as a message is sent, instead of keeping it until the room is changed

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.spec.tsx
@@ -1,0 +1,110 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import MessageBox from './MessageBox';
+import type { createComposerAPI } from './createComposerAPI';
+import type { ChatAPI } from '../../../../lib/chats/ChatAPI';
+import { useFileUpload } from '../../body/hooks/useFileUpload';
+import { useChat } from '../../contexts/ChatContext';
+import { useComposerPopupOptions } from '../../contexts/ComposerPopupContext';
+import { useRoom, useRoomSubscription } from '../../contexts/RoomContext';
+
+jest.mock('../../../../lib/rooms/roomCoordinator', () => ({
+	roomCoordinator: { getRoomDirectives: () => ({ canSendMessage: () => true }) },
+}));
+jest.mock('../../../../lib/getURL', () => ({ getURL: (url: string) => url }));
+jest.mock('../../hooks/useE2EERoomState', () => ({ useE2EERoomState: jest.fn() }));
+jest.mock('../../contexts/ChatContext', () => ({ useChat: jest.fn() }));
+jest.mock('../../contexts/RoomContext', () => ({ useRoom: jest.fn(), useRoomSubscription: jest.fn() }));
+jest.mock('../../contexts/ComposerPopupContext', () => ({ useComposerPopupOptions: jest.fn() }));
+jest.mock('../../body/hooks/useFileUpload', () => ({ useFileUpload: jest.fn() }));
+
+const createChatStub = () => {
+	const chat = {
+		composer: undefined as ReturnType<typeof createComposerAPI> | undefined,
+		setComposerAPI: (composer?: ReturnType<typeof createComposerAPI>) => {
+			chat.composer?.release();
+			chat.composer = composer;
+		},
+		currentEditingMessage: { getMID: () => undefined },
+		action: { start: jest.fn(), stop: jest.fn(), performContinuously: jest.fn() },
+		emojiPicker: { open: jest.fn(), close: jest.fn() },
+		flows: {},
+	};
+
+	return chat as unknown as ChatAPI & { composer?: ReturnType<typeof createComposerAPI> };
+};
+
+const renderMessageBox = (onSend: jest.Mock, endpointHandler: jest.Mock) => {
+	const chat = createChatStub();
+
+	(useChat as jest.Mock).mockReturnValue(chat);
+
+	const view = render(<MessageBox showFormattingTips={false} onSend={onSend} />, {
+		wrapper: mockAppRoot().withUserPreference('sendOnEnter', 'normal').withEndpoint('POST', '/v1/rooms.saveDraft', endpointHandler).build(),
+	});
+
+	return { chat, ...view };
+};
+
+beforeEach(() => {
+	(useRoom as jest.Mock).mockReturnValue({ _id: 'rid', t: 'c', name: 'general' });
+	(useRoomSubscription as jest.Mock).mockReturnValue({ rid: 'rid' });
+	(useComposerPopupOptions as jest.Mock).mockReturnValue([]);
+	(useFileUpload as jest.Mock).mockReturnValue({
+		hasUploads: false,
+		handleUploadFiles: jest.fn(),
+		isUploading: false,
+		isProcessingUploads: false,
+	});
+});
+
+afterEach(() => {
+	localStorage.clear();
+	jest.clearAllMocks();
+});
+
+describe('MessageBox drafts', () => {
+	it('should not discard a newer draft when a pending send resolves after the room changed', async () => {
+		const user = userEvent.setup();
+		const endpointHandler = jest.fn(() => null);
+
+		let resolveSend: (() => void) | undefined;
+		// Mirrors the real send flow: it clears the composer, then awaits the server response.
+		const onSend = jest.fn(() => {
+			chat.composer?.clear();
+
+			return new Promise<void>((resolve) => {
+				resolveSend = () => resolve();
+			});
+		});
+
+		const { chat, unmount } = renderMessageBox(onSend, endpointHandler);
+
+		const composer = screen.getByRole('textbox', { name: 'Message #general' });
+
+		// Send a message and keep its response pending.
+		await user.type(composer, 'message A');
+		// The composer listens for `which`, which userEvent does not set.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.keyDown(composer, { key: 'Enter', which: 13, keyCode: 13 });
+		await waitFor(() => expect(onSend).toHaveBeenCalledWith(expect.objectContaining({ value: 'message A' })));
+
+		// Type a new draft while the send is still in flight.
+		await user.type(composer, 'draft B');
+		await waitFor(() => expect(localStorage.getItem('messagebox_rid')).toBe('draft B'));
+
+		// Leave the room: the draft is flushed to the server on unmount.
+		unmount();
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: 'draft B' }));
+
+		// The delayed send finally resolves.
+		await act(async () => {
+			resolveSend?.();
+		});
+
+		expect(endpointHandler).toHaveBeenCalledTimes(1);
+		expect(endpointHandler).not.toHaveBeenCalledWith(expect.objectContaining({ draft: '' }));
+	});
+});

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -136,7 +136,7 @@ const MessageBox = ({
 
 	const { hasUploads, handleUploadFiles, isUploading, isProcessingUploads } = useFileUpload();
 
-	const handleSendMessage = useStableCallback(() => {
+	const handleSendMessage = useStableCallback(async () => {
 		if (isUploading || isProcessingUploads) {
 			return;
 		}
@@ -144,12 +144,14 @@ const MessageBox = ({
 		const text = chat.composer?.text ?? '';
 		popup.clear();
 
-		onSend?.({
+		await onSend?.({
 			value: text,
 			tshow,
 			previewUrls,
 			isSlashCommandAllowed,
 		});
+
+		flushDraft(chat.composer?.text ?? '');
 	});
 
 	const closeEditing = async (event: KeyboardEvent | MouseEvent<HTMLElement>) => {

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -144,14 +144,14 @@ const MessageBox = ({
 		const text = chat.composer?.text ?? '';
 		popup.clear();
 
-		await onSend?.({
+		void onSend?.({
 			value: text,
 			tshow,
 			previewUrls,
 			isSlashCommandAllowed,
+		}).then(() => {
+			flushDraft(chat.composer?.text ?? '');
 		});
-
-		flushDraft(chat.composer?.text ?? '');
 	});
 
 	const closeEditing = async (event: KeyboardEvent | MouseEvent<HTMLElement>) => {

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBox.tsx
@@ -141,7 +141,8 @@ const MessageBox = ({
 			return;
 		}
 
-		const text = chat.composer?.text ?? '';
+		const { composer } = chat;
+		const text = composer?.text ?? '';
 		popup.clear();
 
 		void onSend?.({
@@ -150,7 +151,11 @@ const MessageBox = ({
 			previewUrls,
 			isSlashCommandAllowed,
 		}).then(() => {
-			flushDraft(chat.composer?.text ?? '');
+			if (!composer) {
+				return;
+			}
+
+			flushDraft(composer.text);
 		});
 	});
 

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
@@ -369,6 +369,78 @@ describe('flushDraft', () => {
 		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
 		expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: 'typed message' });
 	});
+
+	it('should flush the given value instead of the persisted draft', async () => {
+		const { result, endpointHandler } = renderUseDraft();
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('edited message');
+		});
+
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
+		expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: 'edited message' });
+	});
+
+	it('should clear the server draft when flushed with an empty value', async () => {
+		const { result, endpointHandler } = renderUseDraft({ serverDraft: 'server draft' });
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('');
+		});
+
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
+		expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: '' });
+	});
+
+	it('should clear the server thread draft when flushed with an empty value', async () => {
+		const { result, endpointHandler } = renderUseDraft({ tmid: 'tmid', serverDraft: 'server draft' });
+
+		act(() => {
+			result.current.persistLocal('typed in thread');
+			result.current.flushDraft('');
+		});
+
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
+		expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: '', tmid: 'tmid' });
+	});
+
+	it('should remove the local copy once the draft is cleared on the server', async () => {
+		const { result } = renderUseDraft({ serverDraft: 'server draft' });
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('');
+		});
+
+		await waitFor(() => expect(readLocalDraft('rid')).toBe(null));
+	});
+
+	it('should not call the endpoint when flushing an empty value with no server draft', () => {
+		const { result, endpointHandler } = renderUseDraft();
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('');
+			result.current.flushDraft('');
+		});
+
+		expect(endpointHandler).not.toHaveBeenCalled();
+	});
+
+	it('should not flush the persisted draft after it was superseded by an explicit flush', async () => {
+		const { result, endpointHandler } = renderUseDraft();
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('sent message');
+			result.current.flushDraft();
+		});
+
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
+		expect(endpointHandler).toHaveBeenCalledWith({ rid: 'rid', draft: 'sent message' });
+	});
 });
 
 describe('referential stability', () => {

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
@@ -484,6 +484,26 @@ describe('flushDraft', () => {
 		expect(readLocalDraft('rid')).toBe('typed message');
 	});
 
+	it('should retry a draft whose save failed instead of discarding the local copy', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const endpointHandler = jest.fn(() => Promise.reject(new Error('save failed')) as unknown as null);
+		const { result } = renderUseDraft({ endpointHandler });
+
+		await act(async () => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft();
+		});
+
+		await act(async () => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft();
+		});
+
+		expect(warn).toHaveBeenCalledTimes(2);
+		expect(endpointHandler).toHaveBeenCalledTimes(2);
+		expect(readLocalDraft('rid')).toBe('typed message');
+	});
+
 	it('should not flush the persisted draft after it was superseded by an explicit flush', async () => {
 		const { result, endpointHandler } = renderUseDraft();
 

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
@@ -40,6 +40,7 @@ const renderUseDraft = ({
 
 afterEach(() => {
 	localStorage.clear();
+	jest.restoreAllMocks();
 });
 
 describe('initialValue', () => {
@@ -469,25 +470,18 @@ describe('flushDraft', () => {
 		expect(readLocalDraft('rid')).toBe('typed while sending');
 	});
 
-	it('should flush the same value again after a failed save', async () => {
+	it('should keep the local copy when the save fails', async () => {
 		const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
 		const endpointHandler = jest.fn(() => Promise.reject(new Error('save failed')) as unknown as null);
-		const { result } = renderUseDraft({ serverDraft: 'server draft', endpointHandler });
+		const { result } = renderUseDraft({ endpointHandler });
 
 		await act(async () => {
-			result.current.flushDraft('');
+			result.current.persistLocal('typed message');
+			result.current.flushDraft();
 		});
 
-		expect(endpointHandler).toHaveBeenCalledTimes(1);
 		expect(warn).toHaveBeenCalledTimes(1);
-
-		await act(async () => {
-			result.current.flushDraft('');
-		});
-
-		expect(endpointHandler).toHaveBeenCalledTimes(2);
-
-		warn.mockRestore();
+		expect(readLocalDraft('rid')).toBe('typed message');
 	});
 
 	it('should not flush the persisted draft after it was superseded by an explicit flush', async () => {

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
@@ -484,9 +484,9 @@ describe('flushDraft', () => {
 		expect(readLocalDraft('rid')).toBe('typed message');
 	});
 
-	it('should retry a draft whose save failed instead of discarding the local copy', async () => {
+	it('should retry a draft whose save failed and drop the local copy once it lands', async () => {
 		const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-		const endpointHandler = jest.fn(() => Promise.reject(new Error('save failed')) as unknown as null);
+		const endpointHandler = jest.fn().mockRejectedValueOnce(new Error('save failed')).mockResolvedValueOnce(null);
 		const { result } = renderUseDraft({ endpointHandler });
 
 		await act(async () => {
@@ -494,14 +494,17 @@ describe('flushDraft', () => {
 			result.current.flushDraft();
 		});
 
+		expect(readLocalDraft('rid')).toBe('typed message');
+
 		await act(async () => {
 			result.current.persistLocal('typed message');
 			result.current.flushDraft();
 		});
 
-		expect(warn).toHaveBeenCalledTimes(2);
+		expect(warn).toHaveBeenCalledTimes(1);
 		expect(endpointHandler).toHaveBeenCalledTimes(2);
-		expect(readLocalDraft('rid')).toBe('typed message');
+		expect(endpointHandler).toHaveBeenNthCalledWith(2, { rid: 'rid', draft: 'typed message' });
+		expect(readLocalDraft('rid')).toBe(null);
 	});
 
 	it('should not flush the persisted draft after it was superseded by an explicit flush', async () => {

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.spec.tsx
@@ -427,6 +427,67 @@ describe('flushDraft', () => {
 		});
 
 		expect(endpointHandler).not.toHaveBeenCalled();
+		expect(readLocalDraft('rid')).toBe(null);
+	});
+
+	it('should remove the local copy when the flushed value already matches the server draft', () => {
+		const { result, endpointHandler } = renderUseDraft({ serverDraft: 'server draft' });
+
+		act(() => {
+			result.current.persistLocal('typed message');
+			result.current.flushDraft('server draft');
+		});
+
+		expect(endpointHandler).not.toHaveBeenCalled();
+		expect(readLocalDraft('rid')).toBe(null);
+	});
+
+	it('should keep a draft persisted while the previous save is still in flight', async () => {
+		let resolveSave: (() => void) | undefined;
+		const endpointHandler = jest.fn(
+			() =>
+				new Promise<null>((resolve) => {
+					resolveSave = () => resolve(null);
+				}),
+		);
+		const { result } = renderUseDraft({ serverDraft: 'server draft', endpointHandler });
+
+		act(() => {
+			result.current.flushDraft('');
+		});
+
+		await waitFor(() => expect(endpointHandler).toHaveBeenCalledTimes(1));
+
+		act(() => {
+			result.current.persistLocal('typed while sending');
+		});
+
+		await act(async () => {
+			resolveSave?.();
+		});
+
+		expect(readLocalDraft('rid')).toBe('typed while sending');
+	});
+
+	it('should flush the same value again after a failed save', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+		const endpointHandler = jest.fn(() => Promise.reject(new Error('save failed')) as unknown as null);
+		const { result } = renderUseDraft({ serverDraft: 'server draft', endpointHandler });
+
+		await act(async () => {
+			result.current.flushDraft('');
+		});
+
+		expect(endpointHandler).toHaveBeenCalledTimes(1);
+		expect(warn).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			result.current.flushDraft('');
+		});
+
+		expect(endpointHandler).toHaveBeenCalledTimes(2);
+
+		warn.mockRestore();
 	});
 
 	it('should not flush the persisted draft after it was superseded by an explicit flush', async () => {

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
@@ -33,26 +33,30 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 		[setLocalDraft],
 	);
 
-	const flushDraft = useCallback(() => {
-		if (draftRef.current === null) {
-			return;
-		}
+	const flushDraft = useCallback(
+		(value?: string) => {
+			const draft = value ?? draftRef.current;
 
-		const draft = draftRef.current;
-		draftRef.current = null;
+			if (draft === null) {
+				return;
+			}
 
-		if (tmid && !threadExistsRef.current && draft) {
-			return;
-		}
+			draftRef.current = null;
 
-		if (draft === serverValueRef.current) {
-			return;
-		}
+			if (tmid && !threadExistsRef.current && draft) {
+				return;
+			}
 
-		serverValueRef.current = draft;
+			if (draft === serverValueRef.current) {
+				return;
+			}
 
-		void saveDraft({ rid, draft, ...(tmid && { tmid }) }).then(() => setLocalDraft());
-	}, [saveDraft, rid, tmid, setLocalDraft]);
+			serverValueRef.current = draft;
+
+			void saveDraft({ rid, draft, ...(tmid && { tmid }) }).then(() => setLocalDraft());
+		},
+		[saveDraft, rid, tmid, setLocalDraft],
+	);
 
 	return {
 		initialValue: initialValueRef.current,

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
@@ -52,10 +52,10 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 				return;
 			}
 
+			serverValueRef.current = draft;
+
 			void saveDraft({ rid, draft, ...(tmid && { tmid }) })
 				.then(() => {
-					serverValueRef.current = draft;
-
 					if (draftRef.current === null) {
 						setLocalDraft();
 					}

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
@@ -48,12 +48,21 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 			}
 
 			if (draft === serverValueRef.current) {
+				setLocalDraft();
 				return;
 			}
 
-			serverValueRef.current = draft;
+			void saveDraft({ rid, draft, ...(tmid && { tmid }) })
+				.then(() => {
+					serverValueRef.current = draft;
 
-			void saveDraft({ rid, draft, ...(tmid && { tmid }) }).then(() => setLocalDraft());
+					if (draftRef.current === null) {
+						setLocalDraft();
+					}
+				})
+				.catch((error) => {
+					console.warn(error);
+				});
 		},
 		[saveDraft, rid, tmid, setLocalDraft],
 	);

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
@@ -62,7 +62,10 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 					}
 				})
 				.catch((error) => {
-					serverValueRef.current = previousServerValue;
+					if (serverValueRef.current === draft) {
+						serverValueRef.current = previousServerValue;
+					}
+
 					console.warn(error);
 				});
 		},

--- a/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/hooks/useDraft.ts
@@ -52,6 +52,7 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 				return;
 			}
 
+			const previousServerValue = serverValueRef.current;
 			serverValueRef.current = draft;
 
 			void saveDraft({ rid, draft, ...(tmid && { tmid }) })
@@ -61,6 +62,7 @@ export const useDraft = (rid: string, serverDraft?: string, tmid?: string, threa
 					}
 				})
 				.catch((error) => {
+					serverValueRef.current = previousServerValue;
 					console.warn(error);
 				});
 		},


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
Drafts were only written to the server when the composer unmounted, so sending a message left the stored draft untouched and the room kept showing the draft indicator until you switched rooms.

`flushDraft` now accepts an optional value, and the send handler flushes the composer content once the send flow settles. The composer is empty by then, so the draft is discarded. If the flow deliberately left text behind, a message over `Message_MaxAllowedSize` for instance, that text is stored as the draft instead. It reuses the same path as the room change flush, so the send handler only needed one extra line.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Type a message in a room, then switch rooms so the draft is saved. The room shows the draft indicator.
2. Go back to the room and send the message.
3. The indicator goes away without leaving the room. Reload to confirm the draft is gone on the server.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

[SCC-31]

[SCC-31]: https://rocketchat.atlassian.net/browse/SCC-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drafts are now cleared after a message is successfully sent, rather than when switching rooms.
  * Clearing a draft removes its local copy and properly clears room- or thread-specific server drafts.
  * Empty drafts without a saved server version no longer trigger unnecessary updates.
  * Drafts remain available when saving fails or when newer edits are still pending.
  * Failed draft saves are retried during the next flush, while unchanged or superseded content is not reprocessed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->