### PR TITLE
chore(base64): add missing eslint to devDependencies

### DIFF
--- a/.changeset/base64-add-eslint-devdep.md
+++ b/.changeset/base64-add-eslint-devdep.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/base64': patch
+---
+
+Add missing `eslint` to `devDependencies`

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -16,6 +16,7 @@
 	"devDependencies": {
 		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
+		"eslint": "~9.39.5",
 		"jest": "~30.2.0",
 		"typescript": "~5.9.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,6 +9224,7 @@ __metadata:
   dependencies:
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/tsconfig": "workspace:*"
+    eslint: "npm:~9.39.5"
     jest: "npm:~30.2.0"
     typescript: "npm:~5.9.3"
   languageName: unknown


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)

Add `"eslint": "~9.39.5"` to `devDependencies` of `@rocket.chat/base64`.

Under Yarn 4 Berry workspace isolation, running `yarn --cwd packages/base64 lint` failed with exit code 127 (`command not found: eslint`) because `eslint` was missing from `devDependencies`.

## Steps to test or reproduce
1. Run `yarn --cwd packages/base64 lint`
2. Verify that ESLint executes and passes without error.

<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

## Issue(s)
### **Broken Monorepo Lint Script in `@rocket.chat/base64`**

- **Category:** Tooling / Dependencies
- **Files:**
    - **`packages/base64/package.json`**
- **Root Cause:** `packages/base64/package.json` specifies:However, unlike all other monorepo packages, `eslint` is **missing** from `packages/base64`'s `devDependencies`.
    
    ```
    json
    "scripts": {
    "lint":"eslint .",
    "lint:fix":"eslint --fix ."
    }
    ```
    
- **Impact:** Under Yarn 4 (Berry) workspace isolation, running `yarn lint` or `turbo run lint` fails with:
    
    ```
    text
    @rocket.chat/base64:lint: command not found: eslint
    ERROR @rocket.chat/base64#lint: command (/home/mudit/Rocket.Chat/packages/base64) exited (127)
    ```
    
- **Contribution Opportunity:** Add `"eslint": "~9.39.5"` to `packages/base64/package.json` under `devDependencies`.
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated development tooling for the Base64 package.
  - Prepared a patch release for the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->