### PR TITLE
chore(docker): use apk in ee services builder stage and run as non-root

### DIFF
--- a/apps/meteor/ee/server/services/Dockerfile
+++ b/apps/meteor/ee/server/services/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:22.22.3-alpine3.23 as build
+FROM node:22.22.3-alpine3.23 AS build
 
 WORKDIR /app
 
-RUN apt-get update \
-    && apt-get install -y build-essential git
+RUN apk add --no-cache build-base git
 
 COPY ./package.json .
 COPY ./yarn.lock .
@@ -78,9 +77,12 @@ RUN apk update && \
     apk upgrade --no-cache openssl && \
     yarn workspaces focus --production && \
     rm -rf /var/cache/apk/* && \
-    apk del build-dependencies
+    apk del build-dependencies && \
+    chown -R node:node /app
 
 WORKDIR /app/apps/meteor/ee/server/services/${SERVICE}
+
+USER node
 
 EXPOSE 3000 9458
 


### PR DESCRIPTION
## Proposed changes

Two pre-existing bugs in `apps/meteor/ee/server/services/Dockerfile`:

- The builder stage runs on `node:*-alpine`, but installed build tools with `apt-get`, which does not exist on Alpine. Replaced with `apk add --no-cache build-base git`.
- The runtime stage ran as root. `/app` is now chowned to `node` and the stage drops to `USER node` before `CMD`, matching what `ee/apps/Dockerfile` and `apps/meteor/.docker/Dockerfile.alpine` already do.

Also normalized `FROM ... as build` to `AS build` to silence the BuildKit casing warning. No image version tags were changed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Services now run as a non-root user, improving container security.
  - Runtime application files are assigned to the service user for smoother operation.

- **Build & Deployment**
  - Container builds now use Alpine’s package management tools for installing build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
found here:  https://github.com/RocketChat/Rocket.Chat/pull/41097
[ARCH-2403](https://rocketchat.atlassian.net/browse/ARCH-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[ARCH-2403]: https://rocketchat.atlassian.net/browse/ARCH-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ