### PR TITLE
chore: remove redundant index creation from push token migration

### DIFF
--- a/apps/meteor/server/startup/migrations/v345.ts
+++ b/apps/meteor/server/startup/migrations/v345.ts
@@ -41,6 +41,5 @@ addMigration({
 		await col.deleteMany({ tokenValue: { $exists: false } });
 
 		await col.dropIndex('appName_1_token_1').catch(() => undefined);
-		await PushToken.createIndexes();
 	},
 });


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Removes the redundant `await PushToken.createIndexes()` from the `v345` migration. `BaseRaw`'s constructor already calls `createIndexes()` on model instantiation, so the indexes are created automatically on boot.

The `dropIndex('appName_1_token_1')` stays: boot-time creation never drops indexes removed from `modelIndexes()`.

## Issue(s)

- [CORE-2101](https://rocketchat.atlassian.net/browse/CORE-2101)
- Follow-up of #41382.

## Steps to test or reproduce

Run migration `v345` and check `_raix_push_app_tokens`: `tokenValue_1` / `tokenType_1` present, `appName_1_token_1` gone.

## Further comments

No changeset — no-op cleanup on an unreleased migration already covered by #41382.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated push token data migration to remove an outdated index after token conversion.
  * Preserved conversion of VOIP and platform-specific token data into the current format.
  * Removed incomplete token records that lack usable token values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[CORE-2101]: https://rocketchat.atlassian.net/browse/CORE-2101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ