### PR TITLE
fix(chat): avoid 404 on empty match in chat.getMessages and handle errors in useParentMessage

### DIFF
--- a/.changeset/base64-add-eslint-devdep.md
+++ b/.changeset/base64-add-eslint-devdep.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/base64': patch
+---
+
+Add missing `eslint` to `devDependencies`

--- a/.changeset/fix-chat-getmessages-batch.md
+++ b/.changeset/fix-chat-getmessages-batch.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fix `/v1/chat.getMessages` returning 404 when no messages match and prevent cascading failures in `useParentMessage`

--- a/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
+++ b/apps/meteor/client/views/room/MessageList/hooks/useParentMessage.ts
@@ -28,7 +28,10 @@ const findParentMessage = (() => {
 		resolve(
 			Promise.all(
 				batches.map((ids) =>
-					sdk.rest.post('/v1/chat.getMessages', { messageIds: ids }).then(({ messages }) => messages.map((msg) => mapMessageFromApi(msg))),
+					sdk.rest
+						.post('/v1/chat.getMessages', { messageIds: ids })
+						.then(({ messages }) => messages.map((msg) => mapMessageFromApi(msg)))
+						.catch(() => []),
 				),
 			).then((results) => results.flat()),
 		);

--- a/apps/meteor/server/api/v1/chat.ts
+++ b/apps/meteor/server/api/v1/chat.ts
@@ -26,7 +26,6 @@ import {
 	isChatGetStarredMessagesProps,
 	isChatGetDiscussionsProps,
 	validateBadRequestErrorResponse,
-	validateNotFoundErrorResponse,
 	validateUnauthorizedErrorResponse,
 	validateForbiddenErrorResponse,
 } from '@rocket.chat/rest-typings';
@@ -1496,7 +1495,6 @@ const chatEndpoints = API.v1
 				400: validateBadRequestErrorResponse,
 				401: validateUnauthorizedErrorResponse,
 				403: validateForbiddenErrorResponse,
-				404: validateNotFoundErrorResponse,
 			},
 		},
 		async function action() {
@@ -1504,7 +1502,7 @@ const chatEndpoints = API.v1
 
 			const messages = await Messages.findVisibleByIds(messageIds).toArray();
 			if (!messages.length) {
-				return API.v1.notFound();
+				return API.v1.success({ messages: [] });
 			}
 
 			const rids = [...new Set(messages.map(({ rid }) => rid))];

--- a/apps/meteor/tests/end-to-end/api/chat.ts
+++ b/apps/meteor/tests/end-to-end/api/chat.ts
@@ -5364,6 +5364,17 @@ describe('Threads', () => {
 			expect(res.body.messages.map((message: IMessage) => message._id)).to.deep.equal([firstMessageId]);
 		});
 
+		it('should return an empty array when none of the message ids resolve to a message', async () => {
+			const res = await request
+				.post(api('chat.getMessages'))
+				.set(credentials)
+				.send({ messageIds: ['does-not-exist'] })
+				.expect(200);
+
+			expect(res.body).to.have.property('success', true);
+			expect(res.body.messages).to.be.an('array').that.is.empty;
+		});
+
 		it('should reject the whole batch when any message belongs to an unreadable room', async () => {
 			const res = await request
 				.post(api('chat.getMessages'))

--- a/packages/base64/package.json
+++ b/packages/base64/package.json
@@ -16,6 +16,7 @@
 	"devDependencies": {
 		"@rocket.chat/jest-presets": "workspace:~",
 		"@rocket.chat/tsconfig": "workspace:*",
+		"eslint": "~9.39.5",
 		"jest": "~30.2.0",
 		"typescript": "~5.9.3"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,6 +9224,7 @@ __metadata:
   dependencies:
     "@rocket.chat/jest-presets": "workspace:~"
     "@rocket.chat/tsconfig": "workspace:*"
+    eslint: "npm:~9.39.5"
     jest: "npm:~30.2.0"
     typescript: "npm:~5.9.3"
   languageName: unknown


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
1. **Backend (`/v1/chat.getMessages`)**:
   - Return `200 OK` with `{ messages: [] }` when none of the requested message IDs resolve to a visible message, rather than returning `404 Not Found`.
   - Remove unused `404: validateNotFoundErrorResponse` response schema.
2. **Frontend (`useParentMessage.ts`)**:
   - Add defensive `.catch(() => [])` error handling per batch in `batches.map(...)`. If a batch request fails, it falls back to an empty array instead of rejecting the global `Promise.all`, preventing cascading failures for valid parent messages across other batches.
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->

3. **Tests**:
   - Added an end-to-end test in `apps/meteor/tests/end-to-end/api/chat.ts` verifying that requesting non-existent message IDs returns `200 OK` with `{ messages: [] }`.

<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Send a POST request to `/v1/chat.getMessages` with `{ messageIds: ['does-not-exist'] }`.
2. Verify the server returns status `200` with body:
   ```json
   {
     "messages": [],
     "success": true
   }


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `chat.getMessages` now returns a successful response with an empty message list when no matching messages are found.
  * Message loading remains resilient when individual parent-message lookups fail, preventing cascading errors.

* **Chores**
  * Added ESLint as a development dependency for the Base64 package.
  * Added automated coverage for empty `chat.getMessages` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->