### PR TITLE
chore: bump Debian base image from bullseye to bookworm

### DIFF
--- a/apps/meteor/.docker/Dockerfile.debian
+++ b/apps/meteor/.docker/Dockerfile.debian
@@ -2,7 +2,7 @@ ARG DENO_VERSION="1.37.1"
 
 FROM denoland/deno:bin-${DENO_VERSION} as deno
 
-FROM node:24.15.0-bullseye-slim
+FROM node:24.15.0-bookworm-slim
 
 LABEL maintainer="buildmaster@rocket.chat"
 


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Bumps the base image of `apps/meteor/.docker/Dockerfile.debian` from the Debian 11 (bullseye) variant to the Debian 12 (bookworm) variant:

```diff
-FROM node:24.15.0-bullseye-slim
+FROM node:24.15.0-bookworm-slim
```

The Node version is intentionally **not** changed here — this PR is only the Debian variant move.

### Why

**1. bullseye is out of security support.**
Debian 11 left regular support on 2024-08-15 and its **LTS window ended on 2026-08-31** ([Debian LTS wiki](https://wiki.debian.org/LTS)). From that date on, the Debian image we publish stops receiving OS security updates unless someone pays for ELTS. Bookworm is supported until 2028-06-30.

**2. `isolated-vm` 6.x needs a full C++20 toolchain.**
`develop` now pins `isolated-vm@6.2.0` (since #41097 landed), which requires full C++20. The bullseye image only provides GCC 10.2, whose C++20 support is partial — so if that install ever falls back to a source compile instead of a prebuilt binary, the Debian image build breaks. Bookworm brings GCC 12 and glibc 2.36.

**3. Toolchain parity with the alpine image.**
`Dockerfile.alpine` already builds on `alpine3.23` and gets a fully C++20-capable toolchain. This brings the Debian image in line rather than leaving the two published images on materially different compilers.

### Verification

- `node:24.15.0-bookworm-slim` exists on Docker Hub.
- Reviewed the rest of `Dockerfile.debian` for anything Debian-11-specific: there is nothing pinned to bullseye. The apt packages installed (`fontconfig`, `g++`, `make`, `python3`, `ca-certificates`) all exist under the same names in bookworm, there are no third-party apt repos or pinned lib versions, and the `deno` stage copies a static binary from `denoland/deno:bin-*` (unaffected by the host distro, and a newer glibc is backward compatible for it).

## Issue(s)

ARCH-1592

## Steps to test or reproduce

Build the Debian image and confirm it starts:

```
docker build -f apps/meteor/.docker/Dockerfile.debian .
```

## Further comments

Found while working on #41097 (Meteor 3.5 / Node 24) — raised there in [this review comment](https://github.com/RocketChat/Rocket.Chat/pull/41097#discussion_r3970018047). It is an independent base-image upgrade rather than part of the Meteor/Node bump, so it was split out into this PR to keep #41097 scoped. #41097 has since merged, so this now applies on top of Node 24.

**No changeset.** Matching precedent in this repo: the comparable image changes — #40536 (Node bump), #40389 (Meteor/Node bump) and #40128 (slim Docker image, which visibly changed the published image) — all landed without one, and there is no CI gate requiring a changeset. Happy to add one if maintainers want the base OS bump called out in the release notes.

Debian 13 (trixie) variants also exist for this Node version. Bookworm is the conservative step and the one raised in review; trixie can be a separate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Debian-based build environment to use Debian Bookworm.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 

 Task: [ARCH-2405]

[ARCH-2405]: https://rocketchat.atlassian.net/browse/ARCH-2405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ