### PR TITLE
fix: long custom status not ellipsed in the user status menu

### DIFF
--- a/.changeset/lazy-hats-hammer.md
+++ b/.changeset/lazy-hats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes long custom statuses being cut off without an ellipsis in the user status menu.

--- a/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
+++ b/apps/meteor/client/navbar/NavBarSettingsToolbar/UserMenu/hooks/useStatusItems.tsx
@@ -110,7 +110,7 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 				status: <UserStatus status={user?.status} />,
 				content: (
 					<>
-						{contentValue && <MarkdownText content={contentValue} parseEmoji variant='inline' />}
+						{contentValue && <MarkdownText withTruncatedText content={contentValue} parseEmoji variant='inline' />}
 						{customStatusExpiration && (
 							<Box color='secondary-info' display='flex' alignItems='center'>
 								<Icon name='clock' size='x16' marginInlineEnd={4} />
@@ -155,7 +155,9 @@ export const useStatusItems = (user?: IUser): GenericMenuItemProps[] => {
 						(status): GenericMenuItemProps => ({
 							id: status.id,
 							status: <UserStatus status={status.statusType} />,
-							content: <MarkdownText content={status.localizeName ? t(status.name) : status.name} parseEmoji variant='inline' />,
+							content: (
+								<MarkdownText withTruncatedText content={status.localizeName ? t(status.name) : status.name} parseEmoji variant='inline' />
+							),
 							addon: <RadioButton checked={user?.statusText === status.name} readOnly />,
 							onClick: () => setStatusMutation.mutate(status),
 						}),


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Long custom statuses were hard-cut in the user status menu, with no ellipsis.

The menu row already sets `text-overflow: ellipsis`, but that only applies to an element's *own* inline content — and the status is rendered through `MarkdownText`, which emits a child `<div>`. The text overflows that inner div and the parent clips it without an ellipsis. Every other menu item passes a plain string, which is why only the status rows were affected.

Fix: pass `withTruncatedText` to the `MarkdownText` of the active custom status and of the admin-defined ones (no length limit on the name). Preset rows are short localized labels and were left untouched.

## Issue(s)

- [CORE-2676](https://rocketchat.atlassian.net/browse/CORE-2676)

## Steps to test or reproduce

1. Open the user menu (avatar, top right) and click **Custom Status**.
2. Set a status message long enough to exceed the menu width, e.g. `Working from the office today and reachable only after the afternoon planning meeting`.
3. Reopen the user menu — the active status row should end with an ellipsis (`…`) instead of being cut off mid-word.
4. In **Admin → User Status**, create a custom status with a long name and reopen the user menu — that row should be ellipsed too.

## Further comments

N/A


[CORE-2676]: https://rocketchat.atlassian.net/browse/CORE-2676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Long custom statuses in the user status menu are now truncated with an ellipsis for clearer display.
  * Applies to both personal and administrator-defined custom statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->