### PR TITLE
test: cover server slash command room management and messaging

### DIFF
--- a/apps/meteor/tests/unit/server/slashcommands/archive.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/archive.spec.ts
@@ -1,0 +1,123 @@
+import { isRegisterUser } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+import { RoomMemberActions } from '../../../../definition/IRoomTypeConfig';
+
+(['archive', 'unarchive'] as const).forEach((command) => {
+	describe(`/${command}`, () => {
+		const actor = { _id: 'actor', username: 'alice', name: 'Alice' };
+		let room: { _id: string; name?: string; t: string; archived: boolean };
+		let findRoom: sinon.SinonStub;
+		let findCurrentRoom: sinon.SinonStub;
+		let findUser: sinon.SinonStub;
+		let allowMemberAction: sinon.SinonStub;
+		let hasPermission: sinon.SinonStub;
+		let changeRoom: sinon.SinonStub;
+		let harness: ReturnType<typeof loadCommand>;
+
+		beforeEach(() => {
+			room = { _id: 'target-room', name: 'general', t: 'c', archived: command === 'unarchive' };
+			findRoom = sinon.stub().resolves(room);
+			findCurrentRoom = sinon.stub().resolves(room);
+			findUser = sinon.stub().resolves(actor);
+			allowMemberAction = sinon.stub().resolves(true);
+			hasPermission = sinon.stub().resolves(true);
+			changeRoom = sinon.stub().resolves();
+			harness = loadCommand(`${command === 'archive' ? 'archiveroom' : 'unarchiveroom'}/server`, {
+				'@rocket.chat/core-typings': { isRegisterUser },
+				'@rocket.chat/models': { Rooms: { findOneById: findCurrentRoom, findOneByName: findRoom }, Users: { findOneById: findUser } },
+				'../../lib/rooms/roomCoordinator': { roomCoordinator: { getRoomDirectives: () => ({ allowMemberAction }) } },
+				'../../lib/authorization/hasPermission': { hasPermissionAsync: hasPermission },
+				[`../../lib/rooms/${command}Room`]: { [`${command}Room`]: changeRoom },
+			});
+		});
+
+		it('changes the named room after checking its member action and scoped permission', async () => {
+			await harness.run(command, { params: '  #general  ' });
+			sinon.assert.calledOnceWithExactly(findRoom, 'general');
+			sinon.assert.calledOnceWithExactly(allowMemberAction, room, RoomMemberActions.ARCHIVE, 'actor');
+			sinon.assert.calledOnceWithExactly(hasPermission, 'actor', `${command}-room`, 'target-room');
+			sinon.assert.calledOnceWithExactly(changeRoom, 'target-room', actor);
+			harness.expectFeedback(command === 'archive' ? 'Channel_Archived' : 'Channel_Unarchived');
+		});
+
+		it('uses the current room when no channel is provided', async () => {
+			await harness.run(command, { params: '  ' });
+			sinon.assert.calledOnceWithExactly(findCurrentRoom, 'current-room');
+			sinon.assert.notCalled(findRoom);
+			sinon.assert.calledOnceWithExactly(changeRoom, 'target-room', actor);
+			expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'general' });
+		});
+
+		it('does not change rooms without an authenticated user', async () => {
+			const result = harness.run(command, { userId: '' });
+			if (command === 'unarchive') await expect(result).to.be.rejectedWith('Invalid user');
+			else await result;
+			sinon.assert.calledOnce(findCurrentRoom);
+			sinon.assert.notCalled(findUser);
+			sinon.assert.notCalled(changeRoom);
+		});
+
+		[null, { _id: 'actor', name: 'Alice' }, { _id: 'actor', username: 'alice' }].forEach((user) => {
+			it(`rejects an invalid actor ${JSON.stringify(user)}`, async () => {
+				findUser.resolves(user);
+				await expect(harness.run(command)).to.be.rejectedWith('Invalid user');
+				sinon.assert.calledOnce(findUser);
+				sinon.assert.notCalled(hasPermission);
+				sinon.assert.notCalled(changeRoom);
+			});
+		});
+
+		it('reports a missing named room without changing it', async () => {
+			findRoom.resolves(null);
+			harness.settings.get.withArgs('Language').returns('pt');
+			await harness.run(command, { params: '#missing' });
+			harness.expectFeedback('Channel_doesnt_exist');
+			expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing', lng: 'pt' });
+			sinon.assert.notCalled(changeRoom);
+		});
+
+		it('handles a missing current room', async () => {
+			findCurrentRoom.resolves(null);
+			await harness.run(command);
+			harness.expectFeedback('Channel_doesnt_exist');
+			sinon.assert.notCalled(changeRoom);
+		});
+
+		it('rejects a room type that disallows the member action', async () => {
+			allowMemberAction.resolves(false);
+			await expect(harness.run(command)).to.be.rejectedWith(`can not be ${command}d`);
+			sinon.assert.calledOnce(allowMemberAction);
+			sinon.assert.notCalled(hasPermission);
+			sinon.assert.notCalled(changeRoom);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+
+		it('rejects a denied room permission without changing the room or announcing success', async () => {
+			hasPermission.resolves(false);
+			await expect(harness.run(command)).to.be.rejectedWith('Not authorized');
+			sinon.assert.calledOnceWithExactly(hasPermission, 'actor', `${command}-room`, 'target-room');
+			sinon.assert.notCalled(changeRoom);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+
+		it('reports an already completed operation without repeating the mutation', async () => {
+			room.archived = command === 'archive';
+			await harness.run(command);
+			harness.expectFeedback(command === 'archive' ? 'Duplicate_archived_channel_name' : 'Channel_already_Unarchived');
+			sinon.assert.calledOnce(hasPermission);
+			sinon.assert.notCalled(changeRoom);
+		});
+
+		it('propagates a failed room mutation without announcing success', async () => {
+			const error = new Error('storage failed');
+			changeRoom.rejects(error);
+			await expect(harness.run(command)).to.be.rejectedWith(error);
+			sinon.assert.calledOnce(changeRoom);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/create.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/create.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/create', () => {
+	const actor = { _id: 'actor', username: 'alice' };
+	let findRoom: sinon.SinonStub;
+	let findUser: sinon.SinonStub;
+	let createChannel: sinon.SinonStub;
+	let createPrivateGroup: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findRoom = sinon.stub().resolves(null);
+		findUser = sinon.stub().resolves(actor);
+		createChannel = sinon.stub().resolves();
+		createPrivateGroup = sinon.stub().resolves();
+		harness = loadCommand('create/server', {
+			'@rocket.chat/models': { Rooms: { findOneByName: findRoom }, Users: { findOneById: findUser } },
+			'../../meteor-methods/rooms/createChannel': { createChannelMethod: createChannel },
+			'../../meteor-methods/rooms/createPrivateGroup': { createPrivateGroupMethod: createPrivateGroup },
+		});
+		harness.settings.get.withArgs('UTF8_Channel_Names_Validation').returns('[a-zA-Z0-9-]+');
+	});
+	it('creates a public channel from the validated name', async () => {
+		await harness.run('create', { params: '  #general  ' });
+		sinon.assert.calledOnceWithExactly(findRoom, 'general');
+		sinon.assert.calledOnceWithExactly(createChannel, 'actor', 'general', []);
+		sinon.assert.notCalled(createPrivateGroup);
+	});
+	it('creates a private group with the authenticated user when --private is present', async () => {
+		await harness.run('create', { params: '#general --other --private' });
+		sinon.assert.calledOnceWithExactly(findUser, 'actor');
+		sinon.assert.calledOnceWithExactly(createPrivateGroup, actor, 'general', []);
+		sinon.assert.notCalled(createChannel);
+	});
+	it('uses the configured channel-name validation for non-ASCII names', async () => {
+		harness.settings.get.withArgs('UTF8_Channel_Names_Validation').returns('[áa-z]+');
+		await harness.run('create', { params: '#olá' });
+		sinon.assert.calledOnceWithExactly(createChannel, 'actor', 'olá', []);
+	});
+	['[a-z]+', '^'].forEach((pattern) => {
+		it(`ignores invalid or empty matches using ${pattern}`, async () => {
+			harness.settings.get.withArgs('UTF8_Channel_Names_Validation').returns(pattern);
+			await harness.run('create', { params: '###' });
+			sinon.assert.notCalled(findRoom);
+			sinon.assert.notCalled(createChannel);
+			sinon.assert.notCalled(createPrivateGroup);
+		});
+	});
+	it('reports a duplicate channel without creating either room type', async () => {
+		findRoom.resolves({ _id: 'existing' });
+		await harness.run('create', { params: '#general' });
+		harness.expectFeedback('Channel_already_exist');
+		expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'general', lng: 'en' });
+		sinon.assert.notCalled(createChannel);
+		sinon.assert.notCalled(createPrivateGroup);
+	});
+	it('does not create a private group for an unknown actor', async () => {
+		findUser.resolves(null);
+		await harness.run('create', { params: '#general --private' });
+		sinon.assert.calledOnce(findUser);
+		sinon.assert.notCalled(createChannel);
+		sinon.assert.notCalled(createPrivateGroup);
+	});
+	it('propagates a creation permission failure without trying another room type', async () => {
+		const error = new Error('Not authorized');
+		createPrivateGroup.rejects(error);
+		await expect(harness.run('create', { params: '#general --private' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(createPrivateGroup);
+		sinon.assert.notCalled(createChannel);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/helpers.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/helpers.ts
@@ -1,0 +1,49 @@
+import { MeteorError } from '@rocket.chat/core-services';
+import type { SlashCommandCallbackParams, SlashCommandOptions } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+type Registration = {
+	command: string;
+	callback: (args: SlashCommandCallbackParams<string>) => unknown;
+	options?: SlashCommandOptions;
+};
+
+// Capture registration and invoke the actual callback without involving the dispatcher.
+export function loadCommand(path: string, dependencies: Record<string, unknown> = {}) {
+	const commands = new Map<string, Registration>();
+	const broadcast = sinon.stub().resolves();
+	const translate = sinon.stub().callsFake((key: string) => `translated:${key}`);
+	const settings = { get: sinon.stub() };
+	proxyquire.noCallThru().load(`../../../../server/slashcommands/${path}`, {
+		'@rocket.chat/core-services': { api: { broadcast } },
+		'meteor/meteor': { Meteor: { Error: MeteorError } },
+		'../../lib/i18n': { i18n: { t: translate } },
+		'../../settings': { settings },
+		...dependencies,
+		'../../lib/utils/slashCommand': {
+			slashCommands: { add: (registration: Registration) => commands.set(registration.command, registration) },
+		},
+	});
+	return {
+		broadcast,
+		translate,
+		settings,
+		commands,
+		async run(command: string, overrides: Partial<SlashCommandCallbackParams<string>> = {}) {
+			const registration = commands.get(command);
+			if (!registration) throw new Error(`Command /${command} was not registered`);
+			return registration.callback({
+				command,
+				params: '',
+				userId: 'actor',
+				message: { _id: 'message', rid: 'current-room' },
+				...overrides,
+			});
+		},
+		expectFeedback(key: string) {
+			expect(broadcast.calledWith('notify.ephemeralMessage', 'actor', 'current-room', { msg: `translated:${key}` })).to.equal(true);
+		},
+	};
+}

--- a/apps/meteor/tests/unit/server/slashcommands/helpers.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/helpers.ts
@@ -23,16 +23,19 @@ export function loadCommand(path: string, dependencies: Dependencies = {}) {
 	const translate = sinon.stub().callsFake((key: string) => `translated:${key}`);
 	const settings = { get: sinon.stub() };
 	let invocation: SlashCommandCallbackParams<string> | undefined;
-	proxyquire.noCallThru().load(`../../../../server/slashcommands/${path}`, {
-		'meteor/meteor': { Meteor: { Error: MeteorError } },
-		'../../lib/i18n': { i18n: { t: translate } },
-		'../../settings': { settings },
-		...dependencies,
-		'@rocket.chat/core-services': { ...coreServices, api: { ...coreServices?.api, broadcast } },
-		'../../lib/utils/slashCommand': {
-			slashCommands: { add: (registration: Registration) => commands.set(registration.command, registration) },
-		},
-	});
+	proxyquire
+		.noCallThru()
+		.noPreserveCache()
+		.load(`../../../../server/slashcommands/${path}`, {
+			'meteor/meteor': { Meteor: { Error: MeteorError } },
+			'../../lib/i18n': { i18n: { t: translate } },
+			'../../settings': { settings },
+			...dependencies,
+			'@rocket.chat/core-services': { ...coreServices, api: { ...coreServices?.api, broadcast } },
+			'../../lib/utils/slashCommand': {
+				slashCommands: { add: (registration: Registration) => commands.set(registration.command, registration) },
+			},
+		});
 	return {
 		broadcast,
 		translate,

--- a/apps/meteor/tests/unit/server/slashcommands/helpers.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/helpers.ts
@@ -15,14 +15,14 @@ type Dependencies = Record<string, unknown> & {
 	};
 };
 
-/** Capture registration and invoke the actual callback without involving the dispatcher. */
-export function loadCommand(path: string, dependencies: Dependencies = {}) {
-	const commands = new Map<string, Registration>();
+export function loadSlashCommand(path: string, dependencies: Dependencies = {}) {
+	const registeredCommands = new Map<string, Registration>();
 	const coreServices = dependencies['@rocket.chat/core-services'];
 	const broadcast = coreServices?.api?.broadcast ?? sinon.stub().resolves();
 	const translate = sinon.stub().callsFake((key: string) => `translated:${key}`);
 	const settings = { get: sinon.stub() };
-	let invocation: SlashCommandCallbackParams<string> | undefined;
+	let lastInvocation: SlashCommandCallbackParams<string> | undefined;
+
 	proxyquire.noCallThru().load(`../../../../server/slashcommands/${path}`, {
 		'meteor/meteor': { Meteor: { Error: MeteorError } },
 		'../../lib/i18n': { i18n: { t: translate } },
@@ -30,31 +30,38 @@ export function loadCommand(path: string, dependencies: Dependencies = {}) {
 		...dependencies,
 		'@rocket.chat/core-services': { ...coreServices, api: { ...coreServices?.api, broadcast } },
 		'../../lib/utils/slashCommand': {
-			slashCommands: { add: (registration: Registration) => commands.set(registration.command, registration) },
+			slashCommands: { add: (registration: Registration) => registeredCommands.set(registration.command, registration) },
 		},
 	});
+
 	return {
 		broadcast,
 		translate,
 		settings,
-		commands,
-		/** Invoke a registered command, retaining its arguments for feedback assertions. */
-		async run(command: string, overrides: Partial<SlashCommandCallbackParams<string>> = {}) {
-			const registration = commands.get(command);
-			if (!registration) throw new Error(`Command /${command} was not registered`);
-			invocation = {
+		registeredCommands,
+		async runCommand(command: string, overrides: Partial<SlashCommandCallbackParams<string>> = {}) {
+			const registration = registeredCommands.get(command);
+
+			if (!registration) {
+				throw new Error(`Command /${command} was not registered`);
+			}
+
+			lastInvocation = {
 				command,
 				params: '',
 				userId: 'actor',
 				message: { _id: 'message', rid: 'current-room' },
 				...overrides,
 			};
-			return registration.callback(invocation);
+
+			return registration.callback(lastInvocation);
 		},
-		/** Assert translated feedback was sent to the user and room from the latest invocation. */
-		expectFeedback(key: string) {
-			if (!invocation) throw new Error('Run a command before asserting feedback');
-			sinon.assert.calledWithExactly(broadcast, 'notify.ephemeralMessage', invocation.userId, invocation.message.rid, {
+		expectTranslatedFeedback(key: string) {
+			if (!lastInvocation) {
+				throw new Error('Run a command before asserting feedback');
+			}
+
+			sinon.assert.calledWithExactly(broadcast, 'notify.ephemeralMessage', lastInvocation.userId, lastInvocation.message.rid, {
 				msg: `translated:${key}`,
 			});
 		},

--- a/apps/meteor/tests/unit/server/slashcommands/helpers.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/helpers.ts
@@ -1,6 +1,5 @@
 import { MeteorError } from '@rocket.chat/core-services';
 import type { SlashCommandCallbackParams, SlashCommandOptions } from '@rocket.chat/core-typings';
-import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
@@ -10,18 +9,26 @@ type Registration = {
 	options?: SlashCommandOptions;
 };
 
-// Capture registration and invoke the actual callback without involving the dispatcher.
-export function loadCommand(path: string, dependencies: Record<string, unknown> = {}) {
+type Dependencies = Record<string, unknown> & {
+	'@rocket.chat/core-services'?: Record<string, unknown> & {
+		api?: Record<string, unknown> & { broadcast?: sinon.SinonStub };
+	};
+};
+
+/** Capture registration and invoke the actual callback without involving the dispatcher. */
+export function loadCommand(path: string, dependencies: Dependencies = {}) {
 	const commands = new Map<string, Registration>();
-	const broadcast = sinon.stub().resolves();
+	const coreServices = dependencies['@rocket.chat/core-services'];
+	const broadcast = coreServices?.api?.broadcast ?? sinon.stub().resolves();
 	const translate = sinon.stub().callsFake((key: string) => `translated:${key}`);
 	const settings = { get: sinon.stub() };
+	let invocation: SlashCommandCallbackParams<string> | undefined;
 	proxyquire.noCallThru().load(`../../../../server/slashcommands/${path}`, {
-		'@rocket.chat/core-services': { api: { broadcast } },
 		'meteor/meteor': { Meteor: { Error: MeteorError } },
 		'../../lib/i18n': { i18n: { t: translate } },
 		'../../settings': { settings },
 		...dependencies,
+		'@rocket.chat/core-services': { ...coreServices, api: { ...coreServices?.api, broadcast } },
 		'../../lib/utils/slashCommand': {
 			slashCommands: { add: (registration: Registration) => commands.set(registration.command, registration) },
 		},
@@ -31,19 +38,25 @@ export function loadCommand(path: string, dependencies: Record<string, unknown> 
 		translate,
 		settings,
 		commands,
+		/** Invoke a registered command, retaining its arguments for feedback assertions. */
 		async run(command: string, overrides: Partial<SlashCommandCallbackParams<string>> = {}) {
 			const registration = commands.get(command);
 			if (!registration) throw new Error(`Command /${command} was not registered`);
-			return registration.callback({
+			invocation = {
 				command,
 				params: '',
 				userId: 'actor',
 				message: { _id: 'message', rid: 'current-room' },
 				...overrides,
-			});
+			};
+			return registration.callback(invocation);
 		},
+		/** Assert translated feedback was sent to the user and room from the latest invocation. */
 		expectFeedback(key: string) {
-			expect(broadcast.calledWith('notify.ephemeralMessage', 'actor', 'current-room', { msg: `translated:${key}` })).to.equal(true);
+			if (!invocation) throw new Error('Run a command before asserting feedback');
+			sinon.assert.calledWithExactly(broadcast, 'notify.ephemeralMessage', invocation.userId, invocation.message.rid, {
+				msg: `translated:${key}`,
+			});
 		},
 	};
 }

--- a/apps/meteor/tests/unit/server/slashcommands/hide.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/hide.spec.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/hide', () => {
+	const actor = { _id: 'actor', username: 'alice', language: 'pt' };
+	let findUser: sinon.SinonStub;
+	let byName: sinon.SinonStub;
+	let findDirect: sinon.SinonStub;
+	let subscription: sinon.SinonStub;
+	let hide: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findUser = sinon.stub().resolves(actor);
+		byName = sinon.stub().resolves({ _id: 'channel' });
+		findDirect = sinon.stub().resolves({ _id: 'direct' });
+		subscription = sinon.stub().resolves({ _id: 'subscription' });
+		hide = sinon.stub().resolves();
+		harness = loadCommand('hide/hide', {
+			'@rocket.chat/models': {
+				Users: { findOneById: findUser },
+				Rooms: { findOneByName: byName, findOne: findDirect },
+				Subscriptions: { findOneByRoomIdAndUserId: subscription },
+			},
+			'../../meteor-methods/rooms/hideRoom': { hideRoomMethod: hide },
+		});
+	});
+	it('hides the current room without a room lookup when no parameter is provided', async () => {
+		await harness.run('hide', { params: '  ' });
+		sinon.assert.calledOnceWithExactly(hide, 'actor', 'current-room');
+		sinon.assert.notCalled(byName);
+		sinon.assert.notCalled(findDirect);
+	});
+	it('hides a named channel after verifying membership', async () => {
+		await harness.run('hide', { params: ' #general ignored ' });
+		sinon.assert.calledOnceWithExactly(byName, 'general');
+		sinon.assert.calledOnceWithExactly(subscription, 'channel', 'actor', { projection: { _id: 1 } });
+		sinon.assert.calledOnceWithExactly(hide, 'actor', 'channel');
+	});
+	it('hides a direct conversation with the named user', async () => {
+		await harness.run('hide', { params: '@bob' });
+		sinon.assert.calledOnceWithExactly(findDirect, { t: 'd', usernames: { $all: ['alice', 'bob'] } });
+		sinon.assert.calledOnceWithExactly(subscription, 'direct', 'actor', { projection: { _id: 1 } });
+		sinon.assert.calledOnceWithExactly(hide, 'actor', 'direct');
+		sinon.assert.notCalled(byName);
+	});
+	it('does nothing without an authenticated actor', async () => {
+		await harness.run('hide', { userId: '' });
+		sinon.assert.notCalled(findUser);
+		sinon.assert.notCalled(hide);
+	});
+	it('does nothing for an unknown actor', async () => {
+		findUser.resolves(null);
+		await harness.run('hide');
+		sinon.assert.calledOnce(findUser);
+		sinon.assert.notCalled(hide);
+	});
+	[
+		{ user: actor, language: 'de', expected: 'pt' },
+		{ user: { _id: 'actor', username: 'alice' }, language: 'de', expected: 'de' },
+		{ user: { _id: 'actor', username: 'alice' }, language: undefined, expected: 'en' },
+	].forEach(({ user, language, expected }) => {
+		it(`reports missing membership in ${expected} without hiding the channel`, async () => {
+			findUser.resolves(user);
+			harness.settings.get.withArgs('Language').returns(language);
+			subscription.resolves(null);
+			await harness.run('hide', { params: '#general' });
+			sinon.assert.calledOnce(subscription);
+			harness.expectFeedback('error-logged-user-not-in-room');
+			expect(harness.translate.firstCall.args[1]).to.include({ roomName: '#general', lng: expected });
+			sinon.assert.notCalled(hide);
+		});
+	});
+	it('reports a missing channel without hiding another room', async () => {
+		byName.resolves(null);
+		subscription.resolves(null);
+		await harness.run('hide', { params: '#missing' });
+		sinon.assert.calledOnceWithExactly(byName, 'missing');
+		harness.expectFeedback('Channel_doesnt_exist');
+		sinon.assert.notCalled(hide);
+	});
+	it('reports a named-channel hide failure to the actor in the originating room', async () => {
+		hide.rejects(new Error('storage failed'));
+		harness.translate.returns('localized hide error');
+		await harness.run('hide', { params: '#general' });
+		sinon.assert.calledOnceWithExactly(hide, 'actor', 'channel');
+		sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+			msg: 'localized hide error',
+		});
+		sinon.assert.calledOnce(harness.translate);
+		expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
@@ -54,9 +54,6 @@ describe('/invite', () => {
 			'../../services/room/hooks/BeforeFederationActions': { FederationActions: { shouldPerformFederationAction: shouldFederate } },
 		});
 	});
-	function expectFeedback(key: string) {
-		sinon.assert.calledWith(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', { msg: `translated:${key}` });
-	}
 	it('splits comma and whitespace separated usernames and invites each user with the actor', async () => {
 		toArray.resolves([bob, carol]);
 		await harness.run('invite', { params: ' @bob,\n @carol ' });
@@ -75,15 +72,18 @@ describe('/invite', () => {
 	});
 	it('reports a missing room before looking up invitees', async () => {
 		findRoom.resolves(null);
-		await harness.run('invite', { params: '@bob' });
-		expectFeedback('error-invalid-room');
+		await harness.run('invite', { params: '@bob', userId: 'other-actor', message: { _id: 'other-message', rid: 'other-room' } });
+		harness.expectFeedback('error-invalid-room');
+		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'other-actor', 'other-room', {
+			msg: 'translated:error-invalid-room',
+		});
 		sinon.assert.notCalled(findUsers);
 		sinon.assert.notCalled(addUsers);
 	});
 	it('reports unknown invitees without changing membership', async () => {
 		toArray.resolves([]);
 		await harness.run('invite', { params: '@bob @carol' });
-		expectFeedback('User_doesnt_exist');
+		harness.expectFeedback('User_doesnt_exist');
 		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob @carol', lng: 'en' });
 		sinon.assert.notCalled(addUsers);
 	});
@@ -91,7 +91,7 @@ describe('/invite', () => {
 		toArray.resolves([bob, carol]);
 		subscription.withArgs('current-room', bob._id).resolves({ _id: 'subscription' });
 		await harness.run('invite', { params: '@bob @carol' });
-		expectFeedback('Username_is_already_in_here');
+		harness.expectFeedback('Username_is_already_in_here');
 		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob' });
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
 	});
@@ -117,7 +117,7 @@ describe('/invite', () => {
 	it('excludes external users from non-federated rooms while still inviting local users', async () => {
 		shouldFederate.returns(false);
 		await harness.run('invite', { params: `${external.username} @bob` });
-		expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		harness.expectFeedback('You_cannot_add_external_users_to_non_federated_room');
 		sinon.assert.notCalled(ensureFederatedUsers);
 		sinon.assert.calledOnceWithExactly(findUsers, ['bob']);
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
@@ -125,7 +125,7 @@ describe('/invite', () => {
 	it('stops when all invitees are external users in a non-federated room', async () => {
 		shouldFederate.returns(false);
 		await harness.run('invite', { params: external.username });
-		expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		harness.expectFeedback('You_cannot_add_external_users_to_non_federated_room');
 		sinon.assert.notCalled(findUsers);
 		sinon.assert.notCalled(addUsers);
 	});
@@ -151,7 +151,7 @@ describe('/invite', () => {
 			addUsers.onFirstCall().rejects(error);
 			harness.settings.get.withArgs('Language').returns('pt');
 			await harness.run('invite', { params: '@bob @carol' });
-			expectFeedback(key);
+			harness.expectFeedback(key);
 			sinon.assert.calledOnce(broadcast);
 			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
 			sinon.assert.calledTwice(addUsers);

--- a/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
@@ -1,0 +1,176 @@
+import { MeteorError, isMeteorError } from '@rocket.chat/core-services';
+import { isBannedSubscription } from '@rocket.chat/core-typings';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/invite', () => {
+	const actor = { _id: 'actor', username: 'alice' };
+	const bob = { _id: 'bob-id', username: 'bob' };
+	const carol = { _id: 'carol-id', username: 'carol' };
+	const external = { _id: 'external-id', username: '@remote:example.org' };
+	let findRoom: sinon.SinonStub;
+	let findUsers: sinon.SinonStub;
+	let toArray: sinon.SinonStub;
+	let findActor: sinon.SinonStub;
+	let subscription: sinon.SinonStub;
+	let addUsers: sinon.SinonStub;
+	let ensureFederatedUsers: sinon.SinonStub;
+	let shouldFederate: sinon.SinonStub;
+	let sanitize: sinon.SinonStub;
+	let broadcast: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findRoom = sinon.stub().resolves({ _id: 'current-room', t: 'c' });
+		toArray = sinon.stub().resolves([bob]);
+		findUsers = sinon.stub().returns({ toArray });
+		findActor = sinon.stub().resolves(actor);
+		subscription = sinon.stub().resolves(null);
+		addUsers = sinon.stub().resolves();
+		ensureFederatedUsers = sinon.stub().resolves();
+		shouldFederate = sinon.stub().returns(true);
+		sanitize = sinon.stub();
+		sanitize.withArgs('').returns('');
+		sanitize.withArgs('@bob').returns('bob');
+		sanitize.withArgs('@carol').returns('carol');
+		sanitize.withArgs(external.username).returns(external.username);
+		broadcast = sinon.stub().resolves();
+		harness = loadCommand('invite/server', {
+			'@rocket.chat/core-services': {
+				api: { broadcast },
+				FederationMatrix: { ensureFederatedUsersExistLocally: ensureFederatedUsers },
+				isMeteorError,
+			},
+			'@rocket.chat/core-typings': { isBannedSubscription },
+			'@rocket.chat/federation-matrix': { validateFederatedUsername: (username: string) => username === external.username },
+			'@rocket.chat/models': {
+				Rooms: { findOneById: findRoom },
+				Users: { findByUsernames: findUsers, findOneById: findActor },
+				Subscriptions: { findOneByRoomIdAndUserId: subscription },
+			},
+			'../../meteor-methods/rooms/addUsersToRoom': { addUsersToRoomMethod: addUsers, sanitizeUsername: sanitize },
+			'../../services/room/hooks/BeforeFederationActions': { FederationActions: { shouldPerformFederationAction: shouldFederate } },
+		});
+	});
+	function expectFeedback(key: string) {
+		sinon.assert.calledWith(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', { msg: `translated:${key}` });
+	}
+	it('splits comma and whitespace separated usernames and invites each user with the actor', async () => {
+		toArray.resolves([bob, carol]);
+		await harness.run('invite', { params: ' @bob,\n @carol ' });
+		sinon.assert.calledOnceWithExactly(findUsers, ['bob', 'carol']);
+		sinon.assert.calledWithExactly(subscription, 'current-room', 'bob-id', { projection: { _id: 1, status: 1 } });
+		sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
+		sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
+		sinon.assert.calledTwice(addUsers);
+		sinon.assert.notCalled(broadcast);
+	});
+	it('does nothing when no usernames remain after sanitization', async () => {
+		await harness.run('invite', { params: ' , \n' });
+		sinon.assert.called(sanitize);
+		sinon.assert.notCalled(findRoom);
+		sinon.assert.notCalled(addUsers);
+	});
+	it('reports a missing room before looking up invitees', async () => {
+		findRoom.resolves(null);
+		await harness.run('invite', { params: '@bob' });
+		expectFeedback('error-invalid-room');
+		sinon.assert.notCalled(findUsers);
+		sinon.assert.notCalled(addUsers);
+	});
+	it('reports unknown invitees without changing membership', async () => {
+		toArray.resolves([]);
+		await harness.run('invite', { params: '@bob @carol' });
+		expectFeedback('User_doesnt_exist');
+		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob @carol', lng: 'en' });
+		sinon.assert.notCalled(addUsers);
+	});
+	it('skips existing members while inviting users without subscriptions', async () => {
+		toArray.resolves([bob, carol]);
+		subscription.withArgs('current-room', bob._id).resolves({ _id: 'subscription' });
+		await harness.run('invite', { params: '@bob @carol' });
+		expectFeedback('Username_is_already_in_here');
+		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob' });
+		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
+	});
+	it('delegates banned subscriptions to the authoritative invitation method', async () => {
+		subscription.resolves({ _id: 'subscription', status: 'BANNED' });
+		await harness.run('invite', { params: '@bob' });
+		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
+		sinon.assert.notCalled(broadcast);
+	});
+	it('rejects an unknown inviter before adding anyone', async () => {
+		findActor.resolves(null);
+		await expect(harness.run('invite', { params: '@bob' })).to.be.rejectedWith('Inviter not found');
+		sinon.assert.calledOnceWithExactly(findActor, 'actor');
+		sinon.assert.notCalled(addUsers);
+	});
+	it('ensures federated users exist locally before querying and inviting them', async () => {
+		toArray.resolves([external]);
+		await harness.run('invite', { params: external.username });
+		sinon.assert.calledOnceWithExactly(ensureFederatedUsers, [external.username]);
+		sinon.assert.callOrder(ensureFederatedUsers, findUsers);
+		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: [external.username] }, actor);
+	});
+	it('excludes external users from non-federated rooms while still inviting local users', async () => {
+		shouldFederate.returns(false);
+		await harness.run('invite', { params: `${external.username} @bob` });
+		expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		sinon.assert.notCalled(ensureFederatedUsers);
+		sinon.assert.calledOnceWithExactly(findUsers, ['bob']);
+		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
+	});
+	it('stops when all invitees are external users in a non-federated room', async () => {
+		shouldFederate.returns(false);
+		await harness.run('invite', { params: external.username });
+		expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		sinon.assert.notCalled(findUsers);
+		sinon.assert.notCalled(addUsers);
+	});
+	it('propagates a federation provisioning failure without inviting anyone', async () => {
+		const error = new Error('federation unavailable');
+		ensureFederatedUsers.rejects(error);
+		await expect(harness.run('invite', { params: external.username })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(ensureFederatedUsers);
+		sinon.assert.notCalled(findUsers);
+		sinon.assert.notCalled(addUsers);
+	});
+	[
+		{
+			error: new MeteorError('error-only-compliant-users-can-be-added-to-abac-rooms', 'ABAC failure'),
+			key: 'error-only-compliant-users-can-be-added-to-abac-rooms',
+		},
+		{ error: { error: 'error-federated-users-in-non-federated-rooms' }, key: 'You_cannot_add_external_users_to_non_federated_room' },
+		{ error: { error: 'cant-invite-for-direct-room' }, key: 'Cannot_invite_users_to_direct_rooms' },
+		{ error: { error: 'other-invitation-error' }, key: 'other-invitation-error' },
+	].forEach(({ error, key }) => {
+		it(`reports ${error.error} while allowing other invitees to proceed`, async () => {
+			toArray.resolves([bob, carol]);
+			addUsers.onFirstCall().rejects(error);
+			harness.settings.get.withArgs('Language').returns('pt');
+			await harness.run('invite', { params: '@bob @carol' });
+			expectFeedback(key);
+			sinon.assert.calledOnce(broadcast);
+			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
+			sinon.assert.calledTwice(addUsers);
+			sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
+		});
+	});
+	it('delivers translated Meteor error feedback while continuing other invitations', async () => {
+		toArray.resolves([bob, carol]);
+		addUsers.onFirstCall().rejects(new MeteorError('error-not-allowed', 'Not allowed'));
+		harness.settings.get.withArgs('Language').returns('pt');
+		// The handler currently translates error.message, including Meteor's error-code suffix.
+		// Protect delivery of the translation result without requiring that translation key.
+		harness.translate.returns('localized invitation error');
+		await harness.run('invite', { params: '@bob @carol' });
+		sinon.assert.calledOnceWithExactly(harness.translate, sinon.match.string, { lng: 'pt' });
+		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+			msg: 'localized invitation error',
+		});
+		sinon.assert.calledTwice(addUsers);
+		sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/invite.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 
-import { loadCommand } from './helpers';
+import { loadSlashCommand } from './helpers';
 
 describe('/invite', () => {
 	const actor = { _id: 'actor', username: 'alice' };
@@ -21,7 +21,8 @@ describe('/invite', () => {
 	let shouldFederate: sinon.SinonStub;
 	let sanitize: sinon.SinonStub;
 	let broadcast: sinon.SinonStub;
-	let harness: ReturnType<typeof loadCommand>;
+	let slashCommand: ReturnType<typeof loadSlashCommand>;
+
 	beforeEach(() => {
 		findRoom = sinon.stub().resolves({ _id: 'current-room', t: 'c' });
 		toArray = sinon.stub().resolves([bob]);
@@ -37,7 +38,7 @@ describe('/invite', () => {
 		sanitize.withArgs('@carol').returns('carol');
 		sanitize.withArgs(external.username).returns(external.username);
 		broadcast = sinon.stub().resolves();
-		harness = loadCommand('invite/server', {
+		slashCommand = loadSlashCommand('invite/server', {
 			'@rocket.chat/core-services': {
 				api: { broadcast },
 				FederationMatrix: { ensureFederatedUsersExistLocally: ensureFederatedUsers },
@@ -54,9 +55,10 @@ describe('/invite', () => {
 			'../../services/room/hooks/BeforeFederationActions': { FederationActions: { shouldPerformFederationAction: shouldFederate } },
 		});
 	});
+
 	it('splits comma and whitespace separated usernames and invites each user with the actor', async () => {
 		toArray.resolves([bob, carol]);
-		await harness.run('invite', { params: ' @bob,\n @carol ' });
+		await slashCommand.runCommand('invite', { params: ' @bob,\n @carol ' });
 		sinon.assert.calledOnceWithExactly(findUsers, ['bob', 'carol']);
 		sinon.assert.calledWithExactly(subscription, 'current-room', 'bob-id', { projection: { _id: 1, status: 1 } });
 		sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
@@ -64,79 +66,96 @@ describe('/invite', () => {
 		sinon.assert.calledTwice(addUsers);
 		sinon.assert.notCalled(broadcast);
 	});
+
 	it('does nothing when no usernames remain after sanitization', async () => {
-		await harness.run('invite', { params: ' , \n' });
+		await slashCommand.runCommand('invite', { params: ' , \n' });
 		sinon.assert.called(sanitize);
 		sinon.assert.notCalled(findRoom);
 		sinon.assert.notCalled(addUsers);
 	});
+
 	it('reports a missing room before looking up invitees', async () => {
 		findRoom.resolves(null);
-		await harness.run('invite', { params: '@bob', userId: 'other-actor', message: { _id: 'other-message', rid: 'other-room' } });
-		harness.expectFeedback('error-invalid-room');
+		await slashCommand.runCommand('invite', {
+			params: '@bob',
+			userId: 'other-actor',
+			message: { _id: 'other-message', rid: 'other-room' },
+		});
+
+		slashCommand.expectTranslatedFeedback('error-invalid-room');
 		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'other-actor', 'other-room', {
 			msg: 'translated:error-invalid-room',
 		});
+
 		sinon.assert.notCalled(findUsers);
 		sinon.assert.notCalled(addUsers);
 	});
+
 	it('reports unknown invitees without changing membership', async () => {
 		toArray.resolves([]);
-		await harness.run('invite', { params: '@bob @carol' });
-		harness.expectFeedback('User_doesnt_exist');
-		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob @carol', lng: 'en' });
+		await slashCommand.runCommand('invite', { params: '@bob @carol' });
+		slashCommand.expectTranslatedFeedback('User_doesnt_exist');
+		expect(slashCommand.translate.firstCall.args[1]).to.include({ username: 'bob @carol', lng: 'en' });
 		sinon.assert.notCalled(addUsers);
 	});
+
 	it('skips existing members while inviting users without subscriptions', async () => {
 		toArray.resolves([bob, carol]);
 		subscription.withArgs('current-room', bob._id).resolves({ _id: 'subscription' });
-		await harness.run('invite', { params: '@bob @carol' });
-		harness.expectFeedback('Username_is_already_in_here');
-		expect(harness.translate.firstCall.args[1]).to.include({ username: 'bob' });
+		await slashCommand.runCommand('invite', { params: '@bob @carol' });
+		slashCommand.expectTranslatedFeedback('Username_is_already_in_here');
+		expect(slashCommand.translate.firstCall.args[1]).to.include({ username: 'bob' });
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
 	});
+
 	it('delegates banned subscriptions to the authoritative invitation method', async () => {
 		subscription.resolves({ _id: 'subscription', status: 'BANNED' });
-		await harness.run('invite', { params: '@bob' });
+		await slashCommand.runCommand('invite', { params: '@bob' });
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
 		sinon.assert.notCalled(broadcast);
 	});
+
 	it('rejects an unknown inviter before adding anyone', async () => {
 		findActor.resolves(null);
-		await expect(harness.run('invite', { params: '@bob' })).to.be.rejectedWith('Inviter not found');
+		await expect(slashCommand.runCommand('invite', { params: '@bob' })).to.be.rejectedWith('Inviter not found');
 		sinon.assert.calledOnceWithExactly(findActor, 'actor');
 		sinon.assert.notCalled(addUsers);
 	});
+
 	it('ensures federated users exist locally before querying and inviting them', async () => {
 		toArray.resolves([external]);
-		await harness.run('invite', { params: external.username });
+		await slashCommand.runCommand('invite', { params: external.username });
 		sinon.assert.calledOnceWithExactly(ensureFederatedUsers, [external.username]);
 		sinon.assert.callOrder(ensureFederatedUsers, findUsers);
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: [external.username] }, actor);
 	});
+
 	it('excludes external users from non-federated rooms while still inviting local users', async () => {
 		shouldFederate.returns(false);
-		await harness.run('invite', { params: `${external.username} @bob` });
-		harness.expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		await slashCommand.runCommand('invite', { params: `${external.username} @bob` });
+		slashCommand.expectTranslatedFeedback('You_cannot_add_external_users_to_non_federated_room');
 		sinon.assert.notCalled(ensureFederatedUsers);
 		sinon.assert.calledOnceWithExactly(findUsers, ['bob']);
 		sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['bob'] }, actor);
 	});
+
 	it('stops when all invitees are external users in a non-federated room', async () => {
 		shouldFederate.returns(false);
-		await harness.run('invite', { params: external.username });
-		harness.expectFeedback('You_cannot_add_external_users_to_non_federated_room');
+		await slashCommand.runCommand('invite', { params: external.username });
+		slashCommand.expectTranslatedFeedback('You_cannot_add_external_users_to_non_federated_room');
 		sinon.assert.notCalled(findUsers);
 		sinon.assert.notCalled(addUsers);
 	});
+
 	it('propagates a federation provisioning failure without inviting anyone', async () => {
 		const error = new Error('federation unavailable');
 		ensureFederatedUsers.rejects(error);
-		await expect(harness.run('invite', { params: external.username })).to.be.rejectedWith(error);
+		await expect(slashCommand.runCommand('invite', { params: external.username })).to.be.rejectedWith(error);
 		sinon.assert.calledOnce(ensureFederatedUsers);
 		sinon.assert.notCalled(findUsers);
 		sinon.assert.notCalled(addUsers);
 	});
+
 	[
 		{
 			error: new MeteorError('error-only-compliant-users-can-be-added-to-abac-rooms', 'ABAC failure'),
@@ -149,27 +168,29 @@ describe('/invite', () => {
 		it(`reports ${error.error} while allowing other invitees to proceed`, async () => {
 			toArray.resolves([bob, carol]);
 			addUsers.onFirstCall().rejects(error);
-			harness.settings.get.withArgs('Language').returns('pt');
-			await harness.run('invite', { params: '@bob @carol' });
-			harness.expectFeedback(key);
+			slashCommand.settings.get.withArgs('Language').returns('pt');
+			await slashCommand.runCommand('invite', { params: '@bob @carol' });
+			slashCommand.expectTranslatedFeedback(key);
 			sinon.assert.calledOnce(broadcast);
-			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
+			expect(slashCommand.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
 			sinon.assert.calledTwice(addUsers);
 			sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
 		});
 	});
+
 	it('delivers translated Meteor error feedback while continuing other invitations', async () => {
 		toArray.resolves([bob, carol]);
 		addUsers.onFirstCall().rejects(new MeteorError('error-not-allowed', 'Not allowed'));
-		harness.settings.get.withArgs('Language').returns('pt');
+		slashCommand.settings.get.withArgs('Language').returns('pt');
 		// The handler currently translates error.message, including Meteor's error-code suffix.
 		// Protect delivery of the translation result without requiring that translation key.
-		harness.translate.returns('localized invitation error');
-		await harness.run('invite', { params: '@bob @carol' });
-		sinon.assert.calledOnceWithExactly(harness.translate, sinon.match.string, { lng: 'pt' });
+		slashCommand.translate.returns('localized invitation error');
+		await slashCommand.runCommand('invite', { params: '@bob @carol' });
+		sinon.assert.calledOnceWithExactly(slashCommand.translate, sinon.match.string, { lng: 'pt' });
 		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
 			msg: 'localized invitation error',
 		});
+
 		sinon.assert.calledTwice(addUsers);
 		sinon.assert.calledWithExactly(addUsers, 'actor', { rid: 'current-room', users: ['carol'] }, actor);
 	});

--- a/apps/meteor/tests/unit/server/slashcommands/inviteall.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/inviteall.spec.ts
@@ -1,0 +1,166 @@
+import { MeteorError } from '@rocket.chat/core-services';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+(['to', 'from'] as const).forEach((direction) => {
+	describe(`/invite-all-${direction}`, () => {
+		const command = `invite-all-${direction}`;
+		const actor = { _id: 'actor', username: 'alice', language: 'pt' };
+		let source: { _id: string; t: string };
+		let target: { _id: string; t: string };
+		let byId: sinon.SinonStub;
+		let byName: sinon.SinonStub;
+		let findUser: sinon.SinonStub;
+		let canAccess: sinon.SinonStub;
+		let count: sinon.SinonStub;
+		let subscriptions: sinon.SinonStub;
+		let addUsers: sinon.SinonStub;
+		let createPublic: sinon.SinonStub;
+		let createPrivate: sinon.SinonStub;
+		let harness: ReturnType<typeof loadCommand>;
+		beforeEach(() => {
+			source = { _id: 'source', t: 'c' };
+			target = { _id: 'target', t: 'c' };
+			byId = sinon.stub().resolves(direction === 'to' ? source : target);
+			byName = sinon.stub().resolves(direction === 'to' ? target : source);
+			findUser = sinon.stub().resolves(actor);
+			canAccess = sinon.stub().resolves(true);
+			count = sinon.stub().resolves(2);
+			subscriptions = sinon.stub().returns({
+				toArray: sinon.stub().resolves([{ u: { username: 'bob' } }, { u: { username: '' } }, { u: {} }, { u: { username: 'carol' } }]),
+			});
+			addUsers = sinon.stub().resolves();
+			createPublic = sinon.stub().resolves();
+			createPrivate = sinon.stub().resolves();
+			harness = loadCommand('inviteall/server', {
+				'@rocket.chat/models': {
+					Rooms: { findOneById: byId, findOneByName: byName },
+					Users: { findOneById: findUser },
+					Subscriptions: { countByRoomIdWhenUsernameExists: count, findByRoomIdWhenUsernameExists: subscriptions },
+				},
+				'../../lib/authorization': { canAccessRoomAsync: canAccess },
+				'../../meteor-methods/rooms/addUsersToRoom': { addUsersToRoomMethod: addUsers },
+				'../../meteor-methods/rooms/createChannel': { createChannelMethod: createPublic },
+				'../../meteor-methods/rooms/createPrivateGroup': { createPrivateGroupMethod: createPrivate },
+			});
+			harness.settings.get.withArgs('API_User_Limit').returns(2);
+		});
+		it('copies named subscribers from the source to the target at the configured limit', async () => {
+			await harness.run(command, { params: ' #general ' });
+			sinon.assert.calledOnceWithExactly(byId, 'current-room');
+			sinon.assert.calledOnceWithExactly(byName, 'general');
+			sinon.assert.calledOnceWithExactly(canAccess, source, actor);
+			sinon.assert.calledOnceWithExactly(count, 'source');
+			sinon.assert.calledOnceWithExactly(subscriptions, 'source', { projection: { 'u.username': 1 } });
+			sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'target', users: ['bob', 'carol'] });
+			harness.expectFeedback('Users_added');
+			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
+			sinon.assert.notCalled(createPublic);
+			sinon.assert.notCalled(createPrivate);
+		});
+		[{ params: ' ' }, { params: '#' }, { params: '#general', userId: '' }, { params: '#general', command: 'unrelated' }].forEach(
+			(overrides) => {
+				it(`ignores invalid invocation ${JSON.stringify(overrides)}`, async () => {
+					await harness.run(command, overrides);
+					sinon.assert.notCalled(findUser);
+					sinon.assert.notCalled(addUsers);
+					sinon.assert.notCalled(createPublic);
+					sinon.assert.notCalled(createPrivate);
+				});
+			},
+		);
+		it('does nothing for an unknown actor', async () => {
+			findUser.resolves(null);
+			await harness.run(command, { params: '#general' });
+			sinon.assert.calledOnce(findUser);
+			sinon.assert.notCalled(byId);
+			sinon.assert.notCalled(addUsers);
+		});
+		it('reports a missing source without changing membership', async () => {
+			(direction === 'to' ? byId : byName).resolves(null);
+			await harness.run(command, { params: '#missing' });
+			harness.expectFeedback('Channel_doesnt_exist');
+			expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing' });
+			sinon.assert.notCalled(canAccess);
+			sinon.assert.notCalled(addUsers);
+		});
+		it('denies access before reading source membership or creating a room', async () => {
+			canAccess.resolves(false);
+			await harness.run(command, { params: '#general' });
+			sinon.assert.calledOnceWithExactly(canAccess, source, actor);
+			harness.expectFeedback('Room_not_exist_or_not_permission');
+			sinon.assert.notCalled(count);
+			sinon.assert.notCalled(subscriptions);
+			sinon.assert.notCalled(addUsers);
+			sinon.assert.notCalled(createPublic);
+			sinon.assert.notCalled(createPrivate);
+		});
+		it('does not bulk invite when the API user limit is disabled', async () => {
+			harness.settings.get.withArgs('API_User_Limit').returns(0);
+			await harness.run(command, { params: '#general' });
+			sinon.assert.calledOnce(canAccess);
+			sinon.assert.notCalled(count);
+			sinon.assert.notCalled(addUsers);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+		it('rejects requests exceeding the user limit before reading or adding users', async () => {
+			count.resolves(3);
+			await harness.run(command, { params: '#general' });
+			harness.expectFeedback('error-user-limit-exceeded');
+			sinon.assert.calledOnce(count);
+			sinon.assert.notCalled(subscriptions);
+			sinon.assert.notCalled(addUsers);
+		});
+		[
+			{ error: 'cant-invite-for-direct-room', key: 'Cannot_invite_users_to_direct_rooms' },
+			{ error: 'error-not-allowed', key: 'error-not-allowed' },
+		].forEach(({ error, key }) => {
+			it(`reports ${error} without success feedback`, async () => {
+				addUsers.rejects(new MeteorError(error));
+				await harness.run(command, { params: '#general' });
+				sinon.assert.calledOnce(addUsers);
+				harness.expectFeedback(key);
+				sinon.assert.calledOnce(harness.broadcast);
+			});
+		});
+		if (direction === 'to') {
+			['c', 'p'].forEach((type) => {
+				it(`creates a missing destination matching source type ${type}`, async () => {
+					source.t = type;
+					byName.resolves(null);
+					await harness.run(command, { params: '#new-room' });
+					if (type === 'c') {
+						sinon.assert.calledOnceWithExactly(createPublic, 'actor', 'new-room', ['bob', 'carol']);
+						sinon.assert.notCalled(createPrivate);
+					} else {
+						sinon.assert.calledOnceWithExactly(createPrivate, actor, 'new-room', ['bob', 'carol']);
+						sinon.assert.notCalled(createPublic);
+					}
+					sinon.assert.notCalled(addUsers);
+					harness.expectFeedback('Channel_created');
+					harness.expectFeedback('Users_added');
+				});
+			});
+			it('does not announce success if destination creation fails', async () => {
+				byName.resolves(null);
+				createPublic.rejects(new MeteorError('error-not-allowed'));
+				await harness.run(command, { params: '#new-room' });
+				sinon.assert.calledOnce(createPublic);
+				harness.expectFeedback('error-not-allowed');
+				sinon.assert.calledOnce(harness.broadcast);
+				sinon.assert.notCalled(addUsers);
+			});
+			['de', undefined].forEach((language) => {
+				it(`uses ${language || 'English'} when the actor has no language`, async () => {
+					findUser.resolves({ _id: 'actor', username: 'alice' });
+					harness.settings.get.withArgs('Language').returns(language);
+					await harness.run(command, { params: '#general' });
+					expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: language || 'en' });
+				});
+			});
+		}
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/inviteall.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/inviteall.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 
-import { loadCommand } from './helpers';
+import { loadSlashCommand } from './helpers';
 
 (['to', 'from'] as const).forEach((direction) => {
 	describe(`/invite-all-${direction}`, () => {
@@ -11,8 +11,8 @@ import { loadCommand } from './helpers';
 		const actor = { _id: 'actor', username: 'alice', language: 'pt' };
 		let source: { _id: string; t: string };
 		let target: { _id: string; t: string };
-		let byId: sinon.SinonStub;
-		let byName: sinon.SinonStub;
+		let findRoomById: sinon.SinonStub;
+		let findRoomByName: sinon.SinonStub;
 		let findUser: sinon.SinonStub;
 		let canAccess: sinon.SinonStub;
 		let count: sinon.SinonStub;
@@ -20,24 +20,26 @@ import { loadCommand } from './helpers';
 		let addUsers: sinon.SinonStub;
 		let createPublic: sinon.SinonStub;
 		let createPrivate: sinon.SinonStub;
-		let harness: ReturnType<typeof loadCommand>;
+		let slashCommand: ReturnType<typeof loadSlashCommand>;
+
 		beforeEach(() => {
 			source = { _id: 'source', t: 'c' };
 			target = { _id: 'target', t: 'c' };
-			byId = sinon.stub().resolves(direction === 'to' ? source : target);
-			byName = sinon.stub().resolves(direction === 'to' ? target : source);
+			findRoomById = sinon.stub().resolves(direction === 'to' ? source : target);
+			findRoomByName = sinon.stub().resolves(direction === 'to' ? target : source);
 			findUser = sinon.stub().resolves(actor);
 			canAccess = sinon.stub().resolves(true);
 			count = sinon.stub().resolves(2);
 			subscriptions = sinon.stub().returns({
 				toArray: sinon.stub().resolves([{ u: { username: 'bob' } }, { u: { username: '' } }, { u: {} }, { u: { username: 'carol' } }]),
 			});
+
 			addUsers = sinon.stub().resolves();
 			createPublic = sinon.stub().resolves();
 			createPrivate = sinon.stub().resolves();
-			harness = loadCommand('inviteall/server', {
+			slashCommand = loadSlashCommand('inviteall/server', {
 				'@rocket.chat/models': {
-					Rooms: { findOneById: byId, findOneByName: byName },
+					Rooms: { findOneById: findRoomById, findOneByName: findRoomByName },
 					Users: { findOneById: findUser },
 					Subscriptions: { countByRoomIdWhenUsernameExists: count, findByRoomIdWhenUsernameExists: subscriptions },
 				},
@@ -46,25 +48,28 @@ import { loadCommand } from './helpers';
 				'../../meteor-methods/rooms/createChannel': { createChannelMethod: createPublic },
 				'../../meteor-methods/rooms/createPrivateGroup': { createPrivateGroupMethod: createPrivate },
 			});
-			harness.settings.get.withArgs('API_User_Limit').returns(2);
+
+			slashCommand.settings.get.withArgs('API_User_Limit').returns(2);
 		});
+
 		it('copies named subscribers from the source to the target at the configured limit', async () => {
-			await harness.run(command, { params: ' #general ' });
-			sinon.assert.calledOnceWithExactly(byId, 'current-room');
-			sinon.assert.calledOnceWithExactly(byName, 'general');
+			await slashCommand.runCommand(command, { params: ' #general ' });
+			sinon.assert.calledOnceWithExactly(findRoomById, 'current-room');
+			sinon.assert.calledOnceWithExactly(findRoomByName, 'general');
 			sinon.assert.calledOnceWithExactly(canAccess, source, actor);
 			sinon.assert.calledOnceWithExactly(count, 'source');
 			sinon.assert.calledOnceWithExactly(subscriptions, 'source', { projection: { 'u.username': 1 } });
 			sinon.assert.calledOnceWithExactly(addUsers, 'actor', { rid: 'target', users: ['bob', 'carol'] });
-			harness.expectFeedback('Users_added');
-			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
+			slashCommand.expectTranslatedFeedback('Users_added');
+			expect(slashCommand.translate.firstCall.args[1]).to.deep.equal({ lng: 'pt' });
 			sinon.assert.notCalled(createPublic);
 			sinon.assert.notCalled(createPrivate);
 		});
+
 		[{ params: ' ' }, { params: '#' }, { params: '#general', userId: '' }, { params: '#general', command: 'unrelated' }].forEach(
 			(overrides) => {
 				it(`ignores invalid invocation ${JSON.stringify(overrides)}`, async () => {
-					await harness.run(command, overrides);
+					await slashCommand.runCommand(command, overrides);
 					sinon.assert.notCalled(findUser);
 					sinon.assert.notCalled(addUsers);
 					sinon.assert.notCalled(createPublic);
@@ -74,64 +79,70 @@ import { loadCommand } from './helpers';
 		);
 		it('does nothing for an unknown actor', async () => {
 			findUser.resolves(null);
-			await harness.run(command, { params: '#general' });
+			await slashCommand.runCommand(command, { params: '#general' });
 			sinon.assert.calledOnce(findUser);
-			sinon.assert.notCalled(byId);
+			sinon.assert.notCalled(findRoomById);
 			sinon.assert.notCalled(addUsers);
 		});
+
 		it('reports a missing source without changing membership', async () => {
-			(direction === 'to' ? byId : byName).resolves(null);
-			await harness.run(command, { params: '#missing' });
-			harness.expectFeedback('Channel_doesnt_exist');
-			expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing' });
+			(direction === 'to' ? findRoomById : findRoomByName).resolves(null);
+			await slashCommand.runCommand(command, { params: '#missing' });
+			slashCommand.expectTranslatedFeedback('Channel_doesnt_exist');
+			expect(slashCommand.translate.firstCall.args[1]).to.include({ channelName: 'missing' });
 			sinon.assert.notCalled(canAccess);
 			sinon.assert.notCalled(addUsers);
 		});
+
 		it('denies access before reading source membership or creating a room', async () => {
 			canAccess.resolves(false);
-			await harness.run(command, { params: '#general' });
+			await slashCommand.runCommand(command, { params: '#general' });
 			sinon.assert.calledOnceWithExactly(canAccess, source, actor);
-			harness.expectFeedback('Room_not_exist_or_not_permission');
+			slashCommand.expectTranslatedFeedback('Room_not_exist_or_not_permission');
 			sinon.assert.notCalled(count);
 			sinon.assert.notCalled(subscriptions);
 			sinon.assert.notCalled(addUsers);
 			sinon.assert.notCalled(createPublic);
 			sinon.assert.notCalled(createPrivate);
 		});
+
 		it('does not bulk invite when the API user limit is disabled', async () => {
-			harness.settings.get.withArgs('API_User_Limit').returns(0);
-			await harness.run(command, { params: '#general' });
+			slashCommand.settings.get.withArgs('API_User_Limit').returns(0);
+			await slashCommand.runCommand(command, { params: '#general' });
 			sinon.assert.calledOnce(canAccess);
 			sinon.assert.notCalled(count);
 			sinon.assert.notCalled(addUsers);
-			sinon.assert.notCalled(harness.broadcast);
+			sinon.assert.notCalled(slashCommand.broadcast);
 		});
+
 		it('rejects requests exceeding the user limit before reading or adding users', async () => {
 			count.resolves(3);
-			await harness.run(command, { params: '#general' });
-			harness.expectFeedback('error-user-limit-exceeded');
+			await slashCommand.runCommand(command, { params: '#general' });
+			slashCommand.expectTranslatedFeedback('error-user-limit-exceeded');
 			sinon.assert.calledOnce(count);
 			sinon.assert.notCalled(subscriptions);
 			sinon.assert.notCalled(addUsers);
 		});
+
 		[
 			{ error: 'cant-invite-for-direct-room', key: 'Cannot_invite_users_to_direct_rooms' },
 			{ error: 'error-not-allowed', key: 'error-not-allowed' },
 		].forEach(({ error, key }) => {
 			it(`reports ${error} without success feedback`, async () => {
 				addUsers.rejects(new MeteorError(error));
-				await harness.run(command, { params: '#general' });
+				await slashCommand.runCommand(command, { params: '#general' });
 				sinon.assert.calledOnce(addUsers);
-				harness.expectFeedback(key);
-				sinon.assert.calledOnce(harness.broadcast);
+				slashCommand.expectTranslatedFeedback(key);
+				sinon.assert.calledOnce(slashCommand.broadcast);
 			});
 		});
+
 		if (direction === 'to') {
 			['c', 'p'].forEach((type) => {
 				it(`creates a missing destination matching source type ${type}`, async () => {
 					source.t = type;
-					byName.resolves(null);
-					await harness.run(command, { params: '#new-room' });
+					findRoomByName.resolves(null);
+					await slashCommand.runCommand(command, { params: '#new-room' });
 					if (type === 'c') {
 						sinon.assert.calledOnceWithExactly(createPublic, 'actor', 'new-room', ['bob', 'carol']);
 						sinon.assert.notCalled(createPrivate);
@@ -140,25 +151,27 @@ import { loadCommand } from './helpers';
 						sinon.assert.notCalled(createPublic);
 					}
 					sinon.assert.notCalled(addUsers);
-					harness.expectFeedback('Channel_created');
-					harness.expectFeedback('Users_added');
+					slashCommand.expectTranslatedFeedback('Channel_created');
+					slashCommand.expectTranslatedFeedback('Users_added');
 				});
 			});
+
 			it('does not announce success if destination creation fails', async () => {
-				byName.resolves(null);
+				findRoomByName.resolves(null);
 				createPublic.rejects(new MeteorError('error-not-allowed'));
-				await harness.run(command, { params: '#new-room' });
+				await slashCommand.runCommand(command, { params: '#new-room' });
 				sinon.assert.calledOnce(createPublic);
-				harness.expectFeedback('error-not-allowed');
-				sinon.assert.calledOnce(harness.broadcast);
+				slashCommand.expectTranslatedFeedback('error-not-allowed');
+				sinon.assert.calledOnce(slashCommand.broadcast);
 				sinon.assert.notCalled(addUsers);
 			});
+
 			['de', undefined].forEach((language) => {
 				it(`uses ${language || 'English'} when the actor has no language`, async () => {
 					findUser.resolves({ _id: 'actor', username: 'alice' });
-					harness.settings.get.withArgs('Language').returns(language);
-					await harness.run(command, { params: '#general' });
-					expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: language || 'en' });
+					slashCommand.settings.get.withArgs('Language').returns(language);
+					await slashCommand.runCommand(command, { params: '#general' });
+					expect(slashCommand.translate.firstCall.args[1]).to.deep.equal({ lng: language || 'en' });
 				});
 			});
 		}

--- a/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 
-import { loadCommand } from './helpers';
+import { loadSlashCommand } from './helpers';
 
 describe('/join', () => {
 	const room = { _id: 'target-room', name: 'general', t: 'c' };
@@ -11,13 +11,14 @@ describe('/join', () => {
 	let findSubscription: sinon.SinonStub;
 	let findUser: sinon.SinonStub;
 	let join: sinon.SinonStub;
-	let harness: ReturnType<typeof loadCommand>;
+	let slashCommand: ReturnType<typeof loadSlashCommand>;
+
 	beforeEach(() => {
 		findRoom = sinon.stub().resolves(room);
 		findSubscription = sinon.stub().resolves(null);
 		findUser = sinon.stub().resolves(user);
 		join = sinon.stub().resolves();
-		harness = loadCommand('join/server', {
+		slashCommand = loadSlashCommand('join/server', {
 			'@rocket.chat/core-services': { Room: { join } },
 			'@rocket.chat/models': {
 				Rooms: { findOneByNameAndType: findRoom },
@@ -26,45 +27,52 @@ describe('/join', () => {
 			},
 		});
 	});
+
 	it('joins the named public room with the authenticated user', async () => {
-		await harness.run('join', { params: ' #general ' });
+		await slashCommand.runCommand('join', { params: ' #general ' });
 		sinon.assert.calledOnceWithExactly(findRoom, 'general', 'c');
 		sinon.assert.calledOnceWithExactly(findSubscription, 'target-room', 'actor', { projection: { _id: 1 } });
 		sinon.assert.calledOnceWithExactly(join, { room, user });
 	});
+
 	[{ params: ' ' }, { params: '#general', userId: '' }].forEach((overrides) => {
 		it(`does not look up or join a room with ${JSON.stringify(overrides)}`, async () => {
-			await harness.run('join', overrides);
+			await slashCommand.runCommand('join', overrides);
 			sinon.assert.notCalled(findRoom);
 			sinon.assert.notCalled(join);
 		});
 	});
+
 	it('reports an unknown public channel', async () => {
 		findRoom.resolves(null);
-		await harness.run('join', { params: '#missing' });
-		sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+		await slashCommand.runCommand('join', { params: '#missing' });
+		sinon.assert.calledOnceWithExactly(slashCommand.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
 			msg: 'translated:Channel_doesnt_exist',
 		});
-		expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing', lng: 'en' });
+
+		expect(slashCommand.translate.firstCall.args[1]).to.include({ channelName: 'missing', lng: 'en' });
 		sinon.assert.notCalled(findSubscription);
 		sinon.assert.notCalled(join);
 	});
+
 	it('rejects existing membership without joining again', async () => {
 		findSubscription.resolves({ _id: 'subscription' });
-		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith('You are already in the channel');
+		await expect(slashCommand.runCommand('join', { params: '#general' })).to.be.rejectedWith('You are already in the channel');
 		sinon.assert.calledOnce(findSubscription);
 		sinon.assert.notCalled(join);
 	});
+
 	it('rejects an unknown actor', async () => {
 		findUser.resolves(null);
-		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith('Invalid user');
+		await expect(slashCommand.runCommand('join', { params: '#general' })).to.be.rejectedWith('Invalid user');
 		sinon.assert.calledOnceWithExactly(findUser, 'actor');
 		sinon.assert.notCalled(join);
 	});
+
 	it('propagates a join service failure', async () => {
 		const error = new Error('join failed');
 		join.rejects(error);
-		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith(error);
+		await expect(slashCommand.runCommand('join', { params: '#general' })).to.be.rejectedWith(error);
 		sinon.assert.calledOnce(join);
 	});
 });

--- a/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
@@ -11,16 +11,14 @@ describe('/join', () => {
 	let findSubscription: sinon.SinonStub;
 	let findUser: sinon.SinonStub;
 	let join: sinon.SinonStub;
-	let broadcast: sinon.SinonStub;
 	let harness: ReturnType<typeof loadCommand>;
 	beforeEach(() => {
 		findRoom = sinon.stub().resolves(room);
 		findSubscription = sinon.stub().resolves(null);
 		findUser = sinon.stub().resolves(user);
 		join = sinon.stub().resolves();
-		broadcast = sinon.stub().resolves();
 		harness = loadCommand('join/server', {
-			'@rocket.chat/core-services': { api: { broadcast }, Room: { join } },
+			'@rocket.chat/core-services': { Room: { join } },
 			'@rocket.chat/models': {
 				Rooms: { findOneByNameAndType: findRoom },
 				Subscriptions: { findOneByRoomIdAndUserId: findSubscription },
@@ -44,7 +42,7 @@ describe('/join', () => {
 	it('reports an unknown public channel', async () => {
 		findRoom.resolves(null);
 		await harness.run('join', { params: '#missing' });
-		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+		sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
 			msg: 'translated:Channel_doesnt_exist',
 		});
 		expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing', lng: 'en' });

--- a/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/join.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/join', () => {
+	const room = { _id: 'target-room', name: 'general', t: 'c' };
+	const user = { _id: 'actor', username: 'alice' };
+	let findRoom: sinon.SinonStub;
+	let findSubscription: sinon.SinonStub;
+	let findUser: sinon.SinonStub;
+	let join: sinon.SinonStub;
+	let broadcast: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findRoom = sinon.stub().resolves(room);
+		findSubscription = sinon.stub().resolves(null);
+		findUser = sinon.stub().resolves(user);
+		join = sinon.stub().resolves();
+		broadcast = sinon.stub().resolves();
+		harness = loadCommand('join/server', {
+			'@rocket.chat/core-services': { api: { broadcast }, Room: { join } },
+			'@rocket.chat/models': {
+				Rooms: { findOneByNameAndType: findRoom },
+				Subscriptions: { findOneByRoomIdAndUserId: findSubscription },
+				Users: { findOneById: findUser },
+			},
+		});
+	});
+	it('joins the named public room with the authenticated user', async () => {
+		await harness.run('join', { params: ' #general ' });
+		sinon.assert.calledOnceWithExactly(findRoom, 'general', 'c');
+		sinon.assert.calledOnceWithExactly(findSubscription, 'target-room', 'actor', { projection: { _id: 1 } });
+		sinon.assert.calledOnceWithExactly(join, { room, user });
+	});
+	[{ params: ' ' }, { params: '#general', userId: '' }].forEach((overrides) => {
+		it(`does not look up or join a room with ${JSON.stringify(overrides)}`, async () => {
+			await harness.run('join', overrides);
+			sinon.assert.notCalled(findRoom);
+			sinon.assert.notCalled(join);
+		});
+	});
+	it('reports an unknown public channel', async () => {
+		findRoom.resolves(null);
+		await harness.run('join', { params: '#missing' });
+		sinon.assert.calledOnceWithExactly(broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+			msg: 'translated:Channel_doesnt_exist',
+		});
+		expect(harness.translate.firstCall.args[1]).to.include({ channelName: 'missing', lng: 'en' });
+		sinon.assert.notCalled(findSubscription);
+		sinon.assert.notCalled(join);
+	});
+	it('rejects existing membership without joining again', async () => {
+		findSubscription.resolves({ _id: 'subscription' });
+		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith('You are already in the channel');
+		sinon.assert.calledOnce(findSubscription);
+		sinon.assert.notCalled(join);
+	});
+	it('rejects an unknown actor', async () => {
+		findUser.resolves(null);
+		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith('Invalid user');
+		sinon.assert.calledOnceWithExactly(findUser, 'actor');
+		sinon.assert.notCalled(join);
+	});
+	it('propagates a join service failure', async () => {
+		const error = new Error('join failed');
+		join.rejects(error);
+		await expect(harness.run('join', { params: '#general' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(join);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/leave.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/leave.spec.ts
@@ -3,43 +3,48 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 
-import { loadCommand } from './helpers';
+import { loadSlashCommand } from './helpers';
 
 describe('/leave and /part', () => {
 	const user = { _id: 'actor', username: 'alice', language: 'pt' };
 	let findUser: sinon.SinonStub;
 	let leave: sinon.SinonStub;
-	let harness: ReturnType<typeof loadCommand>;
+	let slashCommand: ReturnType<typeof loadSlashCommand>;
+
 	beforeEach(() => {
 		findUser = sinon.stub().resolves(user);
 		leave = sinon.stub().resolves();
-		harness = loadCommand('leave/leave', {
+		slashCommand = loadSlashCommand('leave/leave', {
 			'@rocket.chat/models': { Users: { findOneById: findUser } },
 			'../../meteor-methods/rooms/leaveRoom': { leaveRoomMethod: leave },
 		});
 	});
+
 	['leave', 'part'].forEach((command) => {
 		it(`/${command} leaves the current room as the authenticated user`, async () => {
-			await harness.run(command);
+			await slashCommand.runCommand(command);
 			sinon.assert.calledOnceWithExactly(findUser, 'actor');
 			sinon.assert.calledOnceWithExactly(leave, user, 'current-room');
-			sinon.assert.notCalled(harness.broadcast);
-			expect(harness.commands.get(command)?.options?.permission).to.deep.equal(['leave-c', 'leave-p']);
+			sinon.assert.notCalled(slashCommand.broadcast);
+			expect(slashCommand.registeredCommands.get(command)?.options?.permission).to.deep.equal(['leave-c', 'leave-p']);
 		});
 	});
+
 	it('does nothing for an unknown actor', async () => {
 		findUser.resolves(null);
-		await harness.run('leave');
+		await slashCommand.runCommand('leave');
 		sinon.assert.calledOnce(findUser);
 		sinon.assert.notCalled(leave);
 	});
+
 	it('propagates an unexpected leave failure without attempting translated feedback', async () => {
 		const error = new Error('storage failure');
 		leave.rejects(error);
-		await expect(harness.run('leave')).to.be.rejectedWith(error);
+		await expect(slashCommand.runCommand('leave')).to.be.rejectedWith(error);
 		sinon.assert.calledOnce(leave);
-		sinon.assert.notCalled(harness.broadcast);
+		sinon.assert.notCalled(slashCommand.broadcast);
 	});
+
 	[
 		{ user, language: 'de', expected: 'pt' },
 		{ user: { _id: 'actor' }, language: 'de', expected: 'de' },
@@ -47,18 +52,19 @@ describe('/leave and /part', () => {
 	].forEach(({ user: feedbackUser, language, expected }) => {
 		it(`preserves a domain error and notifies the actor using ${expected}`, async () => {
 			findUser.onSecondCall().resolves(feedbackUser);
-			harness.settings.get.withArgs('Language').returns(language);
-			harness.translate.returns('localized leave error');
+			slashCommand.settings.get.withArgs('Language').returns(language);
+			slashCommand.translate.returns('localized leave error');
 			leave.rejects(new MeteorError('error-not-allowed', 'Cannot leave room'));
-			await expect(harness.run('leave'))
+			await expect(slashCommand.runCommand('leave'))
 				.to.be.rejectedWith(MeteorError, 'Cannot leave room')
 				.and.eventually.have.property('error', 'error-not-allowed');
 			sinon.assert.calledOnce(leave);
-			sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+			sinon.assert.calledOnceWithExactly(slashCommand.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
 				msg: 'localized leave error',
 			});
-			sinon.assert.calledOnce(harness.translate);
-			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: expected });
+
+			sinon.assert.calledOnce(slashCommand.translate);
+			expect(slashCommand.translate.firstCall.args[1]).to.deep.equal({ lng: expected });
 		});
 	});
 });

--- a/apps/meteor/tests/unit/server/slashcommands/leave.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/leave.spec.ts
@@ -1,0 +1,64 @@
+import { MeteorError } from '@rocket.chat/core-services';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/leave and /part', () => {
+	const user = { _id: 'actor', username: 'alice', language: 'pt' };
+	let findUser: sinon.SinonStub;
+	let leave: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findUser = sinon.stub().resolves(user);
+		leave = sinon.stub().resolves();
+		harness = loadCommand('leave/leave', {
+			'@rocket.chat/models': { Users: { findOneById: findUser } },
+			'../../meteor-methods/rooms/leaveRoom': { leaveRoomMethod: leave },
+		});
+	});
+	['leave', 'part'].forEach((command) => {
+		it(`/${command} leaves the current room as the authenticated user`, async () => {
+			await harness.run(command);
+			sinon.assert.calledOnceWithExactly(findUser, 'actor');
+			sinon.assert.calledOnceWithExactly(leave, user, 'current-room');
+			sinon.assert.notCalled(harness.broadcast);
+			expect(harness.commands.get(command)?.options?.permission).to.deep.equal(['leave-c', 'leave-p']);
+		});
+	});
+	it('does nothing for an unknown actor', async () => {
+		findUser.resolves(null);
+		await harness.run('leave');
+		sinon.assert.calledOnce(findUser);
+		sinon.assert.notCalled(leave);
+	});
+	it('propagates an unexpected leave failure without attempting translated feedback', async () => {
+		const error = new Error('storage failure');
+		leave.rejects(error);
+		await expect(harness.run('leave')).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(leave);
+		sinon.assert.notCalled(harness.broadcast);
+	});
+	[
+		{ user, language: 'de', expected: 'pt' },
+		{ user: { _id: 'actor' }, language: 'de', expected: 'de' },
+		{ user: null, language: undefined, expected: 'en' },
+	].forEach(({ user: feedbackUser, language, expected }) => {
+		it(`preserves a domain error and notifies the actor using ${expected}`, async () => {
+			findUser.onSecondCall().resolves(feedbackUser);
+			harness.settings.get.withArgs('Language').returns(language);
+			harness.translate.returns('localized leave error');
+			leave.rejects(new MeteorError('error-not-allowed', 'Cannot leave room'));
+			await expect(harness.run('leave'))
+				.to.be.rejectedWith(MeteorError, 'Cannot leave room')
+				.and.eventually.have.property('error', 'error-not-allowed');
+			sinon.assert.calledOnce(leave);
+			sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+				msg: 'localized leave error',
+			});
+			sinon.assert.calledOnce(harness.translate);
+			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: expected });
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/messages.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/messages.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/me', () => {
+	it('formats action text and preserves the message identity and thread', async () => {
+		const send = sinon.stub().resolves();
+		const harness = loadCommand('me/me', { '../../meteor-methods/messages/sendMessage': { executeSendMessage: send } });
+		await harness.run('me', { params: 'waves hello', message: { _id: 'message', rid: 'current-room', tmid: 'thread' } });
+		sinon.assert.calledOnceWithExactly(send, 'actor', { _id: 'message', rid: 'current-room', tmid: 'thread', msg: '_waves hello_' });
+	});
+	it('does not send or mutate the message for whitespace-only input', async () => {
+		const send = sinon.stub().resolves();
+		const harness = loadCommand('me/me', { '../../meteor-methods/messages/sendMessage': { executeSendMessage: send } });
+		const message = { _id: 'message', rid: 'current-room', msg: 'original' };
+		await harness.run('me', { params: '  ', message });
+		sinon.assert.notCalled(send);
+		expect(message.msg).to.equal('original');
+	});
+	it('propagates a send failure', async () => {
+		const error = new Error('send failed');
+		const send = sinon.stub().rejects(error);
+		const harness = loadCommand('me/me', { '../../meteor-methods/messages/sendMessage': { executeSendMessage: send } });
+		await expect(harness.run('me', { params: 'waves' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(send);
+	});
+});
+
+describe('/help', () => {
+	it('sends the translated keyboard shortcuts privately in the current thread', async () => {
+		const findUser = sinon.stub().resolves({ language: 'pt' });
+		const harness = loadCommand('help/server', { '@rocket.chat/models': { Users: { findOneById: findUser } } });
+		harness.translate.callsFake((key: string, options: { shortcut: string }) => `${key}: ${options.shortcut}`);
+		await harness.run('help', { message: { _id: 'message', rid: 'current-room', tmid: 'thread' } });
+		sinon.assert.calledOnceWithExactly(findUser, 'actor');
+		sinon.assert.calledOnceWithExactly(harness.broadcast, 'notify.ephemeralMessage', 'actor', 'current-room', {
+			msg: '\nOpen_channel_user_search: Command (or Ctrl) + p OR Command (or Ctrl) + k\nMark_all_as_read: Shift (or Ctrl) + ESC\nEdit_previous_message: Up Arrow\nMove_beginning_message: Command (or Alt) + Left Arrow\nMove_beginning_message: Command (or Alt) + Up Arrow\nMove_end_message: Command (or Alt) + Right Arrow\nMove_end_message: Command (or Alt) + Down Arrow\nNew_line_message_compose_input: Shift + Enter',
+			tmid: 'thread',
+		});
+		expect(harness.translate.getCalls().every((call) => call.args[1].lng === 'pt')).to.equal(true);
+	});
+	it('provides English help without a user preference or thread', async () => {
+		const harness = loadCommand('help/server', { '@rocket.chat/models': { Users: { findOneById: sinon.stub().resolves(null) } } });
+		await harness.run('help');
+		sinon.assert.calledOnce(harness.broadcast);
+		expect(harness.broadcast.firstCall.args.slice(0, 3)).to.deep.equal(['notify.ephemeralMessage', 'actor', 'current-room']);
+		expect(harness.broadcast.firstCall.args[3]).not.to.have.property('tmid');
+		expect(harness.translate.getCalls()).to.have.length(8);
+		expect(harness.translate.getCalls().every((call) => call.args[1].lng === 'en')).to.equal(true);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 
-import { loadCommand } from './helpers';
+import { loadSlashCommand } from './helpers';
 
 const cases = [
 	{
@@ -53,14 +53,14 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 		let findActor: sinon.SinonStub;
 		let action: sinon.SinonStub;
 		let sanitizeUsername: sinon.SinonStub;
-		let harness: ReturnType<typeof loadCommand>;
+		let slashCommand: ReturnType<typeof loadSlashCommand>;
 
 		beforeEach(() => {
 			findTarget = sinon.stub().resolves({ _id: 'target', username: 'Bob' });
 			findActor = sinon.stub().resolves({ _id: 'actor', language: 'pt' });
 			action = sinon.stub().resolves();
 			sanitizeUsername = sinon.stub().returns('Bob');
-			harness = loadCommand(path, {
+			slashCommand = loadSlashCommand(path, {
 				'@rocket.chat/models': { Users: { findOneByUsernameIgnoringCase: findTarget, findOneById: findActor } },
 				'../../meteor-methods/rooms/addUsersToRoom': { sanitizeUsername },
 				[dependency]: { [method]: action },
@@ -68,21 +68,25 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 		});
 
 		it('passes the actor, room and normalized target to the authoritative method', async () => {
-			await harness.run(command, { params: '  @Bob  ' });
-			if (sanitizes) sinon.assert.calledOnceWithExactly(sanitizeUsername, '@Bob');
+			await slashCommand.runCommand(command, { params: '  @Bob  ' });
+			if (sanitizes) {
+				sinon.assert.calledOnceWithExactly(sanitizeUsername, '@Bob');
+			}
 			sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
 			sinon.assert.calledOnceWithExactly(action, 'actor', { rid: 'current-room', username: 'Bob' });
-			sinon.assert.notCalled(harness.broadcast);
-			expect(harness.commands.get(command)?.options?.permission).to.equal(permission);
+			sinon.assert.notCalled(slashCommand.broadcast);
+			expect(slashCommand.registeredCommands.get(command)?.options?.permission).to.equal(permission);
 		});
 
 		it('does not look up or modify a user for empty input', async () => {
 			sanitizeUsername.returns('');
-			await harness.run(command, { params: '   ' });
-			if (sanitizes) sinon.assert.calledOnceWithExactly(sanitizeUsername, '');
+			await slashCommand.runCommand(command, { params: '   ' });
+			if (sanitizes) {
+				sinon.assert.calledOnceWithExactly(sanitizeUsername, '');
+			}
 			sinon.assert.notCalled(findTarget);
 			sinon.assert.notCalled(action);
-			sinon.assert.notCalled(harness.broadcast);
+			sinon.assert.notCalled(slashCommand.broadcast);
 		});
 
 		// TODO: Fix /mute to return after unknown-user feedback, then enable these tests.
@@ -92,11 +96,11 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 				async () => {
 					findTarget.resolves(null);
 					findActor.resolves(null);
-					harness.settings.get.withArgs('Language').returns(language);
-					await harness.run(command, { params: '@Bob' });
+					slashCommand.settings.get.withArgs('Language').returns(language);
+					await slashCommand.runCommand(command, { params: '@Bob' });
 					sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
-					harness.expectFeedback('Username_doesnt_exist');
-					expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
+					slashCommand.expectTranslatedFeedback('Username_doesnt_exist');
+					expect(slashCommand.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
 					sinon.assert.notCalled(action);
 				},
 			);
@@ -105,9 +109,9 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 		it('propagates authorization failures from the authoritative method', async () => {
 			const error = new Error('Not authorized');
 			action.rejects(error);
-			await expect(harness.run(command, { params: '@Bob' })).to.be.rejectedWith(error);
+			await expect(slashCommand.runCommand(command, { params: '@Bob' })).to.be.rejectedWith(error);
 			sinon.assert.calledOnce(action);
-			sinon.assert.notCalled(harness.broadcast);
+			sinon.assert.notCalled(slashCommand.broadcast);
 		});
 	});
 });

--- a/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
@@ -30,14 +30,6 @@ const cases = [
 		sanitizes: true,
 	},
 	{
-		command: 'mute',
-		path: 'mute/mute',
-		dependency: '../../meteor-methods/rooms/muteUserInRoom',
-		method: 'muteUserInRoom',
-		permission: 'mute-user',
-		sanitizes: false,
-	},
-	{
 		command: 'unmute',
 		path: 'mute/unmute',
 		dependency: '../../meteor-methods/rooms/unmuteUserInRoom',
@@ -85,21 +77,18 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 			sinon.assert.notCalled(harness.broadcast);
 		});
 
-		// /mute currently falls through after missing-user feedback; leave that bug outside this contract.
-		if (command !== 'mute') {
-			['pt', undefined].forEach((language) => {
-				it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
-					findTarget.resolves(null);
-					findActor.resolves(null);
-					harness.settings.get.withArgs('Language').returns(language);
-					await harness.run(command, { params: '@Bob' });
-					sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
-					harness.expectFeedback('Username_doesnt_exist');
-					expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
-					sinon.assert.notCalled(action);
-				});
+		['pt', undefined].forEach((language) => {
+			it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
+				findTarget.resolves(null);
+				findActor.resolves(null);
+				harness.settings.get.withArgs('Language').returns(language);
+				await harness.run(command, { params: '@Bob' });
+				sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
+				harness.expectFeedback('Username_doesnt_exist');
+				expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
+				sinon.assert.notCalled(action);
 			});
-		}
+		});
 
 		it('propagates authorization failures from the authoritative method', async () => {
 			const error = new Error('Not authorized');

--- a/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
@@ -30,6 +30,14 @@ const cases = [
 		sanitizes: true,
 	},
 	{
+		command: 'mute',
+		path: 'mute/mute',
+		dependency: '../../meteor-methods/rooms/muteUserInRoom',
+		method: 'muteUserInRoom',
+		permission: 'mute-user',
+		sanitizes: false,
+	},
+	{
 		command: 'unmute',
 		path: 'mute/unmute',
 		dependency: '../../meteor-methods/rooms/unmuteUserInRoom',
@@ -77,18 +85,20 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 			sinon.assert.notCalled(harness.broadcast);
 		});
 
-		['pt', undefined].forEach((language) => {
-			it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
-				findTarget.resolves(null);
-				findActor.resolves(null);
-				harness.settings.get.withArgs('Language').returns(language);
-				await harness.run(command, { params: '@Bob' });
-				sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
-				harness.expectFeedback('Username_doesnt_exist');
-				expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
-				sinon.assert.notCalled(action);
+		if (command !== 'mute') {
+			['pt', undefined].forEach((language) => {
+				it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
+					findTarget.resolves(null);
+					findActor.resolves(null);
+					harness.settings.get.withArgs('Language').returns(language);
+					await harness.run(command, { params: '@Bob' });
+					sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
+					harness.expectFeedback('Username_doesnt_exist');
+					expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
+					sinon.assert.notCalled(action);
+				});
 			});
-		});
+		}
 
 		it('propagates authorization failures from the authoritative method', async () => {
 			const error = new Error('Not authorized');

--- a/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
@@ -85,9 +85,11 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 			sinon.assert.notCalled(harness.broadcast);
 		});
 
-		if (command !== 'mute') {
-			['pt', undefined].forEach((language) => {
-				it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
+		// TODO: Fix /mute to return after unknown-user feedback, then enable these tests.
+		['pt', undefined].forEach((language) => {
+			(command === 'mute' ? it.skip : it)(
+				`reports an unknown target with ${language || 'English fallback'} and performs no mutation`,
+				async () => {
 					findTarget.resolves(null);
 					findActor.resolves(null);
 					harness.settings.get.withArgs('Language').returns(language);
@@ -96,9 +98,9 @@ cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => 
 					harness.expectFeedback('Username_doesnt_exist');
 					expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
 					sinon.assert.notCalled(action);
-				});
-			});
-		}
+				},
+			);
+		});
 
 		it('propagates authorization failures from the authoritative method', async () => {
 			const error = new Error('Not authorized');

--- a/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/moderation.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+const cases = [
+	{
+		command: 'ban',
+		path: 'ban/ban',
+		dependency: '../../lib/banUserFromRoom',
+		method: 'banUserFromRoomMethod',
+		permission: 'ban-user',
+		sanitizes: true,
+	},
+	{
+		command: 'unban',
+		path: 'ban/unban',
+		dependency: '../../lib/unbanUserFromRoom',
+		method: 'unbanUserFromRoom',
+		permission: 'ban-user',
+		sanitizes: true,
+	},
+	{
+		command: 'kick',
+		path: 'kick/server',
+		dependency: '../../meteor-methods/rooms/removeUserFromRoom',
+		method: 'removeUserFromRoomMethod',
+		permission: 'remove-user',
+		sanitizes: true,
+	},
+	{
+		command: 'mute',
+		path: 'mute/mute',
+		dependency: '../../meteor-methods/rooms/muteUserInRoom',
+		method: 'muteUserInRoom',
+		permission: 'mute-user',
+		sanitizes: false,
+	},
+	{
+		command: 'unmute',
+		path: 'mute/unmute',
+		dependency: '../../meteor-methods/rooms/unmuteUserInRoom',
+		method: 'unmuteUserInRoom',
+		permission: 'mute-user',
+		sanitizes: false,
+	},
+];
+
+cases.forEach(({ command, path, dependency, method, permission, sanitizes }) => {
+	describe(`/${command}`, () => {
+		let findTarget: sinon.SinonStub;
+		let findActor: sinon.SinonStub;
+		let action: sinon.SinonStub;
+		let sanitizeUsername: sinon.SinonStub;
+		let harness: ReturnType<typeof loadCommand>;
+
+		beforeEach(() => {
+			findTarget = sinon.stub().resolves({ _id: 'target', username: 'Bob' });
+			findActor = sinon.stub().resolves({ _id: 'actor', language: 'pt' });
+			action = sinon.stub().resolves();
+			sanitizeUsername = sinon.stub().returns('Bob');
+			harness = loadCommand(path, {
+				'@rocket.chat/models': { Users: { findOneByUsernameIgnoringCase: findTarget, findOneById: findActor } },
+				'../../meteor-methods/rooms/addUsersToRoom': { sanitizeUsername },
+				[dependency]: { [method]: action },
+			});
+		});
+
+		it('passes the actor, room and normalized target to the authoritative method', async () => {
+			await harness.run(command, { params: '  @Bob  ' });
+			if (sanitizes) sinon.assert.calledOnceWithExactly(sanitizeUsername, '@Bob');
+			sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
+			sinon.assert.calledOnceWithExactly(action, 'actor', { rid: 'current-room', username: 'Bob' });
+			sinon.assert.notCalled(harness.broadcast);
+			expect(harness.commands.get(command)?.options?.permission).to.equal(permission);
+		});
+
+		it('does not look up or modify a user for empty input', async () => {
+			sanitizeUsername.returns('');
+			await harness.run(command, { params: '   ' });
+			if (sanitizes) sinon.assert.calledOnceWithExactly(sanitizeUsername, '');
+			sinon.assert.notCalled(findTarget);
+			sinon.assert.notCalled(action);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+
+		// /mute currently falls through after missing-user feedback; leave that bug outside this contract.
+		if (command !== 'mute') {
+			['pt', undefined].forEach((language) => {
+				it(`reports an unknown target with ${language || 'English fallback'} and performs no mutation`, async () => {
+					findTarget.resolves(null);
+					findActor.resolves(null);
+					harness.settings.get.withArgs('Language').returns(language);
+					await harness.run(command, { params: '@Bob' });
+					sinon.assert.calledOnceWithExactly(findTarget, 'Bob');
+					harness.expectFeedback('Username_doesnt_exist');
+					expect(harness.translate.firstCall.args[1]).to.include({ username: 'Bob', lng: language || 'en' });
+					sinon.assert.notCalled(action);
+				});
+			});
+		}
+
+		it('propagates authorization failures from the authoritative method', async () => {
+			const error = new Error('Not authorized');
+			action.rejects(error);
+			await expect(harness.run(command, { params: '@Bob' })).to.be.rejectedWith(error);
+			sinon.assert.calledOnce(action);
+			sinon.assert.notCalled(harness.broadcast);
+		});
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/msg.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/msg.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/msg', () => {
+	let findTarget: sinon.SinonStub;
+	let findActor: sinon.SinonStub;
+	let createDirect: sinon.SinonStub;
+	let send: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findTarget = sinon.stub().resolves({ _id: 'target', username: 'bob' });
+		findActor = sinon.stub().resolves({ _id: 'actor', language: 'pt' });
+		createDirect = sinon.stub().resolves({ rid: 'direct-room' });
+		send = sinon.stub().resolves();
+		harness = loadCommand('msg/server', {
+			'@rocket.chat/models': { Users: { findOneByUsernameIgnoringCase: findTarget, findOneById: findActor } },
+			'@rocket.chat/random': { Random: { id: () => 'generated-id' } },
+			'../../meteor-methods/messages/createDirectMessage': { createDirectMessage: createDirect },
+			'../../meteor-methods/messages/sendMessage': { executeSendMessage: send },
+		});
+	});
+	it('sends the entire message to the direct room for the normalized recipient', async () => {
+		await harness.run('msg', { params: '  @bob hello  there  ' });
+		sinon.assert.calledOnceWithExactly(findTarget, 'bob');
+		sinon.assert.calledOnceWithExactly(createDirect, ['bob'], 'actor');
+		sinon.assert.calledOnceWithExactly(send, 'actor', { _id: 'generated-id', rid: 'direct-room', msg: 'hello  there' });
+		sinon.assert.notCalled(harness.broadcast);
+	});
+	['', '@bob'].forEach((params) => {
+		it(`reports incomplete input ${JSON.stringify(params)} without creating a conversation`, async () => {
+			await harness.run('msg', { params });
+			harness.expectFeedback('Username_and_message_must_not_be_empty');
+			sinon.assert.notCalled(findTarget);
+			sinon.assert.notCalled(createDirect);
+			sinon.assert.notCalled(send);
+		});
+	});
+	[
+		{ user: { language: 'pt' }, language: 'de', expected: 'pt' },
+		{ user: {}, language: 'de', expected: 'de' },
+		{ user: null, language: undefined, expected: 'en' },
+	].forEach(({ user, language, expected }) => {
+		it(`reports an unknown recipient in ${expected} without sending`, async () => {
+			findTarget.resolves(null);
+			findActor.resolves(user);
+			harness.settings.get.withArgs('Language').returns(language);
+			await harness.run('msg', { params: '@bob hello' });
+			sinon.assert.calledOnceWithExactly(findTarget, 'bob');
+			harness.expectFeedback('Username_doesnt_exist');
+			expect(harness.translate.firstCall.args[1]).to.include({ username: '@bob', lng: expected });
+			sinon.assert.notCalled(createDirect);
+			sinon.assert.notCalled(send);
+		});
+	});
+	it('does not send when creation of the direct room fails', async () => {
+		const error = new Error('Not authorized');
+		createDirect.rejects(error);
+		await expect(harness.run('msg', { params: 'bob hello' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(createDirect);
+		sinon.assert.notCalled(send);
+	});
+	it('propagates a send failure', async () => {
+		const error = new Error('send failed');
+		send.rejects(error);
+		await expect(harness.run('msg', { params: 'bob hello' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(send);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/status.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/status.spec.ts
@@ -1,0 +1,65 @@
+import { MeteorError } from '@rocket.chat/core-services';
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/status', () => {
+	let findUser: sinon.SinonStub;
+	let setStatus: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		findUser = sinon.stub().resolves({ _id: 'actor', language: 'pt' });
+		setStatus = sinon.stub().resolves();
+		harness = loadCommand('status/status', {
+			'@rocket.chat/models': { Users: { findOneById: findUser } },
+			'../../meteor-methods/users/setUserStatus': { setUserStatusMethod: setStatus },
+		});
+	});
+	[
+		{ user: { _id: 'actor', language: 'pt' }, language: 'de', expected: 'pt' },
+		{ user: { _id: 'actor' }, language: 'de', expected: 'de' },
+		{ user: { _id: 'actor' }, language: undefined, expected: 'en' },
+	].forEach(({ user, language, expected }) => {
+		it(`updates status text and reports success in ${expected}`, async () => {
+			findUser.resolves(user);
+			harness.settings.get.withArgs('Language').returns(language);
+			await harness.run('status', { params: 'On vacation' });
+			sinon.assert.calledOnceWithExactly(setStatus, user, undefined, 'On vacation');
+			harness.expectFeedback('StatusMessage_Changed_Successfully');
+			expect(harness.translate.firstCall.args[1]).to.deep.equal({ lng: expected });
+		});
+	});
+	it('allows clearing the status text', async () => {
+		await harness.run('status');
+		sinon.assert.calledOnceWithExactly(setStatus, { _id: 'actor', language: 'pt' }, undefined, '');
+	});
+	it('does nothing without an actor', async () => {
+		await harness.run('status', { userId: '' });
+		sinon.assert.notCalled(findUser);
+		sinon.assert.notCalled(setStatus);
+	});
+	it('does nothing for an unknown actor', async () => {
+		findUser.resolves(null);
+		await harness.run('status');
+		sinon.assert.calledOnce(findUser);
+		sinon.assert.notCalled(setStatus);
+		sinon.assert.notCalled(harness.broadcast);
+	});
+	it('reports disabled status editing and rethrows the permission error without success feedback', async () => {
+		const error = new MeteorError('error-not-allowed');
+		setStatus.rejects(error);
+		await expect(harness.run('status')).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(setStatus);
+		harness.expectFeedback('StatusMessage_Change_Disabled');
+		sinon.assert.calledOnce(harness.broadcast);
+	});
+	it('rethrows unexpected errors without success feedback', async () => {
+		const error = new Error('storage failed');
+		setStatus.rejects(error);
+		await expect(harness.run('status')).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(setStatus);
+		sinon.assert.notCalled(harness.broadcast);
+	});
+});

--- a/apps/meteor/tests/unit/server/slashcommands/topic.spec.ts
+++ b/apps/meteor/tests/unit/server/slashcommands/topic.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { loadCommand } from './helpers';
+
+describe('/topic', () => {
+	let permission: sinon.SinonStub;
+	let save: sinon.SinonStub;
+	let harness: ReturnType<typeof loadCommand>;
+	beforeEach(() => {
+		permission = sinon.stub().resolves(true);
+		save = sinon.stub().resolves();
+		harness = loadCommand('topic/topic', {
+			'../../lib/authorization/hasPermission': { hasPermissionAsync: permission },
+			'../../meteor-methods/rooms/saveRoomSettings': { saveRoomSettings: save },
+		});
+	});
+	['New topic', ''].forEach((params) => {
+		it(`saves ${params ? 'a new' : 'an empty'} topic with the actor and current room`, async () => {
+			await harness.run('topic', { params });
+			sinon.assert.calledOnceWithExactly(permission, 'actor', 'edit-room', 'current-room');
+			sinon.assert.calledOnceWithExactly(save, 'actor', 'current-room', 'roomTopic', params);
+		});
+	});
+	it('does not save when the actor lacks edit-room permission', async () => {
+		permission.resolves(false);
+		await harness.run('topic', { params: 'Forbidden' });
+		sinon.assert.calledOnceWithExactly(permission, 'actor', 'edit-room', 'current-room');
+		sinon.assert.notCalled(save);
+	});
+	it('does not check permission or save without an actor', async () => {
+		await harness.run('topic', { userId: '' });
+		sinon.assert.notCalled(permission);
+		sinon.assert.notCalled(save);
+	});
+	it('propagates persistence failures', async () => {
+		const error = new Error('save failed');
+		save.rejects(error);
+		await expect(harness.run('topic', { params: 'New topic' })).to.be.rejectedWith(error);
+		sinon.assert.calledOnce(save);
+	});
+});


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

Server slash commands for room management and messaging had no dedicated unit tests. This adds 68 tests covering `/archive`, `/unarchive`, `/create`, `/hide`, `/topic`, `/status`, `/msg`, `/me` and `/help`.

The tests cover room-scoped permissions, creation and membership guards, direct-message delivery, message/thread preservation, language precedence, and failure feedback to the requesting user in the originating room. They reuse the callback helper from the base PR, explicitly disable cache preservation with `noPreserveCache()`, and follow the existing Mocha/Chai/Sinon/proxyquire conventions. Database models and service methods are isolated; no production code changed.

### Coverage — room management and messaging handlers in `apps/meteor/server/slashcommands`

| | Before | After |
| --- | ---: | ---: |
| Lines | 0% | **99.50%** (201/202) |
| Statements | 0% | **99.50%** (201/202) |
| Functions | 0% | **100.00%** (11/11) |
| Branches | 0% | **96.15%** (100/104) |

Targeted NYC coverage for the nine handler files under `archiveroom`, `unarchiveroom`, `create`, `hide`, `topic`, `status`, `msg`, `me` and `help`; import-only index files and client-only ASCII-art commands are excluded. The baseline is the membership/moderation branch, whose unit suite does not load these handlers. Before and after use the same `ts-node/register` instrumentation and source-file denominators.

Full server Mocha suite: **2,620 passing, 14 pending, 0 failing** (2,552 passing on the base branch). This PR's targeted tests: **68 passing**; both PRs together: **150 passing, 2 pending**. Targeted ESLint and TypeScript checks pass.

## Issue(s)

[CORE-2659](https://rocketchat.atlassian.net/browse/CORE-2659)

## Steps to test or reproduce

```sh
cd apps/meteor
yarn exec mocha --config .mocharc.base.json 'tests/unit/server/slashcommands/{archive,create,hide,topic,status,msg,messages}.spec.ts'
```

## Further comments

Stacked on https://github.com/RocketChat/Rocket.Chat/pull/42096. This PR targets `test/server-slash-command-membership` to show the seven new test files and the shared helper adjustment. Merge the base PR first, then retarget this PR to `develop`.

One existing issue is kept separate: `/help` reads the workspace setting `language` instead of the registered `Language`, so users without a language preference can receive English help despite another workspace language. The tests do not require that incorrect setting key. Remaining coverage gaps are `/create` safeguards unreachable after its input guards and `/hide` fallback branches requiring inconsistent room/subscription results. Missing-room feedback tests do not require duplicate notifications.

No changeset: tests only, nothing user-facing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for `/archive`, `/unarchive`, `/create`, `/hide`, `/me`, `/help`, `/msg`, `/status`, and `/topic`.
  - Verified permissions, validation, room and user handling, localization, threading, and successful operations.
  - Added coverage for missing resources, invalid requests, persistence and delivery failures, and other error scenarios.
  - Improved test isolation so each command is evaluated independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[CORE-2659]: https://rocketchat.atlassian.net/browse/CORE-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ