### PR TITLE
fix(media-calls): fix typo in SipServerSession getContactUri method name

### DIFF
--- a/.changeset/fix-sip-getcontacturi-typo.md
+++ b/.changeset/fix-sip-getcontacturi-typo.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/media-calls': patch
+---
+
+Fix typo in SipServerSession method name `geContactUri` -> `getContactUri`

--- a/ee/packages/media-calls/src/sip/Session.spec.ts
+++ b/ee/packages/media-calls/src/sip/Session.spec.ts
@@ -1,0 +1,103 @@
+import type { MediaCallContact } from '@rocket.chat/core-typings';
+
+import { SipServerSession } from './Session';
+import type { IMediaCallServerSettings } from '../definition/IMediaCallServer';
+import { getDefaultSettings } from '../server/getDefaultSettings';
+
+jest.mock('drachtio-srf', () => {
+	return jest.fn().mockImplementation(() => ({
+		on: jest.fn(),
+		use: jest.fn(),
+		invite: jest.fn(),
+		connect: jest.fn(),
+		disconnect: jest.fn(),
+	}));
+});
+
+describe('SipServerSession', () => {
+	let session: SipServerSession;
+	let settings: IMediaCallServerSettings;
+
+	beforeEach(() => {
+		session = new SipServerSession();
+		settings = {
+			...getDefaultSettings(),
+			sip: {
+				...getDefaultSettings().sip,
+				sipServer: {
+					host: 'pbx.example.com',
+					port: 5060,
+				},
+			},
+		};
+		session.configure(settings);
+	});
+
+	describe('getExtensionUri', () => {
+		it('should format URI with extension, host, and port', () => {
+			expect(session.getExtensionUri('1001')).toBe('sip:1001@pbx.example.com:5060');
+		});
+
+		it('should format URI without port when port is 0 or undefined', () => {
+			settings.sip.sipServer.port = 0;
+			session.configure(settings);
+			expect(session.getExtensionUri('1001')).toBe('sip:1001@pbx.example.com');
+		});
+
+		it('should throw error when host is not configured', () => {
+			settings.sip.sipServer.host = '';
+			session.configure(settings);
+			expect(() => session.getExtensionUri('1001')).toThrow('Sip Server Host is not configured');
+		});
+	});
+
+	describe('getContactUri', () => {
+		it('should prioritize sipExtension if present on contact', () => {
+			const contact: MediaCallContact = {
+				type: 'user',
+				id: 'user123',
+				username: 'john.doe',
+				sipExtension: '4001',
+			};
+
+			expect(session.getContactUri(contact)).toBe('sip:4001@pbx.example.com:5060');
+		});
+
+		it('should use id if contact type is sip and no sipExtension is present', () => {
+			const contact: MediaCallContact = {
+				type: 'sip',
+				id: '5001',
+			};
+
+			expect(session.getContactUri(contact)).toBe('sip:5001@pbx.example.com:5060');
+		});
+
+		it('should prefix username with user- if contact has username but no sipExtension', () => {
+			const contact: MediaCallContact = {
+				type: 'user',
+				id: 'user123',
+				username: 'john.doe',
+			};
+
+			expect(session.getContactUri(contact)).toBe('sip:user-john.doe@pbx.example.com:5060');
+		});
+
+		it('should prefix id with user- if contact has only id', () => {
+			const contact: MediaCallContact = {
+				type: 'user',
+				id: 'user123',
+			};
+
+			expect(session.getContactUri(contact)).toBe('sip:user-user123@pbx.example.com:5060');
+		});
+
+		it('should fallback to unknown if no identifier is present', () => {
+			const contact = {
+				type: 'user',
+				id: '',
+			} as unknown as MediaCallContact;
+
+			expect(session.getContactUri(contact)).toBe('sip:unknown@pbx.example.com:5060');
+		});
+	});
+});

--- a/ee/packages/media-calls/src/sip/Session.spec.ts
+++ b/ee/packages/media-calls/src/sip/Session.spec.ts
@@ -38,8 +38,14 @@ describe('SipServerSession', () => {
 			expect(session.getExtensionUri('1001')).toBe('sip:1001@pbx.example.com:5060');
 		});
 
-		it('should format URI without port when port is 0 or undefined', () => {
+		it('should format URI without port when port is 0', () => {
 			settings.sip.sipServer.port = 0;
+			session.configure(settings);
+			expect(session.getExtensionUri('1001')).toBe('sip:1001@pbx.example.com');
+		});
+
+		it('should format URI without port when port is undefined', () => {
+			delete (settings.sip.sipServer as Partial<typeof settings.sip.sipServer>).port;
 			session.configure(settings);
 			expect(session.getExtensionUri('1001')).toBe('sip:1001@pbx.example.com');
 		});

--- a/ee/packages/media-calls/src/sip/Session.ts
+++ b/ee/packages/media-calls/src/sip/Session.ts
@@ -90,7 +90,7 @@ export class SipServerSession {
 		return this.srf.createUAC(uri, opts, progressCallbacks);
 	}
 
-	public geContactUri(contact: MediaCallContact): string {
+	public getContactUri(contact: MediaCallContact): string {
 		const sipExtension = contact.sipExtension || (contact.type === 'sip' && contact.id) || null;
 		const username = contact.username && `user-${contact.username}`;
 		const userId = contact.id && `user-${contact.id}`;
@@ -121,9 +121,9 @@ export class SipServerSession {
 
 		// Sip targets can only be referred to other sip users
 		const referToActor = await mediaCallDirector.cast.getContactForActor(transferredTo, { requiredType: 'sip' });
-		const referredBy = transferredBy && this.geContactUri(transferredBy);
+		const referredBy = transferredBy && this.getContactUri(transferredBy);
 
-		const referTo = referToActor && this.geContactUri(referToActor);
+		const referTo = referToActor && this.getContactUri(referToActor);
 		if (!referTo) {
 			throw new Error('invalid-transfer');
 		}

--- a/ee/packages/media-calls/src/sip/providers/OutgoingSipCall.ts
+++ b/ee/packages/media-calls/src/sip/providers/OutgoingSipCall.ts
@@ -110,7 +110,7 @@ export class OutgoingSipCall extends BaseSipCall {
 		}
 
 		this.lastCallState = 'ringing';
-		const referredBy = call.parentCallId && this.session.geContactUri(call.createdBy);
+		const referredBy = call.parentCallId && this.session.getContactUri(call.createdBy);
 
 		let hangupReason: CallHangupReason | null = null;
 		try {


### PR DESCRIPTION
<!-- 

Please see our guide for opening issues: https://developer.rocket.chat/rocket.chat/contribute-to-rocket.chat/ways-to-contribute/report-bugs

If you have questions or are looking for help/support please see: https://rocket.chat/docs/getting-support

If you are experiencing a bug please search our issues to be sure it is not already present: https://github.com/RocketChat/Rocket.Chat/issues

-->

### Description:
In PR #42020 (commit `67f2bda92e`), a helper method was introduced in `SipServerSession` to generate a SIP contact URI:
```typescript
// ee/packages/media-calls/src/sip/Session.ts:93
public geContactUri(contact: MediaCallContact): string {
    const sipExtension = contact.sipExtension || (contact.type === 'sip' && contact.id) || null;
    ...
} 
```
The method name has a typo: geContactUri instead of getContactUri (missing 't').

It is currently being referenced with this misspelled name in:

ee/packages/media-calls/src/sip/Session.ts:124
ee/packages/media-calls/src/sip/Session.ts:126
ee/packages/media-calls/src/sip/providers/OutgoingSipCall.ts:113
<!-- A clear and concise description of what the bug is. -->
Closes #42056


### Steps to reproduce:
Got to :- ee/packages/media-calls/src/sip/Session.ts at line 93.
Note the declaration public geContactUri(...).


### Expected behavior:
The method name should follow standard naming conventions and be spelled correctly as getContactUri.
<!-- What you expect to happen -->

### Actual behavior:
The method is named geContactUri.
<!-- What actually happens with SCREENSHOT, if applicable -->

### Additional context
How i am going to fix this issue
Rename geContactUri to getContactUri in Session.ts and OutgoingSipCall.ts.
Add unit tests in ee/packages/media-calls for getContactUri to verify contact URI resolution for different contact types (SIP extension, username, and user ID).
<!-- Add any other context about the problem here. -->



<!-- Logs from both SERVER and BROWSER -->
<!-- For more information about collecting logs please see: https://rocket.chat/docs/contributing/reporting-issues#gathering-logs -->
