### PR TITLE
fix: preserve SAML credentials through two-factor validation

### DIFF
--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.spec.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.spec.tsx
@@ -1,0 +1,46 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TwoFactorTotpModal from './TwoFactorTotpModal';
+
+describe('TwoFactorTotpModal', () => {
+	const dispatchToastMessage = jest.fn();
+	const wrapper = mockAppRoot().withToastMessageDispatch(dispatchToastMessage).build();
+
+	beforeEach(() => jest.clearAllMocks());
+
+	it('should show an invalid-code error and allow another attempt', async () => {
+		const user = userEvent.setup();
+		const onConfirm = jest.fn().mockRejectedValueOnce({ error: 'totp-invalid' }).mockResolvedValue(undefined);
+		render(<TwoFactorTotpModal onConfirm={onConfirm} onClose={jest.fn()} />, { wrapper });
+
+		await user.type(screen.getByRole('textbox'), '123456');
+		await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+		expect(await screen.findByText('Invalid_two_factor_code')).toBeInTheDocument();
+		expect(screen.getByRole('textbox')).toHaveValue('');
+		expect(dispatchToastMessage).not.toHaveBeenCalled();
+
+		await user.type(screen.getByRole('textbox'), '654321');
+		await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+		await waitFor(() => expect(onConfirm).toHaveBeenLastCalledWith('654321', 'totp'));
+		expect(screen.queryByText('Invalid_two_factor_code')).not.toBeInTheDocument();
+	});
+
+	it.each([
+		{ error: 403, reason: 'No matching login attempt found' },
+		{ error: 'totp-max-attempts', reason: 'TOTP Maximun Failed Attempts Reached' },
+		new Error('Network unavailable'),
+	])('should report a non-code failure without labeling the code invalid: %s', async (error) => {
+		const user = userEvent.setup();
+		render(<TwoFactorTotpModal onConfirm={jest.fn().mockRejectedValue(error)} onClose={jest.fn()} />, { wrapper });
+
+		await user.type(screen.getByRole('textbox'), '123456');
+		await user.click(screen.getByRole('button', { name: 'Verify' }));
+
+		await waitFor(() => expect(dispatchToastMessage).toHaveBeenCalledWith({ type: 'error', message: error }));
+		expect(screen.queryByText('Invalid_two_factor_code')).not.toBeInTheDocument();
+	});
+});

--- a/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
+++ b/apps/meteor/client/components/TwoFactorModal/TwoFactorTotpModal.tsx
@@ -1,12 +1,14 @@
 import { Box } from '@rocket.chat/fuselage';
 import { FieldGroup, TextInput, Field, FieldLabel, FieldRow, FieldError } from '@rocket.chat/fuselage-forms';
 import { GenericModal } from '@rocket.chat/ui-client';
+import { useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import type { OnConfirm } from './TwoFactorModal';
 import { Method } from './TwoFactorModal';
+import { isTotpInvalidError } from '../../lib/2fa/utils';
 
 export type TwoFactorTotpModalProps = {
 	onConfirm: OnConfirm;
@@ -20,6 +22,7 @@ type TwoFactorTotpFormData = {
 };
 
 const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: TwoFactorTotpModalProps) => {
+	const dispatchToastMessage = useToastMessageDispatch();
 	const { t } = useTranslation();
 
 	const {
@@ -46,6 +49,10 @@ const TwoFactorTotpModal = ({ onConfirm, onClose, onDismiss, invalidAttempt }: T
 		try {
 			await onConfirm(code, Method.TOTP);
 		} catch (error) {
+			if (!isTotpInvalidError(error)) {
+				dispatchToastMessage({ type: 'error', message: error });
+				return;
+			}
 			setError('code', {
 				type: 'manual',
 				message: t('Invalid_two_factor_code'),

--- a/apps/meteor/server/lib/auth/startup.js
+++ b/apps/meteor/server/lib/auth/startup.js
@@ -1,6 +1,6 @@
 import { Apps, AppEvents } from '@rocket.chat/apps';
 import { User } from '@rocket.chat/core-services';
-import { Roles, Settings, Users } from '@rocket.chat/models';
+import { CredentialTokens, Roles, Settings, Users } from '@rocket.chat/models';
 import { escapeRegExp, escapeHTML, getLoginExpirationInDays, removeEmpty } from '@rocket.chat/tools';
 import { Accounts } from 'meteor/accounts-base';
 import { Match } from 'meteor/check';
@@ -473,9 +473,42 @@ const validateLoginAttemptAsync = async function (login) {
 	return true;
 };
 
-Accounts.validateLoginAttempt(function (...args) {
+Accounts.validateLoginAttempt(async function (login) {
 	// Depends on meteor support for Async
-	return validateLoginAttemptAsync.call(this, ...args);
+	if (login.type !== 'saml') {
+		return validateLoginAttemptAsync.call(this, login);
+	}
+
+	let [request] = login.methodArguments;
+	// The TOTP login handler delegates to the original login request.
+	while (request?.totp?.code) {
+		request = request.totp.login;
+	}
+	const credentialToken = request?.credentialToken;
+	if (!request?.saml || typeof credentialToken !== 'string') {
+		throw new Meteor.Error(Accounts.LoginCancelledError.numericError, 'No matching login attempt found');
+	}
+
+	try {
+		const allowed = await validateLoginAttemptAsync.call(this, login);
+		if (!allowed) {
+			await CredentialTokens.removeById(credentialToken);
+			return allowed;
+		}
+
+		// Consume atomically before Meteor issues a login token, not in the deferred
+		// afterValidateLogin hook. Concurrent attempts and expired credentials must fail.
+		if (!(await CredentialTokens.removeNotExpiredById(credentialToken))) {
+			throw new Meteor.Error(Accounts.LoginCancelledError.numericError, 'No matching login attempt found');
+		}
+		return allowed;
+	} catch (error) {
+		// Only a retryable 2FA challenge may reuse the credential, with its original expiry.
+		if (error?.error !== 'totp-required' && error?.error !== 'totp-invalid') {
+			await CredentialTokens.removeById(credentialToken);
+		}
+		throw error;
+	}
 });
 
 Accounts.validateNewUser((user) => {

--- a/apps/meteor/server/lib/saml/loginHandler.ts
+++ b/apps/meteor/server/lib/saml/loginHandler.ts
@@ -27,14 +27,15 @@ Accounts.registerLoginHandler('saml', async (loginRequest) => {
 
 	const loginResult = await SAML.retrieveCredential(loginRequest.credentialToken);
 
-	await CredentialTokens.removeById(loginRequest.credentialToken);
 	SAMLUtils.log({ msg: 'RESULT', loginResult });
 
 	if (!loginResult) {
+		await CredentialTokens.removeById(loginRequest.credentialToken);
 		return makeError('No matching login attempt found');
 	}
 
 	if (!loginResult.profile) {
+		await CredentialTokens.removeById(loginRequest.credentialToken);
 		return makeError('No profile information found');
 	}
 
@@ -43,8 +44,10 @@ Accounts.registerLoginHandler('saml', async (loginRequest) => {
 		const updatedUser = await SAML.insertOrUpdateSAMLUser(userObject);
 		SAMLUtils.events.emit('updateCustomFields', loginResult, updatedUser);
 
+		// The awaited login validator consumes the credential after 2FA succeeds.
 		return updatedUser;
 	} catch (err: any) {
+		await CredentialTokens.removeById(loginRequest.credentialToken);
 		SystemLogger.error({ err });
 
 		let message = err.toString();

--- a/apps/meteor/tests/unit/server/lib/saml/loginHandler.spec.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/loginHandler.spec.ts
@@ -1,10 +1,40 @@
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it, beforeEach, afterEach } from 'mocha';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
 const retrieveCredential = sinon.stub().resolves(null);
 const removeById = sinon.stub().resolves();
+const removeNotExpiredById = sinon.stub();
+const insertOrUpdateSAMLUser = sinon.stub();
+const validateLoginAttempt = sinon.stub();
+const checkCodeForUser = sinon.stub();
+const isValidLoginAttemptByIp = sinon.stub();
+const runCallback = sinon.stub();
+const loginHandlers = new Map<string, (...args: any[]) => any>();
+const accountsMock = {
+	LoginCancelledError: { numericError: 403 },
+	registerLoginHandler: (name: string, fn: (...args: any[]) => any) => loginHandlers.set(name, fn),
+	_runLoginHandlers: (_context: unknown, request: any) => loginHandlers.get(request.totp?.code ? 'totp' : 'saml')?.(request),
+	config: sinon.stub(),
+	_defaultPublishFields: { projection: {} },
+	emailTemplates: { verifyEmail: {}, resetPassword: {}, enrollAccount: {} },
+	urls: {},
+	onCreateUser: sinon.stub(),
+	validateNewUser: sinon.stub(),
+	onLogin: sinon.stub(),
+	validateLoginAttempt: (fn: (...args: any[]) => any) => validateLoginAttempt.callsFake(fn),
+};
+class MeteorError extends Error {
+	constructor(
+		public error: string | number,
+		public reason?: string,
+	) {
+		super(reason || String(error));
+	}
+}
+const meteorMock = { Error: MeteorError, startup: sinon.stub() };
+const credentialTokensMock = { removeById, removeNotExpiredById };
 const samlUtilsMock = {
 	serviceProviders: [{ provider: 'test-saml' }] as any[],
 	log: sinon.stub(),
@@ -12,40 +42,127 @@ const samlUtilsMock = {
 	events: { emit: sinon.stub() },
 };
 
-const handler = sinon.stub();
 proxyquire.noCallThru().load('../../../../../server/lib/saml/loginHandler', {
 	'@rocket.chat/models': {
-		CredentialTokens: { removeById },
+		CredentialTokens: credentialTokensMock,
 	},
 	'meteor/accounts-base': {
-		Accounts: {
-			LoginCancelledError: { numericError: 403 },
-			registerLoginHandler: (_name: string, fn: any) => {
-				handler.callsFake(fn);
-			},
-		},
+		Accounts: accountsMock,
 	},
 	'meteor/meteor': {
-		Meteor: { Error },
+		Meteor: meteorMock,
 	},
 	'./lib/SAML': {
-		SAML: { retrieveCredential },
+		SAML: { retrieveCredential, insertOrUpdateSAMLUser },
 	},
 	'./lib/Utils': {
 		SAMLUtils: samlUtilsMock,
 	},
 	'../i18n': { i18n: { t: sinon.stub().returns('') } },
 	'../logger/system': { SystemLogger: { error: sinon.stub() } },
+	'../premiumAuthDeprecation': { warnUnlicensedAuthService: sinon.stub() },
 });
 
+proxyquire.noCallThru().load('../../../../../server/lib/2fa/loginHandler', {
+	'meteor/accounts-base': { Accounts: accountsMock },
+	'meteor/check': { check: sinon.stub() },
+	'meteor/meteor': { Meteor: meteorMock },
+	'meteor/oauth': { OAuth: {} },
+	'./code': { checkCodeForUser },
+	'../callbacks': {
+		callbacks: {
+			priority: { MEDIUM: 0 },
+			add: (_name: string, fn: (...args: any[]) => any) => runCallback.callsFake(fn),
+		},
+	},
+});
+
+proxyquire.noCallThru().load('../../../../../server/lib/auth/startup', {
+	'@rocket.chat/apps': { Apps: {}, AppEvents: {} },
+	'@rocket.chat/core-services': {},
+	'@rocket.chat/models': { CredentialTokens: credentialTokensMock, Users: { updateLastLoginById: sinon.stub().resolves() } },
+	'@rocket.chat/tools': {},
+	'meteor/accounts-base': { Accounts: accountsMock },
+	'meteor/check': {},
+	'meteor/meteor': { Meteor: meteorMock },
+	'underscore': {},
+	'./restrictLoginAttempts': { isValidAttemptByUser: sinon.stub().resolves(true), isValidLoginAttemptByIp },
+	'../../../lib/utils/parseCSV': {},
+	'../../../lib/utils/safeHtmlDots': {},
+	'../../services/user/lib/getNewUserRoles': {},
+	'../../settings': {},
+	'../callbacks': {
+		callbacks: { run: (name: string, login: unknown) => (name === 'onValidateLogin' ? runCallback(login) : login) },
+	},
+	'../callbacks/beforeCreateUserCallback': {},
+	'../getClientAddress': { getClientAddress: sinon.stub().returns('127.0.0.1') },
+	'../getMaxLoginTokens': {},
+	'../i18n': {},
+	'../notifications/email/api': {},
+	'../notifyListener': {},
+	'../roles/addUserRoles': {},
+	'../rooms/joinDefaultChannels': {},
+	'../users/getAvatarSuggestionForUser': {},
+	'../users/setUserAvatar': {},
+	'../utils/functions/getBaseUserFields': { getBaseUserFields: () => ({}) },
+});
+
+const handler = (request: unknown) => loginHandlers.get('saml')?.(request);
+
 describe('SAML loginHandler', () => {
+	let clock: sinon.SinonFakeTimers;
+	let credential: { expireAt: Date; userInfo: { profile?: object } } | undefined;
+	const request = { saml: true, credentialToken: 'saml-token' };
+	const retry = (code: string) => ({ totp: { code, login: request } });
+	const user = { _id: 'user-id', active: true, roles: ['user'], type: 'user' };
+
+	// Meteor awaits the registered login handler, then the login validators, before issuing a login token.
+	const attemptLogin = async (args: any, loginUser = user) => {
+		const result = await accountsMock._runLoginHandlers({}, args);
+		const allowed = await validateLoginAttempt({
+			type: 'saml',
+			allowed: !!result.userId && !result.error,
+			error: result.error,
+			user: result.userId ? loginUser : undefined,
+			methodName: 'login',
+			methodArguments: [args],
+			connection: {},
+		});
+		if (!allowed) {
+			throw result.error;
+		}
+		return result;
+	};
+
 	beforeEach(() => {
+		clock = sinon.useFakeTimers({ toFake: ['Date'] });
+		credential = { expireAt: new Date(Date.now() + 60000), userInfo: { profile: {} } };
 		retrieveCredential.reset();
-		retrieveCredential.resolves(null);
+		retrieveCredential.callsFake(async () => (credential && credential.expireAt > new Date() ? credential.userInfo : undefined));
 		removeById.reset();
-		removeById.resolves();
+		removeById.callsFake(async () => {
+			credential = undefined;
+		});
+		removeNotExpiredById.reset();
+		removeNotExpiredById.callsFake(async () => {
+			const result = credential && credential.expireAt > new Date() ? credential : null;
+			if (result) {
+				credential = undefined;
+			}
+			return result;
+		});
+		insertOrUpdateSAMLUser.reset();
+		insertOrUpdateSAMLUser.resolves({ userId: user._id });
+		checkCodeForUser.reset();
+		checkCodeForUser.resolves(true);
+		isValidLoginAttemptByIp.reset();
+		isValidLoginAttemptByIp.resolves(true);
+		samlUtilsMock.mapProfileToUserObject.reset();
+		samlUtilsMock.mapProfileToUserObject.returns({});
 		samlUtilsMock.serviceProviders = [{ provider: 'test-saml' }];
 	});
+
+	afterEach(() => clock.restore());
 
 	it('should reject non-string credentialToken and never query the database (NoSQL injection prevention)', async () => {
 		expect(await handler({ saml: true, credentialToken: { $gt: '' } })).to.be.undefined;
@@ -65,10 +182,104 @@ describe('SAML loginHandler', () => {
 		expect(retrieveCredential.called).to.be.false;
 	});
 
-	it('should delete the credential token after retrieval', async () => {
-		await handler({ saml: true, credentialToken: 'token-to-delete' });
+	it('should preserve the credential through an initial challenge and wrong-code retry, then consume it on success', async () => {
+		const expireAt = credential?.expireAt;
+		checkCodeForUser.onFirstCall().rejects(new MeteorError('totp-required'));
+		checkCodeForUser.onSecondCall().rejects(new MeteorError('totp-invalid'));
 
-		expect(removeById.calledOnce).to.be.true;
-		expect(removeById.calledWith('token-to-delete')).to.be.true;
+		await expect(attemptLogin(request)).to.be.rejectedWith('totp-required');
+		clock.tick(20000);
+		await expect(attemptLogin(retry('wrong-code'))).to.be.rejectedWith('totp-invalid');
+		expect(credential?.expireAt).to.equal(expireAt);
+		expect(removeById.called).to.be.false;
+		expect(removeNotExpiredById.called).to.be.false;
+
+		await expect(attemptLogin(retry('correct-code'))).to.eventually.deep.equal({ userId: user._id });
+		expect(checkCodeForUser.lastCall.args[0].code).to.equal('correct-code');
+		expect(removeNotExpiredById.calledOnceWithExactly(request.credentialToken)).to.be.true;
+		expect(credential).to.be.undefined;
+		await expect(attemptLogin(retry('correct-code'))).to.be.rejectedWith('No matching login attempt found');
+	});
+
+	it('should consume a non-2FA login before returning success', async () => {
+		await attemptLogin(request);
+		expect(removeNotExpiredById.calledOnceWithExactly(request.credentialToken)).to.be.true;
+		expect(credential).to.be.undefined;
+		await expect(attemptLogin(request)).to.be.rejectedWith('No matching login attempt found');
+	});
+
+	it('should allow only one concurrent successful login with the same credential', async () => {
+		const results = await Promise.allSettled([attemptLogin(request), attemptLogin(request)]);
+		expect(results.filter(({ status }) => status === 'fulfilled')).to.have.lengthOf(1);
+		expect(results.filter(({ status }) => status === 'rejected')).to.have.lengthOf(1);
+	});
+
+	it('should reject expired credentials even before the TTL cleanup runs', async () => {
+		checkCodeForUser.rejects(new MeteorError('totp-required'));
+		await expect(attemptLogin(request)).to.be.rejectedWith('totp-required');
+		clock.tick(60000);
+		await expect(attemptLogin(retry('correct-code'))).to.be.rejectedWith('No matching login attempt found');
+		expect(insertOrUpdateSAMLUser.calledOnce).to.be.true;
+		expect(credential).to.be.undefined;
+	});
+
+	it('should reject a credential that expires during validation', async () => {
+		checkCodeForUser.callsFake(async () => clock.tick(60000));
+		await expect(attemptLogin(request)).to.be.rejectedWith('No matching login attempt found');
+		expect(credential).to.be.undefined;
+	});
+
+	for (const error of ['totp-max-attempts', 'error-login-blocked-for-user', 'unexpected-validation-error']) {
+		it(`should remove credentials on terminal validation failure: ${error}`, async () => {
+			checkCodeForUser.rejects(new MeteorError(error));
+			await expect(attemptLogin(retry('code'))).to.be.rejectedWith(error);
+			expect(credential).to.be.undefined;
+		});
+	}
+
+	it('should remove credentials on failures before the 2FA validator', async () => {
+		isValidLoginAttemptByIp.resolves(false);
+		await expect(attemptLogin(request)).to.be.rejectedWith('Login has been temporarily blocked For IP');
+		expect(checkCodeForUser.called).to.be.false;
+		expect(credential).to.be.undefined;
+	});
+
+	it('should consume credentials even when validation skips the 2FA callback', async () => {
+		await attemptLogin(request, { ...user, type: 'visitor' });
+		expect(checkCodeForUser.called).to.be.false;
+		expect(credential).to.be.undefined;
+	});
+
+	it('should consume the innermost credential for nested TOTP login requests', async () => {
+		await attemptLogin({ totp: { code: 'outer-code', login: retry('inner-code') } });
+		expect(removeNotExpiredById.calledOnceWithExactly(request.credentialToken)).to.be.true;
+		expect(credential).to.be.undefined;
+	});
+
+	it('should not change credentials when validating another login service', async () => {
+		await validateLoginAttempt({
+			type: 'oauth',
+			allowed: true,
+			user,
+			methodName: 'login',
+			methodArguments: [request],
+			connection: {},
+		});
+		expect(removeById.called).to.be.false;
+		expect(removeNotExpiredById.called).to.be.false;
+	});
+
+	it('should remove credentials without profile information', async () => {
+		credential!.userInfo = {};
+		const result = await handler(request);
+		expect(result.error.reason).to.equal('No profile information found');
+		expect(credential).to.be.undefined;
+	});
+
+	it('should remove credentials if updating the SAML user fails', async () => {
+		insertOrUpdateSAMLUser.rejects(new Error('Unable to update user'));
+		const result = await handler(request);
+		expect(result.error.reason).to.equal('Error: Unable to update user');
+		expect(credential).to.be.undefined;
 	});
 });


### PR DESCRIPTION
SAML login deleted its credential before 2FA validation, causing every authenticator-code retry to fail. The TOTP modal then mislabeled the missing-credential error as an invalid code.

- **Credential lifecycle:** Retain credentials for `totp-required` and `totp-invalid` retries without extending their original 60-second expiry. Atomically consume unexpired credentials in the awaited login validator before session issuance; remove them on terminal failures.
- **Error reporting:** Reserve invalid-code messaging for `totp-invalid`; surface other failures through the standard error toast.
- **Regression coverage:** Cover challenge/retry/success, expiration, replay and concurrent consumption, terminal cleanup, and modal error classification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



Resolves: https://github.com/RocketChat/Rocket.Chat/pull/42069

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved two-factor authentication error handling: invalid codes show field-level feedback and can be retried, while other failures appear as error notifications.
  - SAML sign-ins now preserve authentication credentials during required two-factor verification and securely consume them after successful completion.
  - Authentication credentials are cleaned up appropriately when sign-in attempts fail or expire.

- **Tests**
  - Expanded coverage for two-factor retries, SAML authentication flows, credential expiry, concurrent sign-ins, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
[COMM-186]

[COMM-186]: https://rocketchat.atlassian.net/browse/COMM-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ