### PR TITLE
test: fix flaky login after E2EE password reset

### DIFF
--- a/apps/meteor/tests/e2e/page-objects/login.ts
+++ b/apps/meteor/tests/e2e/page-objects/login.ts
@@ -53,7 +53,9 @@ export class LoginPage {
 				window.localStorage.setItem(name, value);
 			});
 
-			require('meteor/accounts-base').Accounts._pollStoredLoginToken();
+			const { Accounts } = require('meteor/accounts-base');
+			Accounts._lastLoginTokenWhenPolled = null;
+			Accounts._pollStoredLoginToken();
 		}, localStorageItems);
 
 		await this.waitForLogin();


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Fixes the flaky final login in `should reset e2e password from the modal` by clearing `Accounts._lastLoginTokenWhenPolled` before polling the restored login token in `loginByUserState()`.

When the restored token matches Meteor's cached value, `_pollStoredLoginToken()` can skip authentication and leave the test on the login screen. Resetting the cached value forces a fresh login attempt and follows the existing pattern in `stubMeteorStream.ts`. The helper retains its existing UI assertions to wait for login completion.

## Issue(s)

[FLAKY-1581](https://rocketchat.atlassian.net/browse/FLAKY-1581)

## Steps to test or reproduce


## Further comments

In the [original CI job](https://github.com/RocketChat/Rocket.Chat/actions/runs/34412627030/job/102675534201), the reset endpoint returned HTTP 200 with `success: true`. The failure occurred during the final login, where the Login button remained visible for five seconds.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[FLAKY-1581]: https://rocketchat.atlassian.net/browse/FLAKY-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ