### PR TITLE
chore: deprecate `getRoomJoinCode` and `raix:push-setuser` meteor methods

### DIFF
--- a/.changeset/ddp-deprecate-get-room-join-code.md
+++ b/.changeset/ddp-deprecate-get-room-join-code.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Deprecates the `getRoomJoinCode` real-time API method. It has had no caller since the room settings panel stopped revealing join codes, and will be removed in 9.0.0 without a replacement.

--- a/.changeset/ddp-deprecate-raix-push-setuser.md
+++ b/.changeset/ddp-deprecate-raix-push-setuser.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Deprecates the `raix:push-setuser` real-time API method. It was inherited from the `raix:push` package for Cordova clients and has never been called by Rocket.Chat clients, which bind push tokens to users through `POST /v1/push.token`. It will be removed in 9.0.0 without a replacement.

--- a/apps/meteor/server/meteor-methods/platform/push.ts
+++ b/apps/meteor/server/meteor-methods/platform/push.ts
@@ -64,8 +64,9 @@ Meteor.methods<ServerMethods>({
 			...(options.metadata && { metadata: options.metadata }),
 		});
 	},
-	// Deprecated
 	async 'raix:push-setuser'(id) {
+		methodDeprecationLogger.method('raix:push-setuser', '9.0.0', []);
+
 		check(id, String);
 		if (!this.userId) {
 			throw new Meteor.Error(403, 'Forbidden access');

--- a/apps/meteor/server/meteor-methods/rooms/getRoomJoinCode.ts
+++ b/apps/meteor/server/meteor-methods/rooms/getRoomJoinCode.ts
@@ -5,6 +5,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 
 import { hasPermissionAsync } from '../../lib/authorization/hasPermission';
+import { methodDeprecationLogger } from '../../lib/deprecationWarningLogger';
 
 declare module '@rocket.chat/ddp-client' {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
@@ -12,9 +13,11 @@ declare module '@rocket.chat/ddp-client' {
 		getRoomJoinCode(rid: string): string | false;
 	}
 }
-/* @deprecated */
+
 Meteor.methods<ServerMethods>({
 	async getRoomJoinCode(rid) {
+		methodDeprecationLogger.method('getRoomJoinCode', '9.0.0', []);
+
 		check(rid, String);
 
 		const userId = Meteor.userId();


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Two Meteor methods carried only a bare `deprecated` comment, so they emitted no warning or metric. This wires both into `methodDeprecationLogger` for 9.0.0 with no replacement. One changeset each.

**`getRoomJoinCode`**: added in `aa8e6c8428` (2017) so admins could reveal a room's join code on demand after `joinCode` was stripped from the room publication. The Blaze panel that called it was replaced by `EditRoomInfo` in #18443 (2020), which only writes new codes. No caller since, in this repo, mobile, desktop, or any SDK.

**`raix:push-setuser`**: server half of the upstream `raix:push` package, vendored in #17338 (2020) already marked deprecated. Its only caller was the package's Cordova client (`Push.setUser()` on login), which was never vendored. Native mobile binds tokens to users through `POST /v1/push.token`. Never called by any Rocket.Chat client.

## Issue(s)

## Steps to test or reproduce

Call either method over DDP → still works, server logs a deprecation warning and increments the deprecation metric.

## Further comments

Removal in 9.0.0 can also drop the `view-join-code` permission, used only by `getRoomJoinCode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Deprecated the `getRoomJoinCode` real-time API method. It is planned for removal in version 9.0.0 with no replacement.
  * Deprecated the `raix:push-setuser` real-time API method. It is planned for removal in version 9.0.0 with no replacement.
  * Added runtime deprecation warnings when either method is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [CORE-2680]

[CORE-2680]: https://rocketchat.atlassian.net/browse/CORE-2680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ