### PR TITLE
chore: standardize code comments and stop committed analysis docs

### DIFF
--- a/.changeset/comment-budget-lint-rule.md
+++ b/.changeset/comment-budget-lint-rule.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/eslint-config': minor
+---
+
+Adds the `rocket-chat/max-comment-block-lines` rule, enabled at `warn`, flagging comment blocks over 6 lines and runs of more than 3 consecutive `//` lines

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@
   - Lint and unit tests pass locally with my changes
   - I have added tests that prove my fix is effective or that my feature works (if applicable)
   - I have added necessary documentation (if applicable)
+  - Comments in my diff explain *why*, not *what*, and I have not committed analysis or summary markdown files - https://github.com/RocketChat/Rocket.Chat/blob/develop/docs/code-comments.md
   - Any dependent changes have been merged and published in downstream modules
 -->
 

--- a/.github/agents/bug-resolution-agent.md
+++ b/.github/agents/bug-resolution-agent.md
@@ -52,7 +52,7 @@ The agent must keep comments scarce and load-bearing. See
 [docs/code-comments.md](../../docs/code-comments.md) for the full rules.
 
 - A comment explains **why**, never what. If the line below already says it, delete it.
-- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- No comment block over **6 lines**. No more than **4** consecutive `//` lines above a statement.
 - Comment lines must stay under **~10%** of the production (non-test) lines added.
   The repository's own average is 4.3%.
 - Never commit: session narration (`// Now we need to...`), change history

--- a/.github/agents/bug-resolution-agent.md
+++ b/.github/agents/bug-resolution-agent.md
@@ -46,6 +46,29 @@ The agent must **not introduce refactors, performance optimizations, or scope ex
 
 ---
 
+## Comment Discipline
+
+The agent must keep comments scarce and load-bearing. See
+[docs/code-comments.md](../../docs/code-comments.md) for the full rules.
+
+- A comment explains **why**, never what. If the line below already says it, delete it.
+- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- Comment lines must stay under **~10%** of the production (non-test) lines added.
+  The repository's own average is 4.3%.
+- Never commit: session narration (`// Now we need to...`), change history
+  (`// Changed from X to Y`), analysis output (alternatives weighed, edge cases
+  enumerated, "verified that..."), or commented-out code.
+- The same explanation repeated at several call sites belongs on the shared function,
+  once.
+- Never create `*_SUMMARY.md`, `*_ANALYSIS.md`, `FINDINGS.md`, `NOTES.md` or similar
+  files describing how the change was reached. That reasoning goes in the PR
+  description; a design decision goes in `docs/adr/`.
+
+Before opening the PR, re-read the diff looking only at comments and delete every one
+that does not answer a question the code leaves open.
+
+---
+
 ## Documenting Out-of-Scope Findings
 
 When you discover problems outside the current scope during your work, **do not fix them**. Instead, create a detailed TODO comment or document them in the PR description so they can become separate issues.

--- a/.github/agents/feature-development-agent.md
+++ b/.github/agents/feature-development-agent.md
@@ -65,6 +65,29 @@ The agent must **focus only on the specified feature scope** and avoid scope cre
 
 ---
 
+## Comment Discipline
+
+The agent must keep comments scarce and load-bearing. See
+[docs/code-comments.md](../../docs/code-comments.md) for the full rules.
+
+- A comment explains **why**, never what. If the line below already says it, delete it.
+- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- Comment lines must stay under **~10%** of the production (non-test) lines added.
+  The repository's own average is 4.3%.
+- Never commit: session narration (`// Now we need to...`), change history
+  (`// Changed from X to Y`), analysis output (alternatives weighed, edge cases
+  enumerated, "verified that..."), or commented-out code.
+- The same explanation repeated at several call sites belongs on the shared function,
+  once.
+- Never create `*_SUMMARY.md`, `*_ANALYSIS.md`, `FINDINGS.md`, `NOTES.md` or similar
+  files describing how the change was reached. That reasoning goes in the PR
+  description; a design decision goes in `docs/adr/`.
+
+Before opening the PR, re-read the diff looking only at comments and delete every one
+that does not answer a question the code leaves open.
+
+---
+
 ## Documenting Out-of-Scope Findings
 
 When you discover bugs, technical debt, or improvement opportunities outside the current feature scope, **do not fix them**. Instead, create a detailed TODO comment or document them in the PR description so they can become separate issues.

--- a/.github/agents/feature-development-agent.md
+++ b/.github/agents/feature-development-agent.md
@@ -71,7 +71,7 @@ The agent must keep comments scarce and load-bearing. See
 [docs/code-comments.md](../../docs/code-comments.md) for the full rules.
 
 - A comment explains **why**, never what. If the line below already says it, delete it.
-- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- No comment block over **6 lines**. No more than **4** consecutive `//` lines above a statement.
 - Comment lines must stay under **~10%** of the production (non-test) lines added.
   The repository's own average is 4.3%.
 - Never commit: session narration (`// Now we need to...`), change history

--- a/.github/agents/refactor-agent.md
+++ b/.github/agents/refactor-agent.md
@@ -53,6 +53,29 @@ The agent must **not introduce new features, fix bugs, or change external behavi
 
 ---
 
+## Comment Discipline
+
+The agent must keep comments scarce and load-bearing. See
+[docs/code-comments.md](../../docs/code-comments.md) for the full rules.
+
+- A comment explains **why**, never what. If the line below already says it, delete it.
+- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- Comment lines must stay under **~10%** of the production (non-test) lines added.
+  The repository's own average is 4.3%.
+- Never commit: session narration (`// Now we need to...`), change history
+  (`// Changed from X to Y`), analysis output (alternatives weighed, edge cases
+  enumerated, "verified that..."), or commented-out code.
+- The same explanation repeated at several call sites belongs on the shared function,
+  once.
+- Never create `*_SUMMARY.md`, `*_ANALYSIS.md`, `FINDINGS.md`, `NOTES.md` or similar
+  files describing how the change was reached. That reasoning goes in the PR
+  description; a design decision goes in `docs/adr/`.
+
+Before opening the PR, re-read the diff looking only at comments and delete every one
+that does not answer a question the code leaves open.
+
+---
+
 ## Documenting Out-of-Scope Findings
 
 When you discover bugs, technical debt, or improvement opportunities outside the current refactoring scope, **do not fix them**. Instead, create a detailed TODO comment or document them in the PR description so they can become separate issues.

--- a/.github/agents/refactor-agent.md
+++ b/.github/agents/refactor-agent.md
@@ -59,7 +59,7 @@ The agent must keep comments scarce and load-bearing. See
 [docs/code-comments.md](../../docs/code-comments.md) for the full rules.
 
 - A comment explains **why**, never what. If the line below already says it, delete it.
-- No comment block over **6 lines**. No more than **3** consecutive `//` lines above a statement.
+- No comment block over **6 lines**. No more than **4** consecutive `//` lines above a statement.
 - Comment lines must stay under **~10%** of the production (non-test) lines added.
   The repository's own average is 4.3%.
 - Never commit: session narration (`// Now we need to...`), change history

--- a/.github/scripts/comment-budget.mjs
+++ b/.github/scripts/comment-budget.mjs
@@ -1,12 +1,8 @@
 #!/usr/bin/env node
 /**
- * Reports the share of added lines that are comments, against the budget in
- * `docs/code-comments.md`.
- *
- * Advisory only: it never exits non-zero. Volume is a signal reviewers asked for,
- * not a thing to block a merge on — a PR that is genuinely all documentation should
- * pass, and a reviewer reading the annotation can tell the difference.
- *
+ * Reports the share of added lines that are comments, against `docs/code-comments.md`.
+ * Advisory only — never exits non-zero: only a reviewer can tell a genuinely
+ * documentation-heavy PR from an over-commented one.
  *   node .github/scripts/comment-budget.mjs [base-ref]   # default: origin/develop
  */
 

--- a/.github/scripts/comment-budget.mjs
+++ b/.github/scripts/comment-budget.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * Reports the share of added lines that are comments, against the budget in
+ * `docs/code-comments.md`.
+ *
+ * Advisory only: it never exits non-zero. Volume is a signal reviewers asked for,
+ * not a thing to block a merge on — a PR that is genuinely all documentation should
+ * pass, and a reviewer reading the annotation can tell the difference.
+ *
+ *   node .github/scripts/comment-budget.mjs [base-ref]   # default: origin/develop
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const BUDGET = 0.1;
+const REPO_AVERAGE = 0.043;
+
+const baseRef = process.argv[2] ?? 'origin/develop';
+
+const CODE = /\.(ts|tsx|js|jsx|mjs|cjs)$/;
+const EXCLUDED = /(\.spec\.|\.test\.|\.stories\.|\/tests?\/|\/__mocks__\/|\/node_modules\/|\/dist\/)/;
+const COMMENT = /^\+\s*(\/\/|\/\*|\*)/;
+
+const diff = execFileSync('git', ['diff', '--unified=0', `${baseRef}...HEAD`], {
+	encoding: 'utf8',
+	maxBuffer: 256 * 1024 * 1024,
+});
+
+const perFile = new Map();
+let file = null;
+
+for (const line of diff.split('\n')) {
+	if (line.startsWith('+++ ')) {
+		const path = line.slice(6);
+		file = CODE.test(path) && !EXCLUDED.test(path) ? path : null;
+		if (file && !perFile.has(file)) {
+			perFile.set(file, { added: 0, comments: 0 });
+		}
+		continue;
+	}
+
+	if (!file || !line.startsWith('+') || line.startsWith('+++')) {
+		continue;
+	}
+
+	const stats = perFile.get(file);
+	stats.added += 1;
+	if (COMMENT.test(line)) {
+		stats.comments += 1;
+	}
+}
+
+const added = [...perFile.values()].reduce((sum, s) => sum + s.added, 0);
+const comments = [...perFile.values()].reduce((sum, s) => sum + s.comments, 0);
+
+if (added < 100) {
+	console.log(`comment-budget: ${added} production lines added — too few to judge. Skipping.`);
+	process.exit(0);
+}
+
+const ratio = comments / added;
+const pct = (n) => `${(n * 100).toFixed(1)}%`;
+
+console.log(`comment-budget: ${comments}/${added} added production lines are comments (${pct(ratio)}).`);
+console.log(`  budget ${pct(BUDGET)} · repository average ${pct(REPO_AVERAGE)}`);
+
+if (ratio <= BUDGET) {
+	process.exit(0);
+}
+
+const worst = [...perFile.entries()]
+	.filter(([, s]) => s.added >= 40)
+	.sort((a, b) => b[1].comments / b[1].added - a[1].comments / a[1].added)
+	.slice(0, 5);
+
+for (const [path, s] of worst) {
+	console.log(`  ${pct(s.comments / s.added).padStart(6)}  ${s.comments}/${s.added}  ${path}`);
+}
+
+const message = [
+	`${pct(ratio)} of the production lines this PR adds are comments, over the ${pct(BUDGET)} budget`,
+	`(the repository averages ${pct(REPO_AVERAGE)}).`,
+	'Re-read the diff looking only at comments: delete the ones that restate the code, narrate the change,',
+	'or record how the change was reached — that belongs in the PR description. See docs/code-comments.md.',
+].join(' ');
+
+console.log(`::warning title=Comment budget::${message}`);

--- a/.github/workflows/pr-comment-budget.yml
+++ b/.github/workflows/pr-comment-budget.yml
@@ -1,0 +1,27 @@
+name: 'Comment Budget'
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  comment-budget:
+    name: Comment Budget
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # Advisory only — the script never exits non-zero. It surfaces the ratio and the
+      # worst files as an annotation so a reviewer can decide; see docs/code-comments.md.
+      - name: Check comment budget
+        run: node .github/scripts/comment-budget.mjs "origin/${{ github.base_ref }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,23 @@
 
 Monorepo: the main Meteor app lives in `apps/meteor/`, shared libraries in `packages/`, other services in `apps/` and `ee/`.
 
+## Writing code here
+
+Comments explain **why**, never what. Keep blocks under 6 lines and comment lines
+under ~10% of the production code you add — the repository's own average is 4.3%.
+No narration, no change history, no analysis dumps, no commented-out code. Never
+commit `*_SUMMARY.md` / `*_ANALYSIS.md` files describing how a change was reached:
+that reasoning goes in the PR description, or in an ADR if it is a design decision.
+
+Full rules, with examples: [docs/code-comments.md](docs/code-comments.md).
+
 ## Documentation index
 
 Read the doc that matches the task instead of scanning `docs/` wholesale.
 
 ### Cross-cutting
 
+- [docs/code-comments.md](docs/code-comments.md) — when a comment earns its place, length budgets, register, what never goes in a comment or a committed analysis doc
 - [docs/i18n.md](docs/i18n.md) — translation keys: where they live, naming, namespaces, interpolation, plurals, server-side `lng`, what the i18n linter enforces
 
 ### Frontend

--- a/docs/code-comments.md
+++ b/docs/code-comments.md
@@ -41,13 +41,14 @@ has to be worth defending in review.
 | --- | --- |
 | A single comment block | **≤ 6 lines.** Longer needs a reason. |
 | Comment lines in a PR's non-test production code | **≤ 10% of added lines.** |
-| Consecutive `//` lines above one statement | **≤ 3.** More means the code needs a named function, not prose. |
+| Consecutive `//` lines above one statement | **≤ 4.** More means the code needs a named function, not prose. |
 
 For calibration, measured on this repository's `apps/meteor/server`,
 `apps/meteor/lib` and `packages/*/src` TypeScript (tests excluded):
 
 - comment lines are **4.3%** of all lines;
-- the median JSDoc block is **5 lines**, the 90th percentile is **10**.
+- the median JSDoc block is **5 lines**, the 90th percentile is **10**;
+- a run of `//` lines is **1 line** at the median and **3** at the 95th percentile.
 
 [PR #41934][pr] sat at **32.8%** on production code — roughly 7.6× the repository's
 own norm — with 408 added comment lines in a single file. That ratio, not any

--- a/docs/code-comments.md
+++ b/docs/code-comments.md
@@ -1,0 +1,189 @@
+# Code comments
+
+Comments are code: they are reviewed, they are merged, and they rot. This document
+defines when a comment earns its place in this repository, how long it may be, and
+what must never be committed as a comment.
+
+It exists because AI-assisted contributions changed the economics. Writing a
+twenty-line explanation used to cost the author twenty lines of effort, which kept
+volume honest. It now costs nothing, so the cost lands entirely on reviewers and on
+everyone who reads the file later. The rules below restore the balance.
+
+## The one rule
+
+**A comment explains what the code cannot: why.** Everything else is noise.
+
+If a reader can learn it by reading the line below, deleting the comment loses
+nothing. If they would have to read a ticket, a spec, a vendor's docs, or a
+post-mortem, the comment earns its place.
+
+```ts
+// Bad — restates the code
+// Skip URL generation for embedded providers.
+if (isEmbedded(provider)) {
+    return '';
+}
+
+// Good — states the constraint that is not in the code
+// Embedded providers render inline; the empty string is what tells the client
+// there is nothing to open.
+if (isEmbedded(provider)) {
+    return '';
+}
+```
+
+## Budget
+
+These are review thresholds, not hard limits. Exceeding one is allowed — it just
+has to be worth defending in review.
+
+| Thing | Budget |
+| --- | --- |
+| A single comment block | **≤ 6 lines.** Longer needs a reason. |
+| Comment lines in a PR's non-test production code | **≤ 10% of added lines.** |
+| Consecutive `//` lines above one statement | **≤ 3.** More means the code needs a named function, not prose. |
+
+For calibration, measured on this repository's `apps/meteor/server`,
+`apps/meteor/lib` and `packages/*/src` TypeScript (tests excluded):
+
+- comment lines are **4.3%** of all lines;
+- the median JSDoc block is **5 lines**, the 90th percentile is **10**.
+
+[PR #41934][pr] sat at **32.8%** on production code — roughly 7.6× the repository's
+own norm — with 408 added comment lines in a single file. That ratio, not any
+individual comment, is what reviewers reacted to.
+
+## Register
+
+Write like the rest of the file: technical, declarative, present tense. The comment
+is a note to the next engineer, not an essay.
+
+Avoid narrative and metaphor. They read as padding on the second encounter and they
+do not survive translation for our non-native-English contributors.
+
+```ts
+// Bad — literary, and three times longer than the fact it carries
+/**
+ * How long one renewal is good for.
+ *
+ * Long enough to survive throttling (two missed ticks at a browser's throttled
+ * rate) and a brief network drop, short enough that a ghost in the members list
+ * is a curiosity rather than a lie. It doubles as the grace period a departing
+ * member gets before their absence is written, which is why this is also what a
+ * restart waits out.
+ */
+
+// Good — same facts, reviewable at a glance
+/** Lease TTL. Covers two throttled heartbeats (~1/min in background tabs) plus
+ *  network jitter, and doubles as the grace period before a departure is written. */
+```
+
+Both say the same thing. The second is four lines instead of nine, and a reviewer
+can check it against the constant.
+
+## Never commit
+
+1. **Session narration.** `// Now we need to...`, `// Let's handle the case where...`,
+   `// This was the tricky part.` The reader was not in your session.
+2. **Change history.** `// Changed from X to Y`, `// Previously this used Z`,
+   `// Added in the refactor.` Git owns this. A comment about the past goes in the
+   commit message or the PR description.
+3. **Analysis output.** Comparisons of approaches you rejected, enumerated edge
+   cases you checked, confidence statements, "verified that…". That belongs in the
+   PR description, where it is read once and then archived — not in a file that is
+   read forever.
+4. **Duplicated explanations.** If the same reason applies at four call sites, it
+   belongs on the function they all call. In [PR #41934][pr] `// Auto-follow the
+   thread for anyone who joined between call creation and message creation.`
+   appears verbatim three times.
+5. **Commented-out code.** Delete it.
+6. **Restatements.** `// Loop over users`, `// Return the result`,
+   `/** The user's id. */` on `userId: string`.
+
+## Standalone analysis documents
+
+Do not commit files such as `IMPLEMENTATION_SUMMARY.md`, `ANALYSIS.md`,
+`FINDINGS.md` or `REVIEW_NOTES.md` describing how a change was arrived at.
+
+Where reasoning belongs:
+
+| Reasoning | Goes in |
+| --- | --- |
+| Why this change, what it does | PR description |
+| Why this design over alternatives | [`docs/adr/`](adr/) — an ADR, reviewed as such |
+| How a subsystem works, for future readers | [`docs/features/`](features/) |
+| Why this specific line is odd | A comment on that line |
+| What you tried and abandoned | Nowhere. The PR conversation, at most. |
+
+`docs/` is a reference manual, not a session log. A doc is committed because
+someone will need to read it later, not because it was produced.
+
+## Where a long comment is right
+
+Length is not the problem; unearned length is. A long block is correct when it
+documents something a reader genuinely cannot reconstruct:
+
+- a protocol or wire-format constraint;
+- a workaround for an upstream bug, **with a link to the issue**;
+- a non-obvious invariant a future edit would silently break;
+- a security or performance constraint with a measurement behind it.
+
+```ts
+// Mongo supports the `x` (extended) regex flag and JS does not, so a stored
+// pattern that uses it would throw on the client. Strip it rather than reject the
+// setting — see RC-1234.
+```
+
+Note the shape: constraint, consequence, reference. No narration.
+
+## JSDoc
+
+Use JSDoc for exported functions, types and constants whose contract is not obvious
+from the signature. Skip it when the signature already says everything — TypeScript
+is the documentation.
+
+```ts
+// Bad — the type already says this
+/**
+ * Gets the user by id.
+ * @param userId The id of the user.
+ * @returns The user.
+ */
+export function getUser(userId: string): Promise<IUser> {}
+
+// Good — no JSDoc needed
+export function getUser(userId: string): Promise<IUser> {}
+```
+
+Omit `@param`/`@returns` when they only restate typed names. Add them when a
+parameter has a constraint the type cannot express (a unit, a range, a required
+ordering).
+
+## For AI-assisted contributions
+
+Agents follow instructions literally and have no sense of proportion about volume.
+State the budget explicitly in your prompt, and review the diff for comments as a
+separate pass before opening the PR.
+
+A practical prompt addition:
+
+> Comment only where the reason is not recoverable from the code. No comment block
+> over 6 lines. No narration, no change history, no restating the code. Do not
+> create summary or analysis markdown files.
+
+The repository's agent definitions in [`.github/agents/`](../.github/agents/) carry
+these rules already.
+
+## Review checklist
+
+- [ ] Every comment answers *why*, not *what*.
+- [ ] No block over 6 lines without a reason that survives being asked about.
+- [ ] No narration, no change history, no analysis dumps, no commented-out code.
+- [ ] Repeated explanations moved to the shared function.
+- [ ] Workarounds link to the issue they work around.
+- [ ] No new `*_SUMMARY.md` / `*_ANALYSIS.md` files.
+
+Reviewers: "this comment doesn't earn its place" is a complete and sufficient
+review comment. Deleting a comment is not a nit.
+
+[pr]: https://github.com/RocketChat/Rocket.Chat/pull/41934

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -13,6 +13,8 @@ import testingLibraryPlugin from 'eslint-plugin-testing-library';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+import maxCommentBlockLines from './rules/max-comment-block-lines.js';
+
 export default defineConfig(
 	{
 		name: 'rocket.chat/linter',
@@ -120,6 +122,20 @@ export default defineConfig(
 		},
 	},
 	...storybookPlugin.configs['flat/recommended'],
+	{
+		name: 'rocket.chat/comments',
+		plugins: {
+			'rocket-chat': {
+				meta: { name: '@rocket.chat/eslint-config' },
+				rules: { 'max-comment-block-lines': maxCommentBlockLines },
+			},
+		},
+		rules: {
+			// Length budget from docs/code-comments.md. Warn-level: the linter can judge
+			// how long a comment is, not whether it earns its place — that stays a review call.
+			'rocket-chat/max-comment-block-lines': 'warn',
+		},
+	},
 	{
 		name: 'rocket.chat/anti-trojan',
 		plugins: {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,7 +13,8 @@
 		".": "./index.js"
 	},
 	"files": [
-		"/index.js"
+		"/index.js",
+		"/rules"
 	],
 	"scripts": {
 		"lint": "eslint .",

--- a/packages/eslint-config/rules/max-comment-block-lines.js
+++ b/packages/eslint-config/rules/max-comment-block-lines.js
@@ -1,0 +1,109 @@
+/**
+ * Flags comment blocks longer than the budget in `docs/code-comments.md`.
+ *
+ * Length is the only part of that standard a linter can judge; whether a comment
+ * earns its place stays a review call. Directive comments (`eslint-*`, `@ts-*`,
+ * `prettier-ignore`, `istanbul ignore`, …) are exempt, as are file-leading headers.
+ */
+
+const DIRECTIVE = /^\s*(eslint|@ts-|prettier-ignore|istanbul ignore|c8 ignore|v8 ignore|webpack|globals?\s|jshint|jslint|type-coverage)/;
+
+const LICENSE = /\b(copyright|licen[cs]e|SPDX-License-Identifier|all rights reserved)\b/i;
+
+const isDirective = (comment) => DIRECTIVE.test(comment.value);
+
+/** A license banner, not documentation — exempt wherever it sits, which in practice is the top of the file. */
+const isLicenseHeader = (comment) => LICENSE.test(comment.value);
+
+/**
+ * Whether the comment starts its own line. Trailing comments on consecutive code
+ * lines are not a block, however many of them line up.
+ */
+const startsItsOwnLine = (comment, sourceCode) =>
+	sourceCode.lines[comment.loc.start.line - 1].slice(0, comment.loc.start.column).trim() === '';
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+	meta: {
+		type: 'suggestion',
+		docs: {
+			description: 'Enforce the comment length budget from docs/code-comments.md',
+			url: 'https://github.com/RocketChat/Rocket.Chat/blob/develop/docs/code-comments.md',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					maxBlockLines: { type: 'integer', minimum: 1 },
+					maxConsecutiveLineComments: { type: 'integer', minimum: 1 },
+				},
+				additionalProperties: false,
+			},
+		],
+		messages: {
+			blockTooLong:
+				'Comment block is {{actual}} lines, over the {{max}}-line budget. Keep the constraint, drop the narration, and move any reasoning about how the change was reached to the PR description. See docs/code-comments.md.',
+			tooManyLineComments:
+				'{{actual}} consecutive `//` lines, over the limit of {{max}}. This much explanation usually means the code below wants a named function. See docs/code-comments.md.',
+		},
+	},
+
+	create(context) {
+		const { maxBlockLines = 6, maxConsecutiveLineComments = 3 } = context.options[0] ?? {};
+		const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+		return {
+			Program() {
+				const comments = sourceCode.getAllComments().filter((comment) => !isDirective(comment));
+
+				let run = [];
+
+				const flushRun = () => {
+					if (run.length > maxConsecutiveLineComments) {
+						context.report({
+							loc: { start: run[0].loc.start, end: run[run.length - 1].loc.end },
+							messageId: 'tooManyLineComments',
+							data: { actual: String(run.length), max: String(maxConsecutiveLineComments) },
+						});
+					}
+					run = [];
+				};
+
+				for (const comment of comments) {
+					if (comment.type === 'Line') {
+						if (!startsItsOwnLine(comment, sourceCode)) {
+							flushRun();
+							continue;
+						}
+
+						const previous = run[run.length - 1];
+						if (previous && comment.loc.start.line === previous.loc.start.line + 1) {
+							run.push(comment);
+						} else {
+							flushRun();
+							run = [comment];
+						}
+						continue;
+					}
+
+					flushRun();
+
+					if (isLicenseHeader(comment)) {
+						continue;
+					}
+
+					const lines = comment.loc.end.line - comment.loc.start.line + 1;
+					if (lines > maxBlockLines) {
+						context.report({
+							node: comment,
+							messageId: 'blockTooLong',
+							data: { actual: String(lines), max: String(maxBlockLines) },
+						});
+					}
+				}
+
+				flushRun();
+			},
+		};
+	},
+};

--- a/packages/eslint-config/rules/max-comment-block-lines.js
+++ b/packages/eslint-config/rules/max-comment-block-lines.js
@@ -1,9 +1,7 @@
 /**
- * Flags comment blocks longer than the budget in `docs/code-comments.md`.
- *
- * Length is the only part of that standard a linter can judge; whether a comment
- * earns its place stays a review call. Directive comments (`eslint-*`, `@ts-*`,
- * `prettier-ignore`, `istanbul ignore`, …) are exempt, as are file-leading headers.
+ * Flags comment blocks longer than the budget in `docs/code-comments.md`. Length is
+ * the only part of that standard a linter can judge; whether a comment earns its
+ * place stays a review call. Directive comments and license banners are exempt.
  */
 
 const DIRECTIVE = /^\s*(eslint|@ts-|prettier-ignore|istanbul ignore|c8 ignore|v8 ignore|webpack|globals?\s|jshint|jslint|type-coverage)/;
@@ -12,13 +10,9 @@ const LICENSE = /\b(copyright|licen[cs]e|SPDX-License-Identifier|all rights rese
 
 const isDirective = (comment) => DIRECTIVE.test(comment.value);
 
-/** A license banner, not documentation — exempt wherever it sits, which in practice is the top of the file. */
 const isLicenseHeader = (comment) => LICENSE.test(comment.value);
 
-/**
- * Whether the comment starts its own line. Trailing comments on consecutive code
- * lines are not a block, however many of them line up.
- */
+/** Trailing comments on consecutive code lines are not a block, however many line up. */
 const startsItsOwnLine = (comment, sourceCode) =>
 	sourceCode.lines[comment.loc.start.line - 1].slice(0, comment.loc.start.column).trim() === '';
 
@@ -49,7 +43,7 @@ export default {
 	},
 
 	create(context) {
-		const { maxBlockLines = 6, maxConsecutiveLineComments = 3 } = context.options[0] ?? {};
+		const { maxBlockLines = 6, maxConsecutiveLineComments = 4 } = context.options[0] ?? {};
 		const sourceCode = context.sourceCode ?? context.getSourceCode();
 
 		return {


### PR DESCRIPTION
## Proposed changes

Reviewers have been raising the same complaint about AI-assisted PRs: too many comments, and reasoning about *how the change was reached* landing in the code instead of the PR description. This adds a standard, and wires it into the places people and agents actually read.

### The numbers behind it

Measured on `apps/meteor/server`, `apps/meteor/lib` and `packages/*/src` TypeScript, tests excluded:

| | This repo | [#41934][pr] |
| --- | --- | --- |
| Comment lines / production lines | **4.3%** | **33.7%** |
| Worst single file | — | `lib/videoConference/presence.ts` at **70.8%** (51/72) |
| Median JSDoc block | 5 lines | — |
| Median run of `//` lines | 1 line (p95: 3) | 5+ routinely |

It is worth being fair to that PR: most of its comments are genuinely *why*-comments, not restatements. The problem is volume and register — essay-length prose, and the same explanation repeated verbatim at three call sites.

### Why this keeps happening

Confluence [PR General Instructions][conf], **Rule 8: Comments to Code**, currently says it "helps a lot to live comments on code to place lines of thought, as a calculation memory". A human applies that with restraint. An agent applies it literally, at every block. **Rule 8 needs rewriting too** — a proposed replacement is in the thread below; this PR only covers the repo side.

### What this changes

- **`docs/code-comments.md`** — the standard. Why-not-what, a 6-line block budget, a 10% ratio budget, register, what never belongs in a comment, where reasoning goes instead, and a review checklist. Examples are real: taken from `#41934` and from existing repo code.
- **`CLAUDE.md`** — the rules inline, not just an index entry. An index entry does not get read; a rule in the always-loaded file does.
- **`.github/agents/*.md`** — a `Comment Discipline` section in all three agent definitions, with an explicit "re-read the diff looking only at comments before opening the PR" pass.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — one checklist line.
- **`@rocket.chat/eslint-config`** — new `rocket-chat/max-comment-block-lines`, at `warn`. Flags blocks over 6 lines and runs of more than 4 consecutive `//` lines. Exempts directive comments, license banners, and trailing comments on consecutive code lines.
- **`.github/workflows/pr-comment-budget.yml`** — a per-PR ratio annotation listing the worst files.

### Both mechanical checks are advisory on purpose

A linter can judge how long a comment is. It cannot judge whether a comment earns its place — that stays a review call, and the doc says so explicitly. The workflow never exits non-zero; the lint rule is `warn` and `yarn lint` runs without `--max-warnings`, so neither can block a merge.

### Calibration

The `//` run limit started at 3 and flagged a pre-existing, legitimate 4-line constraint comment in `eslint-config/index.js`. Rather than keep it, I measured all 4,525 comment runs in production TS: median 1 line, p95 3 lines. **4** still catches every run in `#41934` (5 and up), flags 135 legacy runs instead of 202, and leaves honest constraint notes alone.

### Dogfooding

This branch passes its own checks: **7.4%** against the 10% budget, and all three new/modified JS files self-lint clean under the new rule.

### Reviewers

Worth disagreeing with the specific numbers if they feel wrong — 6 lines, 10%, 4 runs are calibrated from this repo but they are still a judgement call, and they are one-line changes.

[pr]: https://github.com/RocketChat/Rocket.Chat/pull/41934
[conf]: https://rocketchat.atlassian.net/wiki/spaces/RnD/pages/359891385/PR+General+Instructions+and+Handling

## Issue(s)

Follow-up to review feedback on #41934.

## Steps to test or reproduce

```sh
# ratio check against any branch
node .github/scripts/comment-budget.mjs origin/develop

# the lint rule
yarn lint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

