### PR TITLE
fix: empty Drafts group rendering in the sidebar after upgrade

### DIFF
--- a/.changeset/sidebar-stale-drafts-category.md
+++ b/.changeset/sidebar-stale-drafts-category.md
@@ -1,0 +1,6 @@
+---
+'@rocket.chat/core-typings': patch
+'@rocket.chat/meteor': patch
+---
+
+Fixes the removed `Drafts` sidebar group reappearing as an empty category on workspaces upgraded from a build that shipped it

--- a/apps/meteor/client/sidebar/categories/hooks/useCreateCustomCategory.ts
+++ b/apps/meteor/client/sidebar/categories/hooks/useCreateCustomCategory.ts
@@ -1,7 +1,6 @@
 import type { ISidebarCategory } from '@rocket.chat/core-typings';
-import { SIDEBAR_SYSTEM_GROUP_KEYS } from '@rocket.chat/core-typings';
 import { Random } from '@rocket.chat/random';
-import { useToastMessageDispatch, useUserPreference } from '@rocket.chat/ui-contexts';
+import { useToastMessageDispatch } from '@rocket.chat/ui-contexts';
 import { useMutation } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
@@ -9,12 +8,13 @@ import { usePersistCategoriesMutation } from './usePersistCategoriesMutation';
 import { useSetCategory } from './useSetCategory';
 import { useUserSidebarCategories, type MovableRoom } from './useUserSidebarCategories';
 import { withDynamicFirst } from '../../hooks/useCategoryList';
+import { useSidebarSectionsOrder } from '../../hooks/useSidebarSectionsOrder';
 
 export const useCreateCustomCategory = ({ settleCallback }: { settleCallback?: () => void } = {}) => {
 	const { t } = useTranslation();
 	const dispatchToastMessage = useToastMessageDispatch();
 	const { rawCategories } = useUserSidebarCategories();
-	const sidebarSectionsOrder: readonly string[] = useUserPreference<string[]>('sidebarSectionsOrder') ?? SIDEBAR_SYSTEM_GROUP_KEYS;
+	const sidebarSectionsOrder = useSidebarSectionsOrder();
 
 	const setCategory = useSetCategory();
 	const { mutateAsync: persistCategories } = usePersistCategoriesMutation();

--- a/apps/meteor/client/sidebar/categories/hooks/useMoveCategoryPosition.ts
+++ b/apps/meteor/client/sidebar/categories/hooks/useMoveCategoryPosition.ts
@@ -1,14 +1,13 @@
-import { SIDEBAR_SYSTEM_GROUP_KEYS } from '@rocket.chat/core-typings';
-import { useUserPreference } from '@rocket.chat/ui-contexts';
 import { useCallback } from 'react';
 
 import { usePersistCategoriesMutation } from './usePersistCategoriesMutation';
 import { useUserSidebarCategories } from './useUserSidebarCategories';
 import { withDynamicFirst } from '../../hooks/useCategoryList';
+import { useSidebarSectionsOrder } from '../../hooks/useSidebarSectionsOrder';
 
 export const useMoveCategoryPosition = () => {
 	const { rawCategories } = useUserSidebarCategories();
-	const sidebarSectionsOrder: readonly string[] = useUserPreference<string[]>('sidebarSectionsOrder') ?? SIDEBAR_SYSTEM_GROUP_KEYS;
+	const sidebarSectionsOrder = useSidebarSectionsOrder();
 	const { mutateAsync: persistCategories } = usePersistCategoriesMutation();
 
 	return useCallback(

--- a/apps/meteor/client/sidebar/categories/hooks/useToggleUnreads.ts
+++ b/apps/meteor/client/sidebar/categories/hooks/useToggleUnreads.ts
@@ -1,15 +1,14 @@
 import type { ISidebarCategory } from '@rocket.chat/core-typings';
-import { SIDEBAR_SYSTEM_GROUP_KEYS } from '@rocket.chat/core-typings';
-import { useUserPreference } from '@rocket.chat/ui-contexts';
 import { useCallback } from 'react';
 
 import { usePersistCategoriesMutation } from './usePersistCategoriesMutation';
 import { useUserSidebarCategories } from './useUserSidebarCategories';
 import { withDynamicFirst } from '../../hooks/useCategoryList';
+import { useSidebarSectionsOrder } from '../../hooks/useSidebarSectionsOrder';
 
 export const useToggleUnreads = () => {
 	const { rawCategories } = useUserSidebarCategories();
-	const sidebarSectionsOrder: readonly string[] = useUserPreference<string[]>('sidebarSectionsOrder') ?? SIDEBAR_SYSTEM_GROUP_KEYS;
+	const sidebarSectionsOrder = useSidebarSectionsOrder();
 	const { mutateAsync: persistCategories } = usePersistCategoriesMutation();
 
 	const upsertGroupEntry = useCallback(

--- a/apps/meteor/client/sidebar/categories/hooks/useUserSidebarCategories.spec.ts
+++ b/apps/meteor/client/sidebar/categories/hooks/useUserSidebarCategories.spec.ts
@@ -1,0 +1,78 @@
+import { useUserPreference } from '@rocket.chat/ui-contexts';
+import { renderHook } from '@testing-library/react';
+
+import { useUserSidebarCategories } from './useUserSidebarCategories';
+import { useHasLicenseModule } from '../../../hooks/useHasLicenseModule';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useUserPreference: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useHasLicenseModule', () => ({
+	useHasLicenseModule: jest.fn(),
+}));
+
+const mockedUseUserPreference = jest.mocked(useUserPreference);
+const mockedUseHasLicenseModule = jest.mocked(useHasLicenseModule);
+
+beforeEach(() => {
+	mockedUseHasLicenseModule.mockReturnValue({ data: true } as any);
+});
+
+const ids = (entries: { _id: string }[]) => entries.map(({ _id }) => _id);
+
+it('returns an empty list when the preference is unset', () => {
+	mockedUseUserPreference.mockReturnValue(undefined);
+
+	const { result } = renderHook(() => useUserSidebarCategories());
+
+	expect(result.current.rawCategories).toEqual([]);
+	expect(result.current.customCategories).toEqual([]);
+});
+
+it('drops entries left behind by a removed system group', () => {
+	mockedUseUserPreference.mockReturnValue([
+		{ _id: 'Favorites', name: 'Favorites', default: true },
+		{ _id: 'Drafts', name: 'Drafts', default: true },
+		{ _id: 'Conversations', name: 'Conversations', default: true },
+	]);
+
+	const { result } = renderHook(() => useUserSidebarCategories());
+
+	expect(ids(result.current.rawCategories)).toEqual(['Favorites', 'Conversations']);
+});
+
+it('keeps custom categories and their stored metadata', () => {
+	mockedUseUserPreference.mockReturnValue([
+		{ _id: 'Drafts', name: 'Drafts', default: true },
+		{ _id: 'custom-xyz', name: 'Work', showUnreads: true },
+	]);
+
+	const { result } = renderHook(() => useUserSidebarCategories());
+
+	expect(ids(result.current.rawCategories)).toEqual(['custom-xyz']);
+	expect(result.current.customCategories).toEqual([{ _id: 'custom-xyz', name: 'Work', showUnreads: true }]);
+});
+
+it('only drops entries flagged as system groups, not custom ids that look like one', () => {
+	const entries = [{ _id: 'Favorites', name: 'My favorites' }];
+	mockedUseUserPreference.mockReturnValue(entries);
+
+	const { result } = renderHook(() => useUserSidebarCategories());
+
+	expect(result.current.rawCategories).toEqual(entries);
+});
+
+it('hides custom categories without the license module but keeps the raw entries', () => {
+	mockedUseHasLicenseModule.mockReturnValue({ data: false } as any);
+	mockedUseUserPreference.mockReturnValue([
+		{ _id: 'Favorites', name: 'Favorites', default: true },
+		{ _id: 'Drafts', name: 'Drafts', default: true },
+		{ _id: 'custom-xyz', name: 'Work' },
+	]);
+
+	const { result } = renderHook(() => useUserSidebarCategories());
+
+	expect(ids(result.current.rawCategories)).toEqual(['Favorites', 'custom-xyz']);
+	expect(result.current.customCategories).toEqual([]);
+});

--- a/apps/meteor/client/sidebar/categories/hooks/useUserSidebarCategories.ts
+++ b/apps/meteor/client/sidebar/categories/hooks/useUserSidebarCategories.ts
@@ -1,4 +1,5 @@
 import type { ISidebarCategory } from '@rocket.chat/core-typings';
+import { isStaleSidebarCategory } from '@rocket.chat/core-typings';
 import { useUserPreference } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
@@ -13,7 +14,7 @@ export const useUserSidebarCategories = () => {
 	const allEntries = useUserPreference<ISidebarCategory[]>('sidebarCategories');
 
 	return useMemo(() => {
-		const rawCategories = allEntries ?? [];
+		const rawCategories = (allEntries ?? []).filter((entry) => !isStaleSidebarCategory(entry));
 		const customCategories = rawCategories.filter((entry) => !entry.default);
 		return hasLicenseModule ? { rawCategories, customCategories } : { rawCategories, customCategories: [] };
 	}, [hasLicenseModule, allEntries]);

--- a/apps/meteor/client/sidebar/hooks/useCategoryList.spec.ts
+++ b/apps/meteor/client/sidebar/hooks/useCategoryList.spec.ts
@@ -1,4 +1,21 @@
-import { SIDEBAR_DYNAMIC_GROUP_KEYS, mergeWithSectionsOrder, withDynamicFirst } from './useCategoryList';
+import { useSetting, useUserPreference } from '@rocket.chat/ui-contexts';
+import { renderHook } from '@testing-library/react';
+
+import { SIDEBAR_DYNAMIC_GROUP_KEYS, mergeWithSectionsOrder, useCategoryList, withDynamicFirst } from './useCategoryList';
+import { useHasLicenseModule } from '../../hooks/useHasLicenseModule';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useSetting: jest.fn(),
+	useUserPreference: jest.fn(),
+}));
+
+jest.mock('../../hooks/useHasLicenseModule', () => ({
+	useHasLicenseModule: jest.fn(),
+}));
+
+const mockedUseSetting = jest.mocked(useSetting);
+const mockedUseUserPreference = jest.mocked(useUserPreference);
+const mockedUseHasLicenseModule = jest.mocked(useHasLicenseModule);
 
 const STATIC_KEYS = ['Favorites', 'Teams', 'Discussions', 'Channels', 'Direct_Messages', 'Conversations'] as const;
 const DYNAMIC_KEYS = [...SIDEBAR_DYNAMIC_GROUP_KEYS];
@@ -61,5 +78,48 @@ describe('withDynamicFirst', () => {
 		expect(result.indexOf('Unread')).toBeLessThan(result.indexOf('Favorites'));
 		expect(result.indexOf('Unread')).toBeLessThan(result.indexOf('Channels'));
 		expect(result.indexOf('Favorites')).toBeLessThan(result.indexOf('Channels'));
+	});
+});
+
+describe('useCategoryList', () => {
+	const preferences: Record<string, unknown> = {};
+	let hasLicenseModule = false;
+
+	beforeEach(() => {
+		for (const key of Object.keys(preferences)) delete preferences[key];
+		Object.assign(preferences, { sidebarGroupByType: false, sidebarShowFavorites: true, sidebarShowUnread: true });
+		hasLicenseModule = false;
+
+		mockedUseUserPreference.mockImplementation((key: string, defaultValue?: unknown) => preferences[key] ?? defaultValue);
+		mockedUseSetting.mockImplementation((_key: string, defaultValue?: unknown) => defaultValue);
+		mockedUseHasLicenseModule.mockImplementation(() => ({ data: hasLicenseModule }) as any);
+	});
+
+	const categoryList = () => renderHook(() => useCategoryList(false, false)).result.current;
+
+	it('ignores a section key of a system group that no longer exists', () => {
+		preferences.sidebarSectionsOrder = ['Incoming_Calls', 'Unread', 'Drafts', 'Favorites', 'Conversations'];
+
+		expect(categoryList()).toEqual(['Incoming_Calls', 'Unread', 'Favorites', 'Conversations']);
+	});
+
+	it('ignores a stale section key with the license module enabled', () => {
+		hasLicenseModule = true;
+		preferences.sidebarSectionsOrder = ['Incoming_Calls', 'Unread', 'Drafts', 'Favorites', 'Conversations'];
+
+		expect(categoryList()).not.toContain('Drafts');
+	});
+
+	it('ignores a stale entry already persisted in sidebarCategories', () => {
+		hasLicenseModule = true;
+		preferences.sidebarSectionsOrder = ['Incoming_Calls', 'Unread', 'Favorites', 'Conversations'];
+		preferences.sidebarCategories = [
+			{ _id: 'Drafts', name: 'Drafts', default: true },
+			{ _id: 'custom-xyz', name: 'Work' },
+		];
+
+		const result = categoryList();
+		expect(result).not.toContain('Drafts');
+		expect(result).toContain('custom-xyz');
 	});
 });

--- a/apps/meteor/client/sidebar/hooks/useCategoryList.ts
+++ b/apps/meteor/client/sidebar/hooks/useCategoryList.ts
@@ -1,10 +1,10 @@
-import type { ISidebarCategory } from '@rocket.chat/core-typings';
-import { SIDEBAR_SYSTEM_GROUP_KEYS } from '@rocket.chat/core-typings';
 import type { SubscriptionWithRoom } from '@rocket.chat/ui-contexts';
 import { useSetting, useUserPreference } from '@rocket.chat/ui-contexts';
 import { useMemo } from 'react';
 
+import { useSidebarSectionsOrder } from './useSidebarSectionsOrder';
 import { useHasLicenseModule } from '../../hooks/useHasLicenseModule';
+import { useUserSidebarCategories } from '../categories/hooks/useUserSidebarCategories';
 
 type FilterSystemCategoriesOptions = {
 	showOmnichannel: boolean;
@@ -169,8 +169,8 @@ export const getRoomCategory = (
 
 export const useCategoryList = (showOmnichannel: boolean, inquiriesEnabled: boolean) => {
 	const { data: hasLicenseModule = false } = useHasLicenseModule('experimental-enterprise-features');
-	const sidebarCategories = useUserPreference<ISidebarCategory[]>('sidebarCategories', []) ?? [];
-	const sidebarSectionsOrder: readonly string[] = useUserPreference<string[]>('sidebarSectionsOrder') ?? SIDEBAR_SYSTEM_GROUP_KEYS;
+	const { rawCategories: sidebarCategories } = useUserSidebarCategories();
+	const sidebarSectionsOrder = useSidebarSectionsOrder();
 	const sidebarGroupByType = useUserPreference<boolean>('sidebarGroupByType') ?? false;
 	const favoritesEnabled = useUserPreference<boolean>('sidebarShowFavorites', true) ?? true;
 	const isDiscussionEnabled = useSetting('Discussion_enabled', true) ?? true;

--- a/apps/meteor/client/sidebar/hooks/useSidebarSectionsOrder.spec.ts
+++ b/apps/meteor/client/sidebar/hooks/useSidebarSectionsOrder.spec.ts
@@ -1,0 +1,51 @@
+import { SIDEBAR_SYSTEM_GROUP_KEYS } from '@rocket.chat/core-typings';
+import { useUserPreference } from '@rocket.chat/ui-contexts';
+import { renderHook } from '@testing-library/react';
+
+import { useSidebarSectionsOrder } from './useSidebarSectionsOrder';
+
+jest.mock('@rocket.chat/ui-contexts', () => ({
+	useUserPreference: jest.fn(),
+}));
+
+const mockedUseUserPreference = jest.mocked(useUserPreference);
+
+it('falls back to the system group keys when the preference is unset', () => {
+	mockedUseUserPreference.mockReturnValue(undefined);
+
+	const { result } = renderHook(() => useSidebarSectionsOrder());
+
+	expect(result.current).toEqual(SIDEBAR_SYSTEM_GROUP_KEYS);
+});
+
+it('drops keys of system groups that no longer exist', () => {
+	mockedUseUserPreference.mockReturnValue(['Unread', 'Drafts', 'Favorites', 'Conversations']);
+
+	const { result } = renderHook(() => useSidebarSectionsOrder());
+
+	expect(result.current).toEqual(['Unread', 'Favorites', 'Conversations']);
+});
+
+it('keeps the stored order of the remaining keys', () => {
+	mockedUseUserPreference.mockReturnValue(['Conversations', 'Drafts', 'Favorites', 'Unread']);
+
+	const { result } = renderHook(() => useSidebarSectionsOrder());
+
+	expect(result.current).toEqual(['Conversations', 'Favorites', 'Unread']);
+});
+
+it('does not treat custom category ids as section keys', () => {
+	mockedUseUserPreference.mockReturnValue(['Favorites', 'custom-xyz']);
+
+	const { result } = renderHook(() => useSidebarSectionsOrder());
+
+	expect(result.current).toEqual(['Favorites']);
+});
+
+it('returns an empty list when every stored key is stale', () => {
+	mockedUseUserPreference.mockReturnValue(['Drafts']);
+
+	const { result } = renderHook(() => useSidebarSectionsOrder());
+
+	expect(result.current).toEqual([]);
+});

--- a/apps/meteor/client/sidebar/hooks/useSidebarSectionsOrder.ts
+++ b/apps/meteor/client/sidebar/hooks/useSidebarSectionsOrder.ts
@@ -1,0 +1,9 @@
+import { SIDEBAR_SYSTEM_GROUP_KEYS, isSidebarSystemGroupKey } from '@rocket.chat/core-typings';
+import { useUserPreference } from '@rocket.chat/ui-contexts';
+import { useMemo } from 'react';
+
+export const useSidebarSectionsOrder = (): readonly string[] => {
+	const stored = useUserPreference<string[]>('sidebarSectionsOrder');
+
+	return useMemo(() => (stored ? stored.filter(isSidebarSystemGroupKey) : SIDEBAR_SYSTEM_GROUP_KEYS), [stored]);
+};

--- a/packages/core-typings/src/IUser.ts
+++ b/packages/core-typings/src/IUser.ts
@@ -181,6 +181,11 @@ export const SIDEBAR_SYSTEM_GROUP_KEYS = [
 	'Conversations',
 ] as const;
 
+export type SidebarSystemGroupKey = (typeof SIDEBAR_SYSTEM_GROUP_KEYS)[number];
+
+export const isSidebarSystemGroupKey = (key: string): key is SidebarSystemGroupKey =>
+	SIDEBAR_SYSTEM_GROUP_KEYS.includes(key as SidebarSystemGroupKey);
+
 export interface ISidebarCategory {
 	_id: string;
 	name: string;
@@ -188,6 +193,14 @@ export interface ISidebarCategory {
 	showUnreads?: boolean;
 	keepUnreadsOnTop?: boolean;
 }
+
+/**
+ * An entry left behind by a system group that no longer exists (e.g. `Drafts`). Read-time guard
+ * until a migration can rewrite `Accounts_Default_User_Preferences_sidebarSectionsOrder` and the
+ * per-user `sidebarCategories` arrays; drop this together with `useSidebarSectionsOrder`.
+ */
+export const isStaleSidebarCategory = ({ _id, default: isDefault }: ISidebarCategory): boolean =>
+	Boolean(isDefault) && !isSidebarSystemGroupKey(_id);
 
 export interface IUser extends IRocketChatRecord {
 	createdAt: Date;


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
`Accounts_Default_User_Preferences_sidebarSectionsOrder` still contains `Drafts` on any workspace upgraded from a build that shipped that group. `SettingsRegistry.add()` never rewrites a stored setting value when the code default changes, so the key survives the upgrade and the sidebar, which builds its category list from that preference, renders an empty `Drafts` group.

The stale key also leaked into user data. `useCreateCustomCategory`, `useMoveCategoryPosition`, and `useToggleUnreads` all persist `sidebarCategories` from the sections order, so anyone who created a category or reordered on an affected workspace now carries `{ _id: 'Drafts', name: 'Drafts', default: true }` in their own preference.

Both are filtered at read time:

* `useSidebarSectionsOrder` (new) drops section keys that no longer name a live system group, falling back to `SIDEBAR_SYSTEM_GROUP_KEYS` when the preference is unset.
* `useUserSidebarCategories` drops stale entries via `isStaleSidebarCategory`.

Every hook that writes `sidebarCategories` reads from those two, so the group stops rendering and stops being written back.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->
1. Add `Drafts` to `Accounts_Default_User_Preferences_sidebarSectionsOrder` directly in the database. The admin multiSelect only offers keys from the current code default, so it cannot reproduce this. 
2. Reload the client. No `Drafts` group appears. On `develop` it renders as an empty group.
3. With `experimental-enterprise-features` license module, create a custom category and check `settings.preferences.sidebarCategories` on the user document. No `Drafts` entry is written.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
The correct fix is a migration rewriting the setting, which can only land in a major, so this is the interim read-time guard. That migration needs to clean two places, the setting and the per-user `sidebarCategories` arrays, and it can delete `isStaleSidebarCategory` and `useSidebarSectionsOrder` along with them.

[SCC-30]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented removed default sidebar groups, such as Drafts, from reappearing as empty categories after workspace upgrades.
  * Preserved custom sidebar categories while filtering out stale system entries.
  * Improved sidebar category ordering by ignoring unavailable system groups and retaining valid custom categories.
* **Tests**
  * Added coverage for stale categories, ordering behavior, custom category preservation, and license-based visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[SCC-30]: https://rocketchat.atlassian.net/browse/SCC-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ