### PR TITLE
feat: keep opened room visible in sidebar collapsed categories

### DIFF
--- a/.changeset/light-kiwis-share.md
+++ b/.changeset/light-kiwis-share.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': minor
+---
+
+Improves the sidebar to keep the room currently open listed under its category even while that category is collapsed, so it stays clear which room is being viewed

--- a/apps/meteor/client/sidebar/hooks/useRoomList.spec.tsx
+++ b/apps/meteor/client/sidebar/hooks/useRoomList.spec.tsx
@@ -7,9 +7,15 @@ import { useRoomList } from './useRoomList';
 import type { SidebarRoomListGroup } from './useRoomList';
 import { createFakeLicenseInfo, createFakeRoom, createFakeSubscription, createFakeUser } from '../../../tests/mocks/data';
 
+let mockOpenedRoom: string | undefined;
+
 jest.mock('../../lib/RoomManager', () => ({
-	useOpenedRoom: () => undefined,
+	useOpenedRoom: () => mockOpenedRoom,
 }));
+
+afterEach(() => {
+	mockOpenedRoom = undefined;
+});
 
 // The hook returns a rich `groups` array; these helpers reproduce the legacy flat views used by the assertions.
 const groupsListOf = (groups: SidebarRoomListGroup[]) => groups.map((group) => group.key);
@@ -256,6 +262,55 @@ it('should hide all rooms and show a badge when a group is collapsed in CE ("Sho
 	expect(result.current.groupsCount[channelsIndex]).toEqual(0);
 	// The header badge accumulates unread data from the hidden rooms.
 	expect(result.current.groups[channelsIndex].unreadInfo.tunread.length).toBeGreaterThan(0);
+});
+
+it('should keep the opened room visible when its group is collapsed', async () => {
+	// Every seeded DM is read, so without this behaviour collapsing "Direct_Messages" would hide all of them.
+	mockOpenedRoom = directRooms[0].rid;
+	const { result } = renderHook(() => useRoomList({ collapsedGroups: ['Direct_Messages'] }), {
+		wrapper: getWrapperSettings({ sidebarGroupByType: true }).build(),
+	});
+
+	const groupsList = groupsListOf(result.current.groups);
+	const directIndex = groupsList.indexOf('Direct_Messages');
+	expect(result.current.groupsCount[directIndex]).toEqual(1);
+	expect(result.current.groups[directIndex].rooms).toEqual([directRooms[0]]);
+});
+
+it('should not count the opened room in the header badge of its collapsed group', async () => {
+	// The opened room stays visible with its own counters, so the collapsed header must not count it again.
+	mockOpenedRoom = unreadChannels[0].rid;
+	const { result } = renderHook(() => useRoomList({ collapsedGroups: ['Channels'] }), {
+		wrapper: getWrapperSettings({ sidebarGroupByType: true }).build(),
+	});
+
+	const groupsList = groupsListOf(result.current.groups);
+	const channelsIndex = groupsList.indexOf('Channels');
+	const hiddenChannels = unreadChannels.slice(1);
+	const { unreadInfo } = result.current.groups[channelsIndex];
+
+	expect(result.current.groups[channelsIndex].rooms).toEqual([unreadChannels[0]]);
+	expect(unreadInfo.tunread).toEqual(hiddenChannels.flatMap((room) => room.tunread || []));
+	expect(unreadInfo.tunreadUser).toEqual(hiddenChannels.flatMap((room) => room.tunreadUser || []));
+	expect(unreadInfo.unread).toEqual(hiddenChannels.reduce((acc, room) => acc + room.unread, 0));
+});
+
+it('should not duplicate the opened room when a collapsed group already shows it as unread', async () => {
+	mockOpenedRoom = unreadChannels[0].rid;
+	const { result } = renderHook(() => useRoomList({ collapsedGroups: ['Channels'] }), {
+		wrapper: getWrapperSettings({
+			sidebarGroupByType: true,
+			isEnterprise: true,
+			sidebarCategories: [{ _id: 'Channels', name: 'Channels', default: true, showUnreads: true }],
+		}).build(),
+	});
+
+	// hasLicenseModule resolves asynchronously from the mock endpoint.
+	await waitFor(() => {
+		const groupsList = groupsListOf(result.current.groups);
+		const channelsIndex = groupsList.indexOf('Channels');
+		expect(result.current.groupsCount[channelsIndex]).toEqual(unreadChannels.length);
+	});
 });
 
 it('should keep unread rooms visible (and show no header badge) when a group is collapsed and "Show unreads" is on in EE', async () => {

--- a/apps/meteor/client/sidebar/hooks/useRoomList.ts
+++ b/apps/meteor/client/sidebar/hooks/useRoomList.ts
@@ -9,6 +9,7 @@ import { useMemo } from 'react';
 import { filterGroupVisibility, getRoomCategory, useCategoryList } from './useCategoryList';
 import { useHasLicenseModule } from '../../hooks/useHasLicenseModule';
 import { useSortQueryOptions } from '../../hooks/useSortQueryOptions';
+import { useOpenedRoom } from '../../lib/RoomManager';
 import { useOmnichannelEnabled } from '../../views/omnichannel/hooks/useOmnichannelEnabled';
 import { useQueuedInquiries } from '../../views/omnichannel/hooks/useQueuedInquiries';
 import { useToggleUnreads } from '../categories/hooks/useToggleUnreads';
@@ -66,6 +67,8 @@ export const useRoomList = ({ collapsedGroups }: { collapsedGroups?: string[] })
 
 	const incomingCalls = useVideoConfIncomingCalls();
 
+	const openedRoom = useOpenedRoom();
+
 	const queue = inquiries.enabled ? inquiries.queue : emptyQueue;
 
 	const groups = useDebouncedValue(
@@ -104,8 +107,8 @@ export const useRoomList = ({ collapsedGroups }: { collapsedGroups?: string[] })
 
 			const emptyUnreadInfo = (): GroupUnreadInfo => ({ userMentions: 0, groupMentions: 0, tunread: [], tunreadUser: [], unread: 0 });
 
-			const buildUnreadInfo = (set: Set<SubscriptionWithRoom>): GroupUnreadInfo =>
-				[...set].reduce<GroupUnreadInfo>((counter, room) => {
+			const buildUnreadInfo = (roomsToCount: SubscriptionWithRoom[]): GroupUnreadInfo =>
+				roomsToCount.reduce<GroupUnreadInfo>((counter, room) => {
 					if (room.hideUnreadStatus) {
 						return counter;
 					}
@@ -134,9 +137,10 @@ export const useRoomList = ({ collapsedGroups }: { collapsedGroups?: string[] })
 				const keepUnreadsOnTopForGroup = hasLicenseModule ? isKeepUnreadsOnTop(key) : false;
 				const keepUnreadsOnTop = category ? Boolean(category.keepUnreadsOnTop) : keepUnreadsOnTopForGroup;
 				const allRooms = [...set];
-				// When collapsed, keep unread rooms visible if "Show unreads" is enabled.
-				const unreadRooms = allRooms.filter((room) => showUnreads && isUnreadRoom(room));
-				let displayRooms = collapsed ? unreadRooms : allRooms;
+				// A collapsed group still shows the room currently open, so the user can locate themselves in the
+				// sidebar, plus its unread rooms when "Show unreads" is enabled.
+				const isVisibleWhileCollapsed = (room: SubscriptionWithRoom) => room.rid === openedRoom || (showUnreads && isUnreadRoom(room));
+				let displayRooms = collapsed ? allRooms.filter(isVisibleWhileCollapsed) : allRooms;
 
 				// "Keep unreads on top": stable-partition so unread rooms come first, each partition keeping the
 				// configured sort (activity / a-z) it already has from the subscription query.
@@ -153,10 +157,10 @@ export const useRoomList = ({ collapsedGroups }: { collapsedGroups?: string[] })
 					keepUnreadsOnTop,
 					collapsed,
 					rooms: displayRooms,
-					// The header total badge is only useful when the unread rooms are hidden — i.e. collapsed AND
-					// "Show unreads" off. With "Show unreads" on, the unread rooms stay visible (with their own
-					// counters) even collapsed, so the header acts as when open and shows no badge.
-					unreadInfo: collapsed && !showUnreads ? buildUnreadInfo(set) : emptyUnreadInfo(),
+					// The header total badge only accounts for what the collapsed group hides. Rooms kept visible
+					// while collapsed — the open one, and the unread ones when "Show unreads" is on — carry their
+					// own counters, so counting them here as well would duplicate them.
+					unreadInfo: collapsed ? buildUnreadInfo(allRooms.filter((room) => !isVisibleWhileCollapsed(room))) : emptyUnreadInfo(),
 					empty: allRooms.length === 0,
 				};
 			};
@@ -164,7 +168,18 @@ export const useRoomList = ({ collapsedGroups }: { collapsedGroups?: string[] })
 			const groups = filterGroupVisibility(unfilteredGroups, hasLicenseModule, makeGroup);
 
 			return groups;
-		}, [categoryList, rooms, hasLicenseModule, collapsedGroups, incomingCalls, queue, customCategories, isShowUnreads, isKeepUnreadsOnTop]),
+		}, [
+			categoryList,
+			rooms,
+			hasLicenseModule,
+			collapsedGroups,
+			incomingCalls,
+			queue,
+			customCategories,
+			isShowUnreads,
+			isKeepUnreadsOnTop,
+			openedRoom,
+		]),
 		50,
 	);
 


### PR DESCRIPTION
<!-- This is a pull request template, you do not need to uncomment or remove the comments, they won't show up in the PR text. -->

<!-- Your Pull Request name should start with one of the following tags
  feat: Adding a new feature
  refactor: A code change that doesn't change behavior (it doesn't add anything and doesn't fix anything)
  fix: For bug fixes that affect the end-user
  chore: For small tasks
  docs: For documentation
  ci: For updating CI configuration
  test: For adding tests
  i18n: For updating any translations
  regression: Issues created/reported/fixed during the development phase. kind of problem that never existed in production and that we don't need to list in a changelog for the end user
-->

<!-- Checklist!!! If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. 
  - I have read the Contributing Guide - https://github.com/RocketChat/Rocket.Chat/blob/develop/.github/CONTRIBUTING.md#contributing-to-rocketchat doc
  - I have signed the CLA - https://cla-assistant.io/RocketChat/Rocket.Chat
  - Lint and unit tests pass locally with my changes
  - I have added tests that prove my fix is effective or that my feature works (if applicable)
  - I have added necessary documentation (if applicable)
  - Any dependent changes have been merged and published in downstream modules
-->

## Proposed changes (including videos or screenshots)
<!--
  Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
  If it fixes a bug or resolves a feature request, be sure to link to that issue below.
  This description won't be displayed to our end users in the release notes, so feel free to add as much technical context as needed.
  If the changes introduced in this pull request must be presented in the release notes, make sure to add a changeset file. Check our guidelines for adding a changeset to your pull request: https://developer.rocket.chat/contribute-to-rocket.chat/modes-of-contribution/participate-in-rocket.chat-development/development-workflow#4.-adding-changeset-to-your-pull-request 
-->
<img width="546" height="175" alt="image" src="https://github.com/user-attachments/assets/488ab9c9-d89b-499a-baf4-a74d78346ebc" />

Collapsing a sidebar category hid every room in it, including the one you were currently viewing — leaving no indication of where you were in the sidebar.

The open room now stays listed under its category while collapsed. `useRoomList` reads it from `useOpenedRoom()` and folds it into the existing collapsed-visibility rule:

```ts
const isVisibleWhileCollapsed = (room) => room.rid === openedRoom || (showUnreads && isUnreadRoom(room));
```

The collapsed header badge now counts only the rooms the group actually hides, so the open room isn't counted both in its own row badge and in the header.

## Issue(s)
<!-- Link the issues being closed by or related to this PR. For example, you can use #594 if this PR closes issue number 594 -->

## Steps to test or reproduce
<!-- Mention how you would reproduce the bug if not mentioned on the issue page already. Also mention which screens are going to have the changes if applicable -->

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
[SCC-34]

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



[SCC-34]: https://rocketchat.atlassian.net/browse/SCC-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The currently open room remains visible in the sidebar even when its category is collapsed.
  - Open rooms stay listed without duplication alongside rooms with unread messages.

- **Bug Fixes**
  - Collapsed category unread counts now exclude unread activity from the room currently being viewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->