### PR TITLE
fix: audio message button disabled when audio/mpeg is whitelisted (#4…

### DIFF
--- a/.changeset/fix-audio-message-mime-type-mismatch.md
+++ b/.changeset/fix-audio-message-mime-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes the audio message (mic) button staying disabled when `audio/mpeg` is whitelisted in the File Upload media type settings. The composer validation still checked for the legacy `audio/mp3` MIME type, while the audio recorder has produced `audio/mpeg` blobs since v3.5.1.

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.spec.tsx
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.spec.tsx
@@ -1,0 +1,39 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { renderHook } from '@testing-library/react';
+
+import { useAudioMessageAction } from './useAudioMessageAction';
+
+jest.mock('../../../../../../lib/AudioRecorder', () => ({
+	AudioRecorder: jest.fn().mockImplementation(() => ({
+		isSupported: () => true,
+	})),
+}));
+
+jest.mock('../../hooks/useMediaPermissions', () => ({
+	useMediaPermissions: () => [false, jest.fn()],
+}));
+
+const setup = (whiteList: string, blackList = '') =>
+	renderHook(() => useAudioMessageAction(false, false), {
+		wrapper: mockAppRoot()
+			.withSetting('FileUpload_Enabled', true)
+			.withSetting('Message_AudioRecorderEnabled', true)
+			.withSetting('FileUpload_MediaTypeWhiteList', whiteList)
+			.withSetting('FileUpload_MediaTypeBlackList', blackList)
+			.build(),
+	});
+
+it('enables the audio message action when the whitelist allows audio/mpeg, which is what the recorder actually produces', () => {
+	const { result } = setup('audio/mpeg');
+	expect(result.current.disabled).toBe(false);
+});
+
+it('still enables the audio message action for the legacy audio/mp3 whitelist entry', () => {
+	const { result } = setup('audio/mp3');
+	expect(result.current.disabled).toBe(false);
+});
+
+it('disables the audio message action when neither audio/mpeg nor audio/mp3 is whitelisted', () => {
+	const { result } = setup('image/png');
+	expect(result.current.disabled).toBe(true);
+});

--- a/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
+++ b/apps/meteor/client/views/room/composer/messageBox/MessageBoxActionsToolbar/hooks/useAudioMessageAction.ts
@@ -24,8 +24,8 @@ export const useAudioMessageAction = (disabled: boolean, isMicrophoneDenied: boo
 					!isMicrophoneDenied &&
 					isFileUploadEnabled &&
 					isAudioRecorderEnabled &&
-					!fileUploadMediaTypeBlackList?.match(/audio\/mp3|audio\/\*/i) &&
-					(!fileUploadMediaTypeWhiteList || fileUploadMediaTypeWhiteList.match(/audio\/mp3|audio\/\*/i)),
+					!fileUploadMediaTypeBlackList?.match(/audio\/mp3|audio\/mpeg|audio\/\*/i) &&
+					(!fileUploadMediaTypeWhiteList || fileUploadMediaTypeWhiteList.match(/audio\/mp3|audio\/mpeg|audio\/\*/i)),
 			),
 		[fileUploadMediaTypeBlackList, fileUploadMediaTypeWhiteList, isAudioRecorderEnabled, isFileUploadEnabled, isMicrophoneDenied],
 	);

--- a/packages/i18n/src/locales/en.i18n.json
+++ b/packages/i18n/src/locales/en.i18n.json
@@ -4237,7 +4237,7 @@
   "Message_Audio_bitRate": "Audio Message Bit Rate",
   "Message_Audio_Recording_Disabled": "Audio message - message audio recording disabled",
   "Message_AudioRecorderEnabled": "Audio Recorder Enabled",
-  "Message_AudioRecorderEnabled_Description": "Requires 'audio/mp3' files to be an accepted media type within 'File Upload' settings.",
+  "Message_AudioRecorderEnabled_Description": "Requires 'audio/mpeg' files to be an accepted media type within 'File Upload' settings.",
   "Message_audit": "Message auditing",
   "Message_auditing": "Audit messages",
   "Message_auditing_log": "Audit logs",


### PR DESCRIPTION
 Fixes #42003

  ## Problem
  The audio recorder (`AudioEncoder.ts`) has produced `audio/mpeg` blobs since
  v3.5.1 (#18426), but the composer's mic-button enable check in
  `useAudioMessageAction.ts` still only matched the legacy `audio/mp3` MIME
  type against the `FileUpload_MediaTypeWhiteList` / `FileUpload_MediaTypeBlackList`
  settings. Admins who correctly whitelisted `audio/mpeg` saw the mic button
  permanently disabled, with no error or log entry.

  ## Fix
  - Match `audio/mpeg` in addition to `audio/mp3` in the whitelist/blacklist
    regex (kept `audio/mp3` for backward compatibility with existing configs).
  - Corrected the `Message_AudioRecorderEnabled_Description` setting text,
    which still referenced `audio/mp3`.
  - Added a unit test covering: mpeg whitelisted → enabled, legacy mp3
    whitelisted → still enabled, neither → disabled.
  - Added a changeset.
  ## How to test
  1. Admin → File Upload → set Media Type White List to `audio/mpeg`
  2. Open any channel — mic button in the composer should now be enabled.

https://github.com/user-attachments/assets/12e7f711-55e1-4a13-9b7f-f53215611511



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the audio message button remaining disabled when `audio/mpeg` is permitted in File Upload settings.
  * Updated audio recording guidance to reference the correct audio media type.

* **Tests**
  * Added coverage for audio message availability when modern, legacy, or no supported audio MIME type is permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->