### PR TITLE
feat: filter channels.list and groups.listAll by custom fields

### DIFF
--- a/.changeset/pink-donkeys-invite.md
+++ b/.changeset/pink-donkeys-invite.md
@@ -1,0 +1,6 @@
+---
+"@rocket.chat/rest-typings": minor
+"@rocket.chat/meteor": minor
+---
+
+Adds a `customFields` parameter to the `channels.list` and `groups.listAll` endpoints, filtering rooms by exact custom field values

--- a/apps/meteor/server/api/v1/channels.ts
+++ b/apps/meteor/server/api/v1/channels.ts
@@ -77,6 +77,7 @@ import { addUserToFileObj } from '../lib/addUserToFileObj';
 import { composeRoomWithLastMessage } from '../lib/composeRoomWithLastMessage';
 import { getPaginationItems } from '../lib/getPaginationItems';
 import { getUserFromParams, getUserListFromParams, getUsernameListFromParams } from '../lib/getUserFromParams';
+import { parseCustomFieldsFilter } from '../lib/parseCustomFieldsFilter';
 
 // Returns the channel IF found otherwise it will return the failure of why it didn't. Check the `statusCode` property
 async function findChannelByIdOrName({
@@ -1453,6 +1454,10 @@ API.v1.get(
 			...(_id ? { _id } : {}),
 			t: 'c',
 		};
+
+		if ('customFields' in this.queryParams && this.queryParams.customFields) {
+			Object.assign(ourQuery, parseCustomFieldsFilter(this.queryParams.customFields));
+		}
 
 		if (!hasPermissionToSeeAllPublicChannels) {
 			const roomIds = (

--- a/apps/meteor/server/api/v1/groups.ts
+++ b/apps/meteor/server/api/v1/groups.ts
@@ -20,6 +20,7 @@ import {
 	isGroupsHistoryProps,
 	isGroupsInfoProps,
 	isGroupsInviteProps,
+	isGroupsListAllProps,
 	isGroupsListProps,
 	isGroupsModeratorsProps,
 	isGroupsOnlineProps,
@@ -65,6 +66,7 @@ import { addUserToFileObj } from '../lib/addUserToFileObj';
 import { composeRoomWithLastMessage } from '../lib/composeRoomWithLastMessage';
 import { getPaginationItems } from '../lib/getPaginationItems';
 import { getUserFromParams, getUserListFromParams, getUsernameListFromParams } from '../lib/getUserFromParams';
+import { parseCustomFieldsFilter } from '../lib/parseCustomFieldsFilter';
 
 async function getRoomFromParams(params: { roomId?: string } | { roomName?: string }): Promise<IRoom> {
 	if (
@@ -1002,7 +1004,7 @@ API.v1.get(
 	'groups.listAll',
 	{
 		authRequired: true,
-		query: isGroupsListProps,
+		query: isGroupsListAllProps,
 		permissionsRequired: ['view-room-administration'],
 		response: {
 			200: groupsListResponseSchema,
@@ -1015,6 +1017,10 @@ API.v1.get(
 		const { offset, count } = await getPaginationItems(this.queryParams);
 		const { sort, fields, query } = await this.parseJsonQuery();
 		const ourQuery = Object.assign({}, query, { t: 'p' as RoomType });
+
+		if ('customFields' in this.queryParams && this.queryParams.customFields) {
+			Object.assign(ourQuery, parseCustomFieldsFilter(this.queryParams.customFields));
+		}
 
 		const { cursor, totalCount } = await Rooms.findPaginated(ourQuery, {
 			sort: sort || { name: 1 },

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -328,6 +328,60 @@ describe('[Channels]', () => {
 			await deleteRoom({ type: 'c', roomId: testChannel._id });
 		});
 
+		describe('filtering by customFields', () => {
+			let taggedRoom: IRoom;
+			const tenant = `tenant-${Date.now()}`;
+
+			before(async () => {
+				taggedRoom = (await createRoom({ type: 'c', name: `channels.list.cf.${Date.now()}` })).body.channel;
+
+				await request
+					.post(api('rooms.saveRoomSettings'))
+					.set(credentials)
+					.send({ rid: taggedRoom._id, roomCustomFields: { CustomerID: tenant } })
+					.expect(200);
+			});
+
+			after(async () => {
+				await deleteRoom({ type: 'c', roomId: taggedRoom._id });
+			});
+
+			it('should return only the room carrying the value', async () => {
+				const response = await request
+					.get(api('channels.list'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: tenant }) })
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(response.body).to.have.property('success', true);
+				expect(response.body.channels).to.be.an('array').with.lengthOf(1);
+				expect(response.body.channels[0]).to.have.property('_id', taggedRoom._id);
+			});
+
+			it('should match on the exact value only', async () => {
+				const response = await request
+					.get(api('channels.list'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: tenant.slice(0, 6) }) })
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(response.body.channels).to.be.an('array').that.is.empty;
+			});
+
+			it('should reject a mongo operator as a value', async () => {
+				const response = await request
+					.get(api('channels.list'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: { $ne: null } }) })
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(response.body).to.have.property('success', false);
+			});
+		});
+
 		it('should succesfully return a list of channels', async () => {
 			await request
 				.get(api('channels.list'))

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -373,6 +373,15 @@ describe('[Channels]', () => {
 				expect(response.body.channels).to.be.an('array').that.is.empty;
 			});
 
+			it('should reject an empty customFields parameter instead of ignoring it', async () => {
+				await request
+					.get(api('channels.list'))
+					.set(credentials)
+					.query({ customFields: '' })
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+			});
+
 			it('should reject a mongo operator as a value', async () => {
 				const response = await request
 					.get(api('channels.list'))

--- a/apps/meteor/tests/end-to-end/api/channels.ts
+++ b/apps/meteor/tests/end-to-end/api/channels.ts
@@ -333,6 +333,9 @@ describe('[Channels]', () => {
 			const tenant = `tenant-${Date.now()}`;
 
 			before(async () => {
+				await updatePermission('view-c-room', ['admin', 'user', 'bot', 'app', 'anonymous']);
+				await updatePermission('view-joined-room', ['guest', 'bot', 'app', 'anonymous']);
+
 				taggedRoom = (await createRoom({ type: 'c', name: `channels.list.cf.${Date.now()}` })).body.channel;
 
 				await request

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -1754,6 +1754,60 @@ describe('[Groups]', () => {
 			return updatePermission('view-room-administration', ['admin']);
 		});
 
+		describe('filtering by customFields', () => {
+			let taggedRoom: IRoom;
+			const tenant = `tenant-${Date.now()}`;
+
+			before(async () => {
+				taggedRoom = (await createRoom({ type: 'p', name: `groups.listAll.cf.${Date.now()}` })).body.group;
+
+				await request
+					.post(api('rooms.saveRoomSettings'))
+					.set(credentials)
+					.send({ rid: taggedRoom._id, roomCustomFields: { CustomerID: tenant } })
+					.expect(200);
+			});
+
+			after(async () => {
+				await deleteRoom({ type: 'p', roomId: taggedRoom._id });
+			});
+
+			it('should return only the room carrying the value', async () => {
+				const response = await request
+					.get(api('groups.listAll'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: tenant }) })
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(response.body).to.have.property('success', true);
+				expect(response.body.groups).to.be.an('array').with.lengthOf(1);
+				expect(response.body.groups[0]).to.have.property('_id', taggedRoom._id);
+			});
+
+			it('should match on the exact value only', async () => {
+				const response = await request
+					.get(api('groups.listAll'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: tenant.slice(0, 6) }) })
+					.expect('Content-Type', 'application/json')
+					.expect(200);
+
+				expect(response.body.groups).to.be.an('array').that.is.empty;
+			});
+
+			it('should reject a mongo operator as a value', async () => {
+				const response = await request
+					.get(api('groups.listAll'))
+					.set(credentials)
+					.query({ customFields: JSON.stringify({ CustomerID: { $ne: null } }) })
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+
+				expect(response.body).to.have.property('success', false);
+			});
+		});
+
 		it('should succeed if user has view-room-administration permission', async () => {
 			await request
 				.get(api('groups.listAll'))

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -1759,6 +1759,8 @@ describe('[Groups]', () => {
 			const tenant = `tenant-${Date.now()}`;
 
 			before(async () => {
+				await updatePermission('view-room-administration', ['admin']);
+
 				taggedRoom = (await createRoom({ type: 'p', name: `groups.listAll.cf.${Date.now()}` })).body.group;
 
 				await request

--- a/apps/meteor/tests/end-to-end/api/groups.ts
+++ b/apps/meteor/tests/end-to-end/api/groups.ts
@@ -1798,6 +1798,15 @@ describe('[Groups]', () => {
 				expect(response.body.groups).to.be.an('array').that.is.empty;
 			});
 
+			it('should reject an empty customFields parameter instead of ignoring it', async () => {
+				await request
+					.get(api('groups.listAll'))
+					.set(credentials)
+					.query({ customFields: '' })
+					.expect('Content-Type', 'application/json')
+					.expect(400);
+			});
+
 			it('should reject a mongo operator as a value', async () => {
 				const response = await request
 					.get(api('groups.listAll'))

--- a/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
+++ b/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
@@ -3,6 +3,7 @@ import { ajvQuery } from '../Ajv';
 
 export type ChannelsListProps = PaginatedRequest<{
 	_id?: string;
+	customFields?: string;
 	/* deprecated */
 	fields?: string;
 }>;
@@ -11,6 +12,9 @@ const channelsListPropsSchema = {
 	type: 'object',
 	properties: {
 		_id: {
+			type: 'string',
+		},
+		customFields: {
 			type: 'string',
 		},
 		query: {

--- a/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
+++ b/packages/rest-typings/src/v1/channels/ChannelsListProps.ts
@@ -16,6 +16,7 @@ const channelsListPropsSchema = {
 		},
 		customFields: {
 			type: 'string',
+			minLength: 1,
 		},
 		query: {
 			type: 'string',

--- a/packages/rest-typings/src/v1/groups/GroupsListAllProps.ts
+++ b/packages/rest-typings/src/v1/groups/GroupsListAllProps.ts
@@ -8,6 +8,7 @@ const groupsListAllPropsSchema = {
 	properties: {
 		customFields: {
 			type: 'string',
+			minLength: 1,
 		},
 	},
 };

--- a/packages/rest-typings/src/v1/groups/GroupsListAllProps.ts
+++ b/packages/rest-typings/src/v1/groups/GroupsListAllProps.ts
@@ -1,0 +1,15 @@
+import type { PaginatedRequest } from '../../helpers/PaginatedRequest';
+import { ajvQuery } from '../Ajv';
+
+export type GroupsListAllProps = PaginatedRequest<{ customFields?: string }>;
+
+const groupsListAllPropsSchema = {
+	type: 'object',
+	properties: {
+		customFields: {
+			type: 'string',
+		},
+	},
+};
+
+export const isGroupsListAllProps = ajvQuery.compile<GroupsListAllProps>(groupsListAllPropsSchema);

--- a/packages/rest-typings/src/v1/groups/groups.ts
+++ b/packages/rest-typings/src/v1/groups/groups.ts
@@ -17,6 +17,7 @@ import type { GroupsInfoProps } from './GroupsInfoProps';
 import type { GroupsInviteProps } from './GroupsInviteProps';
 import type { GroupsKickProps } from './GroupsKickProps';
 import type { GroupsLeaveProps } from './GroupsLeaveProps';
+import type { GroupsListAllProps } from './GroupsListAllProps';
 import type { GroupsListProps } from './GroupsListProps';
 import type { GroupsMembersProps } from './GroupsMembersProps';
 import type { GroupsMessagesProps } from './GroupsMessagesProps';
@@ -154,7 +155,7 @@ export type GroupsEndpoints = {
 		};
 	};
 	'/v1/groups.listAll': {
-		GET: (params: GroupsListProps) => {
+		GET: (params: GroupsListAllProps) => {
 			count: number;
 			offset: number;
 			groups: IRoom[];

--- a/packages/rest-typings/src/v1/groups/index.ts
+++ b/packages/rest-typings/src/v1/groups/index.ts
@@ -20,6 +20,7 @@ export * from './GroupsAddOwnerProps';
 export * from './GroupsGetIntegrationsProps';
 export * from './GroupsInfoProps';
 export * from './GroupsInviteProps';
+export * from './GroupsListAllProps';
 export * from './GroupsListProps';
 export * from './GroupsOnlineProps';
 export * from './GroupsOpenProps';


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Adds a `customFields` filter to two room list endpoints, matching the one added to `users.list`:

```
GET /v1/channels.list?customFields={"CustomerID":"acct-4821"}
```

Same parser: exact match, no operators, no nesting, keys carrying `$` or `.` rejected, every key prefixed with `customFields.`.

**No permission of its own, deliberately.** `channels.list` and `groups.listAll` project only the four default exclusions (`joinCode`, `members`, `importIds`, `e2e`), so they already return `customFields` for every room they list. A caller can list and filter client-side today; doing it server-side reveals nothing new. That is the opposite of `users.list`, which projects nine fixed fields with `customFields` absent — which is why that one gates on `view-full-other-user-info`. Each endpoint's own permission (`view-c-room` / `view-joined-room`, and `view-room-administration`) already bounds which rooms are searchable.

## Issue(s)

CORE-2679

Follows the `users.list` filter, and precedes the removal of `ALLOW_UNSAFE_QUERY_AND_FIELDS_API_PARAMS`.

## Steps to test or reproduce

Create a channel, then `POST /v1/rooms.saveRoomSettings` with `roomCustomFields: { CustomerID: "abc", BAID: "b9" }`, and a second channel without any. Every row below was run against a local server.

| Request | Expected |
|---|---|
| `channels.list?customFields={"CustomerID":"abc"}` | only the room carrying it |
| `...customFields={"CustomerID":"ab"}` | no match — the value is compared whole |
| `...customFields={"CustomerID":"abc","BAID":"b9"}` | both conditions, combined with AND |
| `channels.list` with no parameter | both rooms, each already carrying `customFields` |
| the same against `groups.listAll` with a private group | only that group |

**Answers `400`:** an operator in the key or value, a nested path, a value that is not a non-empty string, a payload that is not an object.

## Further comments

**Draft on purpose: no reported usage backs it.** Both endpoints accept `query` today and lose it with the removal, so the capability is real, but no integration has been documented filtering rooms by a custom field.

**Incomplete by an accident of implementation.** `groups.list` and `channels.list.joined` build their query inside `findPaginatedByTypeAndIds`, which takes no extra filter, so they are left out. The argument is identical for them; closing the gap needs an optional filter argument on a model method with two callers.

**No index** covers `customFields.*` on `Rooms`, so these are collection scans.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exact custom-field filtering to the `channels.list` and `groups.listAll` REST endpoints.
  * Added support for the `customFields` query parameter in API request definitions.
  * Invalid filter values, including MongoDB operators, are rejected with a `400` response.

* **Tests**
  * Added coverage for matching, partial-value, and invalid custom-field filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->