### PR TITLE
fix: home page custom content card overflows on narrow viewports

### DIFF
--- a/.changeset/home-custom-content-card-controls-wrap.md
+++ b/.changeset/home-custom-content-card-controls-wrap.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the custom content card on the home page overflowing horizontally on narrow viewports, by allowing its action buttons to wrap onto multiple lines

--- a/apps/meteor/client/views/home/cards/CustomContentCard.tsx
+++ b/apps/meteor/client/views/home/cards/CustomContentCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Card, CardBody, CardControls, CardHeader, Icon, Tag } from '@rocket.chat/fuselage';
+import { Box, Button, ButtonGroup, Card, CardBody, CardControls, CardHeader, Icon, Tag } from '@rocket.chat/fuselage';
 import { useRole, useSettingSetValue, useSetting, useToastMessageDispatch, useRouter } from '@rocket.chat/ui-contexts';
 import type { ComponentProps } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -60,27 +60,29 @@ const CustomContentCard = (props: Omit<ComponentProps<typeof Card>, 'type'>) => 
 				</CardHeader>
 				<CardBody>{isCustomContentBodyEmpty ? t('Homepage_Custom_Content_Default_Message') : <CustomHomepageContent />}</CardBody>
 				<CardControls>
-					<Button medium onClick={() => router.navigate('/admin/settings/Layout')} title={t('Layout_Home_Page_Content')}>
-						{t('Customize_Content')}
-					</Button>
-					<Button
-						icon={willNotShowCustomContent ? 'eye' : 'eye-off'}
-						disabled={isCustomContentBodyEmpty || (isCustomContentVisible && isCustomContentOnly)}
-						title={isCustomContentBodyEmpty ? t('Action_Available_After_Custom_Content_Added') : userVisibilityTooltipText}
-						onClick={handleChangeCustomContentVisibility}
-						medium
-					>
-						{willNotShowCustomContent ? t('Show_To_Workspace') : t('Hide_On_Workspace')}
-					</Button>
-					<Button
-						icon='lightning'
-						disabled={willNotShowCustomContent || !isEnterprise}
-						title={!isEnterprise ? t('Premium_only') : customContentOnlyTooltipText}
-						onClick={handleOnlyShowCustomContent}
-						medium
-					>
-						{!isCustomContentOnly ? t('Show_Only_This_Content') : t('Show_default_content')}
-					</Button>
+					<ButtonGroup wrap>
+						<Button medium onClick={() => router.navigate('/admin/settings/Layout')} title={t('Layout_Home_Page_Content')}>
+							{t('Customize_Content')}
+						</Button>
+						<Button
+							icon={willNotShowCustomContent ? 'eye' : 'eye-off'}
+							disabled={isCustomContentBodyEmpty || (isCustomContentVisible && isCustomContentOnly)}
+							title={isCustomContentBodyEmpty ? t('Action_Available_After_Custom_Content_Added') : userVisibilityTooltipText}
+							onClick={handleChangeCustomContentVisibility}
+							medium
+						>
+							{willNotShowCustomContent ? t('Show_To_Workspace') : t('Hide_On_Workspace')}
+						</Button>
+						<Button
+							icon='lightning'
+							disabled={willNotShowCustomContent || !isEnterprise}
+							title={!isEnterprise ? t('Premium_only') : customContentOnlyTooltipText}
+							onClick={handleOnlyShowCustomContent}
+							medium
+						>
+							{!isCustomContentOnly ? t('Show_Only_This_Content') : t('Show_default_content')}
+						</Button>
+					</ButtonGroup>
 				</CardControls>
 			</Card>
 		);


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

The custom content card on the home page renders three action buttons inside `CardControls`. That container is a flex row without `flex-wrap`, so on narrow viewports the buttons stay on one line, the card stretches past the edge of the screen, and the third button is cut off.

| Before | After |
| --- | --- |
| ![Third button clipped at the right edge of the viewport](https://raw.githubusercontent.com/ayan-alam07/Rocket.Chat/pr-assets/before.png) | ![All three buttons wrapped inside the card](https://raw.githubusercontent.com/ayan-alam07/Rocket.Chat/pr-assets/after.png) |

Both captured on the admin home page at 414 x 896, the iPhone X viewport. Measured from the rendered page:

- Before: the card is 524px wide inside a 414px viewport, the controls sit on one 32px row, and the last button's right edge lands at 504px.
- After: the card is 366px wide, the controls wrap onto two rows totalling 72px, and the last button's right edge lands at 343px.

This change wraps the three buttons in a `ButtonGroup` with the `wrap` prop. Fuselage already styles `.rcx-button-group--wrap` with `flex-wrap: wrap`, so the buttons move onto a second line when the card is too narrow to fit them on one.

`ButtonGroup` is what fuselage documents for "grouping buttons that semantically share a common action context", which describes these three. It also renders `role="group"`, so the grouping is exposed to assistive technology. `TagList.tsx` and `MarketplaceHeader.tsx` already use the same prop.

I fixed this on the app side because the root cause is in fuselage and has not been released. RocketChat/fuselage#1440 tracks the missing `flex-wrap` on `.rcx-card__controls` and RocketChat/fuselage#2074 proposes adding it. Both are open, and 0.88.0, the version this repository depends on, does not contain the fix. If that PR lands, the `ButtonGroup` here remains correct and can be simplified later if maintainers prefer.

## Issue(s)

Closes #42083

## Steps to test or reproduce

1. Sign in as a user with the admin role.
2. Open the home page.
3. Open browser devtools and switch to a mobile viewport, for example iPhone X at 414 x 896.
4. Scroll to the custom content card at the end of the card group.

Before this change the third button is clipped at the edge of the screen. After it the buttons wrap onto a second line and stay inside the card.

## Further comments

Only the admin branch of `CustomContentCard` changes. The other branches render no controls, so they are unaffected. No unit or e2e test covers this component today.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed horizontal overflow of custom content cards on narrow screens.
  - Custom content action buttons now wrap onto multiple lines when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->