### PR TITLE
fix: normalize the id used to key cached store records

### DIFF
--- a/.changeset/olive-pandas-listen.md
+++ b/.changeset/olive-pandas-listen.md
@@ -1,0 +1,5 @@
+---
+'@rocket.chat/meteor': patch
+---
+
+Fixes rooms showing up more than once in the sidebar, caused by the cached stores keeping a separate entry for every merge of a record whose `_id` does not arrive as a string.

--- a/apps/meteor/client/lib/cachedStores/DocumentMapStore.spec.ts
+++ b/apps/meteor/client/lib/cachedStores/DocumentMapStore.spec.ts
@@ -10,6 +10,7 @@ interface ITestRecord {
 
 const fromBinary = { _id: binaryId as unknown as string, rid: hexId };
 const fromString = { _id: hexId, rid: hexId };
+const objectId = { toHexString: () => hexId };
 
 describe('cachedStores/DocumentMapStore', () => {
 	describe('toRecordId', () => {
@@ -19,6 +20,10 @@ describe('cachedStores/DocumentMapStore', () => {
 
 		it('should read the hexadecimal id out of a binary id', () => {
 			expect(toRecordId(binaryId)).toBe(hexId);
+		});
+
+		it('should read the hexadecimal id out of an ObjectId', () => {
+			expect(toRecordId(objectId)).toBe(hexId);
 		});
 	});
 
@@ -64,6 +69,51 @@ describe('cachedStores/DocumentMapStore', () => {
 
 			store.getState().store(fromBinary);
 			store.getState().delete(fromBinary._id);
+
+			expect(store.getState().records.size).toBe(0);
+		});
+
+		it('should merge a document carrying an ObjectId with the same document carrying a string id', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store({ _id: objectId as unknown as string, rid: hexId });
+			store.getState().store(fromString);
+
+			expect(store.getState().records.size).toBe(1);
+			expect([...store.getState().records.keys()]).toEqual([hexId]);
+		});
+
+		it('should keep an updated document keyed by its hexadecimal id', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+			store.getState().update(
+				(record) => record.rid === hexId,
+				(record) => ({ ...record }),
+			);
+
+			expect(store.getState().records.size).toBe(1);
+			expect([...store.getState().records.keys()]).toEqual([hexId]);
+		});
+
+		it('should keep an asynchronously updated document keyed by its hexadecimal id', async () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+			await store.getState().updateAsync(
+				(record) => record.rid === hexId,
+				async (record) => ({ ...record }),
+			);
+
+			expect(store.getState().records.size).toBe(1);
+			expect([...store.getState().records.keys()]).toEqual([hexId]);
+		});
+
+		it('should remove a document that was stored under a binary id', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+			store.getState().remove((record) => record.rid === hexId);
 
 			expect(store.getState().records.size).toBe(0);
 		});

--- a/apps/meteor/client/lib/cachedStores/DocumentMapStore.spec.ts
+++ b/apps/meteor/client/lib/cachedStores/DocumentMapStore.spec.ts
@@ -1,0 +1,71 @@
+import { createDocumentMapStore, toRecordId } from './DocumentMapStore';
+
+const hexId = '6a7fc7b8376b837b4b8aa6c3';
+const binaryId = Uint8Array.from(hexId.match(/../g) ?? [], (byte) => parseInt(byte, 16));
+
+interface ITestRecord {
+	_id: string;
+	rid: string;
+}
+
+const fromBinary = { _id: binaryId as unknown as string, rid: hexId };
+const fromString = { _id: hexId, rid: hexId };
+
+describe('cachedStores/DocumentMapStore', () => {
+	describe('toRecordId', () => {
+		it('should keep a string id as it is', () => {
+			expect(toRecordId(hexId)).toBe(hexId);
+		});
+
+		it('should read the hexadecimal id out of a binary id', () => {
+			expect(toRecordId(binaryId)).toBe(hexId);
+		});
+	});
+
+	describe('createDocumentMapStore', () => {
+		it('should store a document carrying a binary id under its hexadecimal id', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+
+			expect([...store.getState().records.keys()]).toEqual([hexId]);
+			expect(store.getState().has(hexId)).toBe(true);
+			expect(store.getState().has(fromBinary._id)).toBe(true);
+			expect(store.getState().get(hexId)?.rid).toBe(hexId);
+		});
+
+		it('should not store the same document twice when its id arrives in different representations', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+			store.getState().store(fromString);
+
+			expect(store.getState().records.size).toBe(1);
+		});
+
+		it('should not duplicate a document when many records are stored at once', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().storeMany([fromBinary, fromString]);
+
+			expect(store.getState().records.size).toBe(1);
+		});
+
+		it('should collapse the records of a cache written with mixed representations', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().replaceAll([fromString, fromBinary, fromBinary, fromString]);
+
+			expect(store.getState().records.size).toBe(1);
+		});
+
+		it('should delete a document by any representation of its id', () => {
+			const store = createDocumentMapStore<ITestRecord>();
+
+			store.getState().store(fromBinary);
+			store.getState().delete(fromBinary._id);
+
+			expect(store.getState().records.size).toBe(0);
+		});
+	});
+});

--- a/apps/meteor/client/lib/cachedStores/DocumentMapStore.ts
+++ b/apps/meteor/client/lib/cachedStores/DocumentMapStore.ts
@@ -1,5 +1,41 @@
 import { create } from 'zustand';
 
+const bytesToHex = (bytes: Uint8Array): string => Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+
+/**
+ * Documents are identified by a string `_id`, but a document can reach the store
+ * carrying another representation of the same id, e.g. a BSON ObjectId or the raw
+ * bytes of an EJSON binary. Those are not stable map keys: every merge of such a
+ * document stores a new entry instead of replacing the previous one, which makes
+ * repeated records pile up in the store (and in the persisted cache).
+ *
+ * @param id - The id of a document, in any of the representations it may arrive in.
+ * @returns The id as a string.
+ */
+export const toRecordId = (id: unknown): string => {
+	if (typeof id === 'string') {
+		return id;
+	}
+
+	if (ArrayBuffer.isView(id)) {
+		return bytesToHex(new Uint8Array(id.buffer, id.byteOffset, id.byteLength));
+	}
+
+	return JSON.stringify(id) ?? String(id);
+};
+
+const withStringId = <T extends { _id: string }>(record: T): T => {
+	const _id = toRecordId(record._id);
+
+	return _id === record._id ? record : { ...record, _id };
+};
+
+const toEntry = <T extends { _id: string }>(record: T): [string, T] => {
+	const stored = withStringId(record);
+
+	return [stored._id, stored];
+};
+
 export interface IDocumentMapStore<T extends { _id: string }> {
 	readonly records: ReadonlyMap<T['_id'], T>;
 	/**
@@ -169,8 +205,8 @@ export interface IDocumentMapStoreHooks<T extends { _id: string }> {
 export const createDocumentMapStore = <T extends { _id: string }>({ onInvalidate, onInvalidateAll }: IDocumentMapStoreHooks<T> = {}) =>
 	create<IDocumentMapStore<T>>()((set, get) => ({
 		records: new Map(),
-		has: (id: T['_id']) => get().records.has(id),
-		get: (id: T['_id']) => get().records.get(id),
+		has: (id: T['_id']) => get().records.has(toRecordId(id)),
+		get: (id: T['_id']) => get().records.get(toRecordId(id)),
 		some: (predicate: (record: T) => boolean) => {
 			for (const record of get().records.values()) {
 				if (predicate(record)) return true;
@@ -213,31 +249,39 @@ export const createDocumentMapStore = <T extends { _id: string }>({ onInvalidate
 			return index;
 		},
 		replaceAll: (records: T[]) => {
-			set({ records: new Map(records.map((record) => [record._id, record])) });
+			set({ records: new Map(records.map(toEntry)) });
 			onInvalidateAll?.();
 		},
 		store: (doc) => {
-			set((state) => ({ records: new Map(state.records).set(doc._id, doc) }));
-			onInvalidate?.(doc);
+			const record = withStringId(doc);
+
+			set((state) => ({ records: new Map(state.records).set(record._id, record) }));
+			onInvalidate?.(record);
 		},
 		storeMany: (docs) => {
+			const stored: T[] = [];
+
 			set((state) => {
 				const records = new Map(state.records);
 
 				for (const doc of docs) {
-					records.set(doc._id, doc);
+					const entry = toEntry(doc);
+
+					records.set(...entry);
+					stored.push(entry[1]);
 				}
 
 				return { records };
 			});
-			onInvalidate?.(...docs);
+			onInvalidate?.(...stored);
 		},
 		delete: (_id) => {
 			const affected: T[] = [];
+			const key = toRecordId(_id);
 			set((state) => {
 				const records = new Map(state.records);
-				if (onInvalidate) affected.push(state.records.get(_id)!);
-				records.delete(_id);
+				if (onInvalidate) affected.push(state.records.get(key)!);
+				records.delete(key);
 				return { records };
 			});
 			onInvalidate?.(...affected);

--- a/apps/meteor/client/lib/cachedStores/DocumentMapStore.ts
+++ b/apps/meteor/client/lib/cachedStores/DocumentMapStore.ts
@@ -17,6 +17,11 @@ export const toRecordId = (id: unknown): string => {
 		return id;
 	}
 
+	// an ObjectId carries the same 24-character id in its hexadecimal form
+	if (typeof (id as { toHexString?: unknown })?.toHexString === 'function') {
+		return (id as { toHexString: () => string }).toHexString();
+	}
+
 	if (ArrayBuffer.isView(id)) {
 		return bytesToHex(new Uint8Array(id.buffer, id.byteOffset, id.byteLength));
 	}
@@ -293,9 +298,10 @@ export const createDocumentMapStore = <T extends { _id: string }>({ onInvalidate
 				const records = new Map<T['_id'], T>();
 				for (const record of state.records.values()) {
 					if (predicate(record)) {
-						const newRecord = modifier(record);
-						records.set(record._id, newRecord);
-						if (onInvalidate) affected.push(newRecord);
+						const entry = toEntry(modifier(record));
+
+						records.set(...entry);
+						if (onInvalidate) affected.push(entry[1]);
 					} else {
 						records.set(record._id, record);
 					}
@@ -312,9 +318,10 @@ export const createDocumentMapStore = <T extends { _id: string }>({ onInvalidate
 
 			for await (const record of get().records.values()) {
 				if (predicate(record)) {
-					const newRecord = await modifier(record);
-					records.set(record._id, newRecord);
-					if (onInvalidate) affected.push(newRecord);
+					const entry = toEntry(await modifier(record));
+
+					records.set(...entry);
+					if (onInvalidate) affected.push(entry[1]);
 				} else {
 					records.set(record._id, record);
 				}


### PR DESCRIPTION
## Proposed changes (including videos or screenshots)

`DocumentMapStore` keys records by the `_id` as it arrives. A record can carry another representation of its id (a BSON ObjectId, or the raw bytes of an EJSON binary) and that is not a stable key, so every merge adds a duplicate entry — visible as the same room repeated in the sidebar, and gone only after clearing site data. Records are now normalized as they enter the store (`store`, `storeMany`, `replaceAll`) and lookups normalize the id they receive, which also covers the keys rebuilt by `update`, `updateAsync` and `remove`. The cache version is untouched: loading a cache re-keys its records in memory.

## Issue(s)

Fixes #42109

## Steps to test or reproduce

- Insert a subscription with `_id: new ObjectId()`, open the room and click "View thread": one row per merge before, one row after
- `yarn .testunit:jest apps/meteor/client/lib/cachedStores/DocumentMapStore.spec.ts`

## Further comments

- Green locally: `turbo run build`, `.testunit:definition` (149), `.testunit:jest` (331 suites / 2627 tests), `.testunit:server:cov` (2470)
- Rejected alternative: another cache version bump — it only discards caches once, the id keeps arriving in another representation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/RocketChat/Rocket.Chat/pull/42110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where rooms could appear multiple times in the sidebar when their identifiers used different formats.
  - Room entries are now consistently recognized as the same room, preventing duplicate listings.
  - Room updates are handled consistently across supported identifier formats, helping keep sidebar entries accurate.

- **Tests**
  - Added coverage for identifier normalization, storage, replacement, bulk updates, deduplication, asynchronous updates, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->