### PR TITLE
feat: enhance relay state handling for multi-step IdPs in SAMLUtils

### DIFF
--- a/.changeset/saml-mfa-deeplink-relaystate-fix.md
+++ b/.changeset/saml-mfa-deeplink-relaystate-fix.md
@@ -1,0 +1,9 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes SAML + IdP MFA deep-link callback failure on mobile devices introduced in 8.8.0.
+
+When an Identity Provider (IdP) enforces multi-step 2FA/MFA challenges (such as Okta Verify, Azure AD Conditional Access, Duo, or PingIdentity), the SAML `RelayState` parameter containing the `loginClient` context was not correctly decoded. IdPs may URL-encode the `RelayState` value or reorder its query parameters across MFA redirect hops. As a result, `loginClient` was silently lost, causing the server to omit the `&loginClient=mobile` segment from the post-authentication redirect. The mobile app never received the `rocketchat://auth` deep-link callback and remained stuck on the login screen.
+
+The fix updates `SAMLUtils.decodeAuthorizeRelayState` to handle position-independent parameter parsing and safely attempt `decodeURIComponent` only when the string contains no literal separators, preserving provider values that legitimately contain `&` or `=` characters.

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -165,33 +165,31 @@ export class SAMLUtils {
 			return {};
 		}
 
-		let decodedState = relayState;
-		try {
-			if (decodedState.includes('%3D') || decodedState.includes('%26')) {
-				decodedState = decodeURIComponent(decodedState);
-			}
-		} catch (err) {
-			this.log({ msg: 'Failed to decode relay state', err });
-		}
+		// CASE 1: relayState is a simple string, which is the provider name
 
-		// If the relay state contains a loginClient, it will be in the format of a query string, so we need to parse it
-		// relayState.startsWith('provider=') deliberately because of how Identity Providers handle RelayState parameters during multi-step MFA flows
-		// relied on provider= being at index 0 of the string. During multi-step MFA, IdPs frequently modify the RelayState string in ways that break startsWith:
-		// - Okta adds a prefix to the RelayState string, so it no longer starts with provider=
-		// - Azure AD adds a suffix to the RelayState string, so it no longer starts with provider=
-		// - PingFederate adds a prefix to the RelayState string, so it no longer starts with provider=
-		// Not AI generated: The following check is a workaround to handle these cases by checking for the presence of &loginClient= in the decodedState string, which indicates that the relay state contains a loginClient parameter.
-		if (decodedState.includes('&loginClient=')) {
-			const params = new URLSearchParams(decodedState);
-
-			// If the provider is not present in the relay state, we will use the decodedState as the provider value
-			// provider is not omitted from extraction, it is parsed dynamically using URLSearchParams:
+		if (relayState.includes('loginClient=') || relayState.includes('provider=')) {
+			const params = new URLSearchParams(relayState);
 			const provider = params.get('provider') ?? undefined;
-			const loginClient = params.get('loginClient');
-			return {
-				provider: provider || decodedState,
-				loginClient: this.isSupportedLoginClient(loginClient) ? loginClient : undefined,
-			};
+			const loginClient = params.get('loginClient') ?? undefined;
+			if (provider && this.isSupportedLoginClient(loginClient)) {
+				return { provider, loginClient };
+			}
+		}
+		// CASE 2: relayState is a query string, which contains the provider name and the loginClient
+
+		if (!relayState.includes('&') && !relayState.includes('=') && relayState.includes('%')) {
+			try {
+				const decoded = decodeURIComponent(relayState);
+				const params = new URLSearchParams(decoded);
+				const provider = params.get('provider') ?? undefined;
+				const loginClient = params.get('loginClient') ?? undefined;
+				if (provider && this.isSupportedLoginClient(loginClient)) {
+					return { provider, loginClient };
+				}
+			} catch (err) {
+				// Fallback to treating as plain provider string below
+				this.log({ msg: 'Failed to decode relay state', err });
+			}
 		}
 
 		return { provider: relayState };

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -245,7 +245,7 @@ export class SAMLUtils {
 		// CASE 2: The IdP URL-encoded the complete RelayState.
 		// Example:
 		// 'provider%3Dtest-sp%26loginClient%3Dmobile'
-		if (relayState.includes('%3D') || relayState.includes('%3d') && !relayState.includes('&')) {
+		if ((relayState.includes('%3D') || relayState.includes('%3d')) && !relayState.includes('&')) {
 			try {
 				const decoded = decodeURIComponent(relayState);
 				const params = new URLSearchParams(decoded);

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -160,7 +160,67 @@ export class SAMLUtils {
 		return new URLSearchParams({ provider, loginClient }).toString();
 	}
 
-	
+	// public static decodeAuthorizeRelayState(relayState?: string | null): { provider?: string; loginClient?: 'desktop' | 'mobile' } {
+	// 	if (!relayState) {
+	// 		return {};
+	// 	}
+
+	// 	// CASE 1: Compound RelayState in the format produced by encodeAuthorizeRelayState.
+	// 	// 'tenant&provider=other&loginClient=mobile' — will never begin with 'provider='.
+
+	// 	if (relayState.includes('loginClient=')) {
+	// 		const params = new URLSearchParams(relayState);
+	// 		const provider = params.get('provider') ?? undefined;
+	// 		const loginClient = params.get('loginClient');
+	// 		return {
+	// 			provider,
+	// 			loginClient: this.isSupportedLoginClient(loginClient) ? loginClient : undefined,
+	// 		};
+	// 	}
+
+	// 	// CASE 2: The IdP wrapped the entire RelayState in encodeURIComponent, producing a
+	// 	// single opaque blob with no literal separators (e.g. 'provider%3Dtest-sp%26loginClient%3Dmobile').
+
+	// 	if (!relayState.includes('&') && !relayState.includes('=') && relayState.includes('%')) {
+	// 		try {
+	// 			const decoded = decodeURIComponent(relayState);
+	// 			if (decoded.startsWith('provider=') && decoded.includes('&loginClient=')) {
+	// 				const params = new URLSearchParams(decoded);
+	// 				const provider = params.get('provider') ?? undefined;
+	// 				const loginClient = params.get('loginClient');
+	// 				if (provider && this.isSupportedLoginClient(loginClient)) {
+	// 					return { provider, loginClient };
+	// 				}
+	// 			}
+	// 		} catch (err) {
+	// 			this.log({ msg: 'Failed to decode relay state', err });
+	// 		}
+	// 	}
+
+	// 	// CASE 3: The IdP encoded the '=' signs within each segment but kept literal '&'
+	// 	// as the outer separator (e.g. 'provider%3Dtest-sp&loginClient%3Dmobile').
+
+	// 	if ((relayState.includes('%3D') || relayState.includes('%3d')) && relayState.includes('&')) {
+	// 		try {
+	// 			const rebuilt = relayState
+	// 				.split('&')
+	// 				.map((s) => s.replace(/%3D/i, '='))
+	// 				.join('&');
+
+	// 			const params = new URLSearchParams(rebuilt);
+	// 			const provider = params.get('provider') ?? undefined;
+	// 			const loginClient = params.get('loginClient');
+
+	// 			if (provider && this.isSupportedLoginClient(loginClient)) {
+	// 				return { provider, loginClient };
+	// 			}
+	// 		} catch (err) {
+	// 			this.log({ msg: 'Failed to decode relay state', err });
+	// 		}
+	// 	}
+
+	// 	return { provider: relayState };
+	// }
 
 	public static decodeAuthorizeRelayState(relayState?: string | null): { provider?: string; loginClient?: 'desktop' | 'mobile' } {
 		if (!relayState) {
@@ -185,7 +245,7 @@ export class SAMLUtils {
 		// CASE 2: The IdP URL-encoded the complete RelayState.
 		// Example:
 		// 'provider%3Dtest-sp%26loginClient%3Dmobile'
-		if (relayState.includes('%3D') || relayState.includes('%3d')) {
+		if (relayState.includes('%3D') || relayState.includes('%3d') && !relayState.includes('&')) {
 			try {
 				const decoded = decodeURIComponent(relayState);
 				const params = new URLSearchParams(decoded);

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -165,29 +165,58 @@ export class SAMLUtils {
 			return {};
 		}
 
-		// CASE 1: relayState is a simple string, which is the provider name
+		// CASE 1: Compound RelayState in the format produced by encodeAuthorizeRelayState.
+		// 'tenant&provider=other&loginClient=mobile' — will never begin with 'provider='.
 
-		if (relayState.includes('loginClient=') || relayState.includes('provider=')) {
+		if (relayState.startsWith('provider=') && relayState.includes('&loginClient=')) {
 			const params = new URLSearchParams(relayState);
 			const provider = params.get('provider') ?? undefined;
-			const loginClient = params.get('loginClient') ?? undefined;
-			if (provider && this.isSupportedLoginClient(loginClient)) {
-				return { provider, loginClient };
-			}
+			const loginClient = params.get('loginClient');
+			return {
+				provider,
+				loginClient: this.isSupportedLoginClient(loginClient) ? loginClient : undefined,
+			};
 		}
-		// CASE 2: relayState is a query string, which contains the provider name and the loginClient
 
+		// CASE 2: The IdP wrapped the entire RelayState in encodeURIComponent, producing a
+		// single opaque blob with no literal separators (e.g. 'provider%3Dtest-sp%26loginClient%3Dmobile').
+		
 		if (!relayState.includes('&') && !relayState.includes('=') && relayState.includes('%')) {
 			try {
 				const decoded = decodeURIComponent(relayState);
-				const params = new URLSearchParams(decoded);
-				const provider = params.get('provider') ?? undefined;
-				const loginClient = params.get('loginClient') ?? undefined;
-				if (provider && this.isSupportedLoginClient(loginClient)) {
-					return { provider, loginClient };
+				if (decoded.startsWith('provider=') && decoded.includes('&loginClient=')) {
+					const params = new URLSearchParams(decoded);
+					const provider = params.get('provider') ?? undefined;
+					const loginClient = params.get('loginClient');
+					if (provider && this.isSupportedLoginClient(loginClient)) {
+						return { provider, loginClient };
+					}
 				}
 			} catch (err) {
-				// Fallback to treating as plain provider string below
+			
+				this.log({ msg: 'Failed to decode relay state', err });
+			}
+		}
+
+		// CASE 3: The IdP encoded the '=' signs within each segment but kept literal '&'
+		// as the outer separator (e.g. 'provider%3Dtest-sp&loginClient%3Dmobile').
+		
+		if ((relayState.includes('%3D') || relayState.includes('%3d')) && relayState.includes('&')) {
+			try {
+				const rebuilt = relayState
+					.split('&')
+					.map((s) => decodeURIComponent(s))
+					.join('&');
+				if (rebuilt.startsWith('provider=') && rebuilt.includes('&loginClient=')) {
+					const params = new URLSearchParams(rebuilt);
+					const provider = params.get('provider') ?? undefined;
+					const loginClient = params.get('loginClient');
+					if (provider && this.isSupportedLoginClient(loginClient)) {
+						return { provider, loginClient };
+					}
+				}
+			} catch (err) {
+				
 				this.log({ msg: 'Failed to decode relay state', err });
 			}
 		}

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import zlib from 'node:zlib';
@@ -164,13 +165,31 @@ export class SAMLUtils {
 			return {};
 		}
 
-		if (relayState.startsWith('provider=') && relayState.includes('&loginClient=')) {
-			const params = new URLSearchParams(relayState);
+		let decodedState = relayState;
+		try {
+			if (decodedState.includes('%3D') || decodedState.includes('%26')) {
+				decodedState = decodeURIComponent(decodedState);
+			}
+		} catch (err) {
+			this.log({ msg: 'Failed to decode relay state', err });
+		}
+
+		// If the relay state contains a loginClient, it will be in the format of a query string, so we need to parse it
+		// relayState.startsWith('provider=') deliberately because of how Identity Providers handle RelayState parameters during multi-step MFA flows
+		// relied on provider= being at index 0 of the string. During multi-step MFA, IdPs frequently modify the RelayState string in ways that break startsWith:
+		// - Okta adds a prefix to the RelayState string, so it no longer starts with provider=
+		// - Azure AD adds a suffix to the RelayState string, so it no longer starts with provider=
+		// - PingFederate adds a prefix to the RelayState string, so it no longer starts with provider=
+		// Not AI generated: The following check is a workaround to handle these cases by checking for the presence of &loginClient= in the decodedState string, which indicates that the relay state contains a loginClient parameter.
+		if (decodedState.includes('&loginClient=')) {
+			const params = new URLSearchParams(decodedState);
+
+			// If the provider is not present in the relay state, we will use the decodedState as the provider value
+			// provider is not omitted from extraction, it is parsed dynamically using URLSearchParams:
 			const provider = params.get('provider') ?? undefined;
 			const loginClient = params.get('loginClient');
-
 			return {
-				provider,
+				provider: provider || decodedState,
 				loginClient: this.isSupportedLoginClient(loginClient) ? loginClient : undefined,
 			};
 		}
@@ -198,7 +217,7 @@ export class SAMLUtils {
 
 	public static async inflateXml(deflatedXml: Buffer<ArrayBuffer>): Promise<Buffer<ArrayBuffer>> {
 		return new Promise((resolve, reject) => {
-			zlib.inflateRaw(deflatedXml, (err, inflatedXml) => {
+			zlib.inflateRaw(deflatedXml, (err: Error | null, inflatedXml: Buffer<ArrayBuffer>) => {
 				if (err) {
 					this.log({ msg: 'Error while inflating.', err });
 					return reject(err);

--- a/apps/meteor/server/lib/saml/lib/Utils.ts
+++ b/apps/meteor/server/lib/saml/lib/Utils.ts
@@ -160,63 +160,71 @@ export class SAMLUtils {
 		return new URLSearchParams({ provider, loginClient }).toString();
 	}
 
+	
+
 	public static decodeAuthorizeRelayState(relayState?: string | null): { provider?: string; loginClient?: 'desktop' | 'mobile' } {
 		if (!relayState) {
 			return {};
 		}
 
 		// CASE 1: Compound RelayState in the format produced by encodeAuthorizeRelayState.
-		// 'tenant&provider=other&loginClient=mobile' — will never begin with 'provider='.
-
-		if (relayState.startsWith('provider=') && relayState.includes('&loginClient=')) {
+		// Parameter order is irrelevant:
+		// 'provider=test-sp&loginClient=mobile'
+		// 'loginClient=mobile&provider=test-sp'
+		if (relayState.includes('loginClient=')) {
 			const params = new URLSearchParams(relayState);
 			const provider = params.get('provider') ?? undefined;
 			const loginClient = params.get('loginClient');
+
 			return {
 				provider,
 				loginClient: this.isSupportedLoginClient(loginClient) ? loginClient : undefined,
 			};
 		}
 
-		// CASE 2: The IdP wrapped the entire RelayState in encodeURIComponent, producing a
-		// single opaque blob with no literal separators (e.g. 'provider%3Dtest-sp%26loginClient%3Dmobile').
-		
-		if (!relayState.includes('&') && !relayState.includes('=') && relayState.includes('%')) {
+		// CASE 2: The IdP URL-encoded the complete RelayState.
+		// Example:
+		// 'provider%3Dtest-sp%26loginClient%3Dmobile'
+		if (relayState.includes('%3D') || relayState.includes('%3d')) {
 			try {
 				const decoded = decodeURIComponent(relayState);
-				if (decoded.startsWith('provider=') && decoded.includes('&loginClient=')) {
-					const params = new URLSearchParams(decoded);
-					const provider = params.get('provider') ?? undefined;
-					const loginClient = params.get('loginClient');
-					if (provider && this.isSupportedLoginClient(loginClient)) {
-						return { provider, loginClient };
-					}
+				const params = new URLSearchParams(decoded);
+
+				const provider = params.get('provider') ?? undefined;
+				const loginClient = params.get('loginClient');
+
+				if (provider && this.isSupportedLoginClient(loginClient)) {
+					return { provider, loginClient };
 				}
 			} catch (err) {
-			
 				this.log({ msg: 'Failed to decode relay state', err });
 			}
 		}
 
-		// CASE 3: The IdP encoded the '=' signs within each segment but kept literal '&'
-		// as the outer separator (e.g. 'provider%3Dtest-sp&loginClient%3Dmobile').
-		
+		// CASE 3: The IdP encoded the '=' separators within each segment
+		// but kept '&' as the outer separator.
+		//
+		// Example:
+		// 'provider%3Dtest-sp&loginClient%3Dmobile'
+		//
+		// Decode only the '=' separator instead of decoding the whole segment.
+		// This prevents an encoded '%26' inside a value from becoming a new
+		// query separator.
 		if ((relayState.includes('%3D') || relayState.includes('%3d')) && relayState.includes('&')) {
 			try {
 				const rebuilt = relayState
 					.split('&')
-					.map((s) => decodeURIComponent(s))
+					.map((segment) => segment.replace(/%3D/gi, '='))
 					.join('&');
-				if (rebuilt.startsWith('provider=') && rebuilt.includes('&loginClient=')) {
-					const params = new URLSearchParams(rebuilt);
-					const provider = params.get('provider') ?? undefined;
-					const loginClient = params.get('loginClient');
-					if (provider && this.isSupportedLoginClient(loginClient)) {
-						return { provider, loginClient };
-					}
+
+				const params = new URLSearchParams(rebuilt);
+				const provider = params.get('provider') ?? undefined;
+				const loginClient = params.get('loginClient');
+
+				if (provider && this.isSupportedLoginClient(loginClient)) {
+					return { provider, loginClient };
 				}
 			} catch (err) {
-				
 				this.log({ msg: 'Failed to decode relay state', err });
 			}
 		}

--- a/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
@@ -1160,6 +1160,18 @@ describe('SAML', () => {
 				const encoded = SAMLUtils.encodeAuthorizeRelayState('a b&c=d', 'mobile');
 				expect(SAMLUtils.decodeAuthorizeRelayState(encoded)).to.be.deep.equal({ provider: 'a b&c=d', loginClient: 'mobile' });
 			});
+
+			it('should handle URL-encoded RelayState strings from multi-step IdPs', () => {
+				const encoded = encodeURIComponent('provider=test-sp&loginClient=mobile');
+				expect(SAMLUtils.decodeAuthorizeRelayState(encoded)).to.be.deep.equal({ provider: 'test-sp', loginClient: 'mobile' });
+			});
+
+			it('should handle reordered RelayState parameters', () => {
+				expect(SAMLUtils.decodeAuthorizeRelayState('loginClient=mobile&provider=test-sp')).to.be.deep.equal({
+					provider: 'test-sp',
+					loginClient: 'mobile',
+				});
+			});
 		});
 	});
 

--- a/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
+++ b/apps/meteor/tests/unit/server/lib/saml/server.tests.ts
@@ -1161,15 +1161,25 @@ describe('SAML', () => {
 				expect(SAMLUtils.decodeAuthorizeRelayState(encoded)).to.be.deep.equal({ provider: 'a b&c=d', loginClient: 'mobile' });
 			});
 
-			it('should handle URL-encoded RelayState strings from multi-step IdPs', () => {
+			it('should handle fully URL-encoded RelayState from multi-step IdPs', () => {
+				// IdP wrapped the entire RelayState in encodeURIComponent
 				const encoded = encodeURIComponent('provider=test-sp&loginClient=mobile');
 				expect(SAMLUtils.decodeAuthorizeRelayState(encoded)).to.be.deep.equal({ provider: 'test-sp', loginClient: 'mobile' });
 			});
 
-			it('should handle reordered RelayState parameters', () => {
-				expect(SAMLUtils.decodeAuthorizeRelayState('loginClient=mobile&provider=test-sp')).to.be.deep.equal({
+			it('should handle mixed-encoded RelayState where only "=" is encoded but "&" is literal', () => {
+				
+				expect(SAMLUtils.decodeAuthorizeRelayState('provider%3Dtest-sp&loginClient%3Dmobile')).to.be.deep.equal({
 					provider: 'test-sp',
 					loginClient: 'mobile',
+				});
+			});
+
+			it('should not misread a raw provider name that contains query-like substrings', () => {
+				// A provider named 'tenant&provider=other&loginClient=mobile' must not be
+				// parsed as a compound RelayState — it does not start with 'provider='.
+				expect(SAMLUtils.decodeAuthorizeRelayState('tenant&provider=other&loginClient=mobile')).to.be.deep.equal({
+					provider: 'tenant&provider=other&loginClient=mobile',
 				});
 			});
 		});


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

## Proposed changes

Fixes an issue where SAML SSO login on mobile devices fails to redirect back to the application via `rocketchat://auth` when the Identity Provider (IdP) enforces a multi-step 2FA/MFA challenge (such as Okta Verify, Azure AD Conditional Access, Duo, or PingIdentity).

### Root Cause
In Rocket.Chat 8.8.0, system-browser SAML authentication was updated to hand off credentials to native apps using `loginClient` via SAML `RelayState`. However, `SAMLUtils.decodeAuthorizeRelayState` relied on a strict prefix check (`relayState.startsWith('provider=')`).

During multi-step MFA, IdPs routinely:
1. **URL-encode** the `RelayState` string (`provider%3D...%26loginClient%3Dmobile`).
2. **Re-order parameters** (`loginClient=mobile&provider=...`).

Because of `startsWith('provider=')`, `decodeAuthorizeRelayState` failed to parse `loginClient`, causing the server to omit `&loginClient=mobile` from the post-authentication redirect. As a result, `SAMLLoginRoute` authenticated the browser session instead of dispatching the `rocketchat://auth` deep link back to the mobile app.

### Fix (#42100)
- Updated `SAMLUtils.decodeAuthorizeRelayState` in `Utils.ts` to URL-decode incoming `RelayState` strings before parsing.
- Replaced the strict prefix check with position-independent `URLSearchParams` extraction.
- Added unit tests covering URL-encoded and reordered `RelayState` parameters in `server.tests.ts`.

## Issue(s)

Fixes SAML + IdP MFA loop in system-browser sign-in flow introduced in 8.8.0.

## Steps to test or reproduce

1. Configure Rocket.Chat with a SAML SSO provider that enforces MFA (e.g., Okta, Azure AD with Conditional Access).
2. Enable modern OAuth flow setting (`Accounts_OAuth_Use_Modern_Flow`).
3. Open the Rocket.Chat mobile app (or navigate to `/home?loginClient=mobile` in a browser).
4. Complete primary credentials prompt in the browser.
5. Complete secondary MFA challenge (e.g. Okta Verify, push notification, TOTP).
6. **Expected result**: The system browser redirects back to the mobile application via `rocketchat://auth?type=saml&credentialToken=...` and authenticates the app.

## Further comments

This change is non-breaking and fully backward-compatible with single-step SAML logins and web browser logins.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SAML sign-in compatibility with fully or partially URL-encoded RelayState values.
  - Correctly handles RelayState parameters regardless of their order.
  - Preserves provider names containing query-like characters instead of misinterpreting them as parameters.
  - Restores mobile MFA deep-link redirects by retaining the mobile sign-in context after authentication.
  - Supports recognized desktop and mobile login contexts when decoding compound RelayState values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->