### PR TITLE
test: fix flaky livechat message assertion after reload

### DIFF
--- a/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat.spec.ts
+++ b/apps/meteor/tests/e2e/omnichannel/omnichannel-livechat.spec.ts
@@ -90,10 +90,12 @@ test.describe.serial('OC - Livechat', () => {
 		});
 
 		await test.step('expect unread counter to be empty after user sends a message after reload', async () => {
+			const message = 'this_a_test_message_from_user_after_reload';
+
 			await poLiveChat.openAnyLiveChat();
-			await poLiveChat.onlineAgentMessage.fill('this_a_test_message_from_user');
+			await poLiveChat.onlineAgentMessage.fill(message);
 			await poLiveChat.btnSendMessageToOnlineAgent.click();
-			await expect(poLiveChat.txtChatMessage('this_a_test_message_from_user')).toBeVisible();
+			await expect(poLiveChat.txtChatMessage(message)).toBeVisible();
 			await expect(poLiveChat.unreadMessagesBadge(2)).toHaveCount(0);
 			await expect(poLiveChat.unreadMessagesBadge(1)).toHaveCount(0);
 		});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Stabilizes the `OC - Livechat - Send message to livechat customer` E2E test after reloading the livechat widget.

The serial suite sent `this_a_test_message_from_user` in two consecutive tests that reused the same visitor and conversation. When both messages were rendered, Playwright's strict locator matched two elements and failed. This change gives the post-reload message unique text so the assertion can only match the newly sent message.

## Issue(s)

[FLAKY-1414](https://rocketchat.atlassian.net/browse/FLAKY-1414)

## Steps to test or reproduce

Run the affected suite five times with one worker:

```sh
yarn workspace @rocket.chat/meteor test:e2e tests/e2e/omnichannel/omnichannel-livechat.spec.ts --repeat-each=5 --workers=1
```

## Further comments

This is a test-only change and does not affect product behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


[FLAKY-1414]: https://rocketchat.atlassian.net/browse/FLAKY-1414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage for Livechat unread-counter behavior after a page reload.
  - Verification now uses a distinct test message to more reliably confirm that the correct message remains visible while the unread count is cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->