### PR TITLE
fix: Custom OAuth modern flow drops email claim, breaking account merge

### DIFF
--- a/.changeset/custom-oauth-modern-flow-email-merge.md
+++ b/.changeset/custom-oauth-modern-flow-email-merge.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes an issue in Custom OAuth with "Use Modern OAuth Flow" enabled where the user's email was dropped, preventing account merging into existing accounts, and causing the login to hang on username collisions.

--- a/apps/meteor/jest.config.ts
+++ b/apps/meteor/jest.config.ts
@@ -52,6 +52,7 @@ export default {
 				'<rootDir>/server/api/v1/middlewares/*.spec.ts',
 				'<rootDir>/server/lib/cloud/version-check/**/*.spec.ts',
 				'<rootDir>/server/lib/auth-providers/apple/**.spec.ts',
+				'<rootDir>/server/lib/oauth/**.spec.ts',
 				'<rootDir>/server/lib/statusVisibility/*.spec.ts',
 				'<rootDir>/server/services/statusVisibility/*.spec.ts',
 			],

--- a/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
+++ b/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
@@ -211,10 +211,6 @@ export class CustomOAuthStrategy extends Strategy {
 			identity.email = this.getEmail(identity);
 		}
 
-		if (identity.email) {
-			identity.emails = [{ value: identity.email }];
-		}
-
 		if (this.avatarField) {
 			identity.avatarUrl = this.getAvatarUrl(identity);
 		}

--- a/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
+++ b/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
@@ -225,7 +225,7 @@ export class CustomOAuthStrategy extends Strategy {
 			identity.name = this.getName(identity);
 		}
 
-		identity.displayName = identity.name;
+		identity.displayName = identity.name || identity.displayName;
 
 		return renameInvalidProperties(identity);
 	}

--- a/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
+++ b/apps/meteor/server/lib/auth-providers/custom-oauth/customOAuth.ts
@@ -211,6 +211,10 @@ export class CustomOAuthStrategy extends Strategy {
 			identity.email = this.getEmail(identity);
 		}
 
+		if (identity.email) {
+			identity.emails = [{ value: identity.email }];
+		}
+
 		if (this.avatarField) {
 			identity.avatarUrl = this.getAvatarUrl(identity);
 		}
@@ -220,6 +224,8 @@ export class CustomOAuthStrategy extends Strategy {
 		} else {
 			identity.name = this.getName(identity);
 		}
+
+		identity.displayName = identity.name;
 
 		return renameInvalidProperties(identity);
 	}

--- a/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
+++ b/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
@@ -28,7 +28,7 @@ export const addPassportCustomOAuth = (
 			serviceName,
 			config as OAuthConfiguration & { clientSecret: string },
 			(accessToken: string, refreshToken: string, profile: Profile, done: DoneCallback) =>
-				verifyFunction(accessToken, refreshToken, profile, done, serviceName),
+				verifyFunction(accessToken, refreshToken, profile, done, serviceName).catch((err) => done(err)),
 		),
 	);
 

--- a/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
+++ b/apps/meteor/server/lib/oauth/addPassportCustomOAuth.ts
@@ -28,7 +28,7 @@ export const addPassportCustomOAuth = (
 			serviceName,
 			config as OAuthConfiguration & { clientSecret: string },
 			(accessToken: string, refreshToken: string, profile: Profile, done: DoneCallback) =>
-				verifyFunction(accessToken, refreshToken, profile, done, serviceName).catch((err) => done(err)),
+				verifyFunction(accessToken, refreshToken, profile, done, serviceName),
 		),
 	);
 

--- a/apps/meteor/server/lib/oauth/configureOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/configureOAuthServices.ts
@@ -1,5 +1,3 @@
-import { Users } from '@rocket.chat/models';
-import { Accounts } from 'meteor/accounts-base';
 import passport from 'passport';
 import type { Profile, DoneCallback } from 'passport';
 
@@ -7,6 +5,7 @@ import { allowPassportOAuthMiddleware } from './allowPassportOAuthMiddleware';
 import type { OAuthServiceConfig } from './createOAuthServiceConfig';
 import { passportOAuthCallback } from './passportOAuthCallback';
 import { removeOAuthRoutes } from './removeOAuthRoutes';
+import { verifyFunction } from './verifyFunction';
 import { oAuthRouter } from '../../configuration/configurePassport';
 import type { ICachedSettings } from '../../settings/CachedSettings';
 
@@ -32,41 +31,8 @@ export const configureOAuthServices = (oauthServiceConfig: OAuthServiceConfig[],
 					pkce: true,
 					profileFields: ['id', 'displayName', 'emails'],
 				},
-				async (accessToken: string, refreshToken: string, profile: Profile, done: DoneCallback) => {
-					try {
-						const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string; email?: string; name?: string };
-						const { _json, _raw, ...restProfile } = profileWithRaw;
-						const email = profile?.emails?.[0]?.value || profileWithRaw.email || (typeof _json?.email === 'string' ? _json.email : undefined);
-						const name = profile.displayName || profileWithRaw.name;
-
-						const user = await Accounts.updateOrCreateUserFromExternalService(
-							config.provider,
-							{
-								accessToken,
-								refreshToken,
-								...restProfile,
-								..._json,
-								...(name ? { name } : {}),
-								...(email ? { email } : {}),
-							},
-							{},
-						);
-
-						if (!user?.userId || typeof user?.userId !== 'string') {
-							return done(new Error('User not found'));
-						}
-
-						const userFromDB = await Users.findOneById(user.userId);
-
-						if (!userFromDB) {
-							return done(new Error('User not found'));
-						}
-
-						return done(null, userFromDB);
-					} catch (error) {
-						return done(error as Error);
-					}
-				},
+				(accessToken: string, refreshToken: string, profile: Profile, done: DoneCallback) =>
+					verifyFunction(accessToken, refreshToken, profile, done, config.provider),
 			),
 		);
 

--- a/apps/meteor/server/lib/oauth/configureOAuthServices.ts
+++ b/apps/meteor/server/lib/oauth/configureOAuthServices.ts
@@ -33,33 +33,39 @@ export const configureOAuthServices = (oauthServiceConfig: OAuthServiceConfig[],
 					profileFields: ['id', 'displayName', 'emails'],
 				},
 				async (accessToken: string, refreshToken: string, profile: Profile, done: DoneCallback) => {
-					const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string };
-					const { _json, _raw, ...restProfile } = profileWithRaw;
+					try {
+						const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string; email?: string; name?: string };
+						const { _json, _raw, ...restProfile } = profileWithRaw;
+						const email = profile?.emails?.[0]?.value || profileWithRaw.email || (typeof _json?.email === 'string' ? _json.email : undefined);
+						const name = profile.displayName || profileWithRaw.name;
 
-					const user = await Accounts.updateOrCreateUserFromExternalService(
-						config.provider,
-						{
-							accessToken,
-							refreshToken,
-							name: profile.displayName,
-							...restProfile,
-							..._json,
-							email: profile?.emails?.[0]?.value,
-						},
-						{},
-					);
+						const user = await Accounts.updateOrCreateUserFromExternalService(
+							config.provider,
+							{
+								accessToken,
+								refreshToken,
+								...restProfile,
+								..._json,
+								...(name ? { name } : {}),
+								...(email ? { email } : {}),
+							},
+							{},
+						);
 
-					if (!user?.userId || typeof user?.userId !== 'string') {
-						return done(new Error('User not found'));
+						if (!user?.userId || typeof user?.userId !== 'string') {
+							return done(new Error('User not found'));
+						}
+
+						const userFromDB = await Users.findOneById(user.userId);
+
+						if (!userFromDB) {
+							return done(new Error('User not found'));
+						}
+
+						return done(null, userFromDB);
+					} catch (error) {
+						return done(error as Error);
 					}
-
-					const userFromDB = await Users.findOneById(user.userId);
-
-					if (!userFromDB) {
-						return done(new Error('User not found'));
-					}
-
-					return done(null, userFromDB);
 				},
 			),
 		);

--- a/apps/meteor/server/lib/oauth/resolveOAuthProfile.ts
+++ b/apps/meteor/server/lib/oauth/resolveOAuthProfile.ts
@@ -1,0 +1,22 @@
+import type { Profile } from 'passport';
+
+export type ExtendedOAuthProfile = Profile & {
+	_json?: Record<string, unknown>;
+	_raw?: string;
+	email?: string;
+	name?: string;
+};
+
+export const resolveOAuthProfile = (profile: Profile): Record<string, unknown> => {
+	const profileWithRaw = profile as ExtendedOAuthProfile;
+	const { _json, _raw, ...restProfile } = profileWithRaw;
+	const email = profile?.emails?.[0]?.value || profileWithRaw.email || (typeof _json?.email === 'string' ? _json.email : undefined);
+	const name = profile.displayName || profileWithRaw.name;
+
+	return {
+		...restProfile,
+		..._json,
+		...(name ? { name } : {}),
+		...(email ? { email } : {}),
+	};
+};

--- a/apps/meteor/server/lib/oauth/verifyFunction.spec.ts
+++ b/apps/meteor/server/lib/oauth/verifyFunction.spec.ts
@@ -1,0 +1,172 @@
+import type { IUser } from '@rocket.chat/core-typings';
+import { Users } from '@rocket.chat/models';
+import { Accounts } from 'meteor/accounts-base';
+import type { Profile } from 'passport';
+
+import { verifyFunction } from './verifyFunction';
+
+jest.mock(
+	'meteor/accounts-base',
+	() => ({
+		Accounts: {
+			updateOrCreateUserFromExternalService: jest.fn(),
+		},
+	}),
+	{ virtual: true },
+);
+
+jest.mock('@rocket.chat/models', () => ({
+	Users: {
+		findOneById: jest.fn(),
+	},
+}));
+
+describe('OAuth verifyFunction', () => {
+	const done = jest.fn();
+	const mockUser: IUser = {
+		_id: 'user-id-123',
+		createdAt: new Date(),
+		_updatedAt: new Date(),
+		username: 'testuser',
+		name: 'Test User',
+		type: 'user',
+		active: true,
+		roles: ['user'],
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.mocked(Accounts.updateOrCreateUserFromExternalService).mockResolvedValue({ userId: 'user-id-123' });
+		jest.mocked(Users.findOneById).mockResolvedValue(mockUser);
+	});
+
+	it('should resolve flat email and name strings from Custom OAuth profile shape', async () => {
+		const customOAuthProfile = {
+			id: 'custom-id-123',
+			email: 'custom@example.com',
+			name: 'Custom User',
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', customOAuthProfile, done, 'custom_oauth');
+
+		expect(Accounts.updateOrCreateUserFromExternalService).toHaveBeenCalledWith(
+			'custom_oauth',
+			expect.objectContaining({
+				accessToken: 'access-token',
+				refreshToken: 'refresh-token',
+				id: 'custom-id-123',
+				email: 'custom@example.com',
+				name: 'Custom User',
+			}),
+			{},
+		);
+		expect(done).toHaveBeenCalledWith(null, mockUser);
+	});
+
+	it('should give precedence to standard Passport profile emails array and displayName', async () => {
+		const standardPassportProfile = {
+			id: 'passport-id-456',
+			displayName: 'Passport Display Name',
+			name: 'Profile Name',
+			email: 'flat@example.com',
+			emails: [{ value: 'passport@example.com' }],
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', standardPassportProfile, done, 'google');
+
+		expect(Accounts.updateOrCreateUserFromExternalService).toHaveBeenCalledWith(
+			'google',
+			expect.objectContaining({
+				accessToken: 'access-token',
+				refreshToken: 'refresh-token',
+				id: 'passport-id-456',
+				email: 'passport@example.com',
+				name: 'Passport Display Name',
+			}),
+			{},
+		);
+		expect(done).toHaveBeenCalledWith(null, mockUser);
+	});
+
+	it('should fall back to _json.email when top-level email and emails array are absent', async () => {
+		const jsonFallbackProfile = {
+			id: 'json-id-789',
+			displayName: 'JSON User',
+			_json: {
+				email: 'json@example.com',
+			},
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', jsonFallbackProfile, done, 'custom_oauth');
+
+		expect(Accounts.updateOrCreateUserFromExternalService).toHaveBeenCalledWith(
+			'custom_oauth',
+			expect.objectContaining({
+				id: 'json-id-789',
+				email: 'json@example.com',
+				name: 'JSON User',
+			}),
+			{},
+		);
+		expect(done).toHaveBeenCalledWith(null, mockUser);
+	});
+
+	it('should protect resolved name from being overwritten by conflicting structured name in profile or _json', async () => {
+		const conflictingNameProfile = {
+			id: 'conflict-id-101',
+			displayName: 'Resolved Display Name',
+			name: {
+				familyName: 'Doe',
+				givenName: 'John',
+			},
+			_json: {
+				name: 'Conflicting JSON Name',
+			},
+			emails: [{ value: 'john.doe@example.com' }],
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', conflictingNameProfile, done, 'custom_oauth');
+
+		expect(Accounts.updateOrCreateUserFromExternalService).toHaveBeenCalledWith(
+			'custom_oauth',
+			expect.objectContaining({
+				id: 'conflict-id-101',
+				name: 'Resolved Display Name',
+				email: 'john.doe@example.com',
+			}),
+			{},
+		);
+		expect(done).toHaveBeenCalledWith(null, mockUser);
+	});
+
+	it('should catch errors from updateOrCreateUserFromExternalService and call done(error) without unhandled rejection', async () => {
+		const error = new Error('Username already exists. [403]');
+		jest.mocked(Accounts.updateOrCreateUserFromExternalService).mockRejectedValue(error);
+
+		const profile = {
+			id: 'error-id-102',
+			email: 'error@example.com',
+			name: 'Error User',
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', profile, done, 'custom_oauth');
+
+		expect(done).toHaveBeenCalledWith(error);
+		expect(done).not.toHaveBeenCalledWith(null, expect.anything());
+	});
+
+	it('should call done with "User not found" error when user is not found in database', async () => {
+		jest.mocked(Users.findOneById).mockResolvedValue(null);
+
+		const profile = {
+			id: 'not-found-id-103',
+			email: 'notfound@example.com',
+			name: 'Not Found User',
+		} as unknown as Profile;
+
+		await verifyFunction('access-token', 'refresh-token', profile, done, 'custom_oauth');
+
+		expect(done).toHaveBeenCalledWith(expect.any(Error));
+		expect(done).toHaveBeenCalledWith(expect.objectContaining({ message: 'User not found' }));
+	});
+});

--- a/apps/meteor/server/lib/oauth/verifyFunction.ts
+++ b/apps/meteor/server/lib/oauth/verifyFunction.ts
@@ -20,7 +20,6 @@ export const verifyFunction = async (
 			{
 				accessToken,
 				refreshToken,
-				...profile,
 				...restProfile,
 				..._json,
 				...(name ? { name } : {}),

--- a/apps/meteor/server/lib/oauth/verifyFunction.ts
+++ b/apps/meteor/server/lib/oauth/verifyFunction.ts
@@ -9,32 +9,38 @@ export const verifyFunction = async (
 	done: DoneCallback,
 	serviceName: string,
 ) => {
-	const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string };
-	const { _json, _raw, ...restProfile } = profileWithRaw;
+	try {
+		const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string; email?: string; name?: string };
+		const { _json, _raw, ...restProfile } = profileWithRaw;
+		const email = profile?.emails?.[0]?.value || profileWithRaw.email || (typeof _json?.email === 'string' ? _json.email : undefined);
+		const name = profile.displayName || profileWithRaw.name;
 
-	const user = await Accounts.updateOrCreateUserFromExternalService(
-		serviceName,
-		{
-			accessToken,
-			refreshToken,
-			name: profile.displayName,
-			...profile,
-			...restProfile,
-			..._json,
-			email: profile?.emails?.[0]?.value,
-		},
-		{},
-	);
+		const user = await Accounts.updateOrCreateUserFromExternalService(
+			serviceName,
+			{
+				accessToken,
+				refreshToken,
+				...profile,
+				...restProfile,
+				..._json,
+				...(name ? { name } : {}),
+				...(email ? { email } : {}),
+			},
+			{},
+		);
 
-	if (!user?.userId || typeof user?.userId !== 'string') {
-		return done(new Error('User not found'));
+		if (!user?.userId || typeof user?.userId !== 'string') {
+			return done(new Error('User not found'));
+		}
+
+		const userFromDB = await Users.findOneById(user.userId);
+
+		if (!userFromDB) {
+			return done(new Error('User not found'));
+		}
+
+		return done(null, userFromDB);
+	} catch (error) {
+		return done(error as Error);
 	}
-
-	const userFromDB = await Users.findOneById(user.userId);
-
-	if (!userFromDB) {
-		return done(new Error('User not found'));
-	}
-
-	return done(null, userFromDB);
 };

--- a/apps/meteor/server/lib/oauth/verifyFunction.ts
+++ b/apps/meteor/server/lib/oauth/verifyFunction.ts
@@ -2,6 +2,8 @@ import { Users } from '@rocket.chat/models';
 import { Accounts } from 'meteor/accounts-base';
 import type { DoneCallback, Profile } from 'passport';
 
+import { resolveOAuthProfile } from './resolveOAuthProfile';
+
 export const verifyFunction = async (
 	accessToken: string,
 	refreshToken: string,
@@ -10,20 +12,14 @@ export const verifyFunction = async (
 	serviceName: string,
 ) => {
 	try {
-		const profileWithRaw = profile as Profile & { _json?: Record<string, unknown>; _raw?: string; email?: string; name?: string };
-		const { _json, _raw, ...restProfile } = profileWithRaw;
-		const email = profile?.emails?.[0]?.value || profileWithRaw.email || (typeof _json?.email === 'string' ? _json.email : undefined);
-		const name = profile.displayName || profileWithRaw.name;
+		const serviceData = resolveOAuthProfile(profile);
 
 		const user = await Accounts.updateOrCreateUserFromExternalService(
 			serviceName,
 			{
 				accessToken,
 				refreshToken,
-				...restProfile,
-				..._json,
-				...(name ? { name } : {}),
-				...(email ? { email } : {}),
+				...serviceData,
 			},
 			{},
 		);


### PR DESCRIPTION
## Fixes #42062

**Custom OAuth "Use Modern OAuth Flow" broke email + account merging.**

### Root cause
`verifyFunction.ts` set `email: profile?.emails?.[0]?.value` as the *last*
key in the object literal — Custom OAuth returns a flat `profile.email`
string, not the `profile.emails` array standard providers use, so this
always evaluated to `undefined` and silently wiped out the valid email.

That cascaded into two symptoms:
- New users got created with no email.
- The email-based merge hook (`findOneByEmailAddress(undefined)`) matched
  nothing, fell through to user creation, collided on username, and threw
  an **unhandled rejection** — hanging the browser indefinitely.

### Fix
| File | Change |
|---|---|
| `resolveOAuthProfile.ts` *(new)* | Shared email/name fallback resolver (`emails[0]` → flat `email` → `_json.email`), applied last so it can't be overwritten |
| `verifyFunction.ts` | Uses the new resolver; wrapped in `try/catch` so errors reach `done(error)` instead of hanging; dropped a redundant `...profile` spread that leaked `_raw` |
| `configureOAuthServices.ts` | Delegates to `verifyFunction()` instead of duplicating the same ~30-line flow (had the identical bug) |
| `customOAuth.ts` | Preserves existing `displayName` instead of overwriting it with `undefined` |
| `verifyFunction.spec.ts` *(new)* | 6 tests: flat shape, Passport array shape, `_json` fallback, name-conflict protection, error propagation, user-not-found |

Changeset added (`@rocket.chat/meteor`, patch).

### Verified
- Traced the original repro (existing user, `Key Field: email`, modern flow
  on) end-to-end against the fix — merges into existing `_id`, no collision.
- All 6 unit tests pass; new files type-check cleanly.
- No other code in `server/lib/oauth/` or `server/lib/auth-providers/`
  depends on the removed `identity.emails` field.